### PR TITLE
Feature/expanding cache methods

### DIFF
--- a/00_Base/src/interfaces/cache/cache.ts
+++ b/00_Base/src/interfaces/cache/cache.ts
@@ -32,6 +32,18 @@ export interface ICache {
   remove(key: string, namespace?: string): Promise<boolean>;
 
   /**
+   * Monitors a key for potential changes to its value.
+   * If key-value does not exist this method will wait for it to exist or return null at the end of the wait period.
+   * If value is removed, the method will return null.
+   * 
+   * @param {string} key - The key for the value.
+   * @param {number} [waitSeconds] - The number of seconds after which the method should return if the value has not been modified by then.
+   * @param {string} [namespace] - The namespace for the key.
+   * @returns {Promise<string | null>} Returns the value as string once it is modified or waitSeconds has elapsed; or null if the key does not exist.
+   * */
+  onChange<T>(key: string, waitSeconds: number, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null>;
+
+  /**
    * Gets a value asynchronously from the underlying cache.
    * 
    * @param {string} key - The key for the value.
@@ -42,15 +54,14 @@ export interface ICache {
   get<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null>;
 
   /**
-   * Gets a value synchronously from the underlying cache.
-   * 
-   * Note: The concrete implementation of this method might use run loop modification to achieve synchronous behavior.
+   * Gets and removes a value asynchronously from the underlying cache.
+   * This is an atomic operation. The value will not be modified or read by any other process between getting and removing.
    * 
    * @param {string} key - The key for the value.
    * @param {string} [namespace] - The namespace for the key.
-   * @returns {string | null} - Returns the value as string or null if the key does not exist.
+   * @returns {Promise<string | null>} - Returns the value as string or null if the key does not exist.
    */
-  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null;
+  getAndRemove<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null>;
 
   /**
    * Sets a value asynchronously in the underlying cache.
@@ -62,6 +73,21 @@ export interface ICache {
    * @returns {Promise<boolean>} - Returns true if the value was set successfully.
    * */
   set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean>;
+
+  /**
+   * Synchronous methods
+   */
+
+  /**
+   * Gets a value synchronously from the underlying cache.
+   * 
+   * Note: The concrete implementation of this method might use run loop modification to achieve synchronous behavior.
+   * 
+   * @param {string} key - The key for the value.
+   * @param {string} [namespace] - The namespace for the key.
+   * @returns {string | null} - Returns the value as string or null if the key does not exist.
+   */
+  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null;
 
   /**
    * Sets a value synchronously in the underlying cache.

--- a/00_Base/src/interfaces/cache/cache.ts
+++ b/00_Base/src/interfaces/cache/cache.ts
@@ -54,6 +54,17 @@ export interface ICache {
   get<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null>;
 
   /**
+   * Gets a value synchronously from the underlying cache.
+   * 
+   * Note: The concrete implementation of this method might use run loop modification to achieve synchronous behavior.
+   * 
+   * @param {string} key - The key for the value.
+   * @param {string} [namespace] - The namespace for the key.
+   * @returns {string | null} - Returns the value as string or null if the key does not exist.
+   */
+  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null;
+
+  /**
    * Gets and removes a value asynchronously from the underlying cache.
    * This is an atomic operation. The value will not be modified or read by any other process between getting and removing.
    * 
@@ -73,21 +84,6 @@ export interface ICache {
    * @returns {Promise<boolean>} - Returns true if the value was set successfully.
    * */
   set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean>;
-
-  /**
-   * Synchronous methods
-   */
-
-  /**
-   * Gets a value synchronously from the underlying cache.
-   * 
-   * Note: The concrete implementation of this method might use run loop modification to achieve synchronous behavior.
-   * 
-   * @param {string} key - The key for the value.
-   * @param {string} [namespace] - The namespace for the key.
-   * @returns {string | null} - Returns the value as string or null if the key does not exist.
-   */
-  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null;
 
   /**
    * Sets a value synchronously in the underlying cache.

--- a/99_Util/src/cache/memory.ts
+++ b/99_Util/src/cache/memory.ts
@@ -30,7 +30,7 @@ export class MemoryCache implements ICache {
 
   constructor() {
     const keySubscriptionMap: Map<string, (arg: string | null) => void> = new Map();
-    const handler: ProxyHandler<Map<string, string>> = {
+    const subscriptionHandler: ProxyHandler<Map<string, string>> = {
       // Returns value when Map.set(key, value) is called
       set(target, property, value) {
         const setOutcome = Reflect.set(target, property, value);
@@ -49,7 +49,7 @@ export class MemoryCache implements ICache {
       },
     };
 
-    this._cache = new Proxy(new Map(), handler);
+    this._cache = new Proxy(new Map(), subscriptionHandler);
     this._keySubscriptionMap = keySubscriptionMap;
     this._keySubscriptionPromiseMap = new Map();
     this._lockMap = new Map();

--- a/99_Util/src/cache/memory.ts
+++ b/99_Util/src/cache/memory.ts
@@ -115,6 +115,20 @@ export class MemoryCache implements ICache {
     });
   }
 
+  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+    const value = this._cache.get(key);
+    if (value) {
+      if (classConstructor) {
+        return plainToInstance(classConstructor(), JSON.parse(value));
+      }
+      return value as T;
+    } else {
+      return null;
+    }
+  }
+  
   set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean> {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;
@@ -128,22 +142,6 @@ export class MemoryCache implements ICache {
       }, expireSeconds * 1000));
     }
     return Promise.resolve(true);
-  }
-
-  // Synchronous versions
-
-  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
-    namespace = namespace || "default";
-    key = `${namespace}:${key}`;
-    const value = this._cache.get(key);
-    if (value) {
-      if (classConstructor) {
-        return plainToInstance(classConstructor(), JSON.parse(value));
-      }
-      return value as T;
-    } else {
-      return null;
-    }
   }
 
   setSync(key: string, value: string, namespace?: string, expireSeconds?: number): boolean {

--- a/99_Util/src/cache/memory.ts
+++ b/99_Util/src/cache/memory.ts
@@ -23,11 +23,36 @@ import { ClassConstructor, plainToInstance } from "class-transformer";
 export class MemoryCache implements ICache {
 
   private _cache: Map<string, string>;
+  private _keySubscriptionMap: Map<string, (arg: string | null) => void>;
+  private _keySubscriptionPromiseMap: Map<string, Promise<string | null>>;
   private _timeoutMap: Map<string, NodeJS.Timeout>;
 
   constructor() {
-    this._cache = new Map();
+    const keySubscriptionMap: Map<string, (arg: string | null) => void> = new Map();
+    const handler: ProxyHandler<Map<string, string>> = {
+      // Returns value when Map.set(key, value) is called
+      set(target, property, value) {
+        const setOutcome = Reflect.set(target, property, value);
+        if (typeof property === "string" && keySubscriptionMap.has(property) && setOutcome) {
+          keySubscriptionMap.get(property)!(value);
+        }
+        return setOutcome;
+      },
+      // Returns null when Map.delete(key) is called
+      deleteProperty(target, property) {
+        const deleteOutcome = Reflect.deleteProperty(target, property);
+        if (typeof property === "string" && keySubscriptionMap.has(property) && deleteOutcome) {
+          keySubscriptionMap.get(property)!(null);
+        }
+        return deleteOutcome;
+      },
+    };
+
+    this._cache = new Proxy(new Map(), handler);
+    this._keySubscriptionMap = keySubscriptionMap;
+    this._keySubscriptionPromiseMap = new Map();
     this._timeoutMap = new Map();
+
   }
 
   exists(key: string, namespace?: string): Promise<boolean> {
@@ -41,6 +66,40 @@ export class MemoryCache implements ICache {
     key = `${namespace}:${key}`;
     return Promise.resolve(this._cache.delete(key));
   }
+
+  onChange<T>(key: string, waitSeconds: number, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null> {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+
+    // Either get existing promise awaiting change on this key or create a new one and store it.
+    // This way, any number of threads can wait for the same key at the same time.
+    // Type must include 'undefined' due to Map.get(key)'s return type, however in no case can it actually be undefined.
+    const onChangeValuePromise: Promise<string | null> | undefined = this._keySubscriptionPromiseMap.has(key)
+      ? this._keySubscriptionPromiseMap.get(key)
+      : this._keySubscriptionPromiseMap.set(key, new Promise<string | null>((resolve) => {
+        this._keySubscriptionMap.set(key, (value: string | null) => {
+          resolve(value);
+        });
+      })).get(key);
+
+    return Promise.race([
+      onChangeValuePromise!.then((value) => {
+        if (typeof value === "string") {
+          if (classConstructor) {
+            return plainToInstance(classConstructor(), JSON.parse(value));
+          } else {
+            return value as T;
+          }
+        } else {
+          return value;
+        }
+      }), new Promise<T | null>((resolve) => {
+      setTimeout(() => {
+        resolve(this.get(key, namespace, classConstructor));
+      }, waitSeconds * 1000);
+    })]);
+  }
+
 
   get<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null> {
     namespace = namespace || "default";
@@ -56,20 +115,6 @@ export class MemoryCache implements ICache {
     });
   }
 
-  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
-    namespace = namespace || "default";
-    key = `${namespace}:${key}`;
-    const value = this._cache.get(key);
-    if (value) {
-      if (classConstructor) {
-        return plainToInstance(classConstructor(), JSON.parse(value));
-      }
-      return value as T;
-    } else {
-      return null;
-    }
-  }
-
   set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean> {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;
@@ -83,6 +128,22 @@ export class MemoryCache implements ICache {
       }, expireSeconds * 1000));
     }
     return Promise.resolve(true);
+  }
+
+  // Synchronous versions
+
+  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+    const value = this._cache.get(key);
+    if (value) {
+      if (classConstructor) {
+        return plainToInstance(classConstructor(), JSON.parse(value));
+      }
+      return value as T;
+    } else {
+      return null;
+    }
   }
 
   setSync(key: string, value: string, namespace?: string, expireSeconds?: number): boolean {

--- a/99_Util/src/cache/memory.ts
+++ b/99_Util/src/cache/memory.ts
@@ -133,10 +133,12 @@ export class MemoryCache implements ICache {
         if (result) {
           if (classConstructor) {
             resolveGet(plainToInstance(classConstructor(), JSON.parse(result)));
+          } else {
+            resolveGet(result as T);
           }
-          resolveGet(result as T);
+        } else {
+          resolveGet(null);
         }
-        resolveGet(null);
         this._cache.delete(key);
         resolveLock();
       }));

--- a/99_Util/src/cache/redis.ts
+++ b/99_Util/src/cache/redis.ts
@@ -17,7 +17,7 @@
 import { ICache } from "@citrineos/base";
 import { ClassConstructor, plainToInstance } from "class-transformer";
 import { default as deasyncPromise } from "deasync-promise";
-import { RedisClientType, createClient } from "redis";
+import { RedisClientType, createClient, PubSubListener } from "redis";
 
 /**
  * Implementation of cache interface with redis storage
@@ -27,6 +27,8 @@ export class RedisCache implements ICache {
 
   constructor(client?: RedisClientType) {
     this._client = client ?? createClient();
+    // Set the notify-keyspace-events config for generic keyspace events such as set, expired, and del
+    this._client.configSet("notify-keyspace-events", "Kg");
   }
 
   exists(key: string, namespace?: string): Promise<boolean> {
@@ -39,6 +41,40 @@ export class RedisCache implements ICache {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;
     return this._client.del(key).then((result) => result === 1);
+  }
+
+  onChange<T>(key: string, waitSeconds: number, namespace?: string | undefined, classConstructor?: (() => ClassConstructor<T>) | undefined): Promise<T | null> {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+
+    // Create a Redis subscriber to listen for operations affecting the key
+    const subscriber = createClient();
+    const onChangeValuePromise: Promise<T | null> = new Promise((resolve) => {
+      // Channel: Key-space, message: the name of the event, which is the command executed on the key
+      subscriber.subscribe(`__keyspace@0__:${key}`, (channel, message) => {
+        switch (message) {
+          case "set":
+            resolve(this.get(key, namespace, classConstructor));
+            subscriber.quit();
+            break;
+          case "del":
+          case "expire":
+            resolve(null);
+            subscriber.quit();
+            break;
+          default:
+            // Do nothing
+            break;
+        }
+      });
+    })
+
+    return Promise.race([onChangeValuePromise, new Promise<T | null>((resolve) => {
+      setTimeout(() => {
+        resolve(this.get(key, namespace, classConstructor));
+        subscriber.quit();
+      }, waitSeconds * 1000);
+    })]);
   }
 
   get<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): Promise<T | null> {
@@ -55,6 +91,40 @@ export class RedisCache implements ICache {
     });
   }
 
+  getAndRemove<T>(key: string, namespace?: string | undefined, classConstructor?: (() => ClassConstructor<T>) | undefined): Promise<T | null> {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+    const transaction = this._client.multi();
+    transaction.get(key);
+    transaction.del(key);
+    return new Promise((resolve) => {
+      transaction.exec().then((replies) => {
+        if (replies[0]) {
+          if (classConstructor) {
+            resolve(plainToInstance(classConstructor(), JSON.parse(replies[0] as string)));
+          } else {
+            resolve(replies[0] as T);
+          }
+        } else {
+          resolve(null);
+        }
+      });
+    });
+  }
+
+  set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean> {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+    return this._client.set(key, value, { EX: expireSeconds }).then((result) => {
+      if (result) {
+        return result === "OK";
+      }
+      return false;
+    });
+  }
+
+  // Synchronous versions
+
   getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;
@@ -67,17 +137,6 @@ export class RedisCache implements ICache {
       }
       return null;
     }));
-  }
-
-  set(key: string, value: string, namespace?: string, expireSeconds?: number): Promise<boolean> {
-    namespace = namespace || "default";
-    key = `${namespace}:${key}`;
-    return this._client.set(key, value, { EX: expireSeconds }).then((result) => {
-      if (result) {
-        return result === "OK";
-      }
-      return false;
-    });
   }
 
   setSync(key: string, value: string, namespace?: string, expireSeconds?: number): boolean {

--- a/99_Util/src/cache/redis.ts
+++ b/99_Util/src/cache/redis.ts
@@ -91,6 +91,20 @@ export class RedisCache implements ICache {
     });
   }
 
+  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
+    namespace = namespace || "default";
+    key = `${namespace}:${key}`;
+    return deasyncPromise(this._client.get(key).then((result) => {
+      if (result) {
+        if (classConstructor) {
+          return plainToInstance(classConstructor(), JSON.parse(result));
+        }
+        return result as T;
+      }
+      return null;
+    }));
+  }
+  
   getAndRemove<T>(key: string, namespace?: string | undefined, classConstructor?: (() => ClassConstructor<T>) | undefined): Promise<T | null> {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;
@@ -121,22 +135,6 @@ export class RedisCache implements ICache {
       }
       return false;
     });
-  }
-
-  // Synchronous versions
-
-  getSync<T>(key: string, namespace?: string, classConstructor?: () => ClassConstructor<T>): T | null {
-    namespace = namespace || "default";
-    key = `${namespace}:${key}`;
-    return deasyncPromise(this._client.get(key).then((result) => {
-      if (result) {
-        if (classConstructor) {
-          return plainToInstance(classConstructor(), JSON.parse(result));
-        }
-        return result as T;
-      }
-      return null;
-    }));
   }
 
   setSync(key: string, value: string, namespace?: string, expireSeconds?: number): boolean {

--- a/99_Util/src/cache/redis.ts
+++ b/99_Util/src/cache/redis.ts
@@ -17,7 +17,7 @@
 import { ICache } from "@citrineos/base";
 import { ClassConstructor, plainToInstance } from "class-transformer";
 import { default as deasyncPromise } from "deasync-promise";
-import { RedisClientType, createClient, PubSubListener } from "redis";
+import { RedisClientType, createClient } from "redis";
 
 /**
  * Implementation of cache interface with redis storage
@@ -104,7 +104,7 @@ export class RedisCache implements ICache {
       return null;
     }));
   }
-  
+
   getAndRemove<T>(key: string, namespace?: string | undefined, classConstructor?: (() => ClassConstructor<T>) | undefined): Promise<T | null> {
     namespace = namespace || "default";
     key = `${namespace}:${key}`;


### PR DESCRIPTION
onChange and getAndRemove added to ICache. Impls added to MemoryCache and RedisCache.
Method descriptions:
onChange
```
   * Monitors a key for potential changes to its value.
   * If key-value does not exist this method will wait for it to exist or return null at the end of the wait period.
   * If value is removed, the method will return null.
```
getAndRemove
```
   * Gets and removes a value asynchronously from the underlying cache.
   * This is an atomic operation. The value will not be modified or read by any other process between getting and removing.
```