### PR TITLE
chore: removing npm run copy-assets from npm run build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "install-all": "npm i --workspaces --verbose",
     "copy-assets": "cp -rv Server/src/assets Server/dist/assets",
-    "build": "tsc --build --verbose && npm run copy-assets",
+    "build": "tsc --build --verbose",
     "fresh": "rm -rf package-lock.json **/package-lock.json **/**/package-lock.json node_modules **/node_modules **/**/node_modules && npm run clean",
     "clean": "rm -rf dist **/dist **/**/dist tsconfig.tsbuildinfo **/tsconfig.tsbuildinfo **/**/tsconfig.tsbuildinfo",
     "start-unix": "cd ./Server && npm run start-unix",


### PR DESCRIPTION
chore: removing npm run copy-assets from npm run build because cp command causes issues from within nodemon on windows, leaving command as a helper support command for now