### PR TITLE
Fix: generate directus flows

### DIFF
--- a/00_Base/src/interfaces/api/AbstractModuleApi.ts
+++ b/00_Base/src/interfaces/api/AbstractModuleApi.ts
@@ -13,14 +13,12 @@ import {
   METADATA_DATA_ENDPOINTS,
   METADATA_MESSAGE_ENDPOINTS,
 } from '.';
-import { OcppRequest, SystemConfig } from '../..';
+import { MessageConfirmationSchema, OcppRequest, SystemConfig } from '../..';
 import { Namespace } from '../../ocpp/persistence';
 import { CallAction } from '../../ocpp/rpc/message';
 import { IMessageConfirmation } from '../messages';
 import { IModule } from '../modules';
-import {
-  IMessageQuerystringSchema,
-} from './MessageQuerystring';
+import { IMessageQuerystringSchema } from './MessageQuerystring';
 import { IModuleApi } from './ModuleApi';
 import { AuthorizationSecurity } from './AuthorizationSecurity';
 
@@ -28,7 +26,8 @@ import { AuthorizationSecurity } from './AuthorizationSecurity';
  * Abstract module api class implementation.
  */
 export abstract class AbstractModuleApi<T extends IModule>
-  implements IModuleApi {
+  implements IModuleApi
+{
   protected readonly _server: FastifyInstance;
   protected readonly _module: T;
   protected readonly _logger: Logger<ILogObj>;
@@ -117,7 +116,7 @@ export abstract class AbstractModuleApi<T extends IModule>
     action: CallAction,
     method: (...args: any[]) => any,
     bodySchema: object,
-    optionalQuerystrings?: Record<string, any>
+    optionalQuerystrings?: Record<string, any>,
   ): void {
     this._logger.debug(
       `Adding message route for ${action}`,
@@ -136,7 +135,8 @@ export abstract class AbstractModuleApi<T extends IModule>
         Querystring: Record<string, any>;
       }>,
     ): Promise<IMessageConfirmation> => {
-      const { identifier, tenantId, callbackUrl, ...extraQueries } = request.query;
+      const { identifier, tenantId, callbackUrl, ...extraQueries } =
+        request.query;
       return method.call(
         this,
         identifier,
@@ -145,7 +145,7 @@ export abstract class AbstractModuleApi<T extends IModule>
         callbackUrl,
         Object.keys(extraQueries).length > 0 ? extraQueries : undefined,
       );
-    }
+    };
 
     const mergedQuerySchema = {
       ...IMessageQuerystringSchema,
@@ -155,20 +155,26 @@ export abstract class AbstractModuleApi<T extends IModule>
       },
     };
 
-    const _opts = {
+    const _opts: any = {
+      method: HttpMethod.Post,
+      url: this._toMessagePath(action),
+      handler: _handler,
       schema: {
         body: bodySchema,
         querystring: mergedQuerySchema,
+        response: {
+          200: MessageConfirmationSchema,
+        },
       } as const,
     };
 
     if (this._module.config.util.swagger?.exposeMessage) {
       this._server.register(async (fastifyInstance) => {
         this.registerSchemaForOpts(fastifyInstance, _opts);
-        fastifyInstance.post(this._toMessagePath(action), _opts, _handler);
+        fastifyInstance.route(_opts);
       });
     } else {
-      this._server.post(this._toMessagePath(action), _opts, _handler);
+      this._server.route(_opts);
     }
   }
 
@@ -326,19 +332,24 @@ export abstract class AbstractModuleApi<T extends IModule>
     fastifyInstance: FastifyInstance,
     schema: any,
   ): object | null => {
+    const id = schema['$id'];
+    if (!id) {
+      this._logger.error('Could not register schema because no ID', schema);
+    }
     try {
-      const id = schema['$id'];
-      if (!id) {
-        this._logger.error('Could not register schema because no ID', schema);
-      }
       const schemaCopy = this.removeUnknownKeys(schema);
       fastifyInstance.addSchema(schemaCopy);
+      this._server.addSchema(schemaCopy);
       return {
         $ref: `${id}`,
       };
     } catch (e: any) {
       // ignore already declared
-      if (e.code !== 'FST_ERR_SCH_ALREADY_PRESENT') {
+      if (e.code === 'FST_ERR_SCH_ALREADY_PRESENT') {
+        return {
+          $ref: `${id}`,
+        };
+      } else {
         this._logger.error('Could not register schema', e, schema);
       }
       return null;

--- a/00_Base/src/interfaces/api/AsDataEndpoint.ts
+++ b/00_Base/src/interfaces/api/AsDataEndpoint.ts
@@ -43,6 +43,10 @@ export const AsDataEndpoint = function (
       METADATA_DATA_ENDPOINTS,
       target.constructor,
     ) as Array<IDataEndpointDefinition>;
+    let tagList: string[] | undefined = undefined;
+    if (tags) {
+      tagList = Array.isArray(tags) ? tags : [tags];
+    }
     dataEndpoints.push({
       method: descriptor.value,
       methodName: propertyKey,
@@ -53,7 +57,7 @@ export const AsDataEndpoint = function (
       paramSchema: paramSchema,
       headerSchema: headerSchema,
       responseSchema: responseSchema,
-      tags: (Array.isArray(tags) ? tags : [tags]) as string[],
+      tags: tagList,
       description: description,
       security: security,
     });

--- a/00_Base/src/ocpp/persistence/index.ts
+++ b/00_Base/src/ocpp/persistence/index.ts
@@ -15,7 +15,7 @@ export { default as UpdateChargingStationPasswordSchema } from './schemas/Update
  * Utility function for creating querystring schemas for fastify route definitions
  * @param properties An array of key-type pairs. Types ending in '[]' will be treated as arrays of that type.
  * @param required An array of required keys.
- * @returns 
+ * @returns
  */
 export function QuerySchema(
   name: string,
@@ -48,3 +48,12 @@ export function QuerySchema(
   }
   return schema;
 }
+
+export const MessageConfirmationSchema = QuerySchema(
+  'MessageConfirmationSchema',
+  [
+    ['success', 'boolean'],
+    ['payload', 'string'],
+  ],
+  ['success'],
+);

--- a/01_Data/src/interfaces/queries/TlsCertificate.ts
+++ b/01_Data/src/interfaces/queries/TlsCertificate.ts
@@ -7,7 +7,7 @@ import { QuerySchema } from '@citrineos/base';
 export const TlsCertificateSchema = QuerySchema(
   'TlsCertificateSchema',
   [
-    ['certificateChain', 'array'],
+    ['certificateChain', 'string[]'],
     ['privateKey', 'string'],
     ['rootCA', 'string'],
     ['subCAKey', 'string'],

--- a/02_Util/src/util/directus.ts
+++ b/02_Util/src/util/directus.ts
@@ -11,13 +11,13 @@ import {
   createOperation,
   DirectusFlow,
   DirectusOperation,
+  readAssetArrayBuffer,
   readFlows,
   rest,
   RestClient,
   staticToken,
   updateFlow,
   updateOperation,
-  readAssetArrayBuffer,
   uploadFiles,
 } from '@directus/sdk';
 import { RouteOptions } from 'fastify';
@@ -74,6 +74,7 @@ export class DirectusUtil implements IFileAccess {
 
   public addDirectusMessageApiFlowsFastifyRouteHook(
     routeOptions: RouteOptions,
+    schemas: Record<string, unknown>,
   ) {
     const messagePath = routeOptions.url; // 'Url' here means the route specified when the endpoint was added to the fastify server, such as '/ocpp/configuration/reset'
     if (messagePath.split('/')[1] === 'ocpp') {
@@ -85,8 +86,14 @@ export class DirectusUtil implements IFileAccess {
         lowercaseAction.charAt(0).toUpperCase() + lowercaseAction.slice(1);
       // _addMessageRoute in AbstractModuleApi adds the bodySchema specified in the @MessageEndpoint decorator to the fastify route schema
       // These body schemas are the ones generated directly from the specification using the json-schema-processor in 00_Base
-      const bodySchema = routeOptions.schema?.body as object;
-      this.addDirectusFlowForAction(action, messagePath, bodySchema);
+      const bodySchema: any = routeOptions.schema?.body;
+      if (bodySchema && bodySchema.$ref && schemas[bodySchema.$ref]) {
+        this.addDirectusFlowForAction(
+          action,
+          messagePath,
+          schemas[bodySchema.$ref] as object,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
- fix: generate directus flows failing because full route object schemas were no longer available after registering schemas and using $refs
- fix: adjusting to register schemas globally so that they can be available when generating directus flows
- feat: added MessageConfirmationSchema and setting default message endpoint responses to be MesageConfirmationSchema
- fix: bug where if shema was already registered it would not properly return the $ref for the schema resulting in missing definition in OpenAPI spec
- fix: TlsCertificates schema to properly set certificateChain as string array
- fix: AsDataEndpoint to properly ignore `undefined` tags instead of setting `[undefined] as the tag list which resulted in incorrect null tags
- fix: registerSchema in AbstractModuleApi to remove empty required lists, recursively register nested schema definitions (which fastify does not do by default), fix property.$refs and property.items.$refs to not use '#/definitions/' since fastify simply expects the unique id
- fix: bringing back a smaller version of OcppTransformObject which now only sets the default tags (if not passed in) based on path key