### PR TITLE
Active Transaction check replaced with TransactionId lookup

### DIFF
--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -56,7 +56,7 @@ export class SequelizeTransactionEventRepository extends SequelizeRepository<Tra
     return await this.s.transaction(async (sequelizeTransaction) => {
       let transaction: Transaction;
       let created = false;
-      let existingTransaction = await this.s.models[Transaction.MODEL_NAME].findOne({
+      const existingTransaction = await this.s.models[Transaction.MODEL_NAME].findOne({
         where: {
           stationId,
           transactionId: value.transactionInfo.transactionId,

--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -56,13 +56,14 @@ export class SequelizeTransactionEventRepository extends SequelizeRepository<Tra
     return await this.s.transaction(async (sequelizeTransaction) => {
       let transaction: Transaction;
       let created = false;
-      const existingTransaction = await this.s.models[Transaction.MODEL_NAME].findOne({
+      let existingTransaction = await this.s.models[Transaction.MODEL_NAME].findOne({
         where: {
           stationId,
-          isActive: value.eventType !== TransactionEventEnumType.Ended,
+          transactionId: value.transactionInfo.transactionId,
         },
         transaction: sequelizeTransaction,
       });
+      
       const updatedTransaction = Transaction.build({
         stationId,
         isActive: value.eventType !== TransactionEventEnumType.Ended,

--- a/03_Modules/Transactions/src/module/module.ts
+++ b/03_Modules/Transactions/src/module/module.ts
@@ -281,6 +281,9 @@ export class TransactionsModule extends AbstractModule {
               );
             }
 
+            // TODO there should only be one active transaction per evse of a station. 
+            // old transactions should be marked inactive and an alert should be raised (this can only happen in the field with charger bugs or missed messages)
+
             // Check for ConcurrentTx
             return this._transactionEventRepository
               .readAllActiveTransactionsByIdToken(transactionEvent.idToken)


### PR DESCRIPTION
Currently we don't ensure only a single transaction is active at a time per evse, so we can't use that condition to look up the current transaction. moving to using transactionId, and adding a TODO for future enforcement of active transaction limit.