### PR TITLE
Map totalKwh during create / update on Transaction

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -59,6 +59,7 @@ export { SystemConfig, WebsocketServerConfig } from './config/types';
 // Utils
 
 export { RequestBuilder } from './util/request';
+export { MeterValueUtils } from './util/MeterValueUtils';
 
 export const LOG_LEVEL_OCPP = 10;
 
@@ -132,9 +133,11 @@ import {
 } from './ocpp/model/index';
 import { CallAction } from './ocpp/rpc/message';
 
-export interface OcppRequest {}
+export interface OcppRequest {
+}
 
-export interface OcppResponse {}
+export interface OcppResponse {
+}
 
 export const CALL_SCHEMA_MAP: Map<CallAction, object> = new Map<
   CallAction,

--- a/00_Base/src/util/MeterValueUtils.ts
+++ b/00_Base/src/util/MeterValueUtils.ts
@@ -1,0 +1,75 @@
+import { MeasurandEnumType, MeterValueType, ReadingContextEnumType, SampledValueType } from '../ocpp/model';
+
+export class MeterValueUtils {
+  private static readonly validContexts = new Set([
+    ReadingContextEnumType.Transaction_Begin,
+    ReadingContextEnumType.Sample_Periodic,
+    ReadingContextEnumType.Transaction_End,
+  ]);
+
+  /**
+   * Calculate the total Kwh
+   *
+   * @param {array} meterValues - meterValues of a transaction.
+   * @return {number} total Kwh based on the overall values (i.e., without phase) in the simpledValues.
+   */
+  public static getTotalKwh(meterValues: MeterValueType[]): number {
+    const filteredValues = this.filterValidMeterValues(meterValues);
+    const timestampToKwhMap = this.getTimestampToKwhMap(filteredValues);
+    const sortedValues = this.getSortedKwhByTimestampAscending(timestampToKwhMap);
+    return this.calculateTotalKwh(sortedValues);
+  }
+
+  private static filterValidMeterValues(meterValues: MeterValueType[]): MeterValueType[] {
+    return meterValues.filter(mv =>
+      // When missing, context is by default Sample_Periodic by spec
+      !mv.sampledValue[0].context || this.validContexts.has(mv.sampledValue[0].context)
+    );
+  }
+
+  private static getTimestampToKwhMap(meterValues: MeterValueType[]): Map<number, number> {
+    const valuesMap = new Map<number, number>();
+    for (const meterValue of meterValues) {
+      const overallValue = this.findOverallValue(meterValue.sampledValue);
+      if (overallValue) {
+        const timestamp = Date.parse(meterValue.timestamp);
+        const normalizedValue = this.normalizeToKwh(overallValue);
+        if (normalizedValue !== null) {
+          valuesMap.set(timestamp, normalizedValue);
+        }
+      }
+    }
+    return valuesMap;
+  }
+
+  private static findOverallValue(sampledValues: SampledValueType[]): SampledValueType | undefined {
+    return sampledValues.find(sv =>
+      !sv.phase &&
+      sv.measurand === MeasurandEnumType.Energy_Active_Import_Register
+    );
+  }
+
+  private static normalizeToKwh(value: SampledValueType): number | null {
+    const unit = value.unitOfMeasure?.unit?.toUpperCase();
+    if (unit === 'KWH') {
+      return value.value;
+    }
+    if (unit === 'WH') {
+      return value.value / 1000;
+    }
+    return null;
+  }
+
+  private static getSortedKwhByTimestampAscending(valuesMap: Map<number, number>): number[] {
+    return Array.from(valuesMap.entries())
+      .sort((a, b) => a[0] - b[0])
+      .map(entry => entry[1]);
+  }
+
+  private static calculateTotalKwh(sortedValues: number[]): number {
+    if (sortedValues.length < 2) {
+      return 0;
+    }
+    return sortedValues[sortedValues.length - 1] - sortedValues[0];
+  }
+}

--- a/00_Base/src/util/MeterValueUtils.ts
+++ b/00_Base/src/util/MeterValueUtils.ts
@@ -49,15 +49,21 @@ export class MeterValueUtils {
     );
   }
 
-  private static normalizeToKwh(value: SampledValueType): number | null {
-    const unit = value.unitOfMeasure?.unit?.toUpperCase();
-    if (unit === 'KWH') {
-      return value.value;
+  private static normalizeToKwh(overallValue: SampledValueType): number | null {
+    let powerOfTen = overallValue.unitOfMeasure?.multiplier ?? 0;
+    const unit = overallValue.unitOfMeasure?.unit?.toUpperCase();
+    switch (unit) {
+      case 'KWH':
+        break;
+      case 'WH':
+      case undefined:
+        powerOfTen -= 3;
+        break
+      default:
+        throw new Error("Unknown unit for Energy.Active.Import.Register: " + unit);
     }
-    if (unit === 'WH') {
-      return value.value / 1000;
-    }
-    return null;
+
+    return overallValue.value * (10 ** powerOfTen);
   }
 
   private static getSortedKwhByTimestampAscending(valuesMap: Map<number, number>): number[] {

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
@@ -3,7 +3,15 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-import { type CustomDataType, EVSEType, Namespace, TransactionEventEnumType, type TransactionEventRequest, TransactionType, TriggerReasonEnumType } from '@citrineos/base';
+import {
+  type CustomDataType,
+  EVSEType,
+  Namespace,
+  TransactionEventEnumType,
+  type TransactionEventRequest,
+  TransactionType,
+  TriggerReasonEnumType
+} from '@citrineos/base';
 import { BelongsTo, Column, DataType, ForeignKey, HasMany, Model, Table } from 'sequelize-typescript';
 import { IdToken } from '../Authorization';
 import { Evse } from '../DeviceModel';
@@ -26,7 +34,7 @@ export class TransactionEvent extends Model implements TransactionEventRequest {
   @Column({
     type: DataType.DATE,
     get() {
-      return this.getDataValue('timestamp').toISOString();
+      return this.getDataValue('timestamp')?.toISOString();
     },
   })
   declare timestamp: string;
@@ -37,7 +45,7 @@ export class TransactionEvent extends Model implements TransactionEventRequest {
   @Column(DataType.INTEGER)
   declare seqNo: number;
 
-  @Column({ type: DataType.BOOLEAN, defaultValue: false })
+  @Column({type: DataType.BOOLEAN, defaultValue: false})
   declare offline?: boolean;
 
   @Column(DataType.INTEGER)


### PR DESCRIPTION
Changing the logic for the totalKwh mapping to be done within one transaction update so that only one event is triggered for a finalized transaction for it to be processed into a CDR.