### PR TITLE
Rename to tenantId for consistency

### DIFF
--- a/00_Base/src/interfaces/api/AbstractModuleApi.ts
+++ b/00_Base/src/interfaces/api/AbstractModuleApi.ts
@@ -23,7 +23,7 @@ import { Namespace } from "../../ocpp/persistence";
 import { CallAction } from "../../ocpp/rpc/message";
 import { IMessageConfirmation } from "../messages";
 import { IModule } from "../modules";
-import { IMessageQuerystring } from "./MessageQuerystring";
+import { IMessageQuerystring, IMessageQuerystringSchema } from "./MessageQuerystring";
 import { IModuleApi } from "./ModuleApi";
 
 /**
@@ -80,20 +80,13 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
          * @return {Promise<IMessageConfirmation>} The promise that resolves to the message confirmation.
          */
         const _handler = async (request: FastifyRequest<{ Body: OcppRequest | OcppResponse, Querystring: IMessageQuerystring }>): Promise<IMessageConfirmation> => {
-            return method.call(this, request.query.identifier, request.query.partyId, request.body);
+            return method.call(this, request.query.identifier, request.query.tenantId, request.body);
         };
 
         const _opts = {
             schema: {
                 body: bodySchema,
-                querystring: {
-                    type: 'object',
-                    properties: {
-                        identifier: { type: 'string' },
-                        partyId: { type: 'string' }
-                    },
-                    required: ['identifier', 'partyId']
-                }
+                querystring: IMessageQuerystringSchema
             } as const
         };
 

--- a/00_Base/src/interfaces/api/MessageQuerystring.ts
+++ b/00_Base/src/interfaces/api/MessageQuerystring.ts
@@ -19,5 +19,17 @@
  */
 export interface IMessageQuerystring {
     identifier: string;
-    partyId: string;
+    tenantId: string;
+}
+
+/**
+ * This message querystring schema describes the {@link IMessageQuerystring} interface.
+ */
+export const IMessageQuerystringSchema = {
+    type: 'object',
+    properties: {
+        identifier: { type: 'string' },
+        tenantId: { type: 'string' }
+    },
+    required: ['identifier', 'tenantId']
 }

