### PR TITLE
Ensuring data for broadcast flow

### DIFF
--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -144,7 +144,10 @@ export class SequelizeTransactionEventRepository extends SequelizeRepository<Tra
       await event.reload({include: [MeterValue], transaction: sequelizeTransaction});
       this.emit('created', [event]);
 
-      await transaction.reload({include: [TransactionEvent, MeterValue], transaction: sequelizeTransaction});
+      await transaction.reload({
+        include: [{model: TransactionEvent, include: [IdToken]}, MeterValue, Evse],
+        transaction: sequelizeTransaction
+      });
       await this.calculateAndUpdateTotalKwh(transaction);
 
 


### PR DESCRIPTION
During the broadcast flow, it needs information from IdToken to map data for the tokens it requires. This PR aims to add the IdToken object, and EVSE object during the event emit to ensure enough data is present for the mapping.