### PR TITLE
Create scheduler base class

### DIFF
--- a/03_Modules/Transactions/src/module/CostNotifier.ts
+++ b/03_Modules/Transactions/src/module/CostNotifier.ts
@@ -2,12 +2,9 @@ import { ITransactionEventRepository } from '@citrineos/data';
 import { AbstractModule, CallAction } from '@citrineos/base';
 import { ILogObj, Logger } from 'tslog';
 import { CostCalculator } from './CostCalculator';
+import { Scheduler } from './Scheduler';
 
-export class CostNotifier {
-  private _registry: Map<string, NodeJS.Timeout> = new Map();
-
-  private readonly _logger: Logger<ILogObj>;
-
+export class CostNotifier extends Scheduler {
   private readonly _transactionEventRepository: ITransactionEventRepository;
   private readonly _module: AbstractModule;
   private readonly _costCalculator: CostCalculator;
@@ -18,12 +15,10 @@ export class CostNotifier {
     costCalculator: CostCalculator,
     logger?: Logger<ILogObj>,
   ) {
+    super(logger);
     this._transactionEventRepository = transactionEventRepository;
     this._module = module;
     this._costCalculator = costCalculator;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
   }
 
   /**
@@ -42,19 +37,13 @@ export class CostNotifier {
     tenantId: string,
     intervalSeconds: number,
   ): void {
-    if (this._isAlreadyRegistered(stationId, transactionId)) {
-      return;
-    }
     this._logger.debug(
-      `Registering periodic cost notifications for ${stationId} station, ${transactionId} transaction, ${tenantId} tenant`,
+      `Scheduling periodic cost notifications for ${stationId} station, ${transactionId} transaction, ${tenantId} tenant`,
     );
-    this._register(
-      stationId,
-      transactionId,
-      setInterval(
-        () => this._tryNotify(stationId, transactionId, tenantId),
-        intervalSeconds * 1000,
-      ),
+    this.schedule(
+      this._key(stationId, transactionId),
+      () => this._tryNotify(stationId, transactionId, tenantId),
+      intervalSeconds,
     );
   }
 
@@ -72,9 +61,9 @@ export class CostNotifier {
 
       if (!transaction?.isActive) {
         this._logger.debug(
-          `Unregistering periodic cost notifications for ${stationId} station, ${transactionId} transaction, ${tenantId} tenant`,
+          `Unscheduling periodic cost notifications for ${stationId} station, ${transactionId} transaction, ${tenantId} tenant`,
         );
-        this._unregister(stationId, transactionId);
+        this.unschedule(this._key(stationId, transactionId));
         return;
       }
 
@@ -100,26 +89,6 @@ export class CostNotifier {
         error,
       );
     }
-  }
-
-  private _register(
-    stationId: string,
-    transactionId: string,
-    timeout: NodeJS.Timeout,
-  ) {
-    const key = this._key(stationId, transactionId);
-    this._registry.set(key, timeout);
-  }
-
-  private _unregister(stationId: string, transactionId: string) {
-    const key = this._key(stationId, transactionId);
-    clearInterval(this._registry.get(key));
-    this._registry.delete(key);
-  }
-
-  private _isAlreadyRegistered(stationId: string, transactionId: string) {
-    const key = this._key(stationId, transactionId);
-    return this._registry.has(key);
   }
 
   private _key(stationId: string, transactionId: string) {

--- a/03_Modules/Transactions/src/module/Scheduler.ts
+++ b/03_Modules/Transactions/src/module/Scheduler.ts
@@ -1,0 +1,49 @@
+import { ILogObj, Logger } from 'tslog';
+
+export abstract class Scheduler {
+  protected readonly _logger: Logger<ILogObj>;
+
+  private _registry: Map<string, NodeJS.Timeout> = new Map();
+
+  constructor(logger?: Logger<ILogObj>) {
+    this._logger = logger
+      ? logger.getSubLogger({ name: this.constructor.name })
+      : new Logger<ILogObj>({ name: this.constructor.name });
+  }
+
+  protected schedule(
+    key: string,
+    task: () => void,
+    intervalSeconds: number,
+  ): void {
+    if (this._isAlreadyRegistered(key)) {
+      this._logger.debug(
+        `Skipping task registration for ${key} as it is already registered`,
+      );
+      return;
+    }
+    this._logger.debug(`Registering scheduled task for ${key}`);
+    this._register(
+      key,
+      setInterval(() => task(), intervalSeconds * 1000),
+    );
+  }
+
+  protected unschedule(key: string) {
+    this._logger.debug(`Unregistering scheduled task for ${key}`);
+    this._unregister(key);
+  }
+
+  private _register(key: string, timeout: NodeJS.Timeout) {
+    this._registry.set(key, timeout);
+  }
+
+  private _unregister(key: string) {
+    clearInterval(this._registry.get(key));
+    this._registry.delete(key);
+  }
+
+  private _isAlreadyRegistered(key: string) {
+    return this._registry.has(key);
+  }
+}

--- a/03_Modules/Transactions/test/module/Scheduler.test.ts
+++ b/03_Modules/Transactions/test/module/Scheduler.test.ts
@@ -1,0 +1,126 @@
+import { expect, jest } from '@jest/globals';
+import { Scheduler } from '../../src/module/Scheduler';
+
+class PassthroughScheduler extends Scheduler {
+  schedule(key: string, task: () => void, intervalSeconds: number) {
+    super.schedule(key, task, intervalSeconds);
+  }
+
+  unschedule(key: string) {
+    super.unschedule(key);
+  }
+}
+
+describe('Scheduler', () => {
+  let scheduler: PassthroughScheduler;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    scheduler = new PassthroughScheduler();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  describe('schedule', () => {
+    it('should periodically execute task', async () => {
+      const taskInterval = 1;
+      const taskKey = `CostUpdated:001:716e8cd7`;
+      const task = jest.fn();
+
+      scheduler.schedule(taskKey, () => task(), taskInterval);
+
+      expect(task).toHaveBeenCalledTimes(0);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(3);
+    });
+
+    it('should periodically execute multiple tasks', async () => {
+      const taskInterval = 1;
+      const taskKey = `CostUpdated:001:716e8cd7`;
+      const task = jest.fn();
+
+      const anotherTaskInterval = 0.5;
+      const anotherTaskKey = `CostUpdated:001:a8a86116`;
+      const anotherTask = jest.fn();
+
+      scheduler.schedule(taskKey, () => task(), taskInterval);
+      scheduler.schedule(
+        anotherTaskKey,
+        () => anotherTask(),
+        anotherTaskInterval,
+      );
+
+      expect(task).toHaveBeenCalledTimes(0);
+      expect(anotherTask).toHaveBeenCalledTimes(0);
+
+      await jest.advanceTimersByTimeAsync(anotherTaskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(0);
+      expect(anotherTask).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(anotherTaskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(1);
+      expect(anotherTask).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(anotherTaskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(1);
+      expect(anotherTask).toHaveBeenCalledTimes(3);
+
+      await jest.advanceTimersByTimeAsync(anotherTaskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+      expect(anotherTask).toHaveBeenCalledTimes(4);
+    });
+
+    it('should stop executing unscheduled tasks', async () => {
+      const taskInterval = 1;
+      const taskKey = `CostUpdated:001:716e8cd7`;
+      const task = jest.fn();
+
+      scheduler.schedule(taskKey, () => task(), taskInterval);
+
+      expect(task).toHaveBeenCalledTimes(0);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+
+      scheduler.unschedule(taskKey);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not duplicate schedules for the same key', async () => {
+      const taskInterval = 1;
+      const taskKey = `CostUpdated:001:716e8cd7`;
+      const task = jest.fn();
+
+      const anotherTaskInterval = 0.5;
+      const anotherTask = jest.fn();
+
+      scheduler.schedule(taskKey, () => task(), taskInterval);
+      scheduler.schedule(taskKey, () => anotherTask(), anotherTaskInterval);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(1);
+      expect(anotherTask).toHaveBeenCalledTimes(0);
+
+      await jest.advanceTimersByTimeAsync(taskInterval * 1000);
+      expect(task).toHaveBeenCalledTimes(2);
+      expect(anotherTask).toHaveBeenCalledTimes(0);
+    });
+  });
+});


### PR DESCRIPTION
This PR is focused on extracting some scheduling logic into a base class to make it more reusable in the future. An alternative approach would be to use composition instead of inheritance, but that comes with its own set of challenges:
- we might run into key collisions between clients. We could either assign each client a unique namespace or have each client use a unique prefix for their keys. Another option is to use different Scheduler (prototype instead of singleton) instance for each client.
- unit testing becomes tricky. For instance, how would we test logic encapsulated in callbacks? We could mock the scheduler to trigger the callback, but it might end up being messy?

Even though I’m not typically a fan of inheritance, it seems like a practical solution in this case. Let me know your thoughts!