### PR TITLE
Add websocket "ping" handler

### DIFF
--- a/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
+++ b/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
@@ -411,6 +411,11 @@ export class WebsocketNetworkConnection {
       this._router.deregisterConnection(identifier);
     });
 
+    ws.on('ping', async (message) => {
+      this._logger.debug(`Ping received for ${identifier} with message ${JSON.stringify(message)}`);
+      ws.pong(message);
+    });
+
     ws.on('pong', async () => {
       this._logger.debug('Pong received for', identifier);
       const clientConnection: string | null = await this._cache.get(


### PR DESCRIPTION
Adding a websocket "ping" handler to `WebsocketNetworkConnection` to send pongs back  with the same incoming payload. 

This merges into `rc-1.2.0` because I'm not certain what release this will be a part of; please let me know if I need to retarget!

I tested this locally with a quick node.js script to open a websocket connection and am properly receiving pongs from a locally running Citrine instance.

<details>
<summary>Local code sample</summary>

```
const { WebSocket } = require('ws');

main = () => {
    console.log('opening websocket to citrine');
    const ws = new WebSocket('ws://localhost:8081/Charger2', 'ocpp2.0.1');

    ws.onopen = () => {
        console.log('sending boot notification');
        var BN = JSON.stringify([2, '1231231231231231', 'BootNotification', {
            'chargingStation': {
                'vendorName': 'local',
                'model': 'localCharger',
                'serialNumber': 'CHARGER02'
            },
            'reason': 'PowerUp'
        }]);
    
        ws.send(BN);
    
        console.log('pinging');
        ws.ping('hello!');
    }    

    ws.on('pong', (data) => {
        console.log(`received pong with data ${JSON.stringify(data)} -- closing websocket now`);
        ws.close();
    });
}

main();
```

</details>

<details>
<summary>Resulting local logs from ping/pong</summary>

- opening websocket to citrine
- sending boot notification
- pinging
- received pong with data {"type":"Buffer","data":[104,101,108,108,111,33]} -- closing websocket now

</details>

<details>
<summary>Resulting Citrine logs from ping/pong</summary>
2024-05-07 14:46:43 2024-05-07 18:46:43.155     DEBUG   /usr/local/apps/citrineos/02_Util/dist/networkconnection/WebsocketNetworkConnection.js:308     CitrineOS Logger:WebsocketNetworkConnection     Ping received for Charger02 with message {"type":"Buffer","data":[104,101,108,108,111,33]}
</details>