### PR TITLE
fix: Check transaction status and set 'active' to false if status is SuspendedEVSE or SuspendedEV

### DIFF
--- a/03_Modules/Transactions/src/module/TransactionService.ts
+++ b/03_Modules/Transactions/src/module/TransactionService.ts
@@ -137,6 +137,19 @@ export class TransactionService {
         }
       }
     }
+    
+    // Check transaction status and set 'active' to false if status is SuspendedEVSE or SuspendedEV
+    if (transactionEvent.transactionInfo?.chargingState === OCPP2_0_1.ChargingStateEnumType.SuspendedEVSE  ||
+      transactionEvent.transactionInfo?.chargingState === OCPP2_0_1.ChargingStateEnumType.SuspendedEV) {
+      this._logger.debug(
+        `${transactionEvent.transactionInfo?.chargingState} for ${transactionEvent.transactionInfo.transactionId} transaction`,
+      );
+      await Transaction.update(
+        { isActive: false },
+        { where: { transactionId: transactionEvent.transactionInfo.transactionId } }
+      );
+    }
+
     this._logger.debug(
       'idToken Authorization final status:',
       response.idTokenInfo.status,


### PR DESCRIPTION
# Fix Description

This update resolves an issue where transactions stuck in **`SuspendedEVSE`** or **`SuspendedEV`** states remain marked as `active`, causing persistent `concurrenttx` errors and blocking new transactions.

---

## Problem  
- Transactions failing to start (e.g., due to concurrency limits, hardware conflicts, or initialization errors) enter `SuspendedEVSE` or `SuspendedEV` states.  
- The `active` flag is not automatically set to `false` in these states, causing the system to treat them as "still running."  
- This triggers infinite loops of `concurrenttx` errors, preventing new transactions from initiating.

---

## Solution  
A conditional check is added to the transaction status handler:  
1. **Status Detection**: Actively monitor transactions for `SuspendedEVSE` or `SuspendedEV` states.  
2. **Flag Update**: Automatically set `active` to `false` when either suspended state is detected.  
3. **Concurrency Handling**: Free up the system to process new transactions by marking stuck ones as inactive.  

**Key Benefits**:  
- 🛑 Prevents infinite `concurrenttx` error loops.  
- 🔄 Enables seamless retries after failures.  
- 🛠 Graceful handling of edge cases where transactions fail to initialize.  

---

## Impact  
- ✅ Transactions in suspended states no longer block subsequent operations.  
- ✅ System stability improves by avoiding zombie transactions.  
- ✅ Users/chargers can retry transactions without manual intervention.  