### PR TITLE
Fix failed npm build and setDispalyMessage method name

### DIFF
--- a/03_Modules/Configuration/src/module/api.ts
+++ b/03_Modules/Configuration/src/module/api.ts
@@ -96,7 +96,7 @@ export class ConfigurationModuleApi extends AbstractModuleApi<ConfigurationModul
     }
 
     @AsMessageEndpoint(CallAction.SetDisplayMessage, SetDisplayMessageRequestSchema)
-    async setDisplayMessages(
+    async setDisplayMessage(
         identifier: string,
         tenantId: string,
         request: SetDisplayMessageRequest,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "./",
     "outDir": "./dist/"
   },
-  "exclude": ["DirectusExtensions"],
+  "exclude": ["DirectusExtensions", "./dist/**/*"],
   "references": [
     {
       "path": "./Server"


### PR DESCRIPTION
 This pr is to fix errors in below. It happens when run `npm run build` second time after changing some code. The fix is based on this answer: https://stackoverflow.com/a/48798945
```
...... omitted similar error logs

error TS5055: Cannot write file '/Users/zcheng/Documents/Citrine/citrineos-core/dist/Swarm/src/config/index.d.ts' because it would overwrite input file.

error TS5055: Cannot write file '/Users/zcheng/Documents/Citrine/citrineos-core/dist/Swarm/src/index.d.ts' because it would overwrite input file.


Found 21 errors.
```

Update the method name of `setDisplayMessage` as well since it only set one message per request.