### PR TITLE
fix: fixing systemConfig route to return configuration object without failure

### DIFF
--- a/00_Base/src/interfaces/api/AbstractModuleApi.ts
+++ b/00_Base/src/interfaces/api/AbstractModuleApi.ts
@@ -88,12 +88,11 @@ export abstract class AbstractModuleApi<T extends IModule>
     this._addDataRoute.call(
       this,
       Namespace.SystemConfig,
-      (request: FastifyRequest<{ Body: SystemConfig }>) => 
+      (request: FastifyRequest<{ Body: SystemConfig }>) =>
         new Promise<void>((resolve) => {
           module.config = request.body;
           resolve();
-        }
-      ),
+        }),
       HttpMethod.Put,
     );
   }

--- a/00_Base/src/interfaces/api/AbstractModuleApi.ts
+++ b/00_Base/src/interfaces/api/AbstractModuleApi.ts
@@ -82,14 +82,18 @@ export abstract class AbstractModuleApi<T extends IModule>
     this._addDataRoute.call(
       this,
       Namespace.SystemConfig,
-      () => module.config,
+      () => new Promise((resolve) => resolve(module.config)),
       HttpMethod.Get,
     );
     this._addDataRoute.call(
       this,
       Namespace.SystemConfig,
-      (request: FastifyRequest<{ Body: SystemConfig }>) =>
-        (module.config = request.body),
+      (request: FastifyRequest<{ Body: SystemConfig }>) => 
+        new Promise<void>((resolve) => {
+          module.config = request.body;
+          resolve();
+        }
+      ),
       HttpMethod.Put,
     );
   }
@@ -160,7 +164,7 @@ export abstract class AbstractModuleApi<T extends IModule>
   // eslint-disable-next-line @typescript-eslint/ban-types
   protected _addDataRoute(
     namespace: Namespace,
-    method: (...args: any[]) => any,
+    method: (...args: any[]) => Promise<any>,
     httpMethod: HttpMethod,
     querySchema?: object,
     bodySchema?: object,


### PR DESCRIPTION
Fixes the previous error on calling systemConfig endpoint:
```
{
    "statusCode": 500,
    "error": "Internal Server Error",
    "message": "method.call(...).catch is not a function"
}
```

- changing addDataRoute call to specify method type to a Promise
- changing addDataRoute parameter methods for systemConfig namespace to return a promise