### PR TITLE
Feature/module receiver refactor

### DIFF
--- a/00_Base/src/interfaces/messages/AbstractMessageHandler.ts
+++ b/00_Base/src/interfaces/messages/AbstractMessageHandler.ts
@@ -20,6 +20,7 @@ export abstract class AbstractMessageHandler implements IMessageHandler {
      */
 
     protected _config: SystemConfig;
+    protected _module?: IModule;
     protected _logger: Logger<ILogObj>;
 
     /**
@@ -28,9 +29,29 @@ export abstract class AbstractMessageHandler implements IMessageHandler {
      * @param config The system configuration.
      * @param logger [Optional] The logger to use.
      */
-    constructor(config: SystemConfig, logger?: Logger<ILogObj>) {
+    constructor(config: SystemConfig, logger?: Logger<ILogObj>, module?: IModule, ) {
         this._config = config;
+        this._module = module;
         this._logger = logger ? logger.getSubLogger({ name: this.constructor.name }) : new Logger<ILogObj>({ name: this.constructor.name });
+    }
+
+    /**
+     * Getter & Setter
+     */
+
+    get module(): IModule | undefined {
+        return this._module;
+    }
+    set module(value: IModule | undefined) {
+        this._module = value;
+    }
+
+    /**
+     * Methods
+     */
+
+    async handle(message: IMessage<OcppRequest | OcppResponse | OcppError>, props?: HandlerProperties): Promise<void> {
+        await this._module?.handle(message, props);
     }
 
     /**
@@ -39,9 +60,5 @@ export abstract class AbstractMessageHandler implements IMessageHandler {
 
     abstract subscribe(identifier: string, actions?: CallAction[], filter?: { [k: string]: string; }): Promise<boolean>;
     abstract unsubscribe(identifier: string): Promise<boolean>;
-    abstract handle(message: IMessage<OcppRequest | OcppResponse | OcppError>, props?: HandlerProperties): Promise<void>;
     abstract shutdown(): void;
-
-    abstract get module(): IModule | undefined;
-    abstract set module(value: IModule | undefined);
 }

--- a/00_Base/src/interfaces/messages/AbstractMessageHandler.ts
+++ b/00_Base/src/interfaces/messages/AbstractMessageHandler.ts
@@ -29,7 +29,7 @@ export abstract class AbstractMessageHandler implements IMessageHandler {
      * @param config The system configuration.
      * @param logger [Optional] The logger to use.
      */
-    constructor(config: SystemConfig, logger?: Logger<ILogObj>, module?: IModule, ) {
+    constructor(config: SystemConfig, logger?: Logger<ILogObj>, module?: IModule) {
         this._config = config;
         this._module = module;
         this._logger = logger ? logger.getSubLogger({ name: this.constructor.name }) : new Logger<ILogObj>({ name: this.constructor.name });

--- a/02_Util/src/queue/kafka/receiver.ts
+++ b/02_Util/src/queue/kafka/receiver.ts
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-import { AbstractMessageHandler, IMessageHandler, IModule, SystemConfig, CallAction, IMessage, OcppRequest, OcppResponse, HandlerProperties, Message, OcppError, RetryMessageError } from "@citrineos/base";
+import { AbstractMessageHandler, IMessageHandler, IModule, SystemConfig, CallAction, OcppRequest, OcppResponse, Message, OcppError, RetryMessageError } from "@citrineos/base";
 import { plainToInstance } from "class-transformer";
 import { Admin, Consumer, EachMessagePayload, Kafka } from "kafkajs";
 import { ILogObj, Logger } from "tslog";
@@ -17,14 +17,12 @@ export class KafkaReceiver extends AbstractMessageHandler implements IMessageHan
      * Fields
      */
     private _client: Kafka;
-    private _module?: IModule;
     private _topicName: string;
     private _consumerMap: Map<string, Consumer>;
 
     constructor(config: SystemConfig, logger?: Logger<ILogObj>, module?: IModule) {
-        super(config, logger);
-
-        this._module = module;
+        super(config, logger, module);
+        
         this._consumerMap = new Map<string, Consumer>();
         this._client = new Kafka({
             brokers: this._config.util.messageBroker.kafka?.brokers || [],
@@ -86,25 +84,10 @@ export class KafkaReceiver extends AbstractMessageHandler implements IMessageHan
             });
     }
 
-    async handle(message: IMessage<OcppRequest | OcppResponse | OcppError>, props?: HandlerProperties): Promise<void> {
-        await this._module?.handle(message, props);
-    }
-
     shutdown(): void {
         this._consumerMap.forEach((value) => {
             value.disconnect();
         });
-    }
-
-    /**
-     * Getter & Setter
-     */
-
-    get module(): IModule | undefined {
-        return this._module;
-    }
-    set module(value: IModule | undefined) {
-        this._module = value;
     }
 
     /**

--- a/02_Util/src/queue/rabbit-mq/receiver.ts
+++ b/02_Util/src/queue/rabbit-mq/receiver.ts
@@ -6,7 +6,7 @@
 import * as amqplib from "amqplib";
 import { ILogObj, Logger } from "tslog";
 import { MemoryCache } from "../..";
-import { AbstractMessageHandler, ICache, IModule, SystemConfig, CallAction, CacheNamespace, IMessage, OcppError, OcppRequest, OcppResponse, HandlerProperties, Message, RetryMessageError } from "@citrineos/base";
+import { AbstractMessageHandler, ICache, IModule, SystemConfig, CallAction, CacheNamespace,  OcppError, OcppRequest, OcppResponse, Message, RetryMessageError } from "@citrineos/base";
 import { plainToInstance } from "class-transformer";
 
 /**
@@ -26,27 +26,14 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
   protected _cache: ICache;
   protected _connection?: amqplib.Connection;
   protected _channel?: amqplib.Channel;
-  protected _module?: IModule;
 
-  constructor(config: SystemConfig, logger?: Logger<ILogObj>, cache?: ICache, module?: IModule) {
-    super(config, logger);
+  constructor(config: SystemConfig, logger?: Logger<ILogObj>, module?: IModule, cache?: ICache) {
+    super(config, logger, module);
     this._cache = cache || new MemoryCache();
-    this._module = module;
 
     this._connect().then(channel => {
       this._channel = channel;
     });
-  }
-
-  /**
-   * Getter & Setter
-   */
-
-  get module(): IModule | undefined {
-    return this._module;
-  }
-  set module(value: IModule | undefined) {
-    this._module = value;
   }
 
   /**
@@ -132,11 +119,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
       }
     });
   }
-
-  async handle(message: IMessage<OcppRequest | OcppResponse | OcppError>, props?: HandlerProperties): Promise<void> {
-    await this._module?.handle(message, props);
-  }
-
+  
   shutdown(): Promise<void> {
     return Promise.resolve();
   }

--- a/03_Modules/Monitoring/src/module/module.ts
+++ b/03_Modules/Monitoring/src/module/module.ts
@@ -5,7 +5,7 @@
 
 import { AbstractModule, CallAction, SystemConfig, ICache, IMessageSender, IMessageHandler, EventGroup, AsHandler, IMessage, NotifyEventRequest, HandlerProperties, NotifyEventResponse, GetVariablesResponse, SetVariablesResponse } from "@citrineos/base";
 import { IDeviceModelRepository, sequelize } from "@citrineos/data";
-import { PubSubReceiver, PubSubSender, Timer } from "@citrineos/util";
+import { RabbitMqReceiver, RabbitMqSender, Timer } from "@citrineos/util";
 import deasyncPromise from "deasync-promise";
 import { ILogObj, Logger } from 'tslog';
 import { DeviceModelService } from "./services";
@@ -64,7 +64,7 @@ export class MonitoringModule extends AbstractModule {
     logger?: Logger<ILogObj>,
     deviceModelRepository?: IDeviceModelRepository
   ) {
-    super(config, cache, handler || new PubSubReceiver(config, logger), sender || new PubSubSender(config, logger), EventGroup.Monitoring, logger);
+    super(config, cache, handler || new RabbitMqReceiver(config, logger), sender || new RabbitMqSender(config, logger), EventGroup.Monitoring, logger);
 
     const timer = new Timer();
     this._logger.info(`Initializing...`);

--- a/03_Modules/Reporting/src/module/module.ts
+++ b/03_Modules/Reporting/src/module/module.ts
@@ -82,7 +82,7 @@ export class ReportingModule extends AbstractModule {
     deviceModelRepository?: IDeviceModelRepository,
     securityEventRepository?: ISecurityEventRepository
   ) {
-    super(config, cache, handler || new RabbitMqReceiver(config, logger, cache), sender || new RabbitMqSender(config, logger), EventGroup.Reporting, logger);
+    super(config, cache, handler || new RabbitMqReceiver(config, logger), sender || new RabbitMqSender(config, logger), EventGroup.Reporting, logger);
 
     const timer = new Timer();
     this._logger.info(`Initializing...`);

--- a/03_Modules/SmartCharging/src/module/module.ts
+++ b/03_Modules/SmartCharging/src/module/module.ts
@@ -60,7 +60,7 @@ export class SmartChargingModule extends AbstractModule {
     handler?: IMessageHandler,
     logger?: Logger<ILogObj>
   ) {
-    super(config, cache, handler || new RabbitMqReceiver(config, logger, cache), sender || new RabbitMqSender(config, logger), EventGroup.SmartCharging, logger);
+    super(config, cache, handler || new RabbitMqReceiver(config, logger), sender || new RabbitMqSender(config, logger), EventGroup.SmartCharging, logger);
 
     const timer = new Timer();
     this._logger.info(`Initializing...`);

--- a/03_Modules/Transactions/src/module/module.ts
+++ b/03_Modules/Transactions/src/module/module.ts
@@ -5,7 +5,7 @@
 
 import { AbstractModule, CallAction, SystemConfig, ICache, IMessageSender, IMessageHandler, EventGroup, AsHandler, IMessage, TransactionEventRequest, HandlerProperties, TransactionEventResponse, AuthorizationStatusEnumType, IdTokenInfoType, AdditionalInfoType, TransactionEventEnumType, MeterValuesRequest, MeterValuesResponse, StatusNotificationRequest, StatusNotificationResponse } from "@citrineos/base";
 import { IAuthorizationRepository, ITransactionEventRepository, sequelize } from "@citrineos/data";
-import { PubSubReceiver, PubSubSender, Timer } from "@citrineos/util";
+import { RabbitMqReceiver, RabbitMqSender, Timer } from "@citrineos/util";
 import deasyncPromise from "deasync-promise";
 import { ILogObj, Logger } from 'tslog';
 
@@ -66,7 +66,7 @@ export class TransactionsModule extends AbstractModule {
     transactionEventRepository?: ITransactionEventRepository,
     authorizeRepository?: IAuthorizationRepository
   ) {
-    super(config, cache, handler || new PubSubReceiver(config, logger), sender || new PubSubSender(config, logger), EventGroup.Transactions, logger);
+    super(config, cache, handler || new RabbitMqReceiver(config, logger), sender || new RabbitMqSender(config, logger), EventGroup.Transactions, logger);
 
     const timer = new Timer();
     this._logger.info(`Initializing...`);


### PR DESCRIPTION
Refactor to put MessageHandler's handle() func and get/set for module into AbstractMessageHandler, simplifying code at implementation level.

Corrected accidental use of PubSub instead of RabbitMQ.