### PR TITLE
fix: name_instance unique constraint in Components and Variables model not working properly

### DIFF
--- a/01_Data/src/layers/sequelize/model/DeviceModel/Component.ts
+++ b/01_Data/src/layers/sequelize/model/DeviceModel/Component.ts
@@ -9,7 +9,17 @@ import { Evse } from './Evse';
 import { Variable } from './Variable';
 import { ComponentVariable } from './ComponentVariable';
 
-@Table
+@Table({
+  indexes: [
+    {
+      unique: true,
+      fields: ['name'],
+      where: {
+        instance: null,
+      },
+    },
+  ],
+})
 export class Component extends Model implements ComponentType {
   static readonly MODEL_NAME: string = Namespace.ComponentType;
 

--- a/01_Data/src/layers/sequelize/model/DeviceModel/Variable.ts
+++ b/01_Data/src/layers/sequelize/model/DeviceModel/Variable.ts
@@ -10,7 +10,17 @@ import { VariableAttribute } from './VariableAttribute';
 import { VariableCharacteristics } from './VariableCharacteristics';
 import { ComponentVariable } from './ComponentVariable';
 
-@Table
+@Table({
+  indexes: [
+    {
+      unique: true,
+      fields: ['name'],
+      where: {
+        instance: null,
+      },
+    },
+  ],
+})
 export class Variable extends Model implements VariableType {
   static readonly MODEL_NAME: string = Namespace.VariableType;
 

--- a/03_Modules/Reporting/src/module/module.ts
+++ b/03_Modules/Reporting/src/module/module.ts
@@ -282,7 +282,7 @@ export class ReportingModule extends AbstractModule {
         await variableAttribute.reload({
           include: [Component, Variable],
         });
-        this._deviceModelRepository.updateResultByStationId(
+        await this._deviceModelRepository.updateResultByStationId(
           {
             attributeType: variableAttribute.type,
             attributeStatus: SetVariableStatusEnumType.Accepted,


### PR DESCRIPTION
- fix: adding await before request to repository to resolve unhandled promise rejection which terminates the server
- feat: adding unique index on `name` field when `instance` field IS NULL because NULL by default is not treated as DISTINCT by Postgres resulting in name_instance unique index not being enforced where instance is null