### PR TITLE
Bugfix/misc

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -53,7 +53,7 @@ export interface IAuthorizationRepository extends ICrudRepository<AuthorizationD
 }
 
 export interface ITransactionEventRepository extends ICrudRepository<TransactionEventRequest> {
-    createByStationId(value: TransactionEventRequest, stationId: string): Promise<TransactionEventRequest | undefined>;
+    createOrUpdateTransactionByTransactionEventAndStationId(value: TransactionEventRequest, stationId: string): Promise<Transaction>;
     readAllByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<TransactionEventRequest[]>;
     readTransactionByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<Transaction | undefined>;
     readAllTransactionsByStationIdAndEvseAndChargingStates(stationId: string, evse: EVSEType, chargingStates?: ChargingStateEnumType[]): Promise<Transaction[]>;

--- a/01_Data/src/layers/sequelize/model/Boot.ts
+++ b/01_Data/src/layers/sequelize/model/Boot.ts
@@ -32,7 +32,12 @@ export class Boot extends Model implements BootConfig {
     @Column(DataType.STRING)
     declare id: string;
 
-    @Column(DataType.STRING)
+    @Column({
+        type: DataType.DATE,
+        get() {
+            return this.getDataValue('lastBootTime').toISOString();
+        }
+    })
     declare lastBootTime?: string;
 
     @Column(DataType.INTEGER)

--- a/01_Data/src/layers/sequelize/model/DeviceModel/VariableAttribute.ts
+++ b/01_Data/src/layers/sequelize/model/DeviceModel/VariableAttribute.ts
@@ -55,7 +55,8 @@ export class VariableAttribute extends Model implements VariableAttributeType {
     declare dataType: DataEnumType;
 
     @Column({
-        type: DataType.STRING,
+        // TODO: Make this configurable?
+        type: DataType.STRING(4000),
         set(valueString) {
             if (valueString) {
                 const valueType = (this as VariableAttribute).dataType;

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
@@ -43,6 +43,11 @@ export class MeterValue extends Model implements MeterValueType {
     @Column(DataType.JSON)
     declare sampledValue: [SampledValueType, ...SampledValueType[]];
 
-    @Column
+    @Column({
+        type: DataType.DATE,
+        get() {
+            return this.getDataValue('timestamp').toISOString();
+        }
+    })
     declare timestamp: string;
 }

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
@@ -23,13 +23,14 @@ import {
     ForeignKey,
     HasMany,
     BelongsTo,
+    BelongsToMany,
   } from 'sequelize-typescript';
 import { IdToken } from '../Authorization';
 import { MeterValue } from './MeterValue';
 import { TransactionEvent } from './TransactionEvent';
 import { Evse } from '../DeviceModel';
 
-@Table({ tableName: 'transactions' })
+@Table
 export class Transaction extends Model implements TransactionType {
 
   static readonly MODEL_NAME: string = Namespace.TransactionType;
@@ -78,10 +79,4 @@ export class Transaction extends Model implements TransactionType {
 
   @Column(DataType.INTEGER)
   declare remoteStartId?: number;
-
-  @ForeignKey(() => IdToken)
-  declare idTokenId?: number;
-
-  @BelongsTo(() => IdToken)
-  declare idToken?: IdToken;
 }

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
@@ -45,13 +45,18 @@ export class TransactionEvent extends Model implements TransactionEventRequest {
   @HasMany(() => MeterValue)
   declare meterValue?: [MeterValue, ...MeterValue[]];
 
-  @Column
+  @Column({
+    type: DataType.DATE,
+    get() {
+        return this.getDataValue('timestamp').toISOString();
+    }
+  })
   declare timestamp: string;
 
   @Column
   declare triggerReason: TriggerReasonEnumType;
 
-  @Column
+  @Column(DataType.INTEGER)
   declare seqNo: number;
 
   @Column({ type: DataType.BOOLEAN, defaultValue: false })

--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -73,7 +73,6 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
         const evseDatabaseId = savedComponent.get('evseDatabaseId');
         for (const variableAttribute of value.variableAttribute) {
             const variableAttributeModel = VariableAttribute.build({
-                id: undefined, // Prevents update from removing id
                 stationId: stationId,
                 variableId: savedVariable.get('id'),
                 componentId: savedComponent.get('id'),
@@ -92,9 +91,9 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
             // Create or update variable attribute
             if (savedVariableAttribute) {
                 for (const k in variableAttributeModel.dataValues) {
-                    const updatedValue = variableAttributeModel.getDataValue(k);
-                    if (updatedValue != undefined) { // Null can still be used to remove data
-                        savedVariableAttribute.setDataValue(k, variableAttributeModel.getDataValue(k));
+                    if (k !== 'id') { // id is not a field that can be updated
+                        const updatedValue = variableAttributeModel.getDataValue(k);
+                        savedVariableAttribute.setDataValue(k, updatedValue);
                     }
                 }
                 savedVariableAttribute = await savedVariableAttribute.save();

--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -110,9 +110,10 @@ export class TransactionEventRepository extends SequelizeRepository<TransactionE
      * @returns List of transactions which meet the requirements.
      */
     readAllTransactionsByStationIdAndEvseAndChargingStates(stationId: string, evse?: EVSEType, chargingStates?: ChargingStateEnumType[] | undefined): Promise<Transaction[]> {
+        const includeObj = evse ? [ { model: Evse, where: { id: evse.id, connectorId: evse.connectorId ? evse.connectorId : null } }, IdToken ] : [IdToken];
         return this.s.models[Transaction.MODEL_NAME].findAll({
             where: { stationId: stationId, ...(chargingStates ? { chargingState: { [Op.in]: chargingStates } } : {}) },
-            include: [IdToken]
+            include: includeObj
         }).then(row => (row as Transaction[]));
     }
 

--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -154,7 +154,7 @@ export class ConfigurationModule extends AbstractModule {
     this._deviceModelRepository = deviceModelRepository || new sequelize.DeviceModelRepository(config, this._logger);
 
     this._deviceModelService = new DeviceModelService(this._deviceModelRepository);
-    
+
     this._logger.info(`Initialized in ${timer.end()}ms...`);
   }
 
@@ -245,23 +245,6 @@ export class ConfigurationModule extends AbstractModule {
         name: "ChargingStation"
       },
       variable: {
-        name: "SerialNumber"
-      },
-      variableAttribute: [
-        {
-          type: AttributeEnumType.Actual,
-          value: chargingStation.serialNumber,
-          mutability: MutabilityEnumType.ReadOnly,
-          persistent: true,
-          constant: true
-        }
-      ]
-    }, stationId);
-    await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
-      component: {
-        name: "ChargingStation"
-      },
-      variable: {
         name: "Model"
       },
       variableAttribute: [
@@ -291,58 +274,84 @@ export class ConfigurationModule extends AbstractModule {
         }
       ]
     }, stationId);
-    await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
-      component: {
-        name: "Controller"
-      },
-      variable: {
-        name: "FirmwareVersion"
-      },
-      variableAttribute: [
-        {
-          type: AttributeEnumType.Actual,
-          value: chargingStation.firmwareVersion,
-          mutability: MutabilityEnumType.ReadOnly,
-          persistent: true,
-          constant: true
-        }
-      ]
-    }, stationId);
-    await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
-      component: {
-        name: "DataLink"
-      },
-      variable: {
-        name: "IMSI"
-      },
-      variableAttribute: [
-        {
-          type: AttributeEnumType.Actual,
-          value: chargingStation.modem?.imsi,
-          mutability: MutabilityEnumType.ReadOnly,
-          persistent: true,
-          constant: true
-        }
-      ]
-    }, stationId);
-    await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
-      component: {
-        name: "DataLink"
-      },
-      variable: {
-        name: "ICCID"
-      },
-      variableAttribute: [
-        {
-          type: AttributeEnumType.Actual,
-          value: chargingStation.modem?.iccid,
-          mutability: MutabilityEnumType.ReadOnly,
-          persistent: true,
-          constant: true
-        }
-      ]
-    }, stationId);
-
+    if (chargingStation.firmwareVersion) {
+      await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
+        component: {
+          name: "Controller"
+        },
+        variable: {
+          name: "FirmwareVersion"
+        },
+        variableAttribute: [
+          {
+            type: AttributeEnumType.Actual,
+            value: chargingStation.firmwareVersion,
+            mutability: MutabilityEnumType.ReadOnly,
+            persistent: true,
+            constant: true
+          }
+        ]
+      }, stationId);
+    }
+    if (chargingStation.serialNumber) {
+      await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
+        component: {
+          name: "ChargingStation"
+        },
+        variable: {
+          name: "SerialNumber"
+        },
+        variableAttribute: [
+          {
+            type: AttributeEnumType.Actual,
+            value: chargingStation.serialNumber,
+            mutability: MutabilityEnumType.ReadOnly,
+            persistent: true,
+            constant: true
+          }
+        ]
+      }, stationId);
+    }
+    if (chargingStation.modem) {
+      if (chargingStation.modem.imsi) {
+        await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
+          component: {
+            name: "DataLink"
+          },
+          variable: {
+            name: "IMSI"
+          },
+          variableAttribute: [
+            {
+              type: AttributeEnumType.Actual,
+              value: chargingStation.modem?.imsi,
+              mutability: MutabilityEnumType.ReadOnly,
+              persistent: true,
+              constant: true
+            }
+          ]
+        }, stationId);
+      }
+      if (chargingStation.modem.iccid) {
+        await this._deviceModelRepository.createOrUpdateDeviceModelByStationId({
+          component: {
+            name: "DataLink"
+          },
+          variable: {
+            name: "ICCID"
+          },
+          variableAttribute: [
+            {
+              type: AttributeEnumType.Actual,
+              value: chargingStation.modem?.iccid,
+              mutability: MutabilityEnumType.ReadOnly,
+              persistent: true,
+              constant: true
+            }
+          ]
+        }, stationId);
+      }
+    }
     // Handle post-response actions
     if (bootNotificationResponseMessageConfirmation.success) {
       this._logger.debug("BootNotification response successfully sent to central system: ", bootNotificationResponseMessageConfirmation);
@@ -505,7 +514,7 @@ export class ConfigurationModule extends AbstractModule {
     this.sendCallResultWithMessage(message, response)
       .then(messageConfirmation => this._logger.debug("FirmwareStatusNotification response sent:", messageConfirmation));
   }
-  
+
   /**
    * Handle responses
    */

--- a/03_Modules/Transactions/src/module/module.ts
+++ b/03_Modules/Transactions/src/module/module.ts
@@ -97,7 +97,7 @@ export class TransactionsModule extends AbstractModule {
   ): Promise<void> {
     this._logger.debug("Transaction event received:", message, props);
 
-    await this._transactionEventRepository.createByStationId(message.payload, message.context.stationId);
+    await this._transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(message.payload, message.context.stationId);
 
     const transactionEvent = message.payload;
     if (transactionEvent.idToken) {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Before you begin, make sure you have the following installed on your system:
 1. Navigate to the CitrineOS Server directory:
 
     ```shell
-    cd citrineos-core/50_Server
+    cd citrineos-core/Server
     ```
 
 1. Install project dependencies:
@@ -93,8 +93,9 @@ a common integrated development environment.
 Once Docker is running, the following services should be available:
 
 -   **CitrineOS** (service name: citrineos) with ports
-    -   `8080`: websocket server tcp connection
-    -   `8081`: webserver http - [Swagger](http://localhost:8081/docs)
+    -   `8080`: webserver http - [Swagger](http://localhost:8080/docs)
+    -   `8081`: websocket server tcp connection without auth
+    -   `8082`: websocket server tcp connection with basic http auth
 -   **RabbitMQ Broker** (service name: amqp-broker) with ports
     -   `5672`: amqp tcp connection
     -   `15672`: RabbitMQ [management interface](http://localhost:15672)
@@ -103,10 +104,10 @@ Once Docker is running, the following services should be available:
 -   **Directus** (service name: directus) on port 8055 with endpoints
     -   `:8055/admin`: web interface (login = admin@citrineos.com:CitrineOS!)
 
-These three services are defined in `50_Server/docker-compose.yml` and they
+These three services are defined in `Server/docker-compose.yml` and they
 live inside the docker network `docker_default` with their respective
 ports. By default these ports are directly accessible by using
-`localhost:8081` for example.
+`localhost:8080` for example.
 
 So, if you want to access the **amqp-broker** default management port via your
 localhost, you need to access `localhost:15672`.
@@ -128,7 +129,6 @@ If you have any questions or need assistance, feel free to reach out to us on ou
 A more detailed roadmap is coming soon.
 
 - Support for Kafka Streams
-- Support for OCPP 2.0.1 Core Profile
 - OCA Certification (OCPP 2.0.1 Core Profile)
 - Adding plugin management
 - Implementing ISO15118 Plug and Charge (PnC)

--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       timeout: 10s
       retries: 3
   ocpp-db:
-    image: citrineos/postgres:latest
+    image: citrineos/postgres:preseeded
     ports:
       - 5432:5432
     volumes:

--- a/Server/nodemon.json
+++ b/Server/nodemon.json
@@ -4,5 +4,8 @@
     ],
     "ext": ".ts,.js",
     "ignore": [],
-    "exec": "npx ts-node ./src/index.ts"
+    "exec": "npx ts-node ./src/index.ts",
+    "events": {
+        "crash": "nodemon --delay 500ms -L"
+    }
 }

--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -64,6 +64,11 @@ class CitrineOSServer {
         // Create server instance
         this._server = server || fastify().withTypeProvider<JsonSchemaToTsProvider>();
 
+        // Add health check
+        this._server.get('/health', async () => {
+            return { status: 'healthy' };
+        });
+
         // Create Ajv JSON schema validator instance
         this._ajv = ajv || new Ajv({ removeAdditional: "all", useDefaults: true, coerceTypes: "array", strict: false });
         addFormats(this._ajv, { mode: "fast", formats: ["date-time"] });


### PR DESCRIPTION
- Making name of createByStationId more appropriate (createOrUpdateTransactionByTransactionEventAndStationId)
- Fixing createOrUpdateTransactionByTransactionEventAndStationId to work and correctly associate evseType with transaction
- Fixing readAllTransactionsByStationIdAndEvseAndChargingStates to correctly filter by evse
- Removing idToken from transaction due to relationship actually being many-to-many
- Fixing column types for timestamps from string to date, transforming when leaving data layer to avoid conflict with extended ocpp type
- Fixing update to variable attribute db entity to skip id field, since ids can't be updated
- Changing postgres docker image tag to use preseeded image with directus tables containing improvements to layout
- Adding clause to nodemon.json to restart application after crashing rather than waiting for file changes so that docker container doesn't need to be restarted to recover application
- Adding health check to http server
- Adding checks for nullable fields before updating device model from boot notification
- Updating README instructions to reflect latest changes