### PR TITLE
Smart Charging Part 3: Remote Start With Charging Profile

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -130,7 +130,7 @@ export interface ICertificateRepository extends CrudRepository<Certificate> {
 }
 
 export interface IChargingProfileRepository extends CrudRepository<ChargingProfile> {
-  createOrUpdateChargingProfile(chargingProfile: ChargingProfileType, stationId: string, evseId: number, chargingLimitSource?: ChargingLimitSourceEnumType, isActive?: boolean): Promise<ChargingProfile>;
+  createOrUpdateChargingProfile(chargingProfile: ChargingProfileType, stationId: string, evseId?: number, chargingLimitSource?: ChargingLimitSourceEnumType, isActive?: boolean): Promise<ChargingProfile>;
   createChargingNeeds(chargingNeeds: NotifyEVChargingNeedsRequest, stationId: string): Promise<ChargingNeeds>;
   findChargingNeedsByEvseDBIdAndTransactionDBId(evseDBId: number, transactionDataBaseId: number): Promise<ChargingNeeds | undefined>;
 }

--- a/01_Data/src/layers/sequelize/model/ChargingProfile/ChargingProfile.ts
+++ b/01_Data/src/layers/sequelize/model/ChargingProfile/ChargingProfile.ts
@@ -21,13 +21,13 @@ export class ChargingProfile extends Model implements ChargingProfileType {
 
   @Column({
     type: DataType.STRING,
-    unique: 'stationId_evseId_id',
+    unique: 'stationId_id',
   })
   declare stationId: string;
 
   @Column({
     type: DataType.INTEGER,
-    unique: 'stationId_evseId_id',
+    unique: 'stationId_id',
   })
   declare id: number;
 
@@ -61,11 +61,8 @@ export class ChargingProfile extends Model implements ChargingProfileType {
   })
   declare validTo?: string;
 
-  @Column({
-    type: DataType.INTEGER,
-    unique: 'stationId_evseId_id',
-  })
-  declare evseId: number;
+  @Column(DataType.INTEGER)
+  declare evseId?: number;
 
   // this value indicates whether the ChargingProfile is set on charger
   @Column({

--- a/01_Data/src/layers/sequelize/repository/ChargingProfile.ts
+++ b/01_Data/src/layers/sequelize/repository/ChargingProfile.ts
@@ -58,7 +58,7 @@ export class SequelizeChargingProfileRepository extends SequelizeRepository<Char
         ...chargingProfile,
         evseId: evseId,
         transactionDatabaseId: transactionDBId,
-        chargingLimitSource: chargingLimitSource ? chargingLimitSource : ChargingLimitSourceEnumType.CSO,
+        chargingLimitSource: chargingLimitSource ?? ChargingLimitSourceEnumType.CSO,
         isActive: isActive === undefined ? false : isActive,
       },
     });
@@ -69,7 +69,7 @@ export class SequelizeChargingProfileRepository extends SequelizeRepository<Char
           stationId: stationId,
           transactionDatabaseId: transactionDBId,
           evseId: evseId,
-          chargingLimitSource: chargingLimitSource ? chargingLimitSource : ChargingLimitSourceEnumType.CSO,
+          chargingLimitSource: chargingLimitSource ?? ChargingLimitSourceEnumType.CSO,
           isActive: isActive === undefined ? false : isActive,
         },
         savedChargingProfile.databaseId.toString(),

--- a/01_Data/src/layers/sequelize/repository/ChargingProfile.ts
+++ b/01_Data/src/layers/sequelize/repository/ChargingProfile.ts
@@ -37,7 +37,7 @@ export class SequelizeChargingProfileRepository extends SequelizeRepository<Char
     this.transaction = transaction ? transaction : new SequelizeRepository<Transaction>(config, Transaction.MODEL_NAME, logger, sequelizeInstance);
   }
 