--- a/00_Base/src/interfaces/modules/Module.ts
+++ b/00_Base/src/interfaces/modules/Module.ts
@@ -24,8 +24,8 @@ import { HandlerProperties, IMessage, IMessageConfirmation, IMessageHandler, IMe
  */
 export interface IModule {
 
-    sendCall(identifier: string, partyId: string, action: CallAction, payload: OcppRequest, origin?: MessageOrigin): Promise<IMessageConfirmation>;
-    sendCallResult(correlationId: string, identifier: string, partyId: string, action: CallAction, payload: OcppResponse, origin?: MessageOrigin): Promise<IMessageConfirmation>;
+    sendCall(identifier: string, tenantId: string, action: CallAction, payload: OcppRequest, origin?: MessageOrigin): Promise<IMessageConfirmation>;
+    sendCallResult(correlationId: string, identifier: string, tenantId: string, action: CallAction, payload: OcppResponse, origin?: MessageOrigin): Promise<IMessageConfirmation>;
     sendCallResultWithMessage(message: IMessage<OcppResponse>, payload: OcppResponse): Promise<IMessageConfirmation>
 
     handle(message: IMessage<OcppRequest | OcppResponse>, props?: HandlerProperties): void;

--- a/01_Provisioning/src/module/api.ts
+++ b/01_Provisioning/src/module/api.ts
@@ -45,16 +45,16 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
     @AsMessageEndpoint(CallAction.GetBaseReport, GetBaseReportRequestSchema)
     getBaseReport(
         identifier: string,
-        partyId: string,
+        tenantId: string,
         request: GetBaseReportRequest
     ): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.GetBaseReport, request);
+        return this._module.sendCall(identifier, tenantId, CallAction.GetBaseReport, request);
     }
 
     @AsMessageEndpoint(CallAction.SetVariables, SetVariablesRequestSchema)
     async setVariables(
         identifier: string,
-        partyId: string,
+        tenantId: string,
         request: SetVariablesRequest
     ): Promise<IMessageConfirmation> {
         const setVariableData = request.setVariableData;
@@ -70,7 +70,7 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
             const itemsPerMessageSetVariables = Number(itemsPerMessageSetVariablesAttributes[0].value);
             while (setVariableData.length > 0) {
                 const setVariableDataSubset = setVariableData.slice(0, itemsPerMessageSetVariables);
-                const messageConfirmation = await this._module.sendCall(identifier, partyId, CallAction.SetVariables,
+                const messageConfirmation = await this._module.sendCall(identifier, tenantId, CallAction.SetVariables,
                     { setVariableData: setVariableDataSubset } as SetVariablesRequest);
                 if (!messageConfirmation.payload) {
                     finalMessageConfirmation.success = false;
@@ -81,7 +81,7 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
             return finalMessageConfirmation;
         } else if (itemsPerMessageSetVariablesAttributes.length == 0) {
             // If no limit reported, no limit used
-            return this._module.sendCall(identifier, partyId, CallAction.SetVariables,
+            return this._module.sendCall(identifier, tenantId, CallAction.SetVariables,
                 { setVariableData: setVariableData } as SetVariablesRequest);
         } else {
             throw new Error("Violation of Standard Component Structure: "
@@ -92,7 +92,7 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
     @AsMessageEndpoint(CallAction.GetVariables, GetVariablesRequestSchema)
     async getVariables(
         identifier: string,
-        partyId: string,
+        tenantId: string,
         request: GetVariablesRequest
     ): Promise<IMessageConfirmation> {
         const getVariableData = request.getVariableData;
@@ -108,7 +108,7 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
             const itemsPerMessageGetVariables = Number(itemsPerMessageGetVariablesAttributes[0].value);
             while (getVariableData.length > 0) {
                 const getVariableDataSubset = getVariableData.slice(0, itemsPerMessageGetVariables);
-                const messageConfirmation = await this._module.sendCall(identifier, partyId, CallAction.GetVariables,
+                const messageConfirmation = await this._module.sendCall(identifier, tenantId, CallAction.GetVariables,
                     { getVariableData: getVariableDataSubset } as GetVariablesRequest);
                 if (!messageConfirmation.payload) {
                     finalMessageConfirmation.success = false;
@@ -119,7 +119,7 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
             return finalMessageConfirmation;
         } else if (itemsPerMessageGetVariablesAttributes.length == 0) {
             // If no limit reported, no limit used
-            return this._module.sendCall(identifier, partyId, CallAction.GetVariables,
+            return this._module.sendCall(identifier, tenantId, CallAction.GetVariables,
                 { getVariableData: getVariableData } as GetVariablesRequest);
         } else {
             throw new Error("Violation of Standard Component Structure: "
@@ -130,19 +130,19 @@ export class ProvisioningModuleApi extends AbstractModuleApi<ProvisioningModule>
     @AsMessageEndpoint(CallAction.SetNetworkProfile, SetNetworkProfileRequestSchema)
     setNetworkProfile(
         identifier: string,
-        partyId: string,
+        tenantId: string,
         request: SetNetworkProfileRequest
     ): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.SetNetworkProfile, request);
+        return this._module.sendCall(identifier, tenantId, CallAction.SetNetworkProfile, request);
     }
 
     @AsMessageEndpoint(CallAction.Reset, ResetRequestSchema)
     reset(
         identifier: string,
-        partyId: string,
+        tenantId: string,
         resetRequest: ResetRequest
     ): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.Reset, resetRequest);
+        return this._module.sendCall(identifier, tenantId, CallAction.Reset, resetRequest);
     }
 
     /**

--- a/01_Provisioning/src/module/interface.ts
+++ b/01_Provisioning/src/module/interface.ts
@@ -20,9 +20,9 @@ import { GetBaseReportRequest, GetVariablesRequest, IMessageConfirmation, ResetR
  * Interface for the provisioning module.
  */
 export interface IProvisioningModuleApi {
-    getBaseReport(identifier: string, partyId: string, request: GetBaseReportRequest): Promise<IMessageConfirmation>;
-    setVariables(identifier: string, partyId: string, request: SetVariablesRequest): Promise<IMessageConfirmation>;
-    getVariables(identifier: string, partyId: string, request: GetVariablesRequest): Promise<IMessageConfirmation>;
-    setNetworkProfile(identifier: string, partyId: string, request: SetNetworkProfileRequest): Promise<IMessageConfirmation>;
-    reset(identifier: string, partyId: string, request: ResetRequest): Promise<IMessageConfirmation>;
+    getBaseReport(identifier: string, tenantId: string, request: GetBaseReportRequest): Promise<IMessageConfirmation>;
+    setVariables(identifier: string, tenantId: string, request: SetVariablesRequest): Promise<IMessageConfirmation>;
+    getVariables(identifier: string, tenantId: string, request: GetVariablesRequest): Promise<IMessageConfirmation>;
+    setNetworkProfile(identifier: string, tenantId: string, request: SetNetworkProfileRequest): Promise<IMessageConfirmation>;
+    reset(identifier: string, tenantId: string, request: ResetRequest): Promise<IMessageConfirmation>;
 }

--- a/02_Authorization/src/module/api.ts
+++ b/02_Authorization/src/module/api.ts
@@ -67,18 +67,18 @@ export class AuthorizationModuleApi extends AbstractModuleApi<AuthorizationModul
      */
 
     @AsMessageEndpoint(CallAction.RequestStartTransaction, RequestStartTransactionRequestSchema)
-    requestStartTransaction(identifier: string, partyId: string, request: RequestStartTransactionRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.RequestStartTransaction, request);
+    requestStartTransaction(identifier: string, tenantId: string, request: RequestStartTransactionRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.RequestStartTransaction, request);
     }
 
     @AsMessageEndpoint(CallAction.RequestStopTransaction, RequestStopTransactionRequestSchema)
-    requestStopTransaction(identifier: string, partyId: string, request: RequestStopTransactionRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.RequestStopTransaction, request);
+    requestStopTransaction(identifier: string, tenantId: string, request: RequestStopTransactionRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.RequestStopTransaction, request);
     }
 
     @AsMessageEndpoint(CallAction.ClearCache, ClearCacheRequestSchema)
-    clearCache(identifier: string, partyId: string, request: ClearCacheRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.ClearCache, request);
+    clearCache(identifier: string, tenantId: string, request: ClearCacheRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.ClearCache, request);
     }
 
     /**

--- a/02_Authorization/src/module/interface.ts
+++ b/02_Authorization/src/module/interface.ts
@@ -20,7 +20,7 @@ import { ClearCacheRequest, IMessageConfirmation, RequestStartTransactionRequest
  * Interface for the authorization module.
  */
 export interface IAuthorizationModuleApi {
-    requestStartTransaction(identifier: string, partyId: string, request: RequestStartTransactionRequest): Promise<IMessageConfirmation>;
-    requestStopTransaction(identifier: string, partyId: string, request: RequestStopTransactionRequest): Promise<IMessageConfirmation>;
-    clearCache(identifier: string, partyId: string, request: ClearCacheRequest): Promise<IMessageConfirmation>;
+    requestStartTransaction(identifier: string, tenantId: string, request: RequestStartTransactionRequest): Promise<IMessageConfirmation>;
+    requestStopTransaction(identifier: string, tenantId: string, request: RequestStopTransactionRequest): Promise<IMessageConfirmation>;
+    clearCache(identifier: string, tenantId: string, request: ClearCacheRequest): Promise<IMessageConfirmation>;
 }

--- a/03_Availability/src/module/api.ts
+++ b/03_Availability/src/module/api.ts
@@ -41,8 +41,8 @@ export class AvailabilityModuleApi extends AbstractModuleApi<AvailabilityModule>
    */
 
     @AsMessageEndpoint(CallAction.ChangeAvailability, ChangeAvailabilityRequestSchema)
-    changeAvailability(identifier: string, partyId: string, request: ChangeAvailabilityRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.ChangeAvailability, request);
+    changeAvailability(identifier: string, tenantId: string, request: ChangeAvailabilityRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.ChangeAvailability, request);
     }
 
     /**

--- a/03_Availability/src/module/interface.ts
+++ b/03_Availability/src/module/interface.ts
@@ -20,5 +20,5 @@ import { ChangeAvailabilityRequest, IMessageConfirmation } from "@citrineos/base
  * Interface for the authorization module.
  */
 export interface IAvailabilityModuleApi {
-    changeAvailability(identifier: string, partyId: string, request: ChangeAvailabilityRequest): Promise<IMessageConfirmation>;
+    changeAvailability(identifier: string, tenantId: string, request: ChangeAvailabilityRequest): Promise<IMessageConfirmation>;
 }

--- a/04_Transaction/src/module/api.ts
+++ b/04_Transaction/src/module/api.ts
@@ -58,8 +58,8 @@ export class TransactionModuleApi extends AbstractModuleApi<TransactionModule> i
      */
 
     @AsMessageEndpoint(CallAction.GetTransactionStatus, GetTransactionStatusRequestSchema)
-    getTransactionStatus(identifier: string, partyId: string, request: GetTransactionStatusRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.GetTransactionStatus, request);
+    getTransactionStatus(identifier: string, tenantId: string, request: GetTransactionStatusRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.GetTransactionStatus, request);
     }
 
     /**

--- a/04_Transaction/src/module/interface.ts
+++ b/04_Transaction/src/module/interface.ts
@@ -20,5 +20,5 @@ import { GetTransactionStatusRequest, IMessageConfirmation } from "@citrineos/ba
  * Interface for the transaction module.
  */
 export interface ITransactionModuleApi {
-    getTransactionStatus(identifier: string, partyId: string, request: GetTransactionStatusRequest): Promise<IMessageConfirmation>
+    getTransactionStatus(identifier: string, tenantId: string, request: GetTransactionStatusRequest): Promise<IMessageConfirmation>
 }

--- a/05_Monitoring/src/module/api.ts
+++ b/05_Monitoring/src/module/api.ts
@@ -41,8 +41,8 @@ export class MonitoringModuleApi extends AbstractModuleApi<MonitoringModule> imp
      */
 
     @AsMessageEndpoint(CallAction.GetMonitoringReport, GetMonitoringReportRequestSchema)
-    getMonitoringReport(identifier: string, partyId: string, request: GetMonitoringReportRequest): Promise<IMessageConfirmation> {
-        return this._module.sendCall(identifier, partyId, CallAction.GetMonitoringReport, request);
+    getMonitoringReport(identifier: string, tenantId: string, request: GetMonitoringReportRequest): Promise<IMessageConfirmation> {
+        return this._module.sendCall(identifier, tenantId, CallAction.GetMonitoringReport, request);
     }
 
 

--- a/05_Monitoring/src/module/interface.ts
+++ b/05_Monitoring/src/module/interface.ts
@@ -20,5 +20,5 @@ import { GetMonitoringReportRequest, IMessageConfirmation } from "@citrineos/bas
  * Interface for the transaction module.
  */
 export interface IMonitoringModuleApi {
-    getMonitoringReport(identifier: string, partyId: string, request: GetMonitoringReportRequest): Promise<IMessageConfirmation>
+    getMonitoringReport(identifier: string, tenantId: string, request: GetMonitoringReportRequest): Promise<IMessageConfirmation>
 }


### PR DESCRIPTION
All endpoints and interfaces renamed with tenantId to be consistent with base interfaces.