### PR TITLE
Feature/persistent admin api

### DIFF
--- a/01_Data/src/interfaces/index.ts
+++ b/01_Data/src/interfaces/index.ts
@@ -10,6 +10,7 @@ export { ChargingStationKeyQuerystring, ChargingStationKeyQuerySchema } from "./
 export { VariableAttributeQuerystring, VariableAttributeQuerySchema, CreateOrUpdateVariableAttributeQuerystring, CreateOrUpdateVariableAttributeQuerySchema } from "./queries/VariableAttribute";
 export { AuthorizationQuerystring, AuthorizationQuerySchema } from "./queries/Authorization";
 export { TransactionEventQuerystring, TransactionEventQuerySchema } from "./queries/TransactionEvent";
+export { ModelKeyQuerystring, ModelKeyQuerystringSchema } from "./queries/Model";
 
 // Data projection models
 export { AuthorizationRestrictions } from "./projections/AuthorizationRestrictions";

--- a/01_Data/src/interfaces/queries/Model.ts
+++ b/01_Data/src/interfaces/queries/Model.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { QuerySchema } from "@citrineos/base";
+
+export interface ModelKeyQuerystring {
+    id: number
+}
+
+export const ModelKeyQuerystringSchema = QuerySchema([["id", "number"]], ["id"]);

--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -33,6 +33,7 @@ import { Transaction } from "../layers/sequelize/model/TransactionEvent";
 import { VariableAttribute } from "../layers/sequelize/model/DeviceModel/VariableAttribute";
 import { AuthorizationRestrictions, VariableAttributeQuerystring } from ".";
 import { Boot, Authorization, Location, SecurityEvent, Component, Variable, VariableMonitoring, EventData, ChargingStation } from "../layers/sequelize";
