### PR TITLE
feature: drop all views before migrate

### DIFF
--- a/01_Data/src/layers/sequelize/sql/index.ts
+++ b/01_Data/src/layers/sequelize/sql/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Will drop all views skipping geography_columns and geometry_columns since they are required by postgis plugin
+ */
+export const dropAllViews = `
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN (
+        SELECT table_schema, table_name 
+        FROM information_schema.views 
+        WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+          AND table_name NOT IN ('geography_columns', 'geometry_columns')
+    ) LOOP
+        EXECUTE 'DROP VIEW IF EXISTS ' || quote_ident(r.table_schema) || '.' || quote_ident(r.table_name) || ' CASCADE';
+    END LOOP;
+END $$;
+`;


### PR DESCRIPTION
feat: created a drop all views script and triggering it before calling sequelize migrate in core to make sure that there arent any conflicts when trying to alter table columns that are part of views.