-  async createOrUpdateChargingProfile(chargingProfile: ChargingProfileType, stationId: string, evseId: number, chargingLimitSource: ChargingLimitSourceEnumType, isActive?: boolean): Promise<ChargingProfile> {
+  async createOrUpdateChargingProfile(chargingProfile: ChargingProfileType, stationId: string, evseId?: number, chargingLimitSource?: ChargingLimitSourceEnumType, isActive?: boolean): Promise<ChargingProfile> {
     let transactionDBId;
     if (chargingProfile.transactionId) {
       const activeTransaction = await Transaction.findOne({
@@ -52,13 +52,13 @@ export class SequelizeChargingProfileRepository extends SequelizeRepository<Char
     const [savedChargingProfile, profileCreated] = await this.readOrCreateByQuery({
       where: {
         stationId: stationId,
-        evseId: evseId,
         id: chargingProfile.id,
       },
       defaults: {
         ...chargingProfile,
+        evseId: evseId,
         transactionDatabaseId: transactionDBId,
-        chargingLimitSource: chargingLimitSource,
+        chargingLimitSource: chargingLimitSource ? chargingLimitSource : ChargingLimitSourceEnumType.CSO,
         isActive: isActive === undefined ? false : isActive,
       },
     });
@@ -69,7 +69,7 @@ export class SequelizeChargingProfileRepository extends SequelizeRepository<Char
           stationId: stationId,
           transactionDatabaseId: transactionDBId,
           evseId: evseId,
-          chargingLimitSource: chargingLimitSource,
+          chargingLimitSource: chargingLimitSource ? chargingLimitSource : ChargingLimitSourceEnumType.CSO,
           isActive: isActive === undefined ? false : isActive,
         },
         savedChargingProfile.databaseId.toString(),

--- a/02_Util/src/index.ts
+++ b/02_Util/src/index.ts
@@ -16,3 +16,4 @@ export { initSwagger } from './util/swagger';
 export { getSizeOfRequest, getBatches } from './util/parser';
 export { DirectusUtil } from './util/directus';
 export { validateLanguageTag } from './util/validator';
+export { generateRequestId } from './util/idGenerator';

--- a/02_Util/src/util/idGenerator.ts
+++ b/02_Util/src/util/idGenerator.ts
@@ -1,0 +1,12 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+/**
+ * Generates request id
+ * TODO: get clear the scope and have a better way to generate unique id
+ * @return {number}
+ */
+export function generateRequestId(): number {
+  return Math.floor(Math.random() * 1000);
+}

--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -64,7 +64,12 @@ import {
   IMessageInfoRepository,
   sequelize,
 } from '@citrineos/data';
-import { RabbitMqReceiver, RabbitMqSender, Timer } from '@citrineos/util';
+import {
+  generateRequestId,
+  RabbitMqReceiver,
+  RabbitMqSender,
+  Timer,
+} from '@citrineos/util';
 import { v4 as uuidv4 } from 'uuid';
 import deasyncPromise from 'deasync-promise';
 import { ILogObj, Logger } from 'tslog';
@@ -787,7 +792,7 @@ export class ConfigurationModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetDisplayMessages,
         {
-          requestId: Math.floor(Math.random() * 1000),
+          requestId: generateRequestId(),
         } as GetDisplayMessagesRequest,
       );
     }
@@ -856,7 +861,7 @@ export class ConfigurationModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetDisplayMessages,
         {
-          requestId: Math.floor(Math.random() * 1000),
+          requestId: generateRequestId(),
         } as GetDisplayMessagesRequest,
       );
     }

--- a/03_Modules/EVDriver/src/module/module.ts
+++ b/03_Modules/EVDriver/src/module/module.ts
@@ -14,8 +14,12 @@ import {
   AuthorizeResponse,
   CallAction,
   CancelReservationResponse,
+  ChargingLimitSourceEnumType,
+  ChargingProfileCriterionType,
+  ChargingProfilePurposeEnumType,
   ClearCacheResponse,
   EventGroup,
+  GetChargingProfilesRequest,
   GetLocalListVersionResponse,
   HandlerProperties,
   ICache,
@@ -26,6 +30,7 @@ import {
   IMessageSender,
   MessageContentType,
   MessageFormatEnumType,
+  RequestStartStopStatusEnumType,
   RequestStartTransactionResponse,
   RequestStopTransactionResponse,
   ReservationStatusUpdateRequest,
@@ -37,8 +42,10 @@ import {
 } from '@citrineos/base';
 import {
   IAuthorizationRepository,
+  IChargingProfileRepository,
   IDeviceModelRepository,
   ITariffRepository,
+  ITransactionEventRepository,
   sequelize,
   Tariff,
   VariableAttribute,
@@ -77,6 +84,8 @@ export class EVDriverModule extends AbstractModule {
   protected _authorizeRepository: IAuthorizationRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
   protected _tariffRepository: ITariffRepository;
+  protected _transactionEventRepository: ITransactionEventRepository;
+  protected _chargingProfileRepository: IChargingProfileRepository;
 
   private _certificateAuthorityService: CertificateAuthorityService;
 
@@ -97,7 +106,7 @@ export class EVDriverModule extends AbstractModule {
    * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
    *
    * @param {IAuthorizationRepository} [authorizeRepository] - An optional parameter of type {@link IAuthorizationRepository} which represents a repository for accessing and manipulating Authorization data.
-   * If no `authorizeRepository` is provided, a default {@link sequelize.AuthorizationRepository} instance is created and used.
+   * If no `authorizeRepository` is provided, a default {@link sequelize:AuthorizationRepository} instance is created and used.
    *
    * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
    * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is
@@ -107,6 +116,14 @@ export class EVDriverModule extends AbstractModule {
    * represents a repository for accessing and manipulating variable data.
    * If no `deviceModelRepository` is provided, a default {@link sequelize:tariffRepository} instance is
    * created and used.
+   *
+   * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository}
+   * which represents a repository for accessing and manipulating transaction data.
+   * If no `transactionRepository` is provided, a default {@link sequelize:transactionEventRepository} instance is created and used.
+   *
+   * @param {IChargingProfileRepository} [chargingProfileRepository] - An optional parameter of type {@link IChargingProfileRepository}
+   * which represents a repository for accessing and manipulating charging profile data.
+   * If no `chargingProfileRepository` is provided, a default {@link sequelize:chargingProfileRepository} instance is created and used.
    *
    * @param {CertificateAuthorityService} [certificateAuthorityService] - An optional parameter of
    * type {@link CertificateAuthorityService} which handles certificate authority operations.
@@ -120,6 +137,8 @@ export class EVDriverModule extends AbstractModule {
     authorizeRepository?: IAuthorizationRepository,
     deviceModelRepository?: IDeviceModelRepository,
     tariffRepository?: ITariffRepository,
+    transactionEventRepository?: ITransactionEventRepository,
+    chargingProfileRepository?: IChargingProfileRepository,
     certificateAuthorityService?: CertificateAuthorityService,
   ) {
     super(
@@ -149,6 +168,12 @@ export class EVDriverModule extends AbstractModule {
     this._tariffRepository =
       tariffRepository ||
       new sequelize.SequelizeTariffRepository(config, logger);
+    this._transactionEventRepository =
+      transactionEventRepository ||
+      new sequelize.SequelizeTransactionEventRepository(config, this._logger);
+    this._chargingProfileRepository =
+      chargingProfileRepository ||
+      new sequelize.SequelizeChargingProfileRepository(config, this._logger);
 
     this._certificateAuthorityService =
       certificateAuthorityService ||
@@ -163,6 +188,14 @@ export class EVDriverModule extends AbstractModule {
 
   get deviceModelRepository(): IDeviceModelRepository {
     return this._deviceModelRepository;
+  }
+
+  get transactionEventRepository(): ITransactionEventRepository {
+    return this._transactionEventRepository;
+  }
+
+  get chargingProfileRepository(): IChargingProfileRepository {
+    return this._chargingProfileRepository;
   }
 
   /**
@@ -456,6 +489,41 @@ export class EVDriverModule extends AbstractModule {
       message,
       props,
     );
+    if (message.payload.status === RequestStartStopStatusEnumType.Accepted) {
+      const stationId: string = message.context.stationId;
+      // Set existing profiles to isActive false
+      await this._chargingProfileRepository.updateAllByQuery(
+        {
+          isActive: false,
+        },
+        {
+          where: {
+            stationId: stationId,
+            isActive: true,
+            chargingLimitSource: ChargingLimitSourceEnumType.CSO,
+            chargingProfilePurpose: ChargingProfilePurposeEnumType.TxProfile,
+          },
+          returning: false,
+        },
+      );
+      // Request charging profiles to get the latest data
+      this.sendCall(
+        stationId,
+        message.context.tenantId,
+        CallAction.GetChargingProfiles,
+        {
+          requestId: Math.floor(Math.random() * 1000),
+          chargingProfile: {
+            chargingProfilePurpose: ChargingProfilePurposeEnumType.TxProfile,
+            chargingLimitSource: [ChargingLimitSourceEnumType.CSO],
+          } as ChargingProfileCriterionType,
+        } as GetChargingProfilesRequest,
+      );
+    } else {
+      this._logger.error(
+        `RequestStartTransaction failed: ${JSON.stringify(message.payload)}`,
+      );
+    }
   }
 
   @AsHandler(CallAction.RequestStopTransaction)

--- a/03_Modules/Monitoring/src/module/module.ts
+++ b/03_Modules/Monitoring/src/module/module.ts
@@ -35,7 +35,12 @@ import {
   IVariableMonitoringRepository,
   sequelize,
 } from '@citrineos/data';
-import { RabbitMqReceiver, RabbitMqSender, Timer } from '@citrineos/util';
+import {
+  generateRequestId,
+  RabbitMqReceiver,
+  RabbitMqSender,
+  Timer,
+} from '@citrineos/util';
 import deasyncPromise from 'deasync-promise';
 import { ILogObj, Logger } from 'tslog';
 import { DeviceModelService } from './services';
@@ -319,7 +324,7 @@ export class MonitoringModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetMonitoringReport,
         {
-          requestId: Math.floor(Math.random() * 1000),
+          requestId: generateRequestId(),
         } as GetMonitoringReportRequest,
       );
     }

--- a/03_Modules/SmartCharging/src/module/module.ts
+++ b/03_Modules/SmartCharging/src/module/module.ts
@@ -36,7 +36,12 @@ import {
   SetChargingProfileResponse,
   SystemConfig,
 } from '@citrineos/base';
-import { RabbitMqReceiver, RabbitMqSender, Timer } from '@citrineos/util';
+import {
+  generateRequestId,
+  RabbitMqReceiver,
+  RabbitMqSender,
+  Timer,
+} from '@citrineos/util';
 import deasyncPromise from 'deasync-promise';
 import { ILogObj, Logger } from 'tslog';
 import {
@@ -95,7 +100,7 @@ export class SmartChargingModule extends AbstractModule {
    *
    * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository}
    * which represents a repository for accessing and manipulating transaction data.
-   * If no `transactionRepository` is provided, a default {@link sequelize:transactionEventRepository} instance is created and used.
+   * If no `transactionEventRepository` is provided, a default {@link sequelize:transactionEventRepository} instance is created and used.
    *
    * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository}
    * which represents a repository for accessing and manipulating variable data.
@@ -301,7 +306,7 @@ export class SmartChargingModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetChargingProfiles,
         {
-          requestId: Math.floor(Math.random() * 1000),
+          requestId: generateRequestId(),
           chargingProfile: {
             chargingLimitSource: [
               ChargingLimitSourceEnumType.CSO,
@@ -364,7 +369,7 @@ export class SmartChargingModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetChargingProfiles,
         {
-          requestId: Math.floor(Math.random() * 1000),
+          requestId: generateRequestId(),
           chargingProfile: {
             chargingLimitSource: [ChargingLimitSourceEnumType.CSO],
           } as ChargingProfileCriterionType,

--- a/Server/src/config/envs/docker.ts
+++ b/Server/src/config/envs/docker.ts
@@ -150,7 +150,7 @@ export function createDockerConfig() {
       },
     },
     logLevel: 2, // debug
-    maxCallLengthSeconds: 100,
-    maxCachingSeconds: 100,
+    maxCallLengthSeconds: 5,
+    maxCachingSeconds: 10,
   });
 }

--- a/Server/src/config/envs/docker.ts
+++ b/Server/src/config/envs/docker.ts
@@ -150,7 +150,7 @@ export function createDockerConfig() {
       },
     },
     logLevel: 2, // debug
-    maxCallLengthSeconds: 5,
-    maxCachingSeconds: 10,
+    maxCallLengthSeconds: 100,
+    maxCachingSeconds: 100,
   });
 }


### PR DESCRIPTION
## Changes
Implement K05 - Remote Start Transaction with Charging Profile
   - add use case specific validation as well as the basic validation for ChargingProfileType
   - change unique constraint of ChargingProfile to 'stationId_id' since the definition of ChargingProfileType's id is not limited by evse and evseId is not always required among different use cases.
   - after receiving RequestStartTransactionResponse, if it is accept, send a GetChargingProfiles to get latest data on the charger.

## Tests
1. Prepare 2 existing charging profiles from 2 chargers containing values: TxProfile, CSO and isActive: true. <img width="874" alt="Screenshot 2024-06-12 at 11 03 57 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/581ad600-37b3-421f-b3ed-dad86ef6f1c7"> <img width="1186" alt="Screenshot 2024-06-12 at 11 00 48 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/4bbec261-3857-4cfe-84d1-d30745304f93">
2. Send RequestStartTransactionRequest <img width="1135" alt="Screenshot 2024-06-12 at 11 04 27 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/6e33ae33-d3d8-47e5-9b71-8ab6981e0fba">
3. A new charging profile is created and charger receives the request <img width="1140" alt="Screenshot 2024-06-12 at 11 02 04 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/77f9342d-63b2-4ff3-ad35-5a6f99ad26f0"> <img width="1130" alt="Screenshot 2024-06-12 at 11 22 12 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/b85a06a6-160c-45ad-babf-babdde900155">
4. Charger send back a accept response <img width="1128" alt="Screenshot 2024-06-12 at 11 22 55 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/20814cfd-e47f-4241-a050-35d5cea43c4a">
5. Citrine set the existing active charging profile for cp001 to isActive: false but another existing active profile for Vector01 should still be isActive: true. <img width="1180" alt="Screenshot 2024-06-12 at 11 02 40 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/7d70d59d-5bb6-4d15-bc07-2b768e5b1828">
6. Charger receive a GetChargingProfiles request <img width="1127" alt="Screenshot 2024-06-12 at 11 25 24 AM" src="https://github.com/citrineos/citrineos-core/assets/21100540/c3379e09-e311-402e-a95a-4f38e143217b">