### PR TITLE
Issue 72: Generalize MeterValue (No.6)

### DIFF
--- a/00_Base/src/ocpp/persistence/namespace.ts
+++ b/00_Base/src/ocpp/persistence/namespace.ts
@@ -10,6 +10,7 @@
 export enum Namespace {
   BootConfig = 'Boot',
   ChargingStation = 'ChargingStation',
+  MeterValue = 'MeterValue',
   StatusNotificationRequest = 'StatusNotification',
 }
 
@@ -35,7 +36,6 @@ export enum OCPP2_0_1_Namespace {
   LocalListAuthorization = 'LocalListAuthorization',
   LocalListVersion = 'LocalListVersion',
   Location = 'Location',
-  MeterValueType = 'MeterValue',
   MessageInfoType = 'MessageInfo',
   PasswordType = 'Password',
   ReserveNowRequest = 'Reservation',

--- a/01_Data/package.json
+++ b/01_Data/package.json
@@ -27,6 +27,7 @@
     "pg": "8.11.3",
     "pg-hstore": "2.3.4",
     "sequelize-typescript": "2.1.6",
-    "class-validator": "0.14.1"
+    "class-validator": "0.14.1",
+    "class-transformer": "0.5.1"
   }
 }

--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -38,6 +38,7 @@ import {
   ChangeConfiguration,
   StatusNotification,
   Connector,
+  TransactionEvent,
 } from '../layers/sequelize';
 import { type AuthorizationRestrictions, type VariableAttributeQuerystring } from '.';
 import { TariffQueryString } from './queries/Tariff';
@@ -129,10 +130,10 @@ export interface ISubscriptionRepository extends CrudRepository<Subscription> {
   deleteByKey(key: string): Promise<Subscription | undefined>;
 }
 
