### PR TITLE
(Release 1.4.X) Bugfix: Fix Boot's lastBootTime "toISOString"

### DIFF
--- a/01_Data/src/layers/sequelize/model/Boot.ts
+++ b/01_Data/src/layers/sequelize/model/Boot.ts
@@ -21,7 +21,8 @@ export class Boot extends Model implements BootConfig {
   @Column({
     type: DataType.DATE,
     get() {
-      return this.getDataValue('lastBootTime').toISOString();
+      const lastBootTimeValue = this.getDataValue('lastBootTime');
+      return lastBootTimeValue ? lastBootTimeValue.toISOString() : null;
     },
   })
   declare lastBootTime?: string;


### PR DESCRIPTION
**NOTE:** Please retarget to the next 1.4-related rc branch when available!

This PR fixes the issue described https://github.com/citrineos/citrineos/issues/37 where attempting to `PUT /data/configuration/boot` causes a `Cannot read properties of undefined (reading 'toISOString')` exception.

Since `lastBootTime` is a nullable field, if it was null or undefined, the `toISOString` call in the getter to fail. With this fix, we'll only call `toISOString` is the value exists - otherwise, we'll return null.

Additionally, I noticed that the PUT behavior for a boot wasn't working 100%, so I updated the `createOrUpdateByKey` method to match with our other more recent implementations of this behavior for consistency.