### PR TITLE
Feature/null for arrays json schemas

### DIFF
--- a/00_Base/json-schema-processor.js
+++ b/00_Base/json-schema-processor.js
@@ -185,8 +185,7 @@ async function processJsonSchema(data, writeToFile = true) {
 
         // Add null type to all optional properties
         // This regex means a string starts with '?:' and ends with ';'
-        // and contains no '[' or ']' in between
-        const regex = /(\?:[^;\[\]]*);/g;
+        const regex = /(\?:[^;]*);/g;
         ts = ts.replaceAll(regex, '$1 | null;');
 
         if (writeToFile) {

--- a/00_Base/src/ocpp/model/types/AuthorizeRequest.ts
+++ b/00_Base/src/ocpp/model/types/AuthorizeRequest.ts
@@ -34,7 +34,8 @@ export interface AuthorizeRequest extends OcppRequest {
         OCSPRequestDataType,
         OCSPRequestDataType,
         OCSPRequestDataType,
-      ];
+      ]
+    | null;
 }
 /**
  * This class does not get 'AdditionalProperties = false' in the schema generation, so it can be extended with arbitrary JSON properties to allow adding custom data.
@@ -52,7 +53,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *

--- a/00_Base/src/ocpp/model/types/AuthorizeResponse.ts
+++ b/00_Base/src/ocpp/model/types/AuthorizeResponse.ts
@@ -67,7 +67,7 @@ export interface IdTokenInfoType {
    *
    * @minItems 1
    */
-  evseId?: [number, ...number[]];
+  evseId?: [number, ...number[]] | null;
   groupIdToken?: IdTokenType | null;
   /**
    * ID_ Token. Language2. Language_ Code
@@ -87,7 +87,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *

--- a/00_Base/src/ocpp/model/types/CustomerInformationRequest.ts
+++ b/00_Base/src/ocpp/model/types/CustomerInformationRequest.ts
@@ -76,7 +76,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *

--- a/00_Base/src/ocpp/model/types/DataTransferRequest.ts
+++ b/00_Base/src/ocpp/model/types/DataTransferRequest.ts
@@ -24,7 +24,7 @@ export interface DataTransferRequest extends OcppRequest {
    *
    */
   data?: {
-    [k: string]: unknown;
+    [k: string]: unknown | null;
   };
   /**
    * This identifies the Vendor specific implementation

--- a/00_Base/src/ocpp/model/types/DataTransferResponse.ts
+++ b/00_Base/src/ocpp/model/types/DataTransferResponse.ts
@@ -22,7 +22,7 @@ export interface DataTransferResponse extends OcppResponse {
    *
    */
   data?: {
-    [k: string]: unknown;
+    [k: string]: unknown | null;
   };
 }
 /**

--- a/00_Base/src/ocpp/model/types/GetChargingProfilesRequest.ts
+++ b/00_Base/src/ocpp/model/types/GetChargingProfilesRequest.ts
@@ -60,7 +60,7 @@ export interface ChargingProfileCriterionType {
    *
    * @minItems 1
    */
-  chargingProfileId?: [number, ...number[]];
+  chargingProfileId?: [number, ...number[]] | null;
   /**
    * For which charging limit sources, charging profiles SHALL be reported. If omitted, the Charging Station SHALL not filter on chargingLimitSource.
    *
@@ -81,5 +81,6 @@ export interface ChargingProfileCriterionType {
         ChargingLimitSourceEnumType,
         ChargingLimitSourceEnumType,
         ChargingLimitSourceEnumType,
-      ];
+      ]
+    | null;
 }

--- a/00_Base/src/ocpp/model/types/GetDisplayMessagesRequest.ts
+++ b/00_Base/src/ocpp/model/types/GetDisplayMessagesRequest.ts
@@ -22,7 +22,7 @@ export interface GetDisplayMessagesRequest extends OcppRequest {
    *
    * @minItems 1
    */
-  id?: [number, ...number[]];
+  id?: [number, ...number[]] | null;
   /**
    * The Id of this request.
    *

--- a/00_Base/src/ocpp/model/types/GetInstalledCertificateIdsRequest.ts
+++ b/00_Base/src/ocpp/model/types/GetInstalledCertificateIdsRequest.ts
@@ -21,10 +21,9 @@ export interface GetInstalledCertificateIdsRequest extends OcppRequest {
    *
    * @minItems 1
    */
-  certificateType?: [
-    GetCertificateIdUseEnumType,
-    ...GetCertificateIdUseEnumType[],
-  ];
+  certificateType?:
+    | [GetCertificateIdUseEnumType, ...GetCertificateIdUseEnumType[]]
+    | null;
 }
 /**
  * This class does not get 'AdditionalProperties = false' in the schema generation, so it can be extended with arbitrary JSON properties to allow adding custom data.

--- a/00_Base/src/ocpp/model/types/GetInstalledCertificateIdsResponse.ts
+++ b/00_Base/src/ocpp/model/types/GetInstalledCertificateIdsResponse.ts
@@ -24,10 +24,9 @@ export interface GetInstalledCertificateIdsResponse extends OcppResponse {
   /**
    * @minItems 1
    */
-  certificateHashDataChain?: [
-    CertificateHashDataChainType,
-    ...CertificateHashDataChainType[],
-  ];
+  certificateHashDataChain?:
+    | [CertificateHashDataChainType, ...CertificateHashDataChainType[]]
+    | null;
 }
 /**
  * This class does not get 'AdditionalProperties = false' in the schema generation, so it can be extended with arbitrary JSON properties to allow adding custom data.
@@ -74,7 +73,8 @@ export interface CertificateHashDataChainType {
         CertificateHashDataType,
         CertificateHashDataType,
         CertificateHashDataType,
-      ];
+      ]
+    | null;
 }
 export interface CertificateHashDataType {
   customData?: CustomDataType | null;

--- a/00_Base/src/ocpp/model/types/GetMonitoringReportRequest.ts
+++ b/00_Base/src/ocpp/model/types/GetMonitoringReportRequest.ts
@@ -18,7 +18,9 @@ export interface GetMonitoringReportRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  componentVariable?: [ComponentVariableType, ...ComponentVariableType[]];
+  componentVariable?:
+    | [ComponentVariableType, ...ComponentVariableType[]]
+    | null;
   /**
    * The Id of the request.
    *
@@ -38,7 +40,8 @@ export interface GetMonitoringReportRequest extends OcppRequest {
         MonitoringCriterionEnumType,
         MonitoringCriterionEnumType,
         MonitoringCriterionEnumType,
-      ];
+      ]
+    | null;
 }
 /**
  * This class does not get 'AdditionalProperties = false' in the schema generation, so it can be extended with arbitrary JSON properties to allow adding custom data.

--- a/00_Base/src/ocpp/model/types/GetReportRequest.ts
+++ b/00_Base/src/ocpp/model/types/GetReportRequest.ts
@@ -18,7 +18,9 @@ export interface GetReportRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  componentVariable?: [ComponentVariableType, ...ComponentVariableType[]];
+  componentVariable?:
+    | [ComponentVariableType, ...ComponentVariableType[]]
+    | null;
   /**
    * The Id of the request.
    *
@@ -44,7 +46,8 @@ export interface GetReportRequest extends OcppRequest {
         ComponentCriterionEnumType,
         ComponentCriterionEnumType,
         ComponentCriterionEnumType,
-      ];
+      ]
+    | null;
 }
 /**
  * This class does not get 'AdditionalProperties = false' in the schema generation, so it can be extended with arbitrary JSON properties to allow adding custom data.

--- a/00_Base/src/ocpp/model/types/NotifyChargingLimitRequest.ts
+++ b/00_Base/src/ocpp/model/types/NotifyChargingLimitRequest.ts
@@ -22,7 +22,7 @@ export interface NotifyChargingLimitRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  chargingSchedule?: [ChargingScheduleType, ...ChargingScheduleType[]];
+  chargingSchedule?: [ChargingScheduleType, ...ChargingScheduleType[]] | null;
   /**
    * The charging schedule contained in this notification applies to an EVSE. evseId must be &gt; 0.
    *
@@ -175,7 +175,8 @@ export interface SalesTariffEntryType {
   consumptionCost?:
     | [ConsumptionCostType]
     | [ConsumptionCostType, ConsumptionCostType]
-    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType];
+    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType]
+    | null;
 }
 /**
  * Relative_ Timer_ Interval

--- a/00_Base/src/ocpp/model/types/NotifyDisplayMessagesRequest.ts
+++ b/00_Base/src/ocpp/model/types/NotifyDisplayMessagesRequest.ts
@@ -22,7 +22,7 @@ export interface NotifyDisplayMessagesRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  messageInfo?: [MessageInfoType, ...MessageInfoType[]];
+  messageInfo?: [MessageInfoType, ...MessageInfoType[]] | null;
   /**
    * The id of the &lt;&lt;getdisplaymessagesrequest,GetDisplayMessagesRequest&gt;&gt; that requested this message.
    *

--- a/00_Base/src/ocpp/model/types/NotifyEVChargingScheduleRequest.ts
+++ b/00_Base/src/ocpp/model/types/NotifyEVChargingScheduleRequest.ts
@@ -172,7 +172,8 @@ export interface SalesTariffEntryType {
   consumptionCost?:
     | [ConsumptionCostType]
     | [ConsumptionCostType, ConsumptionCostType]
-    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType];
+    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType]
+    | null;
 }
 /**
  * Relative_ Timer_ Interval

--- a/00_Base/src/ocpp/model/types/NotifyMonitoringReportRequest.ts
+++ b/00_Base/src/ocpp/model/types/NotifyMonitoringReportRequest.ts
@@ -18,7 +18,7 @@ export interface NotifyMonitoringReportRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  monitor?: [MonitoringDataType, ...MonitoringDataType[]];
+  monitor?: [MonitoringDataType, ...MonitoringDataType[]] | null;
   /**
    * The id of the GetMonitoringRequest that requested this report.
    *

--- a/00_Base/src/ocpp/model/types/NotifyReportRequest.ts
+++ b/00_Base/src/ocpp/model/types/NotifyReportRequest.ts
@@ -28,7 +28,7 @@ export interface NotifyReportRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  reportData?: [ReportDataType, ...ReportDataType[]];
+  reportData?: [ReportDataType, ...ReportDataType[]] | null;
   /**
    * “to be continued” indicator. Indicates whether another part of the report follows in an upcoming notifyReportRequest message. Default value when omitted is false.
    *

--- a/00_Base/src/ocpp/model/types/PublishFirmwareStatusNotificationRequest.ts
+++ b/00_Base/src/ocpp/model/types/PublishFirmwareStatusNotificationRequest.ts
@@ -22,7 +22,7 @@ export interface PublishFirmwareStatusNotificationRequest extends OcppRequest {
    *
    * @minItems 1
    */
-  location?: [string, ...string[]];
+  location?: [string, ...string[]] | null;
   /**
    * The request id that was
    * provided in the

--- a/00_Base/src/ocpp/model/types/ReportChargingProfilesRequest.ts
+++ b/00_Base/src/ocpp/model/types/ReportChargingProfilesRequest.ts
@@ -241,7 +241,8 @@ export interface SalesTariffEntryType {
   consumptionCost?:
     | [ConsumptionCostType]
     | [ConsumptionCostType, ConsumptionCostType]
-    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType];
+    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType]
+    | null;
 }
 /**
  * Relative_ Timer_ Interval

--- a/00_Base/src/ocpp/model/types/RequestStartTransactionRequest.ts
+++ b/00_Base/src/ocpp/model/types/RequestStartTransactionRequest.ts
@@ -52,7 +52,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *
@@ -268,7 +268,8 @@ export interface SalesTariffEntryType {
   consumptionCost?:
     | [ConsumptionCostType]
     | [ConsumptionCostType, ConsumptionCostType]
-    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType];
+    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType]
+    | null;
 }
 /**
  * Relative_ Timer_ Interval

--- a/00_Base/src/ocpp/model/types/ReserveNowRequest.ts
+++ b/00_Base/src/ocpp/model/types/ReserveNowRequest.ts
@@ -50,7 +50,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *

--- a/00_Base/src/ocpp/model/types/SendLocalListRequest.ts
+++ b/00_Base/src/ocpp/model/types/SendLocalListRequest.ts
@@ -23,7 +23,7 @@ export interface SendLocalListRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  localAuthorizationList?: [AuthorizationData, ...AuthorizationData[]];
+  localAuthorizationList?: [AuthorizationData, ...AuthorizationData[]] | null;
   /**
    * In case of a full update this is the version number of the full list. In case of a differential update it is the version number of the list after the update has been applied.
    *
@@ -56,7 +56,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *
@@ -118,7 +118,7 @@ export interface IdTokenInfoType {
    *
    * @minItems 1
    */
-  evseId?: [number, ...number[]];
+  evseId?: [number, ...number[]] | null;
   groupIdToken?: IdTokenType | null;
   /**
    * ID_ Token. Language2. Language_ Code

--- a/00_Base/src/ocpp/model/types/SetChargingProfileRequest.ts
+++ b/00_Base/src/ocpp/model/types/SetChargingProfileRequest.ts
@@ -226,7 +226,8 @@ export interface SalesTariffEntryType {
   consumptionCost?:
     | [ConsumptionCostType]
     | [ConsumptionCostType, ConsumptionCostType]
-    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType];
+    | [ConsumptionCostType, ConsumptionCostType, ConsumptionCostType]
+    | null;
 }
 /**
  * Relative_ Timer_ Interval

--- a/00_Base/src/ocpp/model/types/TransactionEventRequest.ts
+++ b/00_Base/src/ocpp/model/types/TransactionEventRequest.ts
@@ -29,7 +29,7 @@ export interface TransactionEventRequest extends OcppRequest {
   /**
    * @minItems 1
    */
-  meterValue?: [MeterValueType, ...MeterValueType[]];
+  meterValue?: [MeterValueType, ...MeterValueType[]] | null;
   /**
    * The date and time at which this transaction event occurred.
    *
@@ -220,7 +220,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *

--- a/00_Base/src/ocpp/model/types/TransactionEventResponse.ts
+++ b/00_Base/src/ocpp/model/types/TransactionEventResponse.ts
@@ -77,7 +77,7 @@ export interface IdTokenInfoType {
    *
    * @minItems 1
    */
-  evseId?: [number, ...number[]];
+  evseId?: [number, ...number[]] | null;
   groupIdToken?: IdTokenType | null;
   /**
    * ID_ Token. Language2. Language_ Code
@@ -97,7 +97,7 @@ export interface IdTokenType {
   /**
    * @minItems 1
    */
-  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]];
+  additionalInfo?: [AdditionalInfoType, ...AdditionalInfoType[]] | null;
   /**
    * IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.
    *


### PR DESCRIPTION
Null should be allowed for optional array fields on Ocpp types created by json-schema-processor.