### PR TITLE
adding support for security profiles 2 and 3

### DIFF
--- a/00_Base/src/interfaces/modules/AbstractModule.ts
+++ b/00_Base/src/interfaces/modules/AbstractModule.ts
@@ -144,7 +144,7 @@ export abstract class AbstractModule implements IModule {
     handle(message: IMessage<OcppRequest | OcppResponse>, props?: HandlerProperties): void {
         if (message.state === MessageState.Response) {
             this.handleMessageApiCallback(message as IMessage<OcppResponse>);
-            this._cache.set(message.context.correlationId, JSON.stringify(message.payload), message.context.stationId, this._config.websocketServer.maxCachingSeconds);
+            this._cache.set(message.context.correlationId, JSON.stringify(message.payload), message.context.stationId, this._config.websocket.maxCachingSeconds);
         }
         const handlerDefinition = (Reflect.getMetadata(AS_HANDLER_METADATA, this.constructor) as Array<IHandlerDefinition>).filter((h) => h.action === message.action).pop();
         if (handlerDefinition) {
@@ -205,7 +205,7 @@ export abstract class AbstractModule implements IModule {
         if (callbackUrl) {
             // TODO: Handle callErrors, failure to send to charger, timeout from charger, with different responses to callback
             this._cache.set(_correlationId, callbackUrl, this.CALLBACK_URL_CACHE_PREFIX + identifier,
-                this._config.websocketServer.maxCachingSeconds); // x2 fudge factor for any network lag
+                this._config.websocket.maxCachingSeconds); // x2 fudge factor for any network lag
         }
         // TODO: Future - Compound key with tenantId
         return this._cache.get<ClientConnection>(identifier, CacheNamespace.Connections, () => ClientConnection).then((connection) => {

--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -384,16 +384,16 @@ export class ConfigurationModule extends AbstractModule {
           // Commenting out this line, using requestId == 0 until fixed (10/26/2023)
           // const requestId = Math.floor(Math.random() * ConfigurationModule.GET_BASE_REPORT_REQUEST_ID_MAX);
           const requestId = 0;
-          this._cache.set(requestId.toString(), 'ongoing', stationId, this.config.websocketServer.maxCachingSeconds);
+          this._cache.set(requestId.toString(), 'ongoing', stationId, this.config.websocket.maxCachingSeconds);
           const getBaseReportMessageConfirmation: IMessageConfirmation = await this.sendCall(stationId, tenantId, CallAction.GetBaseReport,
             { requestId: requestId, reportBase: ReportBaseEnumType.FullInventory } as GetBaseReportRequest);
           if (getBaseReportMessageConfirmation.success) {
             this._logger.debug("GetBaseReport successfully sent to charger: ", getBaseReportMessageConfirmation);
 
             // Wait for GetBaseReport to complete
-            let getBaseReportCacheValue = await this._cache.onChange(requestId.toString(), this.config.websocketServer.maxCachingSeconds, stationId);
+            let getBaseReportCacheValue = await this._cache.onChange(requestId.toString(), this.config.websocket.maxCachingSeconds, stationId);
             while (getBaseReportCacheValue == 'ongoing') {
-              getBaseReportCacheValue = await this._cache.onChange(requestId.toString(), this.config.websocketServer.maxCachingSeconds, stationId);
+              getBaseReportCacheValue = await this._cache.onChange(requestId.toString(), this.config.websocket.maxCachingSeconds, stationId);
             }
 
             if (getBaseReportCacheValue == 'complete') {
@@ -424,7 +424,7 @@ export class ConfigurationModule extends AbstractModule {
           while (setVariableData.length > 0) {
             // Below pattern is preferred way of receiving CallResults in an async mannner.
             const correlationId = uuidv4();
-            const cacheCallbackPromise: Promise<string | null> = this._cache.onChange(correlationId, this.config.websocketServer.maxCachingSeconds, stationId); // x2 fudge factor for any network lag
+            const cacheCallbackPromise: Promise<string | null> = this._cache.onChange(correlationId, this.config.websocket.maxCachingSeconds, stationId); // x2 fudge factor for any network lag
             this.sendCall(stationId, tenantId, CallAction.SetVariables,
               { setVariableData: setVariableData.slice(0, itemsPerMessageSetVariables) } as SetVariablesRequest, undefined, correlationId);
             setVariableData = setVariableData.slice(itemsPerMessageSetVariables);

--- a/03_Modules/Reporting/src/module/module.ts
+++ b/03_Modules/Reporting/src/module/module.ts
@@ -113,7 +113,7 @@ export class ReportingModule extends AbstractModule {
       this._logger.info("Completed", success, message.payload.requestId);
     } else { // tbc (to be continued) is true
       // Continue to set get base report ongoing. Will extend the timeout.
-      const success = await this._cache.set(message.payload.requestId.toString(), ReportingModule.GET_BASE_REPORT_ONGOING_CACHE_VALUE, message.context.stationId, this.config.websocketServer.maxCachingSeconds);
+      const success = await this._cache.set(message.payload.requestId.toString(), ReportingModule.GET_BASE_REPORT_ONGOING_CACHE_VALUE, message.context.stationId, this.config.websocket.maxCachingSeconds);
       this._logger.info("Ongoing", success, message.payload.requestId);
     }
 

--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     ports:
       - 8080:8080
       - 8081:8081
+      - 8082:8082
     volumes:
       - ./:/usr/server
       - /usr/server/node_modules

--- a/Server/docker/Dockerfile
+++ b/Server/docker/Dockerfile
@@ -153,5 +153,6 @@ RUN npm run build
 
 EXPOSE 8080
 EXPOSE 8081
+EXPOSE 8082
 
 CMD [ "npm", "run", "start-unix:docker" ]

--- a/Server/src/config/envs/docker.ts
+++ b/Server/src/config/envs/docker.ts
@@ -6,7 +6,7 @@ export function createDockerConfig() {
         modules: {
             certificates: {
                 endpointPrefix: "/certificates",
-                port: 8081
+                port: 8080
             },
             configuration: {
                 heartbeatInterval: 60,
@@ -16,27 +16,27 @@ export function createDockerConfig() {
                 bootWithRejectedVariables: true,
                 autoAccept: false,
                 endpointPrefix: "/configuration",
-                port: 8081
+                port: 8080
             },
             evdriver: {
                 endpointPrefix: "/evdriver",
-                port: 8081
+                port: 8080
             },
             monitoring: {
                 endpointPrefix: "/monitoring",
-                port: 8081
+                port: 8080
             },
             reporting: {
                 endpointPrefix: "/reporting",
-                port: 8081
+                port: 8080
             },
             smartcharging: {
                 endpointPrefix: "/smartcharging",
-                port: 8081
+                port: 8080
             },
             transactions: {
                 endpointPrefix: "/transactions",
-                port: 8081
+                port: 8080
             },
         },
         data: {
@@ -66,23 +66,30 @@ export function createDockerConfig() {
             }
         },
         server: {
-            logLevel: 3,
+            logLevel: 2, // debug
             host: "0.0.0.0",
-            port: 8081,
+            port: 8080,
             swagger: {
                 path: "/docs",
                 exposeData: true,
                 exposeMessage: true
             }
-        },
-        websocketServer: {
-            tlsFlag: false,
-            host: "0.0.0.0",
-            port: 8080,
-            protocol: "ocpp2.0.1",
+        },        
+        websocket: {
             pingInterval: 60,
             maxCallLengthSeconds: 5,
             maxCachingSeconds: 10
-        }
+        },
+        websocketServer: [{
+            securityProfile: 0,
+            host: "0.0.0.0",
+            port: 8081,
+            protocol: "ocpp2.0.1"
+        },{
+            securityProfile: 1,
+            host: "0.0.0.0",
+            port: 8082,
+            protocol: "ocpp2.0.1"
+        }]
     });
 }

--- a/Server/src/config/envs/local.ts
+++ b/Server/src/config/envs/local.ts
@@ -75,14 +75,16 @@ export function createLocalConfig() {
                 exposeMessage: true
             }
         },
-        websocketServer: {
-            tlsFlag: false,
-            host: "localhost",
-            port: 8080,
-            protocol: "ocpp2.0.1",
+        websocket: {
             pingInterval: 60,
             maxCallLengthSeconds: 5,
             maxCachingSeconds: 10
-        }
+        },
+        websocketServer: [{
+            securityProfile: 1,
+            host: "localhost",
+            port: 8080,
+            protocol: "ocpp2.0.1"
+        }]
     });
 }

--- a/Server/src/config/envs/prod.ts
+++ b/Server/src/config/envs/prod.ts
@@ -47,7 +47,8 @@ export function createProdConfig() {
                 exposeMessage: true
             }
         },
-        websocketServer: {
-        }
+        websocket: {
+        },
+        websocketServer: [{}]
     });
 }


### PR DESCRIPTION
- new security profiles: TLS with basic auth (2) and mTLS (3)
- changed structure of system config to support new security profiles and multiple websocket servers
  - adjusted references to system config to reflect new structure
  - adjusted docker system config to spin up two websocket servers, on security profiles 0 and 1
- added health check/http request handling to websocket servers