### PR TITLE
feat: adding sequelize alter option

### DIFF
--- a/00_Base/src/config/types.ts
+++ b/00_Base/src/config/types.ts
@@ -104,6 +104,7 @@ export const systemConfigInputSchema = z.object({
       password: z.string().optional(),
       storage: z.string().default('csms.sqlite').optional(),
       sync: z.boolean().default(false).optional(),
+      alter: z.boolean().default(false).optional(),
     }),
   }),
   util: z.object({
@@ -351,6 +352,7 @@ export const systemConfigSchema = z
         password: z.string(),
         storage: z.string(),
         sync: z.boolean(),
+        alter: z.boolean().optional(),
       }),
     }),
     util: z.object({

--- a/01_Data/src/layers/sequelize/util.ts
+++ b/01_Data/src/layers/sequelize/util.ts
@@ -104,7 +104,11 @@ export class DefaultSequelizeInstance {
       },
     });
 
-    if (config.data.sequelize.sync && sync) {
+    if (config.data.sequelize.alter) {
+      sequelize.sync({ alter: true }).then(() => {
+        sequelizeLogger.info('Database altered');
+      });
+    } else if (config.data.sequelize.sync && sync) {
       sequelize.sync({ force: true }).then(() => {
         sequelizeLogger.info('Database synchronized');
       });

--- a/Server/src/config/envs/local.ts
+++ b/Server/src/config/envs/local.ts
@@ -55,6 +55,7 @@ export function createLocalConfig() {
         password: 'citrine',
         storage: '',
         sync: false,
+        alter: true
       },
     },
     util: {


### PR DESCRIPTION
feat: adding sequelize alter option (https://sequelize.org/docs/v7/models/model-synchronization/), as an alternative to sync, to allow for automatic DB schema migration during server startup to match latest state of models defined via code but without dropping all tables first like sync does.