### PR TITLE
Bugfix: making @fastify/swagger static to 8.14.0

### DIFF
--- a/02_Util/package.json
+++ b/02_Util/package.json
@@ -38,7 +38,7 @@
     "@citrineos/base": "1.3.1",
     "@citrineos/data": "1.3.1",
     "@directus/sdk": "^15.0.3",
-    "@fastify/swagger": "^8.10.1",
+    "@fastify/swagger": "8.14.0",
     "@fastify/swagger-ui": "^1.9.3",
     "@google-cloud/pubsub": "^3.6.0",
     "@peculiar/webcrypto": "^1.4.6",


### PR DESCRIPTION
The new version of @fastify/swagger@8.15.0 changes the type declarations of the `swaggerObject` and `openapiObject` and causes build errors. This PR is the quick fix to this issue while we properly handle dependency changes like this.