### PR TITLE
Fix: logs in the cloud broken into multiple lines

### DIFF
--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -302,6 +302,49 @@ export class CitrineOSServer {
       name: 'CitrineOS Logger',
       minLevel: systemConfig.logLevel,
       hideLogPositionForProduction: systemConfig.env === 'production',
+      overwrite:
+        systemConfig &&
+        systemConfig.logLevel !== undefined &&
+        systemConfig.logLevel <= 2
+          ? undefined
+          : {
+              transportJSON: (logObj: any) => {
+                function jsonStringifyRecursive(obj: unknown) {
+                  const cache = new Set();
+                  return JSON.stringify(obj, (key, value) => {
+                    if (typeof value === 'object' && value !== null) {
+                      if (cache.has(value)) {
+                        // Circular reference found, discard key
+                        return '[Circular]';
+                      }
+                      // Store value in our collection
+                      cache.add(value);
+                    }
+                    if (typeof value === 'bigint') {
+                      return `${value}`;
+                    }
+                    if (typeof value === 'undefined') {
+                      return '[undefined]';
+                    }
+                    return value;
+                  });
+                }
+                if (logObj._meta) {
+                  const { path, name, date, logLevelId, logLevelName } =
+                    logObj._meta;
+                  const { _meta, ...rest } = logObj;
+                  logObj = {
+                    ...rest,
+                    path: path?.fullFilePath,
+                    name,
+                    date,
+                    logLevelId,
+                    logLevelName,
+                  };
+                }
+                console.log(jsonStringifyRecursive(logObj));
+              },
+            },
       // Disable colors for cloud deployment as some cloud logging environments such as cloudwatch can not interpret colors
       stylePrettyLogs: !isCloud,
       type: isCloud ? 'json' : 'pretty',

--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -297,12 +297,14 @@ export class CitrineOSServer {
   }
 
   private initLogger() {
+    const isCloud = process.env.DEPLOYMENT_TARGET === 'cloud';
     return new Logger<ILogObj>({
       name: 'CitrineOS Logger',
       minLevel: systemConfig.logLevel,
       hideLogPositionForProduction: systemConfig.env === 'production',
       // Disable colors for cloud deployment as some cloud logging environments such as cloudwatch can not interpret colors
-      stylePrettyLogs: process.env.DEPLOYMENT_TARGET !== 'cloud',
+      stylePrettyLogs: !isCloud,
+      type: isCloud ? 'json' : 'pretty',
     });
   }
 


### PR DESCRIPTION
- fix: using json log type when initializing logger and process.env.DEPLOYMENT_TARGET is 'cloud' to help make sure that logs in the cloud are not split into multiple lines
- feat: setting transportJSON override to remove _meta when systemConfig.logLevel > 2 to ensure that it does not include unnecessary information