### PR TITLE
Disable logging colors for cloud

### DIFF
--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -65,8 +65,11 @@ class CitrineOSServer {
         this._logger = new Logger<ILogObj>({
             name: "CitrineOS Logger",
             minLevel: systemConfig.logLevel,
-            hideLogPositionForProduction: systemConfig.env === "production"
-        });
+            hideLogPositionForProduction: systemConfig.env === "production",
+            //Disable colors for cloud deployment as some cloude logging environments such as cloudwatch can not interpret colors
+            stylePrettyLogs: process.env.DEPLOYMENT_TARGET != "cloud"
+
+    });
 
         // Set cache implementation
         this._cache = cache || new MemoryCache();

--- a/Swarm/src/index.ts
+++ b/Swarm/src/index.ts
@@ -63,7 +63,9 @@ class CitrineOSServer {
         this._logger = new Logger<ILogObj>({
             name: "CitrineOS Logger",
             minLevel: systemConfig.logLevel,
-            hideLogPositionForProduction: systemConfig.env === "production"
+            hideLogPositionForProduction: systemConfig.env === "production",
+            //Disable colors for cloud deployment as some cloude logging environments such as cloudwatch can not interpret colors
+            stylePrettyLogs: process.env.DEPLOYMENT_TARGET != "cloud"
         });
 
         // Force sync database


### PR DESCRIPTION
Using a new environment variable `DEPLOYMENT_TARGET` to set not logging with colors to fix ascii encoding issues with cloud watch.
I put this where the logger is initialized, further down in the implementation only gets the sub logger. 