### PR TITLE
(Release 1.4) Clear Variable Monitoring handler unit tests

### DIFF
--- a/03_Modules/Monitoring/jest.config.ts
+++ b/03_Modules/Monitoring/jest.config.ts
@@ -1,0 +1,11 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const jestConfig: JestConfigWithTsJest = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+.tsx?$': ['ts-jest', {}],
+  },
+  displayName: 'Monitoring Module',
+};
+
+export default jestConfig;

--- a/03_Modules/Monitoring/package.json
+++ b/03_Modules/Monitoring/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "prepublish": "npx eslint",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --config jest.config.ts"
   },
   "keywords": [
     "ocpp",

--- a/03_Modules/Monitoring/src/module/MonitoringService.ts
+++ b/03_Modules/Monitoring/src/module/MonitoringService.ts
@@ -1,0 +1,59 @@
+import { IVariableMonitoringRepository } from '@citrineos/data/dist/interfaces/repositories';
+import { ILogObj, Logger } from 'tslog';
+import {
+  CallAction,
+  ClearMonitoringResultType,
+  ClearMonitoringStatusEnumType,
+  StatusInfoType,
+} from '@citrineos/base';
+
+export class MonitoringService {
+  protected _variableMonitoringRepository: IVariableMonitoringRepository;
+  protected _logger: Logger<ILogObj>;
+
+  constructor(
+    variableMonitoringRepository: IVariableMonitoringRepository,
+    logger?: Logger<ILogObj>,
+  ) {
+    this._variableMonitoringRepository = variableMonitoringRepository;
+    this._logger = logger
+      ? logger.getSubLogger({ name: this.constructor.name })
+      : new Logger<ILogObj>({ name: this.constructor.name });
+  }
+
+  async processClearMonitoringResult(
+    stationId: string,
+    clearMonitoringResult: [
+      ClearMonitoringResultType,
+      ...ClearMonitoringResultType[],
+    ],
+  ): Promise<void> {
+    for (const clearMonitoringResultType of clearMonitoringResult) {
+      const resultStatus: ClearMonitoringStatusEnumType =
+        clearMonitoringResultType.status;
+      const monitorId: number = clearMonitoringResultType.id;
+
+      // Reject the variable monitoring if Charging Station accepts to clear or cannot find it.
+      if (
+        resultStatus === ClearMonitoringStatusEnumType.Accepted ||
+        resultStatus === ClearMonitoringStatusEnumType.NotFound
+      ) {
+        await this._variableMonitoringRepository.rejectVariableMonitoringByIdAndStationId(
+          CallAction.ClearVariableMonitoring,
+          monitorId,
+          stationId,
+        );
+      } else {
+        const statusInfo: StatusInfoType | undefined | null =
+          clearMonitoringResultType.statusInfo;
+        this._logger.error(
+          'Failed to clear variable monitoring.',
+          monitorId,
+          resultStatus,
+          statusInfo?.reasonCode,
+          statusInfo?.additionalInfo,
+        );
+      }
+    }
+  }
+}

--- a/03_Modules/Monitoring/src/module/module.ts
+++ b/03_Modules/Monitoring/src/module/module.ts
@@ -7,7 +7,6 @@ import {
   AbstractModule,
   AsHandler,
   CallAction,
-  ClearMonitoringStatusEnumType,
   ClearVariableMonitoringResponse,
   EventDataType,
   EventGroup,
@@ -34,7 +33,8 @@ import {
 import {
   IDeviceModelRepository,
   IVariableMonitoringRepository,
-  sequelize,
+  SequelizeDeviceModelRepository,
+  SequelizeVariableMonitoringRepository,
 } from '@citrineos/data';
 import {
   generateRequestId,
@@ -52,6 +52,7 @@ import { MonitoringService } from './MonitoringService';
  */
 export class MonitoringModule extends AbstractModule {
   public _deviceModelService: DeviceModelService;
+  protected _monitoringService: MonitoringService;
 
   protected _requests: CallAction[] = [CallAction.NotifyEvent];
   protected _responses: CallAction[] = [
@@ -67,8 +68,6 @@ export class MonitoringModule extends AbstractModule {
   protected _deviceModelRepository: IDeviceModelRepository;
   protected _variableMonitoringRepository: IVariableMonitoringRepository;
 
-  protected _monitoringService: MonitoringService;
-
   /**
    * This is the constructor function that initializes the {@link MonitoringModule}.
    *
@@ -83,14 +82,14 @@ export class MonitoringModule extends AbstractModule {
    * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
    *
    * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
+   * It is used to propagate system-wide logger settings and will serve as the parent logger for any subcomponent logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
    *
    * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize.DeviceModelRepository} instance is created and used.
+   * If no `deviceModelRepository` is provided, a default {@link SequelizeDeviceModelRepository} instance is created and used.
    *
    * @param {IVariableMonitoringRepository} [variableMonitoringRepository] - An optional parameter of type {@link IVariableMonitoringRepository}
    * which represents a repository for accessing and manipulating variable monitoring data.
-   * If no `variableMonitoringRepository` is provided, a default {@link sequelize:variableMonitoringRepository} }
+   * If no `variableMonitoringRepository` is provided, a default {@link SequelizeVariableMonitoringRepository}
    * instance is created and used.
    */
   constructor(
@@ -122,10 +121,10 @@ export class MonitoringModule extends AbstractModule {
 
     this._deviceModelRepository =
       deviceModelRepository ||
-      new sequelize.SequelizeDeviceModelRepository(config, this._logger);
+      new SequelizeDeviceModelRepository(config, this._logger);
     this._variableMonitoringRepository =
       variableMonitoringRepository ||
-      new sequelize.SequelizeVariableMonitoringRepository(config, this._logger);
+      new SequelizeVariableMonitoringRepository(config, this._logger);
 
     this._deviceModelService = new DeviceModelService(
       this._deviceModelRepository,

--- a/03_Modules/Monitoring/test/module/MonitoringService.test.ts
+++ b/03_Modules/Monitoring/test/module/MonitoringService.test.ts
@@ -1,4 +1,4 @@
-import { IVariableMonitoringRepository } from '@citrineos/data/dist/interfaces/repositories';
+import { IVariableMonitoringRepository } from '@citrineos/data';
 import { MonitoringService } from '../../src/module/MonitoringService';
 import {
   ClearMonitoringResultType,

--- a/03_Modules/Monitoring/test/module/MonitoringService.test.ts
+++ b/03_Modules/Monitoring/test/module/MonitoringService.test.ts
@@ -1,0 +1,15 @@
+import { IVariableMonitoringRepository } from '@citrineos/data/dist/interfaces/repositories';
+import { MonitoringService } from '../../src/module/MonitoringService';
+
+describe('MonitoringService', () => {
+  let mockVariableMonitoringRepository: jest.Mocked<IVariableMonitoringRepository>;
+  let monitoringService: MonitoringService;
+
+  beforeEach(() => {
+    mockVariableMonitoringRepository = {
+      rejectVariableMonitoringByIdAndStationId: jest.fn(),
+    } as unknown as jest.Mocked<IVariableMonitoringRepository>;
+
+    monitoringService = new MonitoringService(mockVariableMonitoringRepository);
+  });
+});

--- a/03_Modules/Monitoring/test/module/MonitoringService.test.ts
+++ b/03_Modules/Monitoring/test/module/MonitoringService.test.ts
@@ -1,5 +1,10 @@
 import { IVariableMonitoringRepository } from '@citrineos/data/dist/interfaces/repositories';
 import { MonitoringService } from '../../src/module/MonitoringService';
+import {
+  ClearMonitoringResultType,
+  ClearMonitoringStatusEnumType,
+} from '@citrineos/base';
+import { aClearMonitoringResult } from '../providers/Monitoring';
 
 describe('MonitoringService', () => {
   let mockVariableMonitoringRepository: jest.Mocked<IVariableMonitoringRepository>;
@@ -11,5 +16,48 @@ describe('MonitoringService', () => {
     } as unknown as jest.Mocked<IVariableMonitoringRepository>;
 
     monitoringService = new MonitoringService(mockVariableMonitoringRepository);
+  });
+
+  describe('processClearMonitoringResult', () => {
+    it('should reject variable monitoring because clear monitoring result status is either Accepted or NotFound', async () => {
+      const monitoringResults: [
+        ClearMonitoringResultType,
+        ...ClearMonitoringResultType[],
+      ] = [
+        aClearMonitoringResult(),
+        aClearMonitoringResult(
+          (cmr) => (cmr.status = ClearMonitoringStatusEnumType.NotFound),
+        ),
+      ];
+
+      await monitoringService.processClearMonitoringResult(
+        'stationId',
+        monitoringResults,
+      );
+
+      expect(
+        mockVariableMonitoringRepository.rejectVariableMonitoringByIdAndStationId,
+      ).toHaveBeenCalledTimes(monitoringResults.length);
+    });
+
+    it('should not reject variable monitoring because  clear monitoring result status is Rejected (so neither Accepted nor NotFound)', async () => {
+      const monitoringResults: [
+        ClearMonitoringResultType,
+        ...ClearMonitoringResultType[],
+      ] = [
+        aClearMonitoringResult(
+          (cmr) => (cmr.status = ClearMonitoringStatusEnumType.Rejected),
+        ),
+      ];
+
+      await monitoringService.processClearMonitoringResult(
+        'stationId',
+        monitoringResults,
+      );
+
+      expect(
+        mockVariableMonitoringRepository.rejectVariableMonitoringByIdAndStationId,
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/03_Modules/Monitoring/test/providers/Monitoring.ts
+++ b/03_Modules/Monitoring/test/providers/Monitoring.ts
@@ -1,0 +1,16 @@
+import {
+  ClearMonitoringResultType,
+  ClearMonitoringStatusEnumType,
+} from '@citrineos/base';
+import { applyUpdateFunction, UpdateFunction } from '../utils/UpdateUtil';
+
+export const aClearMonitoringResult = (
+  updateFunction?: UpdateFunction<ClearMonitoringResultType>,
+): ClearMonitoringResultType => {
+  const clear = {
+    status: ClearMonitoringStatusEnumType.Accepted,
+    id: Math.floor(Math.random() * 1000),
+  };
+
+  return applyUpdateFunction(clear, updateFunction);
+};

--- a/03_Modules/Monitoring/test/utils/UpdateUtil.ts
+++ b/03_Modules/Monitoring/test/utils/UpdateUtil.ts
@@ -1,0 +1,11 @@
+export type UpdateFunction<T> = (item: T) => void;
+
+export const applyUpdateFunction = <T>(
+  item: T,
+  updateFunction?: UpdateFunction<T>,
+): T => {
+  if (updateFunction) {
+    updateFunction(item);
+  }
+  return item;
+};


### PR DESCRIPTION
This PR adds unit tests for the `ClearVariableMonitoring` handler in Monitoring module by moving out the functionality into a dedicated `MonitoringService`. The intention is to setup this service for PRs down the line that can expand upon the tests and add more of the Monitoring module's handler's functionality into the service.

Note: We're at the point where we're repeating enough test-related utils (i.e. `UpdateUtils`) that we'd want to refactor and pull it out into the a folder like `02_Util` to be reused for all the modules, but that will be a separate PR 😄 

Additionally, the repository imports were updated in the module itself since we now export the repositories individually rather than under the `sequelize` export.