+import { Subscription } from "../layers/sequelize/model/Subscription/Subscription";
 
 
 export interface IAuthorizationRepository extends ICrudRepository<AuthorizationData> {
@@ -74,6 +75,12 @@ export interface ILocationRepository extends ICrudRepository<Location> {
 export interface ISecurityEventRepository extends ICrudRepository<SecurityEvent> {
     createByStationId(value: SecurityEventNotificationRequest, stationId: string): Promise<SecurityEvent | undefined>;
     readByStationIdAndTimestamps(stationId: string, from?: Date, to?: Date): Promise<SecurityEvent[]>;
+    deleteByKey(key: string): Promise<boolean>;
+}
+
+export interface ISubscriptionRepository extends ICrudRepository<Subscription> {   
+    create(value: Subscription): Promise<Subscription | undefined>;
+    readAllByStationId(stationId: string): Promise<Subscription[]>
     deleteByKey(key: string): Promise<boolean>;
 }
 

--- a/01_Data/src/layers/sequelize/index.ts
+++ b/01_Data/src/layers/sequelize/index.ts
@@ -11,6 +11,7 @@ export { Transaction, TransactionEvent, MeterValue } from "./model/TransactionEv
 export { SecurityEvent } from "./model/SecurityEvent";
 export { VariableMonitoring, EventData, VariableMonitoringStatus } from "./model/VariableMonitoring";
 export { ChargingStation, Location } from "./model/Location";
+export { Subscription } from "./model/Subscription";
 
 // Sequelize Repositories
 export { SequelizeRepository } from "./repository/Base";

--- a/01_Data/src/layers/sequelize/index.ts
+++ b/01_Data/src/layers/sequelize/index.ts
@@ -22,6 +22,7 @@ export { LocationRepository } from "./repository/Location";
 export { TransactionEventRepository } from "./repository/TransactionEvent";
 export { SecurityEventRepository } from "./repository/SecurityEvent";
 export { VariableMonitoringRepository } from "./repository/VariableMonitoring";
+export { SubscriptionRepository } from "./repository/Subscription";
 
 // Sequelize Utilities
 export { DefaultSequelizeInstance } from "./util";

--- a/01_Data/src/layers/sequelize/model/Subscription/Subscription.ts
+++ b/01_Data/src/layers/sequelize/model/Subscription/Subscription.ts
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache 2.0
 
 import { Namespace } from "@citrineos/base";
-import { Column, Model, Table } from "sequelize-typescript";
+import { Column, Index, Model, Table } from "sequelize-typescript";
 
 @Table
 export class Subscription extends Model {
     static readonly MODEL_NAME: string = Namespace.Subscription;
 
+    @Index
     @Column
     declare stationId: string;
 

--- a/01_Data/src/layers/sequelize/model/Subscription/Subscription.ts
+++ b/01_Data/src/layers/sequelize/model/Subscription/Subscription.ts
@@ -1,0 +1,40 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Namespace } from "@citrineos/base";
+import { Column, Model, Table } from "sequelize-typescript";
+
+@Table
+export class Subscription extends Model {
+    static readonly MODEL_NAME: string = Namespace.Subscription;
+
+    @Column
+    declare stationId: string;
+
+    @Column({
+        defaultValue: false
+    })
+    declare onConnect: boolean;
+
+    @Column({
+        defaultValue: false
+    })
+    declare onClose: boolean;
+
+    @Column({
+        defaultValue: false
+    })
+    declare onMessage: boolean;
+
+    @Column({
+        defaultValue: false
+    })
+    declare sentMessage: boolean;
+
+    @Column
+    declare messageRegexFilter?: string;
+
+    @Column
+    declare url: string;
+}

--- a/01_Data/src/layers/sequelize/model/Subscription/index.ts
+++ b/01_Data/src/layers/sequelize/model/Subscription/index.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+export { Subscription } from "./Subscription";

--- a/01_Data/src/layers/sequelize/repository/Subscription.ts
+++ b/01_Data/src/layers/sequelize/repository/Subscription.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { SequelizeRepository, Subscription } from "..";
+import { ISubscriptionRepository } from "../../..";
+
+
+export class SubscriptionRepository extends SequelizeRepository<Subscription> implements ISubscriptionRepository {
+    
+    readAllByStationId(stationId: string): Promise<Subscription[]> {
+        return super.readAllByQuery({ where: { stationId: stationId } }, Subscription.MODEL_NAME);
+    }
+
+    deleteByKey(key: string): Promise<boolean> {
+        return super.deleteByKey(key, Subscription.MODEL_NAME);
+    }
+}

--- a/01_Data/src/layers/sequelize/repository/Subscription.ts
+++ b/01_Data/src/layers/sequelize/repository/Subscription.ts
@@ -5,10 +5,24 @@
 
 import { SequelizeRepository, Subscription } from "..";
 import { ISubscriptionRepository } from "../../..";
+import { Model } from "sequelize-typescript";
 
 
 export class SubscriptionRepository extends SequelizeRepository<Subscription> implements ISubscriptionRepository {
     
+    /**
+     * Creates a new {@link Subscription} in the database.
+     * Input is assumed to not have an id, and id will be removed if present.
+     * Object is rebuilt to ensure access to essential {@link Model} function {@link Model.save()} (Model is extended by Subscription).
+     * 
+     * @param value {@link Subscription} object which may have been deserialized from JSON
+     * @returns Saved {@link Subscription} if successful, undefined otherwise
+     */
+    create(value: Subscription): Promise<Subscription | undefined> {
+        const { id, ...rawSubscription } = value;
+        return super.create(Subscription.build({...rawSubscription}));
+    }
+
     readAllByStationId(stationId: string): Promise<Subscription[]> {
         return super.readAllByQuery({ where: { stationId: stationId } }, Subscription.MODEL_NAME);
     }

--- a/01_Data/src/layers/sequelize/util.ts
+++ b/01_Data/src/layers/sequelize/util.ts
@@ -8,7 +8,7 @@ import { Dialect } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
 import { ILogObj, Logger } from "tslog";
 import { ComponentVariable } from "./model/DeviceModel/ComponentVariable";
-import { AdditionalInfo, Authorization, Boot, ChargingStation, Component, EventData, Evse, IdToken, IdTokenInfo, Location, MeterValue, SecurityEvent, Transaction, TransactionEvent, Variable, VariableAttribute, VariableCharacteristics, VariableMonitoring, VariableMonitoringStatus } from ".";
+import { AdditionalInfo, Authorization, Boot, ChargingStation, Component, EventData, Evse, IdToken, IdTokenInfo, Location, MeterValue, SecurityEvent, Subscription, Transaction, TransactionEvent, Variable, VariableAttribute, VariableCharacteristics, VariableMonitoring, VariableMonitoringStatus } from ".";
 import { VariableStatus } from "./model/DeviceModel";
 
 export class DefaultSequelizeInstance {
@@ -43,7 +43,7 @@ export class DefaultSequelizeInstance {
             storage: config.data.sequelize.storage,
             models: [AdditionalInfo, Authorization, Boot, ChargingStation, Component,
                 ComponentVariable, Evse, EventData, IdToken, IdTokenInfo, Location, MeterValue,
-                SecurityEvent, Transaction, TransactionEvent, VariableAttribute,
+                SecurityEvent, Subscription, Transaction, TransactionEvent, VariableAttribute,
                 VariableCharacteristics, VariableMonitoring, VariableMonitoringStatus, VariableStatus, Variable],
             logging: (sql: string, timing?: number) => {
                 // TODO: Look into fixing that

--- a/03_Modules/OcppRouter/src/module/api.ts
+++ b/03_Modules/OcppRouter/src/module/api.ts
@@ -39,7 +39,7 @@ export class AdminApi extends AbstractModuleApi<MessageRouterImpl> implements IA
      * @return {Promise<number>} The id of the created subscription.
      */
     @AsDataEndpoint(Namespace.Subscription, HttpMethod.Post)
-    async putSubscription(request: FastifyRequest<{ Body: Subscription }>): Promise<number> {
+    async postSubscription(request: FastifyRequest<{ Body: Subscription }>): Promise<number> {
         return this._module.subscriptionRepository.create(request.body as Subscription).then((subscription) => subscription?.id);
     }
 

--- a/03_Modules/OcppRouter/src/module/api.ts
+++ b/03_Modules/OcppRouter/src/module/api.ts
@@ -7,8 +7,9 @@ import { AbstractModuleApi, AsDataEndpoint, CallAction, HttpMethod, MessageOrigi
 import { FastifyInstance, FastifyRequest } from 'fastify';
 import { ILogObj, Logger } from 'tslog';
 import { IAdminApi } from './interface';
-import { MessageRouterImpl, Subscription } from './router';
+import { MessageRouterImpl } from './router';
 import { ChargingStationKeyQuerystring, ModelKeyQuerystring } from '@citrineos/data';
+import { Subscription } from '@citrineos/data/lib/layers/sequelize';
 
 /**
  * Server API for the Certificates module.

--- a/03_Modules/OcppRouter/src/module/api.ts
+++ b/03_Modules/OcppRouter/src/module/api.ts
@@ -31,6 +31,8 @@ export class AdminApi extends AbstractModuleApi<MessageRouterImpl> implements IA
      * Data endpoints
      */
 
+    // N.B.: When adding subscriptions, chargers may be connected to a different instance of Citrine.
+    // If this is the case, new subscriptions will not take effect until the charger reconnects.
     /**
      * Creates a {@link Subscription}.
      * Will always create a new entity and return its id.

--- a/03_Modules/OcppRouter/src/module/api.ts
+++ b/03_Modules/OcppRouter/src/module/api.ts
@@ -12,7 +12,7 @@ import { ChargingStationKeyQuerystring, ModelKeyQuerystring } from '@citrineos/d
 import { Subscription } from '@citrineos/data/lib/layers/sequelize';
 
 /**
- * Server API for the Certificates module.
+ * Admin API for the OcppRouter.
  */
 export class AdminApi extends AbstractModuleApi<MessageRouterImpl> implements IAdminApi {
 

--- a/03_Modules/OcppRouter/src/module/router.ts
+++ b/03_Modules/OcppRouter/src/module/router.ts
@@ -49,9 +49,9 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
         sender: IMessageSender,
         handler: IMessageHandler,
         networkHook: (identifier: string, message: string) => Promise<boolean>,
-        subscriptionRepository?: ISubscriptionRepository,
         logger?: Logger<ILogObj>,
         ajv?: Ajv,
+        subscriptionRepository?: ISubscriptionRepository
     ) {
         super(config, cache, handler, sender, networkHook, logger, ajv);
 


### PR DESCRIPTION
Alters Subscriptions to be persistent in SQL db, added GET and DELETE CRUD endpoints to api for Subscriptions now that they are db entities.

N.B.: The PUT Subscription was altered to a POST since the requests are not Idempotent (calling the endpoint repeatedly will create many new entries rather than updating the first created, due to the database id being generated in the data layer).
