### PR TITLE
ensuring callErrors are processed when able, and do not crash citrine

### DIFF
--- a/00_Base/src/interfaces/router/AbstractRouter.ts
+++ b/00_Base/src/interfaces/router/AbstractRouter.ts
@@ -119,7 +119,7 @@ export abstract class AbstractMessageRouter implements IMessageRouter {
    * Public Methods
    */
 
-  async handle(message: IMessage<OcppRequest | OcppResponse>): Promise<void> {
+  async handle(message: IMessage<OcppRequest | OcppResponse | OcppError>): Promise<void> {
     this._logger.debug('Received message:', message);
 
     if (message.state === MessageState.Response) {

--- a/03_Modules/OcppRouter/src/module/router.ts
+++ b/03_Modules/OcppRouter/src/module/router.ts
@@ -617,13 +617,6 @@ export class MessageRouterImpl
           this._config.maxCallLengthSeconds,
         );
       })
-      .catch((error) => {
-        if (error instanceof OcppError) {
-          // TODO: identifier may not be unique, may require combination of tenantId and identifier.
-          // find way to include actual tenantId.
-          this.sendCallError(messageId, identifier, 'undefined', action, error);
-        }
-      })
       .then((successfullySet) => {
         if (!successfullySet) {
           throw new OcppError(
@@ -647,12 +640,23 @@ export class MessageRouterImpl
         }
       })
       .catch((error) => {
-        if (error instanceof OcppError) {
-          // TODO: identifier may not be unique, may require combination of tenantId and identifier.
-          // find way to include tenantId here
-          this.sendCallError(messageId, identifier, 'undefined', action, error);
+        const callError = error instanceof OcppError ? error : new OcppError(
+          messageId,
+          ErrorCode.InternalError,
+          'Call failed',
+          { details: error },
+        );
+        // TODO: identifier may not be unique, may require combination of tenantId and identifier.
+        // find way to include tenantId here
+        this.sendCallError(
+          messageId,
+          identifier,
+          'undefined',
+          action,
+          callError,
+        ).finally(() => {
           this._cache.remove(identifier, CacheNamespace.Transactions);
-        }
+        });
       });
   }
 
@@ -721,6 +725,7 @@ export class MessageRouterImpl
         }
       })
       .catch((error) => {
+        // TODO: There's no such thing as a CallError in response to a CallResult. The above call error exceptions should be replaced.
         // TODO: Ideally the error log is also stored in the database in a failed invocations table to ensure these are visible outside of a log file.
         this._logger.error('Failed processing call result: ', error);
       });
@@ -766,12 +771,7 @@ export class MessageRouterImpl
       })
       .then((confirmation) => {
         if (!confirmation.success) {
-          throw new OcppError(
-            messageId,
-            ErrorCode.InternalError,
-            'CallError failed',
-            { details: confirmation.payload },
-          );
+          this._logger.warn('Unable to route call error: ', confirmation);
         }
       })
       .catch((error) => {
@@ -914,7 +914,8 @@ export class MessageRouterImpl
     this._handleMessageApiCallback(_message);
 
     // No error routing currently done
-    throw new Error('Method not implemented.');
+    this._logger.warn('Error routing not implemented');
+    return { success: false };
   }
 
   private async _handleMessageApiCallback(


### PR DESCRIPTION
CallError handling has not worked as expected. This PR aims to fix some of the problems seen in testing which prevented CallErrors from being sent, caused exceptions that should have been CallErrors to crash citrine, or sent CallErrors when they should not have been sent.