### PR TITLE
Bind fastify to both ipv4 and ipv6

### DIFF
--- a/Server/src/config/envs/local.ts
+++ b/Server/src/config/envs/local.ts
@@ -9,7 +9,7 @@ export function createLocalConfig() {
   return defineConfig({
     env: 'development',
     centralSystem: {
-      host: '0.0.0.0',
+      host: '::',
       port: 8080,
     },
     modules: {


### PR DESCRIPTION
When running automated tests for the operator ui against real services, I ran into the issue that the test couldn't resolve to the citrine-core server. After some deeper digging it turned out that the server only was binding to ipv4 but the test was trying to find for ipv6. 
Fastify mentions here: https://fastify.dev/docs/v4.28.x/Reference/Server/#listentextresolver that docker should bind to `0.0.0.0`. But this is only binding to ipv4. So for local we now bind `::` which listens to everything on both v4 and v6.

<img width="949" alt="Screenshot 2024-11-26 at 10 25 45 AM" src="https://github.com/user-attachments/assets/d88a7606-cb1b-4273-b845-61611b2ad799">
