### PR TITLE
chore: bump used action versions to avoid EOL node16

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: [18]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies

--- a/.github/workflows/push-release-tagged-server.yml
+++ b/.github/workflows/push-release-tagged-server.yml
@@ -33,7 +33,7 @@ jobs:
           install: true
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/test-build-server.yml
+++ b/.github/workflows/test-build-server.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
 
       - name: Set permissions on the uploads directory
         run: |


### PR DESCRIPTION
In the actions there was always a warning about usage of end of life node16. This is just a quick bump of the versions that were mentioned to avoid using EOL software.