### PR TITLE
(Release 1.4) Status Notification Unit Tests

### DIFF
--- a/03_Modules/Transactions/src/module/StatusNotificationService.ts
+++ b/03_Modules/Transactions/src/module/StatusNotificationService.ts
@@ -1,0 +1,94 @@
+import {
+  Component,
+  Evse,
+  IDeviceModelRepository,
+  ILocationRepository,
+  Variable,
+} from '@citrineos/data';
+import { ILogObj, Logger } from 'tslog';
+import {
+  CrudRepository,
+  ReportDataType,
+  StatusNotificationRequest,
+} from '@citrineos/base';
+
+export class StatusNotificationService {
+  protected _componentRepository: CrudRepository<Component>;
+  protected _deviceModelRepository: IDeviceModelRepository;
+  protected _locationRepository: ILocationRepository;
+  protected _logger: Logger<ILogObj>;
+
+  constructor(
+    componentRepository: CrudRepository<Component>,
+    deviceModelRepository: IDeviceModelRepository,
+    locationRepository: ILocationRepository,
+    logger?: Logger<ILogObj>,
+  ) {
+    this._componentRepository = componentRepository;
+    this._deviceModelRepository = deviceModelRepository;
+    this._locationRepository = locationRepository;
+    this._logger = logger
+      ? logger.getSubLogger({ name: this.constructor.name })
+      : new Logger<ILogObj>({ name: this.constructor.name });
+  }
+
+  async processStatusNotification(
+    stationId: string,
+    statusNotificationRequest: StatusNotificationRequest,
+  ) {
+    const chargingStation =
+      await this._locationRepository.readChargingStationByStationId(stationId);
+    if (chargingStation) {
+      await this._locationRepository.addStatusNotificationToChargingStation(
+        stationId,
+        statusNotificationRequest,
+      );
+    } else {
+      this._logger.warn(
+        `Charging station ${stationId} not found. Status notification cannot be associated with a charging station.`,
+      );
+    }
+
+    const component = await this._componentRepository.readOnlyOneByQuery({
+      where: {
+        name: 'Connector',
+      },
+      include: [
+        {
+          model: Evse,
+          where: {
+            id: statusNotificationRequest.evseId,
+            connectorId: statusNotificationRequest.connectorId,
+          },
+        },
+        {
+          model: Variable,
+          where: {
+            name: 'AvailabilityState',
+          },
+        },
+      ],
+    });
+    const variable = component?.variables?.[0];
+    if (!component || !variable) {
+      this._logger.warn(
+        'Missing component or variable for status notification. Status notification cannot be assigned to device model.',
+      );
+    } else {
+      const reportDataType: ReportDataType = {
+        component: component,
+        variable: variable,
+        variableAttribute: [
+          {
+            value: statusNotificationRequest.connectorStatus,
+          },
+        ],
+      };
+      await this._deviceModelRepository.createOrUpdateDeviceModelByStationId(
+        reportDataType,
+        stationId,
+        statusNotificationRequest.timestamp,
+      );
+    }
+  }
+}

--- a/03_Modules/Transactions/src/module/StatusNotificationService.ts
+++ b/03_Modules/Transactions/src/module/StatusNotificationService.ts
@@ -32,6 +32,12 @@ export class StatusNotificationService {
       : new Logger<ILogObj>({ name: this.constructor.name });
   }
 
+  /**
+   * Stores an internal record of the incoming status, then updates the device model for the updated connector.
+   *
+   * @param {string} stationId - The Charging Station sending the status notification request
+   * @param {StatusNotificationRequest} statusNotificationRequest
+   */
   async processStatusNotification(
     stationId: string,
     statusNotificationRequest: StatusNotificationRequest,

--- a/03_Modules/Transactions/test/module/StatusNotificationService.test.ts
+++ b/03_Modules/Transactions/test/module/StatusNotificationService.test.ts
@@ -41,7 +41,7 @@ describe('StatusNotificationService', () => {
     );
   });
 
-  it('should save StatusNotification to Charging Station because Charging Station exists', async () => {
+  it('should save StatusNotification for Charging Station because Charging Station exists', async () => {
     locationRepository.readChargingStationByStationId.mockResolvedValue(
       aChargingStation(),
     );
@@ -56,7 +56,7 @@ describe('StatusNotificationService', () => {
     ).toHaveBeenCalled();
   });
 
-  it('should not save StatusNotification to Charging Station because Charging Station does not', async () => {
+  it('should not save StatusNotification for Charging Station because Charging Station does not exist', async () => {
     locationRepository.readChargingStationByStationId.mockResolvedValue(
       undefined,
     );

--- a/03_Modules/Transactions/test/module/StatusNotificationService.test.ts
+++ b/03_Modules/Transactions/test/module/StatusNotificationService.test.ts
@@ -1,0 +1,124 @@
+import {
+  Component,
+  IDeviceModelRepository,
+  ILocationRepository,
+} from '@citrineos/data';
+import { CrudRepository } from '@citrineos/base';
+import { StatusNotificationService } from '../../src/module/StatusNotificationService';
+import { aStatusNotificationRequest } from '../providers/StatusNotification';
+import {
+  aChargingStation,
+  aComponent,
+  anEvse,
+  aVariable,
+  MOCK_STATION_ID,
+} from '../providers/DeviceModel';
+
+describe('StatusNotificationService', () => {
+  let statusNotificationService: StatusNotificationService;
+  let componentRepository: jest.Mocked<CrudRepository<Component>>;
+  let deviceModelRepository: jest.Mocked<IDeviceModelRepository>;
+  let locationRepository: jest.Mocked<ILocationRepository>;
+
+  beforeEach(() => {
+    componentRepository = {
+      readOnlyOneByQuery: jest.fn(),
+    } as unknown as jest.Mocked<CrudRepository<Component>>;
+
+    deviceModelRepository = {
+      createOrUpdateDeviceModelByStationId: jest.fn(),
+    } as unknown as jest.Mocked<IDeviceModelRepository>;
+
+    locationRepository = {
+      addStatusNotificationToChargingStation: jest.fn(),
+      readChargingStationByStationId: jest.fn(),
+    } as unknown as jest.Mocked<ILocationRepository>;
+
+    statusNotificationService = new StatusNotificationService(
+      componentRepository,
+      deviceModelRepository,
+      locationRepository,
+    );
+  });
+
+  it('should save StatusNotification to Charging Station because Charging Station exists', async () => {
+    locationRepository.readChargingStationByStationId.mockResolvedValue(
+      aChargingStation(),
+    );
+
+    await statusNotificationService.processStatusNotification(
+      MOCK_STATION_ID,
+      aStatusNotificationRequest(),
+    );
+
+    expect(
+      locationRepository.addStatusNotificationToChargingStation,
+    ).toHaveBeenCalled();
+  });
+
+  it('should not save StatusNotification to Charging Station because Charging Station does not', async () => {
+    locationRepository.readChargingStationByStationId.mockResolvedValue(
+      undefined,
+    );
+
+    await statusNotificationService.processStatusNotification(
+      MOCK_STATION_ID,
+      aStatusNotificationRequest(),
+    );
+
+    expect(
+      locationRepository.addStatusNotificationToChargingStation,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('should save Component and Variable ReportData because Component and Variable exist', async () => {
+    componentRepository.readOnlyOneByQuery.mockResolvedValue(
+      aComponent((c) => {
+        c.name = 'Connector';
+        c.evse = anEvse();
+        c.variables = [
+          aVariable((v) => {
+            v.name = 'AvailabilityState';
+          }),
+        ];
+      }),
+    );
+
+    await statusNotificationService.processStatusNotification(
+      MOCK_STATION_ID,
+      aStatusNotificationRequest(),
+    );
+
+    expect(
+      deviceModelRepository.createOrUpdateDeviceModelByStationId,
+    ).toHaveBeenCalled();
+  });
+
+  describe('Component or Variable does not exist', () => {
+    it('should not save Component and Variable ReportData because Component does not exist', async () => {
+      componentRepository.readOnlyOneByQuery.mockResolvedValue(undefined);
+
+      await statusNotificationService.processStatusNotification(
+        MOCK_STATION_ID,
+        aStatusNotificationRequest(),
+      );
+
+      expect(
+        deviceModelRepository.createOrUpdateDeviceModelByStationId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should not save Component and Variable ReportData because Variable does not exist', async () => {
+      componentRepository.readOnlyOneByQuery.mockResolvedValue(aComponent());
+
+      await statusNotificationService.processStatusNotification(
+        MOCK_STATION_ID,
+        aStatusNotificationRequest(),
+      );
+
+      expect(
+        deviceModelRepository.createOrUpdateDeviceModelByStationId,
+      ).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/03_Modules/Transactions/test/providers/DeviceModel.ts
+++ b/03_Modules/Transactions/test/providers/DeviceModel.ts
@@ -1,0 +1,44 @@
+import { applyUpdateFunction, UpdateFunction } from '../utils/UpdateUtil';
+import { ChargingStation, Component, Evse, Variable } from '@citrineos/data';
+
+export const MOCK_STATION_ID = 'Station01';
+export const MOCK_EVSE_ID = 1;
+export const MOCK_CONNECTOR_ID = 1;
+
+export function aChargingStation(
+  updateFunction?: UpdateFunction<ChargingStation>,
+): ChargingStation {
+  const chargingStation: ChargingStation = {
+    id: MOCK_STATION_ID,
+  } as ChargingStation;
+
+  return applyUpdateFunction(chargingStation, updateFunction);
+}
+
+export function anEvse(updateFunction?: UpdateFunction<Evse>): Evse {
+  const evse: Evse = {
+    databaseId: MOCK_EVSE_ID,
+    id: MOCK_CONNECTOR_ID,
+    connectorId: MOCK_CONNECTOR_ID,
+  } as Evse;
+
+  return applyUpdateFunction(evse, updateFunction);
+}
+
+export function aComponent(
+  updateFunction?: UpdateFunction<Component>,
+): Component {
+  const component: Component = {
+    name: 'Any',
+  } as Component;
+
+  return applyUpdateFunction(component, updateFunction);
+}
+
+export function aVariable(updateFunction?: UpdateFunction<Variable>): Variable {
+  const variable: Variable = {
+    name: 'Any',
+  } as Variable;
+
+  return applyUpdateFunction(variable, updateFunction);
+}

--- a/03_Modules/Transactions/test/providers/StatusNotification.ts
+++ b/03_Modules/Transactions/test/providers/StatusNotification.ts
@@ -1,0 +1,19 @@
+import {
+  ConnectorStatusEnumType,
+  StatusNotificationRequest,
+} from '@citrineos/base';
+import { applyUpdateFunction, UpdateFunction } from '../utils/UpdateUtil';
+import { MOCK_CONNECTOR_ID, MOCK_EVSE_ID } from './DeviceModel';
+
+export function aStatusNotificationRequest(
+  updateFunction?: UpdateFunction<StatusNotificationRequest>,
+): StatusNotificationRequest {
+  const item: StatusNotificationRequest = {
+    timestamp: new Date().toISOString(),
+    connectorStatus: ConnectorStatusEnumType.Available,
+    evseId: MOCK_EVSE_ID,
+    connectorId: MOCK_CONNECTOR_ID,
+  } as StatusNotificationRequest;
+
+  return applyUpdateFunction(item, updateFunction);
+}

--- a/03_Modules/Transactions/test/providers/StatusNotification.ts
+++ b/03_Modules/Transactions/test/providers/StatusNotification.ts
@@ -8,12 +8,12 @@ import { MOCK_CONNECTOR_ID, MOCK_EVSE_ID } from './DeviceModel';
 export function aStatusNotificationRequest(
   updateFunction?: UpdateFunction<StatusNotificationRequest>,
 ): StatusNotificationRequest {
-  const item: StatusNotificationRequest = {
+  const request: StatusNotificationRequest = {
     timestamp: new Date().toISOString(),
     connectorStatus: ConnectorStatusEnumType.Available,
     evseId: MOCK_EVSE_ID,
     connectorId: MOCK_CONNECTOR_ID,
   } as StatusNotificationRequest;
 
-  return applyUpdateFunction(item, updateFunction);
+  return applyUpdateFunction(request, updateFunction);
 }


### PR DESCRIPTION
This PR adds unit tests for the StatusNotification handler found in the Transactions module. The strategy was to move the StatusNotification-related functionality into its own service, and add unit tests based around this new service.

Changes:
* Added new service `StatusNotificationService` to handle StatusNotification-related functionality in the Transactions module.
* Added new test `StatusNotificationService.test` to test aforementioned service.
* Added providers for aforementioned tests.
* Updated StatusNotification handler in TransactionsModule to use new StatusNotificationService.