### PR TITLE
Fix: Avoid to overwrite mutability and other fields in stored VariableAttribute when call set variable

### DIFF
--- a/03_Modules/Monitoring/src/module/api.ts
+++ b/03_Modules/Monitoring/src/module/api.ts
@@ -29,6 +29,7 @@ import {
   HttpMethod,
   IMessageConfirmation,
   MonitorEnumType,
+  MutabilityEnumType,
   Namespace,
   ReportDataType,
   ReportDataTypeSchema,
@@ -447,6 +448,16 @@ export class MonitoringModuleApi
       Querystring: CreateOrUpdateVariableAttributeQuerystring;
     }>,
   ): Promise<sequelize.VariableAttribute[]> {
+    // To keep consistency with VariableAttributeType in OCPP 2.0.1:
+    // (1) persistent and constant: Default when omitted is false.
+    // if they are not present, we set them to false by adding default value in ReportDataTypeSchema
+    // (2) mutability: Default is ReadWrite when omitted.
+    // if it is not present, we set it to ReadWrite
+    for (const variableAttr of request.body.variableAttribute) {
+      if (!variableAttr.mutability) {
+        variableAttr.mutability = MutabilityEnumType.ReadWrite;
+      }
+    }
     return this._module.deviceModelRepository
       .createOrUpdateDeviceModelByStationId(
         request.body,

--- a/03_Modules/Reporting/src/module/module.ts
+++ b/03_Modules/Reporting/src/module/module.ts
@@ -21,6 +21,7 @@ import {
   IMessageSender,
   LogStatusNotificationRequest,
   LogStatusNotificationResponse,
+  MutabilityEnumType,
   NotifyCustomerInformationRequest,
   NotifyCustomerInformationResponse,
   NotifyMonitoringReportRequest,
@@ -261,6 +262,14 @@ export class ReportingModule extends AbstractModule {
     for (const reportDataType of message.payload.reportData
       ? message.payload.reportData
       : []) {
+      // To keep consistency with VariableAttributeType defined in OCPP 2.0.1:
+      // mutability: Default is ReadWrite when omitted.
+      // if it is not present, we set it to ReadWrite
+      for (const variableAttr of reportDataType.variableAttribute) {
+        if (!variableAttr.mutability) {
+          variableAttr.mutability = MutabilityEnumType.ReadWrite;
+        }
+      }
       const variableAttributes =
         await this._deviceModelRepository.createOrUpdateDeviceModelByStationId(
           reportDataType,


### PR DESCRIPTION
### Goal
This PR is to fix an issue with SetVariables overwriting data that it does not contain (i.e. mutability is reset).
The cause of the issue is that, when storing VariableAttribute in db, we always set default values for some fields, e.g., mutability, when they are omitted in the given object and then store these default values in db. So the stored values are overwrite by default values. This way of setting default values works for use case handle NotifyReport req since OCPP 2.0.1 expect us to do so. But we need a fix for use case SetVariable where default values should not overwrite stored values in db.

### Changes
1. In `createOrUpdateDeviceModelByStationId`, replace upsert with create and update so that default values are used when creation. When updating, it depends on values in the given entity. We don't set any default values when any fields omitted.
2. In usages of `createOrUpdateDeviceModelByStationId` we make sure to set the correct values in the entity and give it to `createOrUpdateDeviceModelByStationId`.
3. In this way, db layer don't need to know which use cases (NotifyReport or SetVariable) it is or whether use default values. 

### Tests
1. Prepare: Manually change values of a VariableAttribute in db <img width="1028" alt="Screenshot 2024-05-10 at 3 49 35 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/977804a2-543d-4257-928d-195e84477be8">
2. Call SetVariable from postman <img width="1148" alt="Screenshot 2024-05-10 at 3 50 30 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/1614dc8b-1dc7-42fd-ad43-d508ff344392">
3. Other fields are not overwritten except for `value` <img width="1138" alt="Screenshot 2024-05-10 at 3 52 30 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/9b6fd1f8-71ba-4497-928e-79e3896e1f56">
4. Send a notifyReport req and omit `mutability`, `consistent` and `persistent` fields. <img width="1374" alt="Screenshot 2024-05-10 at 3 54 24 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/fad0d395-2464-42c7-952f-ce7ab17a361b">
5. The saved VariableAttribute are overwritten with default values.  <img width="1017" alt="Screenshot 2024-05-10 at 3 56 56 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/49c22834-5772-45f3-8c24-41e8647ed157">