### PR TITLE
Feature/unknown 404

### DIFF
--- a/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
+++ b/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
@@ -270,11 +270,11 @@ export class WebsocketNetworkConnection {
         wss.emit('connection', ws, req);
       });
     } catch (error: any) {
-      this._logger.warn(error);
       /**
        * See {@link IUpgradeError.terminateConnection}
        **/
       error?.terminateConnection?.(socket) || this._terminateConnectionInternalError(socket);
+      this._logger.warn(error);
     }
   }
 

--- a/02_Util/src/networkconnection/authenticator/BasicAuthenticationFilter.ts
+++ b/02_Util/src/networkconnection/authenticator/BasicAuthenticationFilter.ts
@@ -33,7 +33,7 @@ export class BasicAuthenticationFilter extends AuthenticatorFilter {
   ): Promise<void> {
     const { username, password } = extractBasicCredentials(request);
     if (!username || !password) {
-      throw Error('Auth header missing or incorrectly formatted');
+      throw new UpgradeAuthenticationError('Auth header missing or incorrectly formatted');
     }
 
     if (

--- a/02_Util/src/networkconnection/authenticator/BasicAuthenticationFilter.ts
+++ b/02_Util/src/networkconnection/authenticator/BasicAuthenticationFilter.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { extractBasicCredentials } from '../../util/RequestOperations';
 import { AuthenticatorFilter } from './AuthenticatorFilter';
 import { AuthenticationOptions } from '@citrineos/base';
+import { UpgradeAuthenticationError } from './errors/AuthenticationError';
 
 /**
  * Filter used to authenticate incoming HTTP requests based on basic authorization header.
@@ -39,7 +40,7 @@ export class BasicAuthenticationFilter extends AuthenticatorFilter {
       username !== identifier ||
       !(await this._isPasswordValid(username, password))
     ) {
-      throw Error(`Unauthorized ${identifier}`);
+      throw new UpgradeAuthenticationError(`Unauthorized ${identifier}`);
     }
   }
 

--- a/02_Util/src/networkconnection/authenticator/ConnectedStationFilter.ts
+++ b/02_Util/src/networkconnection/authenticator/ConnectedStationFilter.ts
@@ -7,6 +7,7 @@ import {
 import { ILogObj, Logger } from 'tslog';
 import { IncomingMessage } from 'http';
 import { AuthenticatorFilter } from './AuthenticatorFilter';
+import { UpgradeAuthenticationError } from './errors/AuthenticationError';
 
 /**
  * Filter used to prevent multiple simultaneous connections for the same charging station.
@@ -31,7 +32,7 @@ export class ConnectedStationFilter extends AuthenticatorFilter {
       await this._cache.get(identifier, CacheNamespace.Connections),
     );
     if (isAlreadyConnected) {
-      throw Error(
+      throw new UpgradeAuthenticationError(
         `New connection attempted for already connected identifier ${identifier}`,
       );
     }

--- a/02_Util/src/networkconnection/authenticator/NetworkProfileFilter.ts
+++ b/02_Util/src/networkconnection/authenticator/NetworkProfileFilter.ts
@@ -5,6 +5,7 @@ import { ChargingStationNetworkProfile, IDeviceModelRepository, ServerNetworkPro
 import { IncomingMessage } from 'http';
 import { AuthenticatorFilter } from './AuthenticatorFilter';
 import { AuthenticationOptions } from '@citrineos/base';
+import { UpgradeAuthenticationError } from './errors/AuthenticationError';
 
 
 /**
@@ -32,7 +33,7 @@ export class NetworkProfileFilter extends AuthenticatorFilter {
     ): Promise<void> {
         const isConfigurationSlotAllowed = await this._isConfigurationSlotAllowed(identifier, options.securityProfile);
         if (!isConfigurationSlotAllowed) {
-            throw Error(`SecurityProfile not allowed ${options.securityProfile}`);
+            throw new UpgradeAuthenticationError(`SecurityProfile not allowed ${options.securityProfile}`);
         }
     }
 

--- a/02_Util/src/networkconnection/authenticator/UnknownStationFilter.ts
+++ b/02_Util/src/networkconnection/authenticator/UnknownStationFilter.ts
@@ -3,6 +3,7 @@ import { ILocationRepository } from '@citrineos/data';
 import { IncomingMessage } from 'http';
 import { AuthenticatorFilter } from './AuthenticatorFilter';
 import { AuthenticationOptions } from '@citrineos/base';
+import { UpgradeUnknownError } from './errors/UnknownError';
 
 /**
  * Filter used to block connections from charging stations that are not recognized in the system.
@@ -32,7 +33,7 @@ export class UnknownStationFilter extends AuthenticatorFilter {
         identifier,
       );
     if (!isStationKnown) {
-      throw Error(`Unknown identifier ${identifier}`);
+      throw new UpgradeUnknownError(`Unknown identifier ${identifier}`);
     }
   }
 }

--- a/02_Util/src/networkconnection/authenticator/errors/AuthenticationError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/AuthenticationError.ts
@@ -1,0 +1,23 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Duplex } from 'stream';
+import { IUpgradeError } from "./IUpgradeError";
+
+export class UpgradeAuthenticationError extends Error implements IUpgradeError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UpgradeAuthenticationError';
+    }
+
+    terminateConnection(socket: Duplex): void {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n');
+        socket.write(
+            'WWW-Authenticate: Basic realm="Access to the WebSocket", charset="UTF-8"\r\n',
+        );
+        socket.write('\r\n');
+        socket.end();
+        socket.destroy();
+    }
+}

--- a/02_Util/src/networkconnection/authenticator/errors/AuthenticationError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/AuthenticationError.ts
@@ -11,13 +11,19 @@ export class UpgradeAuthenticationError extends Error implements IUpgradeError {
         this.name = 'UpgradeAuthenticationError';
     }
 
-    terminateConnection(socket: Duplex): void {
-        socket.write('HTTP/1.1 401 Unauthorized\r\n');
-        socket.write(
-            'WWW-Authenticate: Basic realm="Access to the WebSocket", charset="UTF-8"\r\n',
-        );
-        socket.write('\r\n');
-        socket.end();
-        socket.destroy();
+    terminateConnection(socket: Duplex): boolean {
+        try {
+            socket.write('HTTP/1.1 401 Unauthorized\r\n');
+            socket.write(
+                'WWW-Authenticate: Basic realm="Access to the WebSocket", charset="UTF-8"\r\n',
+            );
+            socket.write('\r\n');
+            socket.end();
+            socket.destroy();
+            return true;
+        } catch (error) {
+            this.message = (error as Error).message;
+            return false;
+        }
     }
 }

--- a/02_Util/src/networkconnection/authenticator/errors/IUpgradeError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/IUpgradeError.ts
@@ -1,0 +1,15 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Duplex } from 'stream';
+
+
+export interface IUpgradeError {
+
+    /**
+     * Terminates the WebSocket connection by sending an error response and closing the socket.
+     * @param {Duplex} socket - The WebSocket duplex stream.
+     */
+    terminateConnection(socket: Duplex): void;
+}

--- a/02_Util/src/networkconnection/authenticator/errors/IUpgradeError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/IUpgradeError.ts
@@ -10,6 +10,7 @@ export interface IUpgradeError {
     /**
      * Terminates the WebSocket connection by sending an error response and closing the socket.
      * @param {Duplex} socket - The WebSocket duplex stream.
+     * @returns {boolean} True if the connection was terminated successfully, false otherwise.
      */
-    terminateConnection(socket: Duplex): void;
+    terminateConnection(socket: Duplex): boolean;
 }

--- a/02_Util/src/networkconnection/authenticator/errors/UnknownError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/UnknownError.ts
@@ -1,0 +1,20 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { Duplex } from 'stream';
+import { IUpgradeError } from "./IUpgradeError";
+
+export class UpgradeUnknownError extends Error implements IUpgradeError {
+    constructor(message: string) {
+        super(message);
+        this.name = 'UpgradeUnknownError';
+    }
+
+    terminateConnection(socket: Duplex): void {
+        socket.write('HTTP/1.1 404 Not Found\r\n');
+        socket.write('\r\n');
+        socket.end();
+        socket.destroy();
+    }
+}

--- a/02_Util/src/networkconnection/authenticator/errors/UnknownError.ts
+++ b/02_Util/src/networkconnection/authenticator/errors/UnknownError.ts
@@ -11,10 +11,16 @@ export class UpgradeUnknownError extends Error implements IUpgradeError {
         this.name = 'UpgradeUnknownError';
     }
 
-    terminateConnection(socket: Duplex): void {
-        socket.write('HTTP/1.1 404 Not Found\r\n');
-        socket.write('\r\n');
-        socket.end();
-        socket.destroy();
+    terminateConnection(socket: Duplex): boolean {
+        try {
+            socket.write('HTTP/1.1 404 Not Found\r\n');
+            socket.write('\r\n');
+            socket.end();
+            socket.destroy();
+            return true;
+        } catch (error) {
+            this.message = (error as Error).message;
+            return false;
+        }
     }
 }


### PR DESCRIPTION
From the OCPP 2.0.1 specification:

> • If the CSMS does not recognize the Charging Station identifier in the URL path, it SHOULD send an HTTP response with status 404 and abort the WebSocket connection as described in [RFC6455].

Citrine previously always gave a 401, this pr gives a 404 when the charger is unknown and 500 when the server itself has an error.