### PR TITLE
updating in order to work with operator ui

### DIFF
--- a/00_Base/src/index.ts
+++ b/00_Base/src/index.ts
@@ -44,6 +44,9 @@ export {
   MessageTypeId,
   OcppError,
 } from './ocpp/rpc/message';
+export {
+  ChargingStationSequenceType,
+} from './ocpp/model/enums/requestIds';
 export { IFileAccess } from './interfaces/fileAccess';
 
 // Persistence Interfaces

--- a/00_Base/src/ocpp/model/enums/requestIds.ts
+++ b/00_Base/src/ocpp/model/enums/requestIds.ts
@@ -1,0 +1,12 @@
+export enum ChargingStationSequenceType {
+    customerInformation = 'customerInformation',
+    getBaseReport = 'getBaseReport',
+    getChargingProfiles = 'getChargingProfiles',
+    getDisplayMessages = 'getDisplayMessages',
+    getLog = 'getLog',
+    getMonitoringReport = 'getMonitoringReport',
+    getReport = 'getReport',
+    publishFirmware = 'publishFirmware',
+    remoteStartId = 'remoteStartId',
+    updateFirmware = 'updateFirmware',
+}

--- a/01_Data/src/index.ts
+++ b/01_Data/src/index.ts
@@ -17,7 +17,6 @@ export {
   ChargingSchedule,
   ChargingStation,
   ChargingStationSequence,
-  ChargingStationSequenceType,
   Component,
   DefaultSequelizeInstance,
   Location,

--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -37,9 +37,10 @@ import {
   ReserveNowRequest,
   MeterValueType,
   UpdateEnumType,
+  ChargingStationSequenceType,
 } from '@citrineos/base';
 import { type AuthorizationQuerystring } from './queries/Authorization';
-import { CallMessage, ChargingStationSecurityInfo, ChargingStationSequence, ChargingStationSequenceType, CompositeSchedule, MeterValue, type Transaction, VariableCharacteristics } from '../layers/sequelize';
+import { CallMessage, ChargingStationSecurityInfo, ChargingStationSequence, CompositeSchedule, MeterValue, type Transaction, VariableCharacteristics } from '../layers/sequelize';
 import { type VariableAttribute } from '../layers/sequelize';
 import { type AuthorizationRestrictions, type VariableAttributeQuerystring } from '.';
 import { type Authorization, type Boot, type Certificate, ChargingNeeds, type ChargingStation, type Component, type EventData, Evse, type Location, type SecurityEvent, type Variable, type VariableMonitoring } from '../layers/sequelize';

--- a/01_Data/src/layers/sequelize/index.ts
+++ b/01_Data/src/layers/sequelize/index.ts
@@ -10,7 +10,7 @@ export { Transaction, TransactionEvent, MeterValue } from './model/TransactionEv
 export { SecurityEvent } from './model/SecurityEvent';
 export { VariableMonitoring, EventData, VariableMonitoringStatus } from './model/VariableMonitoring';
 export { ChargingStation, Location, StatusNotification } from './model/Location';
-export { ChargingStationSequence, ChargingStationSequenceType } from './model/ChargingStationSequence';
+export { ChargingStationSequence } from './model/ChargingStationSequence';
 export { MessageInfo } from './model/MessageInfo';
 export { Tariff } from './model/Tariff';
 export { Subscription } from './model/Subscription';

--- a/01_Data/src/layers/sequelize/model/ChargingStationSequence/ChargingStationSequence.ts
+++ b/01_Data/src/layers/sequelize/model/ChargingStationSequence/ChargingStationSequence.ts
@@ -1,26 +1,23 @@
-import { BelongsTo, Column, DataType, ForeignKey, Model, PrimaryKey, Table } from 'sequelize-typescript';
+import { BelongsTo, Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
 import { ChargingStation } from '../Location';
+import { ChargingStationSequenceType } from '@citrineos/base';
 
-export type ChargingStationSequenceType = 'remoteStartId' | 'getDisplayMessages' | 'getChargingProfiles' | 'getMonitoringReport';
-
-@Table({
-  timestamps: false,
-})
+@Table
 export class ChargingStationSequence extends Model {
   static readonly MODEL_NAME: string = 'ChargingStationSequence';
 
-  @PrimaryKey
   @ForeignKey(() => ChargingStation)
   @Column({
     type: DataType.STRING(36),
     allowNull: false,
+    unique: 'stationId_type',
   })
   declare stationId: string;
 
-  @PrimaryKey
   @Column({
     type: DataType.STRING,
     allowNull: false,
+    unique: 'stationId_type',
   })
   type!: ChargingStationSequenceType;
 

--- a/01_Data/src/layers/sequelize/model/ChargingStationSequence/index.ts
+++ b/01_Data/src/layers/sequelize/model/ChargingStationSequence/index.ts
@@ -1,1 +1,1 @@
-export { ChargingStationSequence, ChargingStationSequenceType } from './ChargingStationSequence';
+export { ChargingStationSequence } from './ChargingStationSequence';

--- a/01_Data/src/layers/sequelize/repository/ChargingStationSequence.ts
+++ b/01_Data/src/layers/sequelize/repository/ChargingStationSequence.ts
@@ -1,7 +1,7 @@
 import { SequelizeRepository } from './Base';
 import { IChargingStationSequenceRepository } from '../../../interfaces';
-import { ChargingStationSequence, ChargingStationSequenceType } from '../model/ChargingStationSequence';
-import { SystemConfig } from '@citrineos/base';
+import { ChargingStationSequence } from '../model/ChargingStationSequence';
+import { ChargingStationSequenceType, SystemConfig } from '@citrineos/base';
 import { ILogObj, Logger } from 'tslog';
 import { Sequelize } from 'sequelize-typescript';
 

--- a/02_Util/src/util/idGenerator.ts
+++ b/02_Util/src/util/idGenerator.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 import { IChargingStationSequenceRepository } from '@citrineos/data';
-import { ChargingStationSequenceType } from '@citrineos/data';
+import { ChargingStationSequenceType } from '@citrineos/base';
 
 export class IdGenerator {
   private _stationSequenceRepository: IChargingStationSequenceRepository;

--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -11,6 +11,7 @@ import {
   BootNotificationResponse,
   CallAction,
   ChangeAvailabilityResponse,
+  ChargingStationSequenceType,
   ClearDisplayMessageResponse,
   ClearMessageStatusEnumType,
   DataTransferRequest,
@@ -563,7 +564,7 @@ export class ConfigurationModule extends AbstractModule {
         CallAction.GetDisplayMessages,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, 'getDisplayMessages',
+            message.context.stationId, ChargingStationSequenceType.getDisplayMessages,
           ),
         } as GetDisplayMessagesRequest,
       );
@@ -634,7 +635,7 @@ export class ConfigurationModule extends AbstractModule {
         CallAction.GetDisplayMessages,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, 'getDisplayMessages',
+            message.context.stationId, ChargingStationSequenceType.getDisplayMessages,
           ),
         } as GetDisplayMessagesRequest,
       );

--- a/03_Modules/EVDriver/src/module/module.ts
+++ b/03_Modules/EVDriver/src/module/module.ts
@@ -18,6 +18,7 @@ import {
   ChargingLimitSourceEnumType,
   ChargingProfileCriterionType,
   ChargingProfilePurposeEnumType,
+  ChargingStationSequenceType,
   ClearCacheResponse,
   EventGroup,
   GetChargingProfilesRequest,
@@ -639,7 +640,7 @@ export class EVDriverModule extends AbstractModule {
         CallAction.GetChargingProfiles,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, 'getChargingProfiles',
+            message.context.stationId, ChargingStationSequenceType.getChargingProfiles,
           ),
           chargingProfile: {
             chargingProfilePurpose: ChargingProfilePurposeEnumType.TxProfile,

--- a/03_Modules/Monitoring/src/module/module.ts
+++ b/03_Modules/Monitoring/src/module/module.ts
@@ -7,6 +7,7 @@ import {
   AbstractModule,
   AsHandler,
   CallAction,
+  ChargingStationSequenceType,
   ClearVariableMonitoringResponse,
   EventDataType,
   EventGroup,
@@ -335,7 +336,7 @@ export class MonitoringModule extends AbstractModule {
         message.context.tenantId,
         CallAction.GetMonitoringReport,
         {
-          requestId: await this._idGenerator.generateRequestId(message.context.stationId, 'getMonitoringReport'),
+          requestId: await this._idGenerator.generateRequestId(message.context.stationId, ChargingStationSequenceType.getMonitoringReport),
         } as GetMonitoringReportRequest,
       );
     }

--- a/03_Modules/SmartCharging/src/module/module.ts
+++ b/03_Modules/SmartCharging/src/module/module.ts
@@ -14,6 +14,7 @@ import {
   ChargingProfilePurposeEnumType,
   ChargingProfileStatusEnumType,
   ChargingProfileType,
+  ChargingStationSequenceType,
   ClearChargingProfileResponse,
   ClearChargingProfileStatusEnumType,
   ClearedChargingLimitResponse,
@@ -438,7 +439,7 @@ export class SmartChargingModule extends AbstractModule {
         CallAction.GetChargingProfiles,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, 'getChargingProfiles',
+            message.context.stationId, ChargingStationSequenceType.getChargingProfiles,
           ),
           chargingProfile: {
             chargingLimitSource: [
@@ -503,7 +504,7 @@ export class SmartChargingModule extends AbstractModule {
         CallAction.GetChargingProfiles,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, 'getChargingProfiles',
+            message.context.stationId, ChargingStationSequenceType.getChargingProfiles,
           ),
           chargingProfile: {
             chargingLimitSource: [ChargingLimitSourceEnumType.CSO],


### PR DESCRIPTION
Fixes & updates relating to: https://github.com/citrineos/citrineos-operator-ui/pull/20

- ChargingStationSequenceType converted to enum, moved def to base
- timestamps added to ChargingStationSequences
- ChargingStationSequences stationId and type no longer compound primary key; default 'id' model field used, compound unique index created on stationId and type