### PR TITLE
Feature/everest helper

### DIFF
--- a/Server/everest/Dockerfile
+++ b/Server/everest/Dockerfile
@@ -20,5 +20,9 @@ RUN sqlite3 /ext/source/build/dist/share/everest/modules/OCPP201/device_model_st
 
 RUN rm /ext/source/build/dist/etc/everest/certs/ca/v2g/*.*
 
-RUN chmod +x /ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh
-CMD ["/ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh"]
+RUN npm i -g http-server
+EXPOSE 8888
+
+COPY ./start.sh /tmp/start.sh
+RUN chmod +x /tmp/start.sh
+CMD ["sh", "-c", "/tmp/start.sh"]

--- a/Server/everest/Dockerfile
+++ b/Server/everest/Dockerfile
@@ -18,5 +18,7 @@ RUN sqlite3 /ext/source/build/dist/share/everest/modules/OCPP201/device_model_st
         WHERE name = 'NetworkConnectionProfiles' \
         );"
 
+RUN rm /ext/source/build/dist/etc/everest/certs/ca/v2g/*.*
+
 RUN chmod +x /ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh
 CMD ["/ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh"]

--- a/Server/everest/Dockerfile
+++ b/Server/everest/Dockerfile
@@ -1,14 +1,17 @@
-ARG EVEREST_TARGET_URL="ws://host.docker.internal:8081/cp001"
-ARG EVEREST_IMAGE_TAG="0.0.16"
+ARG EVEREST_IMAGE_TAG=0.0.16
+
 # todo make tag work dynamically
 FROM --platform=linux/x86_64 ghcr.io/everest/everest-demo/manager:${EVEREST_IMAGE_TAG}
+
+ARG EVEREST_TARGET_URL=host.docker.internal/cp001
+ENV EVEREST_TARGET_URL $EVEREST_TARGET_URL
 
 WORKDIR /workspace
 RUN ["/entrypoint.sh"]
 RUN apk update && apk add sqlite
 RUN sqlite3 /ext/source/build/dist/share/everest/modules/OCPP201/device_model_storage.db \
         "UPDATE VARIABLE_ATTRIBUTE \
-        SET value = '[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"${EVEREST_TARGET_URL}\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}},{\"configurationSlot\": 2, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"${EVEREST_TARGET_URL}\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]' \
+        SET value = '[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}},{\"configurationSlot\": 2, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]' \
         WHERE \
         variable_Id IN ( \
         SELECT id FROM VARIABLE \

--- a/Server/everest/Dockerfile
+++ b/Server/everest/Dockerfile
@@ -1,0 +1,19 @@
+ARG EVEREST_TARGET_URL="ws://host.docker.internal:8081/cp001"
+ARG EVEREST_IMAGE_TAG="0.0.16"
+# todo make tag work dynamically
+FROM --platform=linux/x86_64 ghcr.io/everest/everest-demo/manager:${EVEREST_IMAGE_TAG}
+
+WORKDIR /workspace
+RUN ["/entrypoint.sh"]
+RUN apk update && apk add sqlite
+RUN sqlite3 /ext/source/build/dist/share/everest/modules/OCPP201/device_model_storage.db \
+        "UPDATE VARIABLE_ATTRIBUTE \
+        SET value = '[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"${EVEREST_TARGET_URL}\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}},{\"configurationSlot\": 2, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"${EVEREST_TARGET_URL}\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]' \
+        WHERE \
+        variable_Id IN ( \
+        SELECT id FROM VARIABLE \
+        WHERE name = 'NetworkConnectionProfiles' \
+        );"
+
+RUN chmod +x /ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh
+CMD ["/ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh"]

--- a/Server/everest/docker-compose.yml
+++ b/Server/everest/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     build:
       dockerfile: Dockerfile
       args:
-        EVEREST_TARGET_URL: "ws://s44.ngrok.io/cp001"
-        EVEREST_IMAGE_TAG: ${EVEREST_IMAGE_TAG}
+        - EVEREST_TARGET_URL=${EVEREST_TARGET_URL}
+        - EVEREST_IMAGE_TAG=${EVEREST_IMAGE_TAG}
     platform: linux/x86_64
     deploy:
       resources:

--- a/Server/everest/docker-compose.yml
+++ b/Server/everest/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         - EVEREST_TARGET_URL=${EVEREST_TARGET_URL}
         - EVEREST_IMAGE_TAG=${EVEREST_IMAGE_TAG}
     platform: linux/x86_64
+    ports:
+      - 8888:8888
     deploy:
       resources:
         limits:

--- a/Server/everest/docker-compose.yml
+++ b/Server/everest/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.6"
+
+services:
+  mqtt-server:
+    image: ghcr.io/everest/everest-demo/mqtt-server:${EVEREST_IMAGE_TAG}
+    platform: linux/x86_64
+    logging:
+      driver: none
+
+  manager:
+    build:
+      dockerfile: Dockerfile
+      args:
+        EVEREST_TARGET_URL: "ws://s44.ngrok.io/cp001"
+        EVEREST_IMAGE_TAG: ${EVEREST_IMAGE_TAG}
+    platform: linux/x86_64
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "4G"
+    depends_on:
+      - mqtt-server
+    environment:
+      - MQTT_SERVER_ADDRESS=mqtt-server
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=0
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  nodered:
+    image: ghcr.io/everest/everest-demo/nodered:${EVEREST_IMAGE_TAG}
+    depends_on:
+      - mqtt-server
+    ports:
+      - 1880:1880
+    environment:
+      - MQTT_SERVER_ADDRESS=mqtt-server
+      - FLOWS=/config/config-sil-two-evse-flow.json

--- a/Server/everest/start.sh
+++ b/Server/everest/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+http-server /tmp/everest_ocpp_logs -p 8888 &
+chmod +x /ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh
+/ext/source/build/run-scripts/run-sil-ocpp201-pnc.sh

--- a/Server/package.json
+++ b/Server/package.json
@@ -15,7 +15,8 @@
     "start-unix": "APP_NAME=all APP_ENV=local nodemon src/index.ts",
     "start-windows": "set APP_NAME=all&& set APP_ENV=local&& RefreshEnv.cmd && npx nodemon src/index.ts",
     "start-docker": "nodemon src/index.ts",
-    "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js"
+    "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
+    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://something.ngrok.io/cp001 docker-compose up"
   },
   "keywords": [
     "ocpp",

--- a/Server/package.json
+++ b/Server/package.json
@@ -16,7 +16,7 @@
     "start-windows": "set APP_NAME=all&& set APP_ENV=local&& RefreshEnv.cmd && npx nodemon src/index.ts",
     "start-docker": "nodemon src/index.ts",
     "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
-    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://something.ngrok.io/cp001 docker-compose up"
+    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker-compose up"
   },
   "keywords": [
     "ocpp",

--- a/Server/package.json
+++ b/Server/package.json
@@ -16,8 +16,8 @@
     "start-windows": "set APP_NAME=all&& set APP_ENV=local&& RefreshEnv.cmd && npx nodemon src/index.ts",
     "start-docker": "nodemon src/index.ts",
     "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
-    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/1 docker-compose up",
-    "start-everest-windows": "cd ./everest && set EVEREST_IMAGE_TAG=0.0.16&& set EVEREST_TARGET_URL=ws://host.docker.internal:8081/1&& docker compose up -d"
+    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker-compose up",
+    "start-everest-windows": "cd ./everest && set EVEREST_IMAGE_TAG=0.0.16&& set EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001&& docker compose up -d"
   },
   "keywords": [
     "ocpp",

--- a/Server/package.json
+++ b/Server/package.json
@@ -16,8 +16,8 @@
     "start-windows": "set APP_NAME=all&& set APP_ENV=local&& RefreshEnv.cmd && npx nodemon src/index.ts",
     "start-docker": "nodemon src/index.ts",
     "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
-    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker-compose up",
-    "start-everest-windows": "cd ./everest && set EVEREST_IMAGE_TAG=0.0.16&& set EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001&& docker compose up -d"
+    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/1 docker-compose up",
+    "start-everest-windows": "cd ./everest && set EVEREST_IMAGE_TAG=0.0.16&& set EVEREST_TARGET_URL=ws://host.docker.internal:8081/1&& docker compose up -d"
   },
   "keywords": [
     "ocpp",

--- a/Server/package.json
+++ b/Server/package.json
@@ -16,7 +16,8 @@
     "start-windows": "set APP_NAME=all&& set APP_ENV=local&& RefreshEnv.cmd && npx nodemon src/index.ts",
     "start-docker": "nodemon src/index.ts",
     "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
-    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker-compose up"
+    "start-everest": "cd ./everest && EVEREST_IMAGE_TAG=0.0.16 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker-compose up",
+    "start-everest-windows": "cd ./everest && set EVEREST_IMAGE_TAG=0.0.16&& set EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001&& docker compose up -d"
   },
   "keywords": [
     "ocpp",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint-fix": "npm run prettier && npx eslint --ext .ts --fix ./",
     "prettier": "prettier --write .",
     "fresh-and-install-all": "npm run fresh && npm run install-all",
-    "start-everest": "npm run start-everest --prefix ./Server"
+    "start-everest": "npm run start-everest --prefix ./Server",
+    "start-everest-windows": "npm run start-everest-windows --prefix ./Server"
   },
   "workspaces": [
     "00_Base",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "npx eslint --ext .ts ./",
     "lint-fix": "npm run prettier && npx eslint --ext .ts --fix ./",
     "prettier": "prettier --write .",
-    "fresh-and-install-all": "npm run fresh && npm run install-all"
+    "fresh-and-install-all": "npm run fresh && npm run install-all",
+    "start-everest": "npm run start-everest --prefix ./Server"
   },
   "workspaces": [
     "00_Base",


### PR DESCRIPTION
feat: creating convenience `npm run start-everest` helper that will perform docker compose up using the newly created docker-compose and Dockerfile in the /Server/everest folder. Dockerfile mimics ghcr.io/everest/everest-demo/manager image but also installs sqlite and performs a SQL query to set the CSMS URL. The Dockerfile supports a `EVEREST_TARGET_URL` build argument that can be used to specify the target that everest should point to. The docker compose file sets this argument as well and is used by npm to start the everest server