### PR TITLE
Resolve onChange when value is updated in MemoryCache

### DIFF
--- a/02_Util/src/cache/memory.ts
+++ b/02_Util/src/cache/memory.ts
@@ -178,6 +178,7 @@ export class MemoryCache implements ICache {
         }, expireSeconds * 1000),
       );
     }
+    this.resolveOnChange(namespaceKey, value);
     return true;
   }
 
@@ -204,6 +205,7 @@ export class MemoryCache implements ICache {
         }, expireSeconds * 1000),
       );
     }
+    this.resolveOnChange(namespaceKey, value);
     return true;
   }
 
@@ -227,6 +229,14 @@ export class MemoryCache implements ICache {
         }, expireSeconds * 1000),
       );
     }
+    this.resolveOnChange(namespaceKey, value);
     return true;
+  }
+
+  private resolveOnChange(namespaceKey: string, value: string) {
+    const resolveOnChangeCallback = this._keySubscriptionMap.get(namespaceKey);
+    if (resolveOnChangeCallback) {
+      resolveOnChangeCallback(value);
+    }
   }
 }


### PR DESCRIPTION
Current MemoryCache implementation does not resolve "onChange" promises when the value associated with a namespace key changes. This PR adds the invocation of "onChange" callback function to resolve promises returned to listeners upon value change. (This is how I understand the "onChange" functionality is expected to work?)