### PR TITLE
Bugfix/Issue61 Fix BootNotification Crash

### DIFF
--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -250,7 +250,7 @@ export class ConfigurationModule extends AbstractModule {
       await this.sendCallResultWithMessage(message, bootNotificationResponse);
 
     // Update device model from boot
-    this._deviceModelService.updateDeviceModel(
+    await this._deviceModelService.updateDeviceModel(
       chargingStation,
       stationId,
       timestamp,
@@ -259,7 +259,7 @@ export class ConfigurationModule extends AbstractModule {
     if (!bootNotificationResponseMessageConfirmation.success) {
       throw new Error(
         'BootNotification failed: ' +
-        bootNotificationResponseMessageConfirmation,
+          bootNotificationResponseMessageConfirmation,
       );
     }
 
@@ -541,15 +541,29 @@ export class ConfigurationModule extends AbstractModule {
     this._logger.debug('SetNetworkProfile response received:', message, props);
 
     if (message.payload.status == SetNetworkProfileStatusEnumType.Accepted) {
-      const setNetworkProfile = await SetNetworkProfile.findOne({ where: { correlationId: message.context.correlationId } });
+      const setNetworkProfile = await SetNetworkProfile.findOne({
+        where: { correlationId: message.context.correlationId },
+      });
       if (setNetworkProfile) {
-        const serverNetworkProfile = await ServerNetworkProfile.findByPk(setNetworkProfile.websocketServerConfigId!);
+        const serverNetworkProfile = await ServerNetworkProfile.findByPk(
+          setNetworkProfile.websocketServerConfigId!,
+        );
         if (serverNetworkProfile) {
-          const chargingStation = await ChargingStation.findByPk(message.context.stationId);
+          const chargingStation = await ChargingStation.findByPk(
+            message.context.stationId,
+          );
           if (chargingStation) {
-            const [chargingStationNetworkProfile] = await ChargingStationNetworkProfile.findOrBuild({ where: { stationId: chargingStation.id, configurationSlot: setNetworkProfile.configurationSlot! } });
-            chargingStationNetworkProfile.websocketServerConfigId = setNetworkProfile.websocketServerConfigId!;
-            chargingStationNetworkProfile.setNetworkProfileId = setNetworkProfile.id;
+            const [chargingStationNetworkProfile] =
+              await ChargingStationNetworkProfile.findOrBuild({
+                where: {
+                  stationId: chargingStation.id,
+                  configurationSlot: setNetworkProfile.configurationSlot!,
+                },
+              });
+            chargingStationNetworkProfile.websocketServerConfigId =
+              setNetworkProfile.websocketServerConfigId!;
+            chargingStationNetworkProfile.setNetworkProfileId =
+              setNetworkProfile.id;
             await chargingStationNetworkProfile.save();
           }
         }
@@ -585,7 +599,8 @@ export class ConfigurationModule extends AbstractModule {
         CallAction.GetDisplayMessages,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, ChargingStationSequenceType.getDisplayMessages,
+            message.context.stationId,
+            ChargingStationSequenceType.getDisplayMessages,
           ),
         } as GetDisplayMessagesRequest,
       );
@@ -656,7 +671,8 @@ export class ConfigurationModule extends AbstractModule {
         CallAction.GetDisplayMessages,
         {
           requestId: await this._idGenerator.generateRequestId(
-            message.context.stationId, ChargingStationSequenceType.getDisplayMessages,
+            message.context.stationId,
+            ChargingStationSequenceType.getDisplayMessages,
           ),
         } as GetDisplayMessagesRequest,
       );


### PR DESCRIPTION
# Context
This PR is to fix the issue:  https://github.com/citrineos/citrineos/issues/61 
With this fix citrine does not crash when handling the invalid BootNotification message from charger.
# Test
Send the invalid BootNotification and receive response. Connection doesn't crash. <img width="887" alt="Screenshot 2024-12-03 at 6 11 24 PM" src="https://github.com/user-attachments/assets/0d614d4d-be91-4faa-b5d0-792fa957903e">