### PR TITLE
Issue 105: Fix citrine crashes when missing charging station

### DIFF
--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -250,7 +250,7 @@ export class ConfigurationModule extends AbstractModule {
       await this.sendCallResultWithMessage(message, bootNotificationResponse);
 
     // Update device model from boot
-    this._deviceModelService.updateDeviceModel(
+    await this._deviceModelService.updateDeviceModel(
       chargingStation,
       stationId,
       timestamp,


### PR DESCRIPTION
This PR is to fix the issue: https://github.com/citrineos/citrineos/issues/105

## Test
Before fixing, citrine crashes. The web socket is disconnected.
<img width="886" alt="Screenshot 2025-01-23 at 2 45 08 PM" src="https://github.com/user-attachments/assets/fd703186-a972-4975-afe1-13d054a81956" />

After fixing, citrine still works.
<img width="888" alt="Screenshot 2025-01-23 at 2 48 05 PM" src="https://github.com/user-attachments/assets/525444cd-2782-4303-9060-6b1e5de94395" />