-export interface ITransactionEventRepository extends CrudRepository<OCPP2_0_1.TransactionEventRequest> {
+export interface ITransactionEventRepository extends CrudRepository<TransactionEvent> {
   createOrUpdateTransactionByTransactionEventAndStationId(value: OCPP2_0_1.TransactionEventRequest, stationId: string): Promise<Transaction>;
   createMeterValue(value: OCPP2_0_1.MeterValueType, transactionDatabaseId?: number | null): Promise<void>;
-  readAllByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<OCPP2_0_1.TransactionEventRequest[]>;
+  readAllByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<TransactionEvent[]>;
   readTransactionByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<Transaction | undefined>;
   readAllTransactionsByStationIdAndEvseAndChargingStates(stationId: string, evse: OCPP2_0_1.EVSEType, chargingStates?: OCPP2_0_1.ChargingStateEnumType[]): Promise<Transaction[]>;
   readAllActiveTransactionsByIdToken(idToken: OCPP2_0_1.IdTokenType): Promise<Transaction[]>;

--- a/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
+++ b/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
@@ -12,36 +12,34 @@ export class MeterValueMapper extends AbstractMapper<MeterValue> {
   @IsArray()
   @ArrayMinSize(1)
   @ValidateNested({ each: true })
-  @Type(() => SampleValue)
-  sampledValue: SampleValue[];
+  @Type(() => SampledValue)
+  sampledValue: SampledValue[];
   timestamp: string;
   transactionDatabaseId?: number | null;
 
-  constructor(sampledValue: SampleValue[], timestamp: string, transactionDatabaseId?: number | null) {
+  constructor(sampledValue: SampledValue[], timestamp: string, transactionDatabaseId?: number | null) {
     super();
     this.sampledValue = sampledValue;
     this.timestamp = timestamp;
     this.transactionDatabaseId = transactionDatabaseId;
-    console.debug(`this meter value: ${JSON.stringify(this)}`);
     this.validate();
   }
 
   toModel(): MeterValue {
     return MeterValue.build({
       timestamp: this.timestamp,
-      sampledValue: this.sampledValue as [SampleValue, ...SampleValue[]],
+      sampledValue: this.sampledValue as [SampledValue, ...SampledValue[]],
       transactionDatabaseId: this.transactionDatabaseId,
     });
   }
 
   static fromModel(meterValue: MeterValue): MeterValueMapper {
-    const sampledValues = plainToInstance(SampleValue, meterValue.sampledValue);
-    console.debug(`sampledValues: ${JSON.stringify(sampledValues)}`);
+    const sampledValues = plainToInstance(SampledValue, meterValue.sampledValue);
     return new MeterValueMapper(sampledValues, meterValue.timestamp, meterValue.transactionDatabaseId);
   }
 }
 
-export class SampleValue {
+export class SampledValue {
   value: string;
   @IsEnum(OCPP1_6.MeterValuesRequestContext, { message: 'Invalid context value.' })
   context?: OCPP1_6.MeterValuesRequestContext | null;

--- a/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
+++ b/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
@@ -1,0 +1,76 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { AbstractMapper } from '../AbstractMapper';
+import { ArrayMinSize, IsArray, IsEnum, ValidateNested } from 'class-validator';
+import { plainToInstance, Type } from 'class-transformer';
+import { MeterValue } from '../../model/TransactionEvent';
+import { OCPP1_6 } from '@citrineos/base';
+
+export class MeterValueMapper extends AbstractMapper<MeterValue> {
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => SampleValue)
+  sampledValue: SampleValue[];
+  timestamp: string;
+  transactionDatabaseId?: number | null;
+
+  constructor(sampledValue: SampleValue[], timestamp: string, transactionDatabaseId?: number | null) {
+    super();
+    this.sampledValue = sampledValue;
+    this.timestamp = timestamp;
+    this.transactionDatabaseId = transactionDatabaseId;
+    console.debug(`this meter value: ${JSON.stringify(this)}`);
+    this.validate();
+  }
+
+  toModel(): MeterValue {
+    return MeterValue.build({
+      timestamp: this.timestamp,
+      sampledValue: this.sampledValue as [SampleValue, ...SampleValue[]],
+      transactionDatabaseId: this.transactionDatabaseId,
+    });
+  }
+
+  static fromModel(meterValue: MeterValue): MeterValueMapper {
+    const sampledValues = plainToInstance(SampleValue, meterValue.sampledValue);
+    console.debug(`sampledValues: ${JSON.stringify(sampledValues)}`);
+    return new MeterValueMapper(sampledValues, meterValue.timestamp, meterValue.transactionDatabaseId);
+  }
+}
+
+export class SampleValue {
+  value: string;
+  @IsEnum(OCPP1_6.MeterValuesRequestContext, { message: 'Invalid context value.' })
+  context?: OCPP1_6.MeterValuesRequestContext | null;
+  @IsEnum(OCPP1_6.MeterValuesRequestFormat, { message: 'Invalid format value.' })
+  format?: OCPP1_6.MeterValuesRequestFormat | null;
+  @IsEnum(OCPP1_6.MeterValuesRequestMeasurand, { message: 'Invalid measurand value.' })
+  measurand?: OCPP1_6.MeterValuesRequestMeasurand | null;
+  @IsEnum(OCPP1_6.MeterValuesRequestPhase, { message: 'Invalid phase value.' })
+  phase?: OCPP1_6.MeterValuesRequestPhase | null;
+  @IsEnum(OCPP1_6.MeterValuesRequestLocation, { message: 'Invalid location value.' })
+  location?: OCPP1_6.MeterValuesRequestLocation | null;
+  @IsEnum(OCPP1_6.MeterValuesRequestUnit, { message: 'Invalid unit value.' })
+  unit?: OCPP1_6.MeterValuesRequestUnit | null;
+
+  constructor(
+    value: string,
+    context?: OCPP1_6.MeterValuesRequestContext,
+    format?: OCPP1_6.MeterValuesRequestFormat,
+    measurand?: OCPP1_6.MeterValuesRequestMeasurand,
+    phase?: OCPP1_6.MeterValuesRequestPhase,
+    location?: OCPP1_6.MeterValuesRequestLocation,
+    unit?: OCPP1_6.MeterValuesRequestUnit,
+  ) {
+    this.value = value;
+    this.context = context;
+    this.format = format;
+    this.measurand = measurand;
+    this.phase = phase;
+    this.location = location;
+    this.unit = unit;
+  }
+}

--- a/01_Data/src/layers/sequelize/mapper/1.6/index.ts
+++ b/01_Data/src/layers/sequelize/mapper/1.6/index.ts
@@ -5,4 +5,4 @@
 
 export { BootMapper } from './BootMapper';
 export { StatusNotificationMapper } from './StatusNotificationMapper';
-export { MeterValueMapper, SampleValue } from './MeterValueMapper';
+export { MeterValueMapper, SampledValue } from './MeterValueMapper';

--- a/01_Data/src/layers/sequelize/mapper/1.6/index.ts
+++ b/01_Data/src/layers/sequelize/mapper/1.6/index.ts
@@ -5,3 +5,4 @@
 
 export { BootMapper } from './BootMapper';
 export { StatusNotificationMapper } from './StatusNotificationMapper';
+export { MeterValueMapper, SampleValue } from './MeterValueMapper';

--- a/01_Data/src/layers/sequelize/mapper/2.0.1/MeterValueMapper.ts
+++ b/01_Data/src/layers/sequelize/mapper/2.0.1/MeterValueMapper.ts
@@ -1,0 +1,76 @@
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { OCPP2_0_1 } from '@citrineos/base';
+import { AbstractMapper } from '../AbstractMapper';
+import { IsArray } from 'class-validator';
+import { MeterValue} from '../../model/TransactionEvent';
+
+export class MeterValueMapper extends AbstractMapper<MeterValue> {
+  @IsArray()
+  sampledValue: [OCPP2_0_1.SampledValueType, ...OCPP2_0_1.SampledValueType[]];
+  timestamp: string;
+  transactionEventId?: number | null;
+  transactionDatabaseId?: number | null;
+  customData?: OCPP2_0_1.CustomDataType | null;
+
+  constructor(sampledValue: [OCPP2_0_1.SampledValueType, ...OCPP2_0_1.SampledValueType[]], timestamp: string, transactionEventId?: number | null, transactionDatabaseId?: number | null, customData?: OCPP2_0_1.CustomDataType | null) {
+    super();
+    this.sampledValue = sampledValue;
+    this.timestamp = timestamp;
+    this.transactionEventId = transactionEventId;
+    this.transactionDatabaseId = transactionDatabaseId;
+    this.customData = customData;
+    this.validate();
+    this.validateSampledValue(sampledValue, 0, '');
+  }
+
+  toModel(): MeterValue {
+    return MeterValue.build({
+      timestamp: this.timestamp,
+      sampledValue: this.sampledValue,
+      transactionEventId: this.transactionEventId,
+      transactionDatabaseId: this.transactionDatabaseId,
+      customData: this.customData,
+    });
+  }
+
+  static fromModel(meterValue: MeterValue): MeterValueMapper {
+    return new MeterValueMapper(
+      meterValue.sampledValue as [OCPP2_0_1.SampledValueType, ...OCPP2_0_1.SampledValueType[]],
+      meterValue.timestamp,
+      meterValue.transactionEventId,
+      meterValue.transactionDatabaseId,
+      meterValue.customData as OCPP2_0_1.CustomDataType | null
+    );
+  }
+
+  private validateSampledValue(sampledValues: [OCPP2_0_1.SampledValueType, ...OCPP2_0_1.SampledValueType[]], index: number, errors: string) {
+    if (index === sampledValues.length) {
+      if (errors.length > 0) {
+        throw new Error(errors);
+      } else {
+        return;
+      }
+    }
+    const sampledValue = sampledValues[index];
+    if (!sampledValue.value) {
+      errors += `sampledValue[${index}].value is not defined. `;
+    }
+    if (sampledValue.context && !Object.values(OCPP2_0_1.ReadingContextEnumType).includes(sampledValue.context)) {
+      errors += `sampledValue[${index}].context: ${sampledValue.context} is invalid. `;
+    }
+    if (sampledValue.measurand && !Object.values(OCPP2_0_1.MeasurandEnumType).includes(sampledValue.measurand)) {
+      errors += `sampledValue[${index}].measurand: ${sampledValue.measurand} is invalid. `;
+    }
+    if (sampledValue.phase && !Object.values(OCPP2_0_1.PhaseEnumType).includes(sampledValue.phase)) {
+      errors += `sampledValue[${index}].phase: ${sampledValue.phase} is invalid. `;
+    }
+    if (sampledValue.location && !Object.values(OCPP2_0_1.LocationEnumType).includes(sampledValue.location)) {
+      errors += `sampledValue[${index}].location: ${sampledValue.location} is invalid. `;
+    }
+
+    this.validateSampledValue(sampledValues, index + 1, errors);
+  }
+}

--- a/01_Data/src/layers/sequelize/mapper/2.0.1/index.ts
+++ b/01_Data/src/layers/sequelize/mapper/2.0.1/index.ts
@@ -4,3 +4,4 @@
 
 export { BootMapper } from './BootMapper';
 export { StatusNotificationMapper } from './StatusNotificationMapper';
+export { MeterValueMapper } from './MeterValueMapper';

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
@@ -3,14 +3,14 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-import { OCPP2_0_1_Namespace, OCPP2_0_1 } from '@citrineos/base';
+import { Namespace } from '@citrineos/base';
 import { Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
 import { TransactionEvent } from './TransactionEvent';
 import { Transaction } from './Transaction';
 
 @Table
-export class MeterValue extends Model implements OCPP2_0_1.MeterValueType {
-  static readonly MODEL_NAME: string = OCPP2_0_1_Namespace.MeterValueType;
+export class MeterValue extends Model {
+  static readonly MODEL_NAME: string = Namespace.MeterValue;
 
   @ForeignKey(() => TransactionEvent)
   @Column(DataType.INTEGER)
@@ -21,7 +21,7 @@ export class MeterValue extends Model implements OCPP2_0_1.MeterValueType {
   declare transactionDatabaseId?: number | null;
 
   @Column(DataType.JSON)
-  declare sampledValue: [OCPP2_0_1.SampledValueType, ...OCPP2_0_1.SampledValueType[]];
+  declare sampledValue: [object, ...object[]];
 
   @Column({
     type: DataType.DATE,
@@ -31,5 +31,5 @@ export class MeterValue extends Model implements OCPP2_0_1.MeterValueType {
   })
   declare timestamp: string;
 
-  declare customData?: OCPP2_0_1.CustomDataType | null;
+  declare customData?: object | null;
 }

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/TransactionEvent.ts
@@ -11,7 +11,7 @@ import { MeterValue } from './MeterValue';
 import { Transaction } from './Transaction';
 
 @Table
-export class TransactionEvent extends Model implements OCPP2_0_1.TransactionEventRequest {
+export class TransactionEvent extends Model {
   static readonly MODEL_NAME: string = OCPP2_0_1_Namespace.TransactionEventRequest;
 
   @Column

--- a/01_Data/test/layers/sequelize/mapper/1.6/MeterValueMapper.test.ts
+++ b/01_Data/test/layers/sequelize/mapper/1.6/MeterValueMapper.test.ts
@@ -1,0 +1,26 @@
+import { expect } from '@jest/globals';
+import { MeterValueMapper } from '../../../../../src/layers/sequelize/mapper/1.6';
+import { aMeterValue, aOcpp16SampledValue } from '../../../../providers/MeterValue';
+
+describe('MeterValueMapper', () => {
+  describe('map MeterValue and MeterValueMapper', () => {
+    it('should map between MeterValue and MeterValueMapper successfully', () => {
+      const givenMeterValue = aMeterValue((m) => (m.sampledValue = [aOcpp16SampledValue()]));
+
+      const actualMapper = MeterValueMapper.fromModel(givenMeterValue);
+      expect(actualMapper).toBeTruthy();
+      expect(actualMapper.timestamp).toBe(givenMeterValue.timestamp);
+      expect(actualMapper.transactionDatabaseId).toBe(givenMeterValue.transactionDatabaseId);
+      expect(actualMapper.sampledValue).toEqual(givenMeterValue.sampledValue);
+    });
+
+    it('should throw error with invalid values', () => {
+      const sampledValueInvalidMeasurand1 = aOcpp16SampledValue((s) => ((s as any).measurand = 'InvalidMeasurand'));
+      const sampledValueInvalidContext = aOcpp16SampledValue((s) => ((s as any).context = 'InvalidContext'));
+      const givenMeterValue = aMeterValue((m) => (m.sampledValue = [sampledValueInvalidMeasurand1, sampledValueInvalidContext]));
+      expect(() => MeterValueMapper.fromModel(givenMeterValue)).toThrowError(
+        `Validation failed: [{"value":[{"value":"79","context":"Transaction.Begin","format":"Raw","measurand":"InvalidMeasurand","phase":"L1","location":"Outlet","unit":"kWh"},{"value":"79","context":"InvalidContext","format":"Raw","measurand":"Energy.Active.Import.Register","phase":"L1","location":"Outlet","unit":"kWh"}],"property":"sampledValue","children":[{"value":{"value":"79","context":"Transaction.Begin","format":"Raw","measurand":"InvalidMeasurand","phase":"L1","location":"Outlet","unit":"kWh"},"property":"0","children":[{"value":"InvalidMeasurand","property":"measurand","children":[],"constraints":{"isEnum":"Invalid measurand value."}}]},{"value":{"value":"79","context":"InvalidContext","format":"Raw","measurand":"Energy.Active.Import.Register","phase":"L1","location":"Outlet","unit":"kWh"},"property":"1","children":[{"value":"InvalidContext","property":"context","children":[],"constraints":{"isEnum":"Invalid context value."}}]}]}]`,
+      );
+    });
+  });
+});

--- a/01_Data/test/layers/sequelize/mapper/2.0.1/MeterValueMapper.test.ts
+++ b/01_Data/test/layers/sequelize/mapper/2.0.1/MeterValueMapper.test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@jest/globals';
+import { MeterValueMapper } from '../../../../../src/layers/sequelize/mapper/2.0.1';
+import { aMeterValue, aOcpp201SampledValue } from '../../../../providers/MeterValue';
+
+describe('MeterValueMapper', () => {
+  describe('map MeterValue and MeterValueMapper', () => {
+    it('should map between MeterValue and MeterValueMapper successfully', () => {
+      const givenMeterValue = aMeterValue();
+
+      const actualMapper = MeterValueMapper.fromModel(givenMeterValue);
+      expect(actualMapper).toBeTruthy();
+      expect(actualMapper.timestamp).toBe(givenMeterValue.timestamp);
+      expect(actualMapper.transactionEventId).toBe(givenMeterValue.transactionEventId);
+      expect(actualMapper.transactionDatabaseId).toBe(givenMeterValue.transactionDatabaseId);
+      expect(actualMapper.customData).toEqual(givenMeterValue.customData);
+      expect(actualMapper.sampledValue).toEqual(givenMeterValue.sampledValue);
+    });
+
+    it('should throw error with invalid values', () => {
+      const sampledValueInvalidMeasurand1 = aOcpp201SampledValue((s) => ((s as any).measurand = 'InvalidMeasurand'));
+      const sampledValueInvalidContext = aOcpp201SampledValue((s) => ((s as any).context = 'InvalidContext'));
+      const givenMeterValue = aMeterValue((m) => (m.sampledValue = [sampledValueInvalidMeasurand1, sampledValueInvalidContext]));
+      expect(() => MeterValueMapper.fromModel(givenMeterValue)).toThrowError(
+        'sampledValue[0].measurand: InvalidMeasurand is invalid. sampledValue[1].context: InvalidContext is invalid. ',
+      );
+    });
+  });
+});

--- a/01_Data/test/providers/MeterValue.ts
+++ b/01_Data/test/providers/MeterValue.ts
@@ -1,0 +1,45 @@
+import { applyUpdateFunction, UpdateFunction } from '../utils/UpdateUtil';
+import { faker } from '@faker-js/faker';
+import { MeterValue } from '../../src';
+
+export function aMeterValue(updateFunction?: UpdateFunction<MeterValue>): MeterValue {
+  const meterValue: MeterValue = {
+    transactionDatabaseId: faker.number.int({ min: 0, max: 100 }),
+    transactionEventId: faker.number.int({ min: 0, max: 100 }),
+    sampledValue: [...[aOcpp201SampledValue()]],
+    timestamp: faker.date.recent().toISOString(),
+    customData: { vendorId: faker.string.alpha(10) },
+  } as MeterValue;
+
+  return applyUpdateFunction(meterValue, updateFunction);
+}
+
+export function aOcpp201SampledValue(updateFunction?: UpdateFunction<object>): object {
+  const sampledValue: object = {
+    measurand: 'Energy.Active.Import.Register',
+    phase: 'L1',
+    unitOfMeasure: {
+      unit: 'kWh',
+      multiplier: faker.number.int({ min: 0, max: 100 }),
+    },
+    value: faker.number.int({ min: 0, max: 100 }),
+    context: 'Transaction.Begin',
+    location: 'Outlet',
+  } as object;
+
+  return applyUpdateFunction(sampledValue, updateFunction);
+}
+
+export function aOcpp16SampledValue(updateFunction?: UpdateFunction<object>): object {
+  const sampledValue: object = {
+    measurand: 'Energy.Active.Import.Register',
+    phase: 'L1',
+    unit: 'kWh',
+    value: '79', // keep it fixed to pass the throw error test case
+    context: 'Transaction.Begin',
+    format: 'Raw',
+    location: 'Outlet',
+  } as object;
+
+  return applyUpdateFunction(sampledValue, updateFunction);
+}

--- a/03_Modules/Transactions/src/module/TransactionService.ts
+++ b/03_Modules/Transactions/src/module/TransactionService.ts
@@ -3,6 +3,7 @@ import {
   IAuthorizationRepository,
   ITransactionEventRepository,
   Transaction,
+  OCPP2_0_1_Mapper
 } from '@citrineos/data';
 import {
   IMessageContext,
@@ -33,11 +34,14 @@ export class TransactionService {
   }
 
   async recalculateTotalKwh(transactionDbId: number) {
-    const totalKwh = MeterValueUtils.getTotalKwh(
+    const storedMeterValues =
       await this._transactionEventRepository.readAllMeterValuesByTransactionDataBaseId(
         transactionDbId,
-      ),
+      );
+    const meterValueMappers = storedMeterValues.map((meterValue) =>
+      OCPP2_0_1_Mapper.MeterValueMapper.fromModel(meterValue),
     );
+    const totalKwh = MeterValueUtils.getTotalKwh(meterValueMappers);
 
     await Transaction.update(
       { totalKwh: totalKwh },


### PR DESCRIPTION
⚠️ This branch is based on another feature branch. Please take care of the merge order or update the destination branch before merging.

This PR is to generalize MeterValue entity. 

## Changes
1. Remove ocpp 2.0.1 references from MeterValue entity
2. Create MeterValue mappers for ocpp 2.0.1 and ocpp 1.6
3. Since in ocpp 1.6 request, `sampledValue` is defined as an general object (e.g., in `MeterValuesRequest`), a `SampledValue` is created in the mapper object so that it can be used in `fromModel`, `fromRequest` or other places.

## Tests
Regression test on running a transaction.
1. Start a transaction.
<img width="1062" alt="Screenshot 2025-01-26 at 9 45 37 AM" src="https://github.com/user-attachments/assets/3e5e7a85-4ea0-49d6-80e9-950d4fd8534d" />
<img width="1081" alt="Screenshot 2025-01-26 at 9 40 38 AM" src="https://github.com/user-attachments/assets/180a458f-df92-4522-b8c1-1a60a8a648f5" />
2. Update the transaction 
<img width="1068" alt="Screenshot 2025-01-26 at 9 45 55 AM" src="https://github.com/user-attachments/assets/20a55151-e42e-4790-b48d-79e9a2b40875" />
<img width="1108" alt="Screenshot 2025-01-26 at 9 41 22 AM" src="https://github.com/user-attachments/assets/d133eee4-120e-486b-9a3c-4c81cfc6e758" />
4. End the transaction and get final cost 
<img width="1065" alt="Screenshot 2025-01-26 at 9 46 18 AM" src="https://github.com/user-attachments/assets/a338d560-d4a8-45a3-88da-6c65ec96e181" />
<img width="1098" alt="Screenshot 2025-01-26 at 9 41 40 AM" src="https://github.com/user-attachments/assets/cee626f4-c339-423a-8cde-28adffce40d4" />