### PR TITLE
Fix/Certificate Unique Constrain

### DIFF
--- a/01_Data/src/interfaces/dtos/GenerateCertificateChainRequest.ts
+++ b/01_Data/src/interfaces/dtos/GenerateCertificateChainRequest.ts
@@ -10,7 +10,6 @@ export class GenerateCertificateChainRequest {
   selfSigned: boolean;
   organizationName: string;
   commonName: string;
-  serialNumber?: number;
   keyLength?: number;
   validBefore?: string;
   countryName?: CountryNameEnumType;
@@ -24,7 +23,6 @@ export class GenerateCertificateChainRequest {
     selfSigned: boolean,
     organizationName: string,
     commonName: string,
-    serialNumber?: number,
     keyLength?: number,
     validBefore?: string,
     countryName?: CountryNameEnumType,
@@ -35,7 +33,6 @@ export class GenerateCertificateChainRequest {
     this.selfSigned = selfSigned;
     this.organizationName = organizationName;
     this.commonName = commonName;
-    this.serialNumber = serialNumber;
     this.keyLength = keyLength;
     this.validBefore = validBefore;
     this.countryName = countryName;

--- a/01_Data/src/interfaces/queries/RootCertificate.ts
+++ b/01_Data/src/interfaces/queries/RootCertificate.ts
@@ -6,7 +6,6 @@ import { QuerySchema } from '@citrineos/base';
 
 export const GenerateCertificateChainSchema = QuerySchema(
   [
-    ['serialNumber', 'number'],
     ['keyLength', 'number'],
     ['organizationName', 'string'],
     ['commonName', 'string'],

--- a/01_Data/src/layers/sequelize/model/Certificate/Certificate.ts
+++ b/01_Data/src/layers/sequelize/model/Certificate/Certificate.ts
@@ -13,22 +13,23 @@ export class Certificate extends Model {
   /**
    * Fields
    */
+  // use serialNumber and issuerName as unique constraint based on 4.1.2.2 in https://www.rfc-editor.org/rfc/rfc5280
   @Column({
     type: DataType.BIGINT,
-    unique: 'serialNumber_organizationName_commonName',
+    unique: 'serialNumber_issuerName',
   })
   declare serialNumber: number;
 
   @Column({
     type: DataType.STRING,
-    unique: 'serialNumber_organizationName_commonName',
+    unique: 'serialNumber_issuerName',
   })
+  declare issuerName: string;
+
+  @Column(DataType.STRING)
   declare organizationName: string;
 
-  @Column({
-    type: DataType.STRING,
-    unique: 'serialNumber_organizationName_commonName',
-  })
+  @Column(DataType.STRING)
   declare commonName: string;
 
   @Column(DataType.INTEGER)
@@ -43,20 +44,20 @@ export class Certificate extends Model {
   })
   declare validBefore?: string;
 
-  @Column
+  @Column(DataType.STRING)
   declare signatureAlgorithm?: SignatureAlgorithmEnumType;
 
-  @Column
+  @Column(DataType.STRING)
   declare countryName?: CountryNameEnumType;
 
-  @Column
+  @Column(DataType.BOOLEAN)
   declare isCA?: boolean;
 
   // A pathLenConstraint of zero indicates that no intermediate CA certificates may
   // follow in a valid certification path. Where it appears, the pathLenConstraint field MUST be greater than or
   // equal to zero. Where pathLenConstraint does not appear, no limit is imposed.
   // Reference: https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9
-  @Column
+  @Column(DataType.INTEGER)
   declare pathLen?: number;
 
   @Column(DataType.STRING)

--- a/01_Data/src/layers/sequelize/repository/Certificate.ts
+++ b/01_Data/src/layers/sequelize/repository/Certificate.ts
@@ -16,12 +16,10 @@ export class SequelizeCertificateRepository extends SequelizeRepository<Certific
 
   async createOrUpdateCertificate(certificate: Certificate): Promise<Certificate> {
     return await this.s.transaction(async (transaction) => {
-      // TODO what to search by
       const savedCert = await this.s.models[Certificate.MODEL_NAME].findOne({
         where: {
           serialNumber: certificate.serialNumber,
-          organizationName: certificate.organizationName,
-          commonName: certificate.commonName,
+          issuerName: certificate.issuerName,
         },
         transaction,
       });

--- a/03_Modules/Certificates/src/module/api.ts
+++ b/03_Modules/Certificates/src/module/api.ts
@@ -46,6 +46,7 @@ import {
 } from '@citrineos/data';
 import fs from 'fs';
 import moment from 'moment';
+import jsrsasign from 'jsrsasign';
 
 const enum PemType {
   Root = 'Root',
@@ -250,9 +251,7 @@ export class CertificatesModuleApi
     const certRequest = request.body as GenerateCertificateChainRequest;
 
     let certificateFromReq = new Certificate();
-    certificateFromReq.serialNumber = certRequest.serialNumber
-      ? certRequest.serialNumber
-      : moment().valueOf();
+    certificateFromReq.serialNumber = moment().valueOf();
     certificateFromReq.keyLength = certRequest.keyLength
       ? certRequest.keyLength
       : 2048;
@@ -602,6 +601,9 @@ export class CertificatesModuleApi
       filePath,
     );
     // Store certificate in db
+    const certObj = new jsrsasign.X509();
+    certObj.readCertPEM(certPem);
+    certificateEntity.issuerName = certObj.getIssuerString();
     return await this._module.certificateRepository.createOrUpdateCertificate(
       certificateEntity,
     );


### PR DESCRIPTION
## Changes

1. Add new column, `issuerName`, in the `Certificate` model
2. Change to use serialNumber and issuerName as unique constraint based on 4.1.2.2 in https://www.rfc-editor.org/rfc/rfc5280
4. Remove `serialNumber` from generate certificate request body to make sure it always generated by citrine.

## Test
Generate certificates and `issuerName` is assigned with correct value. <img width="1137" alt="Screenshot 2024-06-06 at 12 04 23 PM" src="https://github.com/citrineos/citrineos-core/assets/21100540/66948381-08d8-4f81-95c0-84ee15531bf3">