### PR TITLE
Fix: Workflows to pull rc candidate branches for OCPI and CORE

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clone citrineos-ocpi repository
-        run: git clone https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
+        run: git clone -b rc-0.2.0 https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/push-release-tagged-server.yml
+++ b/.github/workflows/push-release-tagged-server.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone citrineos-ocpi repository
-        run: git clone https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
+        run: git clone -b rc-0.2.0 https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/test-build-server.yml
+++ b/.github/workflows/test-build-server.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clone citrineos-ocpi repository
-        run: git clone https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
+        run: git clone -b rc-0.2.0 https://github.com/citrineos/citrineos-ocpi.git ../citrineos-ocpi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
fix: adjusting workflows to clone rc branch for now otherwise CI breaks, then this can be toggled back to main as part of release