### PR TITLE
Database querying issues

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -40,12 +40,12 @@ import { Tariff } from '../layers/sequelize/model/Tariff';
 import { TariffQueryString } from './queries/Tariff';
 
 export interface IAuthorizationRepository extends CrudRepository<AuthorizationData> {
-  createOrUpdateByQuery: (value: AuthorizationData, query: AuthorizationQuerystring) => Promise<Authorization | undefined>;
-  updateRestrictionsByQuery: (value: AuthorizationRestrictions, query: AuthorizationQuerystring) => Promise<Authorization[]>;
-  readAllByQuery: (query: AuthorizationQuerystring) => Promise<Authorization[]>;
-  readOnlyOneByQuery: (query: AuthorizationQuerystring) => Promise<Authorization | undefined>;
-  existByQuery: (query: AuthorizationQuerystring) => Promise<number>;
-  deleteAllByQuery: (query: AuthorizationQuerystring) => Promise<Authorization[]>;
+  createOrUpdateByQuerystring: (value: AuthorizationData, query: AuthorizationQuerystring) => Promise<Authorization | undefined>;
+  updateRestrictionsByQuerystring: (value: AuthorizationRestrictions, query: AuthorizationQuerystring) => Promise<Authorization[]>;
+  readAllByQuerystring: (query: AuthorizationQuerystring) => Promise<Authorization[]>;
+  readOnlyOneByQuerystring: (query: AuthorizationQuerystring) => Promise<Authorization | undefined>;
+  existByQuerystring: (query: AuthorizationQuerystring) => Promise<number>;
+  deleteAllByQuerystring: (query: AuthorizationQuerystring) => Promise<Authorization[]>;
 }
 
 /**
@@ -66,9 +66,9 @@ export interface IDeviceModelRepository extends CrudRepository<VariableAttribute
   createOrUpdateBySetVariablesDataAndStationId(setVariablesData: SetVariableDataType[], stationId: string): Promise<VariableAttribute[]>;
   updateResultByStationId(result: SetVariableResultType, stationId: string): Promise<VariableAttribute | undefined>;
   readAllSetVariableByStationId(stationId: string): Promise<SetVariableDataType[]>;
-  readAllByQuery(query: VariableAttributeQuerystring): Promise<VariableAttribute[]>;
-  existByQuery(query: VariableAttributeQuerystring): Promise<number>;
-  deleteAllByQuery(query: VariableAttributeQuerystring): Promise<VariableAttribute[]>;
+  readAllByQuerystring(query: VariableAttributeQuerystring): Promise<VariableAttribute[]>;
+  existByQuerystring(query: VariableAttributeQuerystring): Promise<number>;
+  deleteAllByQuerystring(query: VariableAttributeQuerystring): Promise<VariableAttribute[]>;
   findComponentAndVariable(componentType: ComponentType, variableType: VariableType): Promise<[Component | undefined, Variable | undefined]>;
   findOrCreateEvseAndComponent(componentType: ComponentType, stationId: string): Promise<Component>;
 }
@@ -114,8 +114,8 @@ export interface IMessageInfoRepository extends CrudRepository<MessageInfoType> 
 
 export interface ITariffRepository extends CrudRepository<Tariff> {
   findByStationId(stationId: string): Promise<Tariff | undefined>;
-  readAllByQuery(query: TariffQueryString): Promise<Tariff[]>;
-  deleteAllByQuery(query: TariffQueryString): Promise<Tariff[]>;
+  readAllByQuerystring(query: TariffQueryString): Promise<Tariff[]>;
+  deleteAllByQuerystring(query: TariffQueryString): Promise<Tariff[]>;
   createOrUpdateTariff(tariff: Tariff): Promise<Tariff>;
 }
 

--- a/01_Data/src/layers/sequelize/repository/Authorization.ts
+++ b/01_Data/src/layers/sequelize/repository/Authorization.ts
@@ -23,12 +23,12 @@ export class SequelizeAuthorizationRepository extends SequelizeRepository<Author
     this.additionalInfo = additionalInfo ? additionalInfo : new SequelizeRepository<AdditionalInfo>(config, AdditionalInfo.MODEL_NAME, logger, sequelizeInstance);
   }
 
-  async createOrUpdateByQuery(value: AuthorizationData, query: AuthorizationQuerystring): Promise<Authorization | undefined> {
+  async createOrUpdateByQuerystring(value: AuthorizationData, query: AuthorizationQuerystring): Promise<Authorization | undefined> {
     if (value.idToken.idToken !== query.idToken || value.idToken.type !== query.type) {
       throw new Error('Authorization idToken does not match query');
     }
 
-    const savedAuthorizationModel: Authorization | undefined = await this.readOnlyOneByQuery(query);
+    const savedAuthorizationModel: Authorization | undefined = await this.readOnlyOneByQuerystring(query);
     const authorizationModel = savedAuthorizationModel ?? Authorization.build({}, this._createInclude(value));
 
     authorizationModel.idTokenId = (await this._updateIdToken(value.idToken, authorizationModel.idTokenId)).id;
@@ -78,23 +78,23 @@ export class SequelizeAuthorizationRepository extends SequelizeRepository<Author
     return await this.create(authorizationModel);
   }
 
-  async updateRestrictionsByQuery(value: AuthorizationRestrictions, query: AuthorizationQuerystring): Promise<Authorization[]> {
+  async updateRestrictionsByQuerystring(value: AuthorizationRestrictions, query: AuthorizationQuerystring): Promise<Authorization[]> {
     return await this.updateAllByQuery(value, query);
   }
 
-  async readAllByQuery(query: AuthorizationQuerystring): Promise<Authorization[]> {
+  async readAllByQuerystring(query: AuthorizationQuerystring): Promise<Authorization[]> {
     return await super.readAllByQuery(this._constructQuery(query));
   }
 
-  async readOnlyOneByQuery(query: AuthorizationQuerystring): Promise<Authorization | undefined> {
+  async readOnlyOneByQuerystring(query: AuthorizationQuerystring): Promise<Authorization | undefined> {
     return await super.readOnlyOneByQuery(this._constructQuery(query));
   }
 
-  async existByQuery(query: AuthorizationQuerystring): Promise<number> {
+  async existByQuerystring(query: AuthorizationQuerystring): Promise<number> {
     return await super.existByQuery(this._constructQuery(query));
   }
 
-  async deleteAllByQuery(query: AuthorizationQuerystring): Promise<Authorization[]> {
+  async deleteAllByQuerystring(query: AuthorizationQuerystring): Promise<Authorization[]> {
     return await super.deleteAllByQuery(this._constructQuery(query), Authorization.MODEL_NAME);
   }
 

--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -281,17 +281,17 @@ export class SequelizeDeviceModelRepository extends SequelizeRepository<Variable
     return variableAttributeArray.map((variableAttribute) => this.createSetVariableDataType(variableAttribute));
   }
 
-  async readAllByQuery(query: VariableAttributeQuerystring): Promise<VariableAttribute[]> {
+  async readAllByQuerystring(query: VariableAttributeQuerystring): Promise<VariableAttribute[]> {
     const readQuery = this.constructQuery(query);
     readQuery.include.push(VariableStatus);
     return await super.readAllByQuery(readQuery);
   }
 
-  async existByQuery(query: VariableAttributeQuerystring): Promise<number> {
+  async existByQuerystring(query: VariableAttributeQuerystring): Promise<number> {
     return await super.existByQuery(this.constructQuery(query));
   }
 
-  async deleteAllByQuery(query: VariableAttributeQuerystring): Promise<VariableAttribute[]> {
+  async deleteAllByQuerystring(query: VariableAttributeQuerystring): Promise<VariableAttribute[]> {
     return await super.deleteAllByQuery(this.constructQuery(query));
   }
 

--- a/01_Data/src/layers/sequelize/repository/Tariff.ts
+++ b/01_Data/src/layers/sequelize/repository/Tariff.ts
@@ -33,7 +33,7 @@ export class SequelizeTariffRepository extends SequelizeRepository<Tariff> imple
     return storedTariff;
   }
 
-  async readAllByQuery(query: TariffQueryString): Promise<Tariff[]> {
+  async readAllByQuerystring(query: TariffQueryString): Promise<Tariff[]> {
     return super.readAllByQuery({
       where: {
         ...(query.stationId ? { stationId: query.stationId } : {}),
@@ -43,7 +43,7 @@ export class SequelizeTariffRepository extends SequelizeRepository<Tariff> imple
     });
   }
 
-  async deleteAllByQuery(query: TariffQueryString): Promise<Tariff[]> {
+  async deleteAllByQuerystring(query: TariffQueryString): Promise<Tariff[]> {
     if (!query.id && !query.stationId && !query.unit) {
       throw new Error('Must specify at least one query parameter');
     }

--- a/02_Util/src/networkconnection/authenticator/Authenticator.ts
+++ b/02_Util/src/networkconnection/authenticator/Authenticator.ts
@@ -71,7 +71,7 @@ export class Authenticator implements IAuthenticator {
 
   private async _checkPassword(username: string, password: string) {
     return await this._deviceModelRepository
-      .readAllByQuery({
+      .readAllByQuerystring({
         stationId: username,
         component_name: 'SecurityCtrlr',
         variable_name: 'BasicAuthPassword',

--- a/03_Modules/Certificates/src/module/module.ts
+++ b/03_Modules/Certificates/src/module/module.ts
@@ -365,7 +365,7 @@ export class CertificatesModule extends AbstractModule {
       CertificateSigningUseEnumType.ChargingStationCertificate
     ) {
       // Verify organization name match the one stored in the device model
-      const organizationName = await this._deviceModelRepository.readAllByQuery(
+      const organizationName = await this._deviceModelRepository.readAllByQuerystring(
         {
           stationId: stationId,
           component_name: 'SecurityCtrlr',

--- a/03_Modules/Configuration/src/module/services.ts
+++ b/03_Modules/Configuration/src/module/services.ts
@@ -26,7 +26,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const itemsPerMessageSetVariablesAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: 'DeviceDataCtrlr',
         variable_name: 'ItemsPerMessage',
@@ -57,7 +57,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const itemsPerMessageGetVariablesAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: 'DeviceDataCtrlr',
         variable_name: 'ItemsPerMessage',

--- a/03_Modules/EVDriver/src/module/api.ts
+++ b/03_Modules/EVDriver/src/module/api.ts
@@ -79,7 +79,7 @@ export class EVDriverModuleApi
       Querystring: AuthorizationQuerystring;
     }>,
   ): Promise<AuthorizationData | undefined> {
-    return this._module.authorizeRepository.createOrUpdateByQuery(
+    return this._module.authorizeRepository.createOrUpdateByQuerystring(
       request.body,
       request.query,
     );
@@ -97,7 +97,7 @@ export class EVDriverModuleApi
       Querystring: AuthorizationQuerystring;
     }>,
   ): Promise<AuthorizationData[]> {
-    return this._module.authorizeRepository.updateRestrictionsByQuery(
+    return this._module.authorizeRepository.updateRestrictionsByQuerystring(
       request.body,
       request.query,
     );
@@ -111,7 +111,7 @@ export class EVDriverModuleApi
   getAuthorization(
     request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
   ): Promise<AuthorizationData[]> {
-    return this._module.authorizeRepository.readAllByQuery(request.query);
+    return this._module.authorizeRepository.readAllByQuerystring(request.query);
   }
 
   @AsDataEndpoint(
@@ -123,7 +123,7 @@ export class EVDriverModuleApi
     request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
   ): Promise<string> {
     return this._module.authorizeRepository
-      .deleteAllByQuery(request.query)
+      .deleteAllByQuerystring(request.query)
       .then(
         (deletedCount) =>
           deletedCount.toString() +

--- a/03_Modules/EVDriver/src/module/module.ts
+++ b/03_Modules/EVDriver/src/module/module.ts
@@ -224,7 +224,7 @@ export class EVDriverModule extends AbstractModule {
     }
 
     this._authorizeRepository
-      .readOnlyOneByQuery({ ...request.idToken })
+      .readOnlyOneByQuerystring({ ...request.idToken })
       .then(async (authorization) => {
         if (authorization) {
           if (authorization.idTokenInfo) {
@@ -277,7 +277,7 @@ export class EVDriverModule extends AbstractModule {
                 if (authorization.allowedConnectorTypes) {
                   evseIds = new Set();
                   const connectorTypes: VariableAttribute[] =
-                    await this._deviceModelRepository.readAllByQuery({
+                    await this._deviceModelRepository.readAllByQuerystring({
                       stationId: message.context.stationId,
                       component_name: 'Connector',
                       variable_name: 'ConnectorType',
@@ -307,7 +307,7 @@ export class EVDriverModule extends AbstractModule {
                   if (authorization.disallowedEvseIdPrefixes) {
                     evseIds = evseIds ? evseIds : new Set();
                     const evseIdAttributes: VariableAttribute[] =
-                      await this._deviceModelRepository.readAllByQuery({
+                      await this._deviceModelRepository.readAllByQuerystring({
                         stationId: message.context.stationId,
                         component_name: 'EVSE',
                         variable_name: 'EvseId',
@@ -375,7 +375,7 @@ export class EVDriverModule extends AbstractModule {
           response.idTokenInfo.status === AuthorizationStatusEnumType.Accepted
         ) {
           const tariffAvailable: VariableAttribute[] =
-            await this._deviceModelRepository.readAllByQuery({
+            await this._deviceModelRepository.readAllByQuerystring({
               stationId: message.context.stationId,
               component_name: 'TariffCostCtrlr',
               variable_name: 'Available',
@@ -384,7 +384,7 @@ export class EVDriverModule extends AbstractModule {
             });
 
           const displayMessageAvailable: VariableAttribute[] =
-            await this._deviceModelRepository.readAllByQuery({
+            await this._deviceModelRepository.readAllByQuerystring({
               stationId: message.context.stationId,
               component_name: 'DisplayMessageCtrlr',
               variable_name: 'Available',

--- a/03_Modules/Monitoring/src/module/api.ts
+++ b/03_Modules/Monitoring/src/module/api.ts
@@ -494,7 +494,7 @@ export class MonitoringModuleApi
   getDeviceModelVariables(
     request: FastifyRequest<{ Querystring: VariableAttributeQuerystring }>,
   ): Promise<sequelize.VariableAttribute[] | undefined> {
-    return this._module.deviceModelRepository.readAllByQuery(request.query);
+    return this._module.deviceModelRepository.readAllByQuerystring(request.query);
   }
 
   @AsDataEndpoint(
@@ -506,7 +506,7 @@ export class MonitoringModuleApi
     request: FastifyRequest<{ Querystring: VariableAttributeQuerystring }>,
   ): Promise<string> {
     return this._module.deviceModelRepository
-      .deleteAllByQuery(request.query)
+      .deleteAllByQuerystring(request.query)
       .then(
         (deletedCount) =>
           deletedCount.toString() +

--- a/03_Modules/Monitoring/src/module/services.ts
+++ b/03_Modules/Monitoring/src/module/services.ts
@@ -28,7 +28,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const itemsPerMessageAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: componentName,
         variable_name: 'ItemsPerMessage',
@@ -61,7 +61,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const bytesPerMessageAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: componentName,
         variable_name: 'BytesPerMessage',

--- a/03_Modules/Reporting/src/module/services.ts
+++ b/03_Modules/Reporting/src/module/services.ts
@@ -24,7 +24,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const itemsPerMessageAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: componentName,
         variable_name: 'ItemsPerMessage',
@@ -57,7 +57,7 @@ export class DeviceModelService {
     stationId: string,
   ): Promise<number | null> {
     const bytesPerMessageAttributes: VariableAttribute[] =
-      await this._deviceModelRepository.readAllByQuery({
+      await this._deviceModelRepository.readAllByQuerystring({
         stationId: stationId,
         component_name: componentName,
         variable_name: 'BytesPerMessage',

--- a/03_Modules/Transactions/src/module/api.ts
+++ b/03_Modules/Transactions/src/module/api.ts
@@ -127,7 +127,7 @@ export class TransactionsModuleApi
   getTariffs(
     request: FastifyRequest<{ Querystring: TariffQueryString }>,
   ): Promise<Tariff[]> {
-    return this._module.tariffRepository.readAllByQuery(request.query);
+    return this._module.tariffRepository.readAllByQuerystring(request.query);
   }
 
   @AsDataEndpoint(Namespace.Tariff, HttpMethod.Delete, TariffQuerySchema)
@@ -135,7 +135,7 @@ export class TransactionsModuleApi
     request: FastifyRequest<{ Querystring: TariffQueryString }>,
   ): Promise<string> {
     return this._module.tariffRepository
-      .deleteAllByQuery(request.query)
+      .deleteAllByQuerystring(request.query)
       .then(
         (deletedCount: { toString: () => string }) =>
           deletedCount.toString() +

--- a/03_Modules/Transactions/src/module/module.ts
+++ b/03_Modules/Transactions/src/module/module.ts
@@ -188,7 +188,7 @@ export class TransactionsModule extends AbstractModule {
     const transactionId = transactionEvent.transactionInfo.transactionId;
     if (transactionEvent.idToken) {
       this._authorizeRepository
-        .readAllByQuery({ ...transactionEvent.idToken })
+        .readAllByQuerystring({ ...transactionEvent.idToken })
         .then((authorizations) => {
           const response: TransactionEventResponse = {
             idTokenInfo: {
@@ -337,7 +337,7 @@ export class TransactionsModule extends AbstractModule {
 
         // I06 - Update Tariff Information During Transaction
         const tariffAvailableAttributes: VariableAttribute[] =
-          await this._deviceModelRepository.readAllByQuery({
+          await this._deviceModelRepository.readAllByQuerystring({
             stationId: stationId,
             component_name: 'TariffCostCtrlr',
             variable_instance: 'Tariff',


### PR DESCRIPTION
Some specialized repositories offer methods for filtering by *Querystring objects. Currently, these methods override some base repository methods (inherited from SequelizeRepository and CrudRepository), which accept Sequelize's FindOptions object for filtering. However, some of these methods are internally used by base repositories and expect Sequelize's FindOptions object instead of *Querystring object. As a result, some queries are not applying any filtering or criteria. 

This PR fixes the issue by simply renaming these methods. Another approach could be adjusting all clients to pass appropriate *Querystring objects, but renaming methods seems safer and more flexible for now.