### PR TITLE
Remove Redis from docker-compose.yml as default cache is the In-Memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The system features:
 - Configurable logical modules with decorators
   - `@AsHandler` to handle incoming OCPP 2.0.1 messages
   - `@AsMessageEndpoint` to expose functions allowing to send messages to charging stations
-  - `@AsDataEndpoint` to expose CRUD access to entities defined in `10_Data`
+  - `@AsDataEndpoint` to expose CRUD access to entities defined in `01_Data`
 - Utilities to connect and extend various message broker and cache mechanisms
   - Currently supported brokers are `RabbitMQ` and Google Cloud `PubSub`
   - Currently supported caches are `In Memory` and `Redis`

--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -31,15 +31,6 @@ services:
       timeout: 10s
       retries: 5
 
-  redis:
-    image: redis:latest
-    ports:
-      - '6379:6379'
-    healthcheck:
-      test: ['CMD', 'redis-cli', 'ping']
-      interval: 10s
-      timeout: 5s
-      retries: 3
   citrine:
     build:
       context: ..
@@ -98,8 +89,6 @@ services:
       amqp-broker:
         condition: service_healthy
       directus:
-        condition: service_healthy
-      redis:
         condition: service_healthy
     ports:
       - 8080:8080


### PR DESCRIPTION
- Removed the Redis instance from docker-compose.yml to simplify it, as the In-Memory cache is the default cache
- Updated a small typo in the README regarding the `01_Data` folder

Merges into rc-1.2.0 but can retarget as needed. Thank you!