### PR TITLE
Issue 90: Implement MeterValues Handler (No.10)

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -143,6 +143,7 @@ export interface ITransactionEventRepository extends CrudRepository<TransactionE
   createOrUpdateTransactionByTransactionEventAndStationId(value: OCPP2_0_1.TransactionEventRequest, stationId: string): Promise<Transaction>;
   createMeterValue(value: OCPP2_0_1.MeterValueType, transactionDatabaseId?: number | null): Promise<void>;
   createTransactionByStartTransaction(request: OCPP1_6.StartTransactionRequest, transactionId: number, stationId: string): Promise<Transaction | undefined>;
+  updateTransactionByMeterValues(meterValues: MeterValue[], stationId: string, connectorId: number, transactionId?: number | null,): Promise<void>;
   readAllByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<TransactionEvent[]>;
   readTransactionByStationIdAndTransactionId(stationId: string, transactionId: string): Promise<Transaction | undefined>;
   readAllTransactionsByStationIdAndEvseAndChargingStates(stationId: string, evse: OCPP2_0_1.EVSEType, chargingStates?: OCPP2_0_1.ChargingStateEnumType[]): Promise<Transaction[]>;

--- a/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
+++ b/01_Data/src/layers/sequelize/mapper/1.6/MeterValueMapper.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache 2.0
 
 import { AbstractMapper } from '../AbstractMapper';
-import { ArrayMinSize, IsArray, IsEnum, ValidateNested } from 'class-validator';
+import { ArrayMinSize, IsArray, IsEnum, ValidateIf, ValidateNested } from 'class-validator';
 import { plainToInstance, Type } from 'class-transformer';
 import { MeterValue } from '../../model/TransactionEvent';
 import { OCPP1_6 } from '@citrineos/base';
@@ -16,12 +16,14 @@ export class MeterValueMapper extends AbstractMapper<MeterValue> {
   sampledValue: SampledValue[];
   timestamp: string;
   transactionDatabaseId?: number | null;
+  connectorDatabaseId?: number | null;
 
-  constructor(sampledValue: SampledValue[], timestamp: string, transactionDatabaseId?: number | null) {
+  constructor(sampledValue: SampledValue[], timestamp: string, transactionDatabaseId?: number | null, connectorDatabaseId?: number | null) {
     super();
     this.sampledValue = sampledValue;
     this.timestamp = timestamp;
     this.transactionDatabaseId = transactionDatabaseId;
+    this.connectorDatabaseId = connectorDatabaseId;
     this.validate();
   }
 
@@ -30,27 +32,43 @@ export class MeterValueMapper extends AbstractMapper<MeterValue> {
       timestamp: this.timestamp,
       sampledValue: this.sampledValue as [SampledValue, ...SampledValue[]],
       transactionDatabaseId: this.transactionDatabaseId,
+      connectorDatabaseId: this.connectorDatabaseId,
     });
   }
 
   static fromModel(meterValue: MeterValue): MeterValueMapper {
     const sampledValues = plainToInstance(SampledValue, meterValue.sampledValue);
-    return new MeterValueMapper(sampledValues, meterValue.timestamp, meterValue.transactionDatabaseId);
+    return new MeterValueMapper(sampledValues, meterValue.timestamp, meterValue.transactionDatabaseId, meterValue.connectorDatabaseId);
+  }
+
+  static fromRequest(request: OCPP1_6.MeterValuesRequest): MeterValueMapper[] {
+    const mappers: MeterValueMapper[] = [];
+    for (const value of request.meterValue) {
+      const sampledValues = plainToInstance(SampledValue, value.sampledValue);
+      mappers.push(new MeterValueMapper(sampledValues, value.timestamp));
+    }
+    return mappers;
   }
 }
 
 export class SampledValue {
   value: string;
+  @ValidateIf((o) => o.context)
   @IsEnum(OCPP1_6.MeterValuesRequestContext, { message: 'Invalid context value.' })
   context?: OCPP1_6.MeterValuesRequestContext | null;
+  @ValidateIf((o) => o.format)
   @IsEnum(OCPP1_6.MeterValuesRequestFormat, { message: 'Invalid format value.' })
   format?: OCPP1_6.MeterValuesRequestFormat | null;
+  @ValidateIf((o) => o.measurand)
   @IsEnum(OCPP1_6.MeterValuesRequestMeasurand, { message: 'Invalid measurand value.' })
   measurand?: OCPP1_6.MeterValuesRequestMeasurand | null;
+  @ValidateIf((o) => o.phase)
   @IsEnum(OCPP1_6.MeterValuesRequestPhase, { message: 'Invalid phase value.' })
   phase?: OCPP1_6.MeterValuesRequestPhase | null;
+  @ValidateIf((o) => o.location)
   @IsEnum(OCPP1_6.MeterValuesRequestLocation, { message: 'Invalid location value.' })
   location?: OCPP1_6.MeterValuesRequestLocation | null;
+  @ValidateIf((o) => o.unit)
   @IsEnum(OCPP1_6.MeterValuesRequestUnit, { message: 'Invalid unit value.' })
   unit?: OCPP1_6.MeterValuesRequestUnit | null;
 

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/MeterValue.ts
@@ -4,9 +4,10 @@
 // SPDX-License-Identifier: Apache 2.0
 
 import { Namespace } from '@citrineos/base';
-import { Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
+import { BelongsTo, Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
 import { TransactionEvent } from './TransactionEvent';
 import { Transaction } from './Transaction';
+import { Connector } from '../Location';
 
 @Table
 export class MeterValue extends Model {
@@ -30,6 +31,12 @@ export class MeterValue extends Model {
     },
   })
   declare timestamp: string;
+
+  @ForeignKey(() => Connector)
+  declare connectorDatabaseId?: number;
+
+  @BelongsTo(() => Connector)
+  declare connector?: Connector;
 
   declare customData?: object | null;
 }

--- a/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
@@ -49,7 +49,7 @@ export class Transaction extends Model {
   declare transactionEventsFilter?: OCPP2_0_1.TransactionEventRequest[];
 
   @HasMany(() => MeterValue)
-  declare meterValues?: OCPP2_0_1.MeterValueType[];
+  declare meterValues?: MeterValue[];
 
   @HasOne(() => StartTransaction)
   declare startTransaction?: StartTransaction;
@@ -80,7 +80,7 @@ export class Transaction extends Model {
     transactionId: string,
     isActive: boolean,
     transactionEvents: OCPP2_0_1.TransactionEventRequest[],
-    meterValues: OCPP2_0_1.MeterValueType[],
+    meterValues: MeterValue[],
     chargingState?: OCPP2_0_1.ChargingStateEnumType,
     timeSpentCharging?: number,
     totalKwh?: number,

--- a/01_Data/test/layers/sequelize/mapper/1.6/MeterValueMapper.test.ts
+++ b/01_Data/test/layers/sequelize/mapper/1.6/MeterValueMapper.test.ts
@@ -12,6 +12,7 @@ describe('MeterValueMapper', () => {
       expect(actualMapper.timestamp).toBe(givenMeterValue.timestamp);
       expect(actualMapper.transactionDatabaseId).toBe(givenMeterValue.transactionDatabaseId);
       expect(actualMapper.sampledValue).toEqual(givenMeterValue.sampledValue);
+      expect(actualMapper.connectorDatabaseId).toBe(givenMeterValue.connectorDatabaseId);
     });
 
     it('should throw error with invalid values', () => {
@@ -22,5 +23,11 @@ describe('MeterValueMapper', () => {
         `Validation failed: [{"value":[{"value":"79","context":"Transaction.Begin","format":"Raw","measurand":"InvalidMeasurand","phase":"L1","location":"Outlet","unit":"kWh"},{"value":"79","context":"InvalidContext","format":"Raw","measurand":"Energy.Active.Import.Register","phase":"L1","location":"Outlet","unit":"kWh"}],"property":"sampledValue","children":[{"value":{"value":"79","context":"Transaction.Begin","format":"Raw","measurand":"InvalidMeasurand","phase":"L1","location":"Outlet","unit":"kWh"},"property":"0","children":[{"value":"InvalidMeasurand","property":"measurand","children":[],"constraints":{"isEnum":"Invalid measurand value."}}]},{"value":{"value":"79","context":"InvalidContext","format":"Raw","measurand":"Energy.Active.Import.Register","phase":"L1","location":"Outlet","unit":"kWh"},"property":"1","children":[{"value":"InvalidContext","property":"context","children":[],"constraints":{"isEnum":"Invalid context value."}}]}]}]`,
       );
     });
+
+    it('should not validate an optional field when it is null or undefined', () => {
+      const sampledValueNullContext = aOcpp16SampledValue((s) => ((s as any).context = null));
+      const givenMeterValue = aMeterValue((m) => (m.sampledValue = [sampledValueNullContext]));
+      expect(() => MeterValueMapper.fromModel(givenMeterValue)).not.toThrowError();
+    })
   });
 });

--- a/01_Data/test/providers/MeterValue.ts
+++ b/01_Data/test/providers/MeterValue.ts
@@ -9,6 +9,7 @@ export function aMeterValue(updateFunction?: UpdateFunction<MeterValue>): MeterV
     sampledValue: [...[aOcpp201SampledValue()]],
     timestamp: faker.date.recent().toISOString(),
     customData: { vendorId: faker.string.alpha(10) },
+    connectorDatabaseId: faker.number.int({ min: 0, max: 5 }),
   } as MeterValue;
 
   return applyUpdateFunction(meterValue, updateFunction);


### PR DESCRIPTION
⚠️ This branch is based on another feature branch. Please take care of the merge order or update the destination branch before merging.

## Changes
This PR is to implement OCPP 1.6 MeterValues handler. When receiving MeterValuesRequest, store meter values in the database.

## Tests
1. Send a MeterValuesRequest to citrine and get response.  <img width="893" alt="Screenshot 2025-02-03 at 5 23 09 PM" src="https://github.com/user-attachments/assets/d66a09d7-2cae-42ae-98b7-e232aef1440c" />
2. meter value with corresponding transaction db id and connector db id is stored. <img width="1179" alt="Screenshot 2025-02-03 at 4 15 26 PM" src="https://github.com/user-attachments/assets/a5c37508-4526-4697-b022-9623e6fef4e5" />