### PR TITLE
chore: update base branch for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,6 @@
   "prHourlyLimit": 2,
   "dependencyDashboard": true,
   "branchPrefix": "renovate/",
+  "baseBranches": ["rc-*"],
   "commitMessagePrefix": "📦 chore(deps): "
 }


### PR DESCRIPTION
chore: update base branch for renovate to point to current release candidate to have dependency updates go there instead of main. **This relies on only one `rc` branch being active**