### PR TITLE
fix string interpolation in exception message

### DIFF
--- a/Server/src/config/index.ts
+++ b/Server/src/config/index.ts
@@ -14,7 +14,7 @@ function getConfig() {
     case 'docker':
       return createDockerConfig();
     default:
-      throw new Error('Invalid APP_ENV "${process.env.APP_ENV}"');
+      throw new Error(`Invalid APP_ENV "${process.env.APP_ENV}"`);
   }
 }
 


### PR DESCRIPTION
While trying to set up CitrineOS locally with EVerest, I got a very unhelpful error message. It looks like the string interpolation in this error message is broken, so I'd like to submit this fix.