### PR TITLE
Fix undefind status error

### DIFF
--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -290,9 +290,9 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
     return {
       where: {
         ...(queryParams.stationId ? { stationId: queryParams.stationId } : {}),
-        ...(queryParams.type !== null ? { type: queryParams.type } : {}),
+        ...(queryParams.type ? { type: queryParams.type } : {}),
         ...(queryParams.value ? { value: queryParams.value } : {}),
-        ...(queryParams.status !== null ? { status: queryParams.status } : {}),
+        ...(queryParams.status ? { status: queryParams.status } : {}),
       },
       include: [
         {

--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -286,7 +286,7 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
             },
           }
         : Evse;
-    const attributeType = (queryParams.type && (queryParams.type).toUpperCase() === 'NULL') ? null : queryParams.type;
+    const attributeType = queryParams.type && queryParams.type.toUpperCase() === 'NULL' ? null : queryParams.type;
     return {
       where: {
         ...(queryParams.stationId ? { stationId: queryParams.stationId } : {}),
@@ -312,7 +312,7 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
             ...(queryParams.variable_instance ? { instance: queryParams.variable_instance } : {}),
           },
           include: [VariableCharacteristics],
-        }
+        },
       ],
     };
   }

--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -4,12 +4,11 @@
 // SPDX-License-Identifier: Apache 2.0
 
 import { AttributeEnumType, type ComponentType, DataEnumType, type GetVariableResultType, MutabilityEnumType, type ReportDataType, type SetVariableDataType, type SetVariableResultType, type VariableType } from '@citrineos/base';
-import { type VariableAttributeQuerystring } from '../../../interfaces/queries/VariableAttribute';
 import { SequelizeRepository } from './Base';
-import { type IDeviceModelRepository } from '../../../interfaces';
+import { type IDeviceModelRepository, type VariableAttributeQuerystring } from '../../../interfaces';
 import { Op } from 'sequelize';
 import { Component, Evse, Variable, VariableAttribute, VariableCharacteristics } from '../model/DeviceModel';
-import { VariableStatus } from '../model/DeviceModel/VariableStatus';
+import { VariableStatus } from '../model/DeviceModel';
 import { ComponentVariable } from '../model/DeviceModel/ComponentVariable';
 
 // TODO: Document this
@@ -287,12 +286,15 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
             },
           }
         : Evse;
+    const attributeType = (queryParams.type && (queryParams.type).toUpperCase() === 'NULL') ? null : queryParams.type;
     return {
       where: {
         ...(queryParams.stationId ? { stationId: queryParams.stationId } : {}),
-        ...(queryParams.type ? { type: queryParams.type } : {}),
+        ...(queryParams.type === undefined ? {} : { type: attributeType }),
         ...(queryParams.value ? { value: queryParams.value } : {}),
-        ...(queryParams.status ? { status: queryParams.status } : {}),
+        // TODO: Currently, the status param doesn't work since status of VariableAttribute are stored in
+        //  VariableStatuses table separately. The table stores status history. We need find a proper way to filter it.
+        ...(queryParams.status === undefined ? {} : { status: queryParams.status }),
       },
       include: [
         {
@@ -310,7 +312,7 @@ export class DeviceModelRepository extends SequelizeRepository<VariableAttribute
             ...(queryParams.variable_instance ? { instance: queryParams.variable_instance } : {}),
           },
           include: [VariableCharacteristics],
-        },
+        }
       ],
     };
   }


### PR DESCRIPTION
When using `VariableAttributeQuerystring` to query any entities in DeviceModel without set `status` value, it returns error as in screenshot. This PR is to fix this error.
<img width="1154" alt="Screenshot 2024-05-02 at 9 08 13 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/61a9be38-5131-4046-bb09-0f2994c338e2">

Local Test
<img width="1284" alt="Screenshot 2024-05-02 at 10 51 05 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/a1cc39ab-4860-4217-98cf-3f02869f7741">