### PR TITLE
Issue 86: Restructure APIs and Implement RemoteStopTransaction (No.11)

### DIFF
--- a/00_Base/src/interfaces/api/AbstractModuleApi.ts
+++ b/00_Base/src/interfaces/api/AbstractModuleApi.ts
@@ -18,6 +18,7 @@ import {
   Namespace,
   OCPP1_6_Namespace,
   OcppRequest,
+  OCPPVersion,
   SystemConfig,
 } from '../..';
 import { OCPP2_0_1_Namespace } from '../../ocpp/persistence';
@@ -68,12 +69,12 @@ export abstract class AbstractModuleApi<T extends IModule>
         expose.optionalQuerystrings,
       );
     });
-    (
-      Reflect.getMetadata(
-        METADATA_DATA_ENDPOINTS,
-        this.constructor,
-      ) as Array<IDataEndpointDefinition>
-    )?.forEach((expose) => {
+
+    const dataEndpointDefinitions = Reflect.getMetadata(
+      METADATA_DATA_ENDPOINTS,
+      this.constructor,
+    ) as Array<IDataEndpointDefinition>;
+    dataEndpointDefinitions?.forEach((expose) => {
       this._addDataRoute.call(
         this,
         expose.namespace,
@@ -89,24 +90,25 @@ export abstract class AbstractModuleApi<T extends IModule>
         expose.security,
       );
     });
-
     // Add API routes for getting and setting SystemConfig
-    this._addDataRoute.call(
-      this,
-      OCPP2_0_1_Namespace.SystemConfig,
-      () => new Promise((resolve) => resolve(module.config)),
-      HttpMethod.Get,
-    );
-    this._addDataRoute.call(
-      this,
-      OCPP2_0_1_Namespace.SystemConfig,
-      (request: FastifyRequest<{ Body: SystemConfig }>) =>
-        new Promise<void>((resolve) => {
-          module.config = request.body;
-          resolve();
-        }),
-      HttpMethod.Put,
-    );
+    if (dataEndpointDefinitions && dataEndpointDefinitions.length > 0) {
+      this._addDataRoute.call(
+        this,
+        OCPP2_0_1_Namespace.SystemConfig,
+        () => new Promise((resolve) => resolve(module.config)),
+        HttpMethod.Get,
+      );
+      this._addDataRoute.call(
+        this,
+        OCPP2_0_1_Namespace.SystemConfig,
+        (request: FastifyRequest<{ Body: SystemConfig }>) =>
+          new Promise<void>((resolve) => {
+            module.config = request.body;
+            resolve();
+          }),
+        HttpMethod.Put,
+      );
+    }
   }
 
   /**
@@ -448,11 +450,13 @@ export abstract class AbstractModuleApi<T extends IModule>
    *
    * @param {CallAction} input - The {@link CallAction} to convert to a URL path.
    * @param {string} prefix - The module name.
+   * @param {OCPPVersion} ocppVersion - The OCPP version.
    * @returns {string} - String representation of URL path.
    */
-  protected _toMessagePath(input: CallAction, prefix?: string): string {
+  protected _toMessagePath(input: CallAction, prefix?: string, ocppVersion?: OCPPVersion): string {
     const endpointPrefix = prefix || '';
-    return `/ocpp${!endpointPrefix.startsWith('/') ? '/' : ''}${endpointPrefix}${!endpointPrefix.endsWith('/') ? '/' : ''}${input.charAt(0).toLowerCase() + input.slice(1)}`;
+    const endpointVersion = ocppVersion || OCPPVersion.OCPP2_0_1;
+    return `/ocpp/${endpointVersion.replace(/^ocpp/, "")}${!endpointPrefix.startsWith('/') ? '/' : ''}${endpointPrefix}${!endpointPrefix.endsWith('/') ? '/' : ''}${input.charAt(0).toLowerCase() + input.slice(1)}`;
   }
 
   /**

--- a/00_Base/src/interfaces/api/AsMessageEndpoint.ts
+++ b/00_Base/src/interfaces/api/AsMessageEndpoint.ts
@@ -11,6 +11,7 @@ import { CallAction } from '../../ocpp/rpc/message';
  *
  * @param {CallAction} action - The call action.
  * @param {object} bodySchema - The body schema.
+ * @param {Record<string, any>} optionalQuerystrings - The optional querystrings.
  * @return {void} This function does not return anything.
  */
 export const AsMessageEndpoint = function (

--- a/02_Util/src/util/swagger.ts
+++ b/02_Util/src/util/swagger.ts
@@ -46,9 +46,13 @@ function OcppTransformObject({
           if (method) {
             // Set tags based on path key if tags were not passed in
             if (!method.tags) {
+              // Get tag index
+              // e.g, '/ocpp/1.6/evdriver' -> 'evdriver'
+              // e.g, '/data/evdriver' -> 'evdriver'
+              const tagIndex = pathKey.includes('data') ? 2 : 3;
               method.tags = pathKey
                 .split('/')
-                .slice(2, -1)
+                .slice(tagIndex, -1)
                 .map((tag) => tag.charAt(0).toUpperCase() + tag.slice(1));
             }
           }

--- a/03_Modules/EVDriver/src/index.ts
+++ b/03_Modules/EVDriver/src/index.ts
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-export { EVDriverModuleApi } from './module/api';
+export { EVDriverModuleApi as EVDriverOcpp201MessageApi } from './module/Ocpp201Api';
+export { EVDriverModuleApi as EVDriverOcpp16MessageApi } from './module/Ocpp16Api';
+export { EVDriverModuleApi as EVDriverDataApi } from './module/DataApi';
 export { IEVDriverModuleApi } from './module/interface';
 export { EVDriverModule } from './module/module';

--- a/03_Modules/EVDriver/src/module/DataApi.ts
+++ b/03_Modules/EVDriver/src/module/DataApi.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { FastifyInstance, FastifyRequest } from 'fastify';
+import { ILogObj, Logger } from 'tslog';
+import { IEVDriverModuleApi } from './interface';
+import { EVDriverModule } from './module';
+import {
+  AbstractModuleApi,
+  AsDataEndpoint,
+  AuthorizationDataSchema,
+  HttpMethod,
+  OCPP2_0_1_Namespace,
+  OCPP2_0_1,
+  OCPP1_6_Namespace,
+  Namespace,
+} from '@citrineos/base';
+import {
+  Authorization,
+  AuthorizationQuerySchema,
+  AuthorizationQuerystring,
+  AuthorizationRestrictions,
+  AuthorizationRestrictionsSchema,
+  ChargingStationKeyQuerySchema,
+  ChargingStationKeyQuerystring,
+  LocalListVersion,
+} from '@citrineos/data';
+
+/**
+ * Server API for the provisioning component.
+ */
+export class EVDriverModuleApi
+  extends AbstractModuleApi<EVDriverModule>
+  implements IEVDriverModuleApi
+{
+  /**
+   * Constructs a new instance of the class.
+   *
+   * @param {EVDriverModule} evDriverModule - The EVDriver module.
+   * @param {FastifyInstance} server - The Fastify server instance.
+   * @param {Logger<ILogObj>} [logger] - The logger for logging.
+   */
+  constructor(
+    evDriverModule: EVDriverModule,
+    server: FastifyInstance,
+    logger?: Logger<ILogObj>,
+  ) {
+    super(evDriverModule, server, logger);
+  }
+
+  /**
+   * Data Endpoint Methods
+   */
+
+  @AsDataEndpoint(
+    OCPP2_0_1_Namespace.AuthorizationData,
+    HttpMethod.Put,
+    AuthorizationQuerySchema,
+    AuthorizationDataSchema,
+  )
+  putAuthorization(
+    request: FastifyRequest<{
+      Body: OCPP2_0_1.AuthorizationData;
+      Querystring: AuthorizationQuerystring;
+    }>,
+  ): Promise<Authorization | undefined> {
+    return this._module.authorizeRepository.createOrUpdateByQuerystring(
+      request.body,
+      request.query,
+    );
+  }
+
+  @AsDataEndpoint(
+    OCPP2_0_1_Namespace.AuthorizationRestrictions,
+    HttpMethod.Put,
+    AuthorizationQuerySchema,
+    AuthorizationRestrictionsSchema,
+  )
+  putAuthorizationRestrictions(
+    request: FastifyRequest<{
+      Body: AuthorizationRestrictions;
+      Querystring: AuthorizationQuerystring;
+    }>,
+  ): Promise<Authorization[]> {
+    return this._module.authorizeRepository.updateRestrictionsByQuerystring(
+      request.body,
+      request.query,
+    );
+  }
+
+  @AsDataEndpoint(
+    OCPP2_0_1_Namespace.AuthorizationData,
+    HttpMethod.Get,
+    AuthorizationQuerySchema,
+  )
+  getAuthorization(
+    request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
+  ): Promise<Authorization[]> {
+    return this._module.authorizeRepository.readAllByQuerystring(request.query);
+  }
+
+  @AsDataEndpoint(
+    OCPP2_0_1_Namespace.AuthorizationData,
+    HttpMethod.Delete,
+    AuthorizationQuerySchema,
+  )
+  async deleteAuthorization(
+    request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
+  ): Promise<string> {
+    return this._module.authorizeRepository
+      .deleteAllByQuerystring(request.query)
+      .then(
+        (deletedCount) =>
+          deletedCount.toString() +
+          ' rows successfully deleted from ' +
+          OCPP2_0_1_Namespace.AuthorizationData,
+      );
+  }
+
+  @AsDataEndpoint(
+    OCPP2_0_1_Namespace.LocalListVersion,
+    HttpMethod.Get,
+    ChargingStationKeyQuerySchema,
+  )
+  async getLocalAuthorizationListVersion(
+    request: FastifyRequest<{ Querystring: ChargingStationKeyQuerystring }>,
+  ): Promise<LocalListVersion | undefined> {
+    return await this._module.localAuthListRepository.readOnlyOneByQuery({
+      stationId: request.query.stationId,
+    });
+  }
+
+  /**
+   * Overrides superclass method to generate the URL path based on the input {@link OCPP2_0_1_Namespace} and the module's endpoint prefix configuration.
+   *
+   * @param {CallAction} input - The input {@link OCPP2_0_1_Namespace}.
+   * @return {string} - The generated URL path.
+   */
+  protected _toDataPath(
+    input: OCPP2_0_1_Namespace | OCPP1_6_Namespace | Namespace,
+  ): string {
+    const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
+    return super._toDataPath(input, endpointPrefix);
+  }
+}

--- a/03_Modules/EVDriver/src/module/Ocpp16Api.ts
+++ b/03_Modules/EVDriver/src/module/Ocpp16Api.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2023 S44, LLC
+// Copyright Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache 2.0
+
+import { FastifyInstance } from 'fastify';
+import { ILogObj, Logger } from 'tslog';
+import { IEVDriverModuleApi } from './interface';
+import { EVDriverModule } from './module';
+import {
+  AbstractModuleApi,
+  AsMessageEndpoint,
+  CallAction,
+  IMessageConfirmation,
+  OCPP1_6,
+  OCPP1_6_CallAction,
+  OCPPVersion,
+} from '@citrineos/base';
+
+/**
+ * Server API for the provisioning component.
+ */
+export class EVDriverModuleApi
+  extends AbstractModuleApi<EVDriverModule>
+  implements IEVDriverModuleApi
+{
+  /**
+   * Constructs a new instance of the class.
+   *
+   * @param {EVDriverModule} evDriverModule - The EVDriver module.
+   * @param {FastifyInstance} server - The Fastify server instance.
+   * @param {Logger<ILogObj>} [logger] - The logger for logging.
+   */
+  constructor(
+    evDriverModule: EVDriverModule,
+    server: FastifyInstance,
+    logger?: Logger<ILogObj>,
+  ) {
+    super(evDriverModule, server, logger);
+  }
+
+  /**
+   * Message Endpoint Methods for OCPP 1.6
+   */
+
+  @AsMessageEndpoint(
+    OCPP1_6_CallAction.RemoteStopTransaction,
+    OCPP1_6.RemoteStopTransactionRequestSchema,
+  )
+  async requestRemoteStopTransaction(
+    identifier: string,
+    tenantId: string,
+    request: OCPP1_6.RemoteStopTransactionRequest,
+    callbackUrl?: string,
+  ): Promise<IMessageConfirmation> {
+    return this._module.sendCall(
+      identifier,
+      tenantId,
+      OCPPVersion.OCPP1_6,
+      OCPP1_6_CallAction.RemoteStopTransaction,
+      request,
+      callbackUrl,
+    );
+  }
+
+  /**
+   * Overrides superclass method to generate the URL path based on the input ({@link OCPP2_0_1_Namespace},
+   * {@link OCPP1_6_Namespace} or {@link Namespace}) and the module's endpoint prefix configuration.
+   *
+   * @param {CallAction} input - The input {@link CallAction}, {@link OCPP1_6_Namespace} or {@link Namespace}.
+   * @return {string} - The generated URL path.
+   */
+  protected _toMessagePath(input: CallAction): string {
+    const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
+    return super._toMessagePath(input, endpointPrefix, OCPPVersion.OCPP1_6);
+  }
+}

--- a/03_Modules/EVDriver/src/module/Ocpp16Api.ts
+++ b/03_Modules/EVDriver/src/module/Ocpp16Api.ts
@@ -64,10 +64,10 @@ export class EVDriverModuleApi
   }
 
   /**
-   * Overrides superclass method to generate the URL path based on the input ({@link OCPP2_0_1_Namespace},
-   * {@link OCPP1_6_Namespace} or {@link Namespace}) and the module's endpoint prefix configuration.
+   * Overrides superclass method to generate the URL path based on the input {@link CallAction},
+   * the module's endpoint prefix configuration and the OCPP version.
    *
-   * @param {CallAction} input - The input {@link CallAction}, {@link OCPP1_6_Namespace} or {@link Namespace}.
+   * @param {CallAction} input - The input {@link CallAction}
    * @return {string} - The generated URL path.
    */
   protected _toMessagePath(input: CallAction): string {

--- a/03_Modules/EVDriver/src/module/Ocpp201Api.ts
+++ b/03_Modules/EVDriver/src/module/Ocpp201Api.ts
@@ -3,35 +3,21 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-import { FastifyInstance, FastifyRequest } from 'fastify';
+import { FastifyInstance } from 'fastify';
 import { ILogObj, Logger } from 'tslog';
 import { IEVDriverModuleApi } from './interface';
 import { EVDriverModule } from './module';
 import {
   AbstractModuleApi,
-  AsDataEndpoint,
   AsMessageEndpoint,
-  AuthorizationDataSchema,
   CallAction,
-  HttpMethod,
   IMessageConfirmation,
-  OCPP2_0_1_Namespace,
   OCPP2_0_1,
   OCPP2_0_1_CallAction,
   OCPPVersion,
-  OCPP1_6_Namespace,
-  Namespace,
 } from '@citrineos/base';
 import {
-  Authorization,
-  AuthorizationQuerySchema,
-  AuthorizationQuerystring,
-  AuthorizationRestrictions,
-  AuthorizationRestrictionsSchema,
   CallMessage,
-  ChargingStationKeyQuerySchema,
-  ChargingStationKeyQuerystring,
-  LocalListVersion,
 } from '@citrineos/data';
 import { validateChargingProfileType } from '@citrineos/util';
 import { v4 as uuidv4 } from 'uuid';
@@ -56,94 +42,6 @@ export class EVDriverModuleApi
     logger?: Logger<ILogObj>,
   ) {
     super(evDriverModule, server, logger);
-  }
-
-  /**
-   * Data Endpoint Methods
-   */
-
-  @AsDataEndpoint(
-    OCPP2_0_1_Namespace.AuthorizationData,
-    HttpMethod.Put,
-    AuthorizationQuerySchema,
-    AuthorizationDataSchema,
-  )
-  putAuthorization(
-    request: FastifyRequest<{
-      Body: OCPP2_0_1.AuthorizationData;
-      Querystring: AuthorizationQuerystring;
-    }>,
-  ): Promise<Authorization | undefined> {
-    // TODO: the change above is just to avoid compile error
-    //  pull the real change when issue 71: generalize authorization task is done
-    return this._module.authorizeRepository.createOrUpdateByQuerystring(
-      request.body,
-      request.query,
-    );
-  }
-
-  @AsDataEndpoint(
-    OCPP2_0_1_Namespace.AuthorizationRestrictions,
-    HttpMethod.Put,
-    AuthorizationQuerySchema,
-    AuthorizationRestrictionsSchema,
-  )
-  putAuthorizationRestrictions(
-    request: FastifyRequest<{
-      Body: AuthorizationRestrictions;
-      Querystring: AuthorizationQuerystring;
-    }>,
-  ): Promise<Authorization[]> {
-    // TODO: the change above is just to avoid compile error
-    //  pull the real change when issue 71: generalize authorization task is done
-    return this._module.authorizeRepository.updateRestrictionsByQuerystring(
-      request.body,
-      request.query,
-    );
-  }
-
-  @AsDataEndpoint(
-    OCPP2_0_1_Namespace.AuthorizationData,
-    HttpMethod.Get,
-    AuthorizationQuerySchema,
-  )
-  getAuthorization(
-    request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
-  ): Promise<Authorization[]> {
-    // TODO: the change above is just to avoid compile error
-    //  pull the real change when issue 71: generalize authorization task is done
-    return this._module.authorizeRepository.readAllByQuerystring(request.query);
-  }
-
-  @AsDataEndpoint(
-    OCPP2_0_1_Namespace.AuthorizationData,
-    HttpMethod.Delete,
-    AuthorizationQuerySchema,
-  )
-  deleteAuthorization(
-    request: FastifyRequest<{ Querystring: AuthorizationQuerystring }>,
-  ): Promise<string> {
-    return this._module.authorizeRepository
-      .deleteAllByQuerystring(request.query)
-      .then(
-        (deletedCount) =>
-          deletedCount.toString() +
-          ' rows successfully deleted from ' +
-          OCPP2_0_1_Namespace.AuthorizationData,
-      );
-  }
-
-  @AsDataEndpoint(
-    OCPP2_0_1_Namespace.LocalListVersion,
-    HttpMethod.Get,
-    ChargingStationKeyQuerySchema,
-  )
-  async getLocalAuthorizationListVersion(
-    request: FastifyRequest<{ Querystring: ChargingStationKeyQuerystring }>,
-  ): Promise<LocalListVersion | undefined> {
-    return await this._module.localAuthListRepository.readOnlyOneByQuery({
-      stationId: request.query.stationId,
-    });
   }
 
   /**
@@ -434,27 +332,14 @@ export class EVDriverModuleApi
   }
 
   /**
-   * Overrides superclass method to generate the URL path based on the input ({@link OCPP2_0_1_Namespace},
-   * {@link OCPP1_6_Namespace} or {@link Namespace}) and the module's endpoint prefix configuration.
+   * Overrides superclass method to generate the URL path based on the input {@link CallAction},
+   *  and the module's endpoint prefix configuration.
    *
-   * @param {CallAction} input - The input {@link CallAction}, {@link OCPP1_6_Namespace} or {@link Namespace}.
+   * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
   protected _toMessagePath(input: CallAction): string {
     const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
     return super._toMessagePath(input, endpointPrefix);
-  }
-
-  /**
-   * Overrides superclass method to generate the URL path based on the input {@link OCPP2_0_1_Namespace} and the module's endpoint prefix configuration.
-   *
-   * @param {CallAction} input - The input {@link OCPP2_0_1_Namespace}.
-   * @return {string} - The generated URL path.
-   */
-  protected _toDataPath(
-    input: OCPP2_0_1_Namespace | OCPP1_6_Namespace | Namespace,
-  ): string {
-    const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
-    return super._toDataPath(input, endpointPrefix);
   }
 }

--- a/03_Modules/EVDriver/src/module/interface.ts
+++ b/03_Modules/EVDriver/src/module/interface.ts
@@ -3,31 +3,7 @@
 //
 // SPDX-License-Identifier: Apache 2.0
 
-import {
-  IMessageConfirmation,
-  OCPP2_0_1
-} from '@citrineos/base';
-
 /**
  * Interface for the EVDriver module.
  */
-export interface IEVDriverModuleApi {
-  requestStartTransaction(
-    identifier: string,
-    tenantId: string,
-    request: OCPP2_0_1.RequestStartTransactionRequest,
-    callbackUrl?: string,
-  ): Promise<IMessageConfirmation>;
-  requestStopTransaction(
-    identifier: string,
-    tenantId: string,
-    request: OCPP2_0_1.RequestStopTransactionRequest,
-    callbackUrl?: string,
-  ): Promise<IMessageConfirmation>;
-  clearCache(
-    identifier: string,
-    tenantId: string,
-    request: OCPP2_0_1.ClearCacheRequest,
-    callbackUrl?: string,
-  ): Promise<IMessageConfirmation>;
-}
+export interface IEVDriverModuleApi {}

--- a/03_Modules/EVDriver/src/module/module.ts
+++ b/03_Modules/EVDriver/src/module/module.ts
@@ -14,6 +14,8 @@ import {
   IMessage,
   IMessageHandler,
   IMessageSender,
+  OCPP1_6,
+  OCPP1_6_CallAction,
   OCPP2_0_1,
   OCPP2_0_1_CallAction,
   OCPPVersion,
@@ -66,6 +68,7 @@ export class EVDriverModule extends AbstractModule {
     OCPP2_0_1_CallAction.ReserveNow,
     OCPP2_0_1_CallAction.SendLocalList,
     OCPP2_0_1_CallAction.UnlockConnector,
+    OCPP1_6_CallAction.RemoteStopTransaction,
   ];
 
   protected _authorizeRepository: IAuthorizationRepository;
@@ -241,7 +244,7 @@ export class EVDriverModule extends AbstractModule {
   }
 
   /**
-   * Handle requests
+   * Handle OCPP 2.0.1 requests
    */
 
   @AsHandler(OCPPVersion.OCPP2_0_1, OCPP2_0_1_CallAction.Authorize)
@@ -557,7 +560,7 @@ export class EVDriverModule extends AbstractModule {
   }
 
   /**
-   * Handle responses
+   * Handle OCPP 2.0.1 responses
    */
 
   @AsHandler(OCPPVersion.OCPP2_0_1, OCPP2_0_1_CallAction.RequestStartTransaction)
@@ -770,6 +773,30 @@ export class EVDriverModule extends AbstractModule {
       message.payload.versionNumber,
       message.context.stationId,
     );
+  }
+
+  /**
+   * Handle OCPP 1.6 responses
+   */
+
+  @AsHandler(OCPPVersion.OCPP1_6, OCPP1_6_CallAction.RemoteStopTransaction)
+  protected async _handleOcpp16RemoteStopTransaction(
+    message: IMessage<OCPP1_6.RemoteStopTransactionResponse>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(
+      'RequestStopTransactionResponse received:',
+      message,
+      props,
+    );
+    if (
+      message.payload.status !==
+      OCPP1_6.RemoteStopTransactionResponseStatus.Accepted
+    ) {
+      this._logger.error(
+        `RemoteStopTransaction failed with status: ${message.payload.status}`,
+      );
+    }
   }
 
   private async _findReservationByCorrelationId(

--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -52,7 +52,7 @@ import {
   CertificatesModule,
   CertificatesModuleApi,
 } from '@citrineos/certificates';
-import { EVDriverModule, EVDriverModuleApi } from '@citrineos/evdriver';
+import { EVDriverModule, EVDriverOcpp201MessageApi, EVDriverOcpp16MessageApi, EVDriverDataApi } from '@citrineos/evdriver';
 import { ReportingModule, ReportingModuleApi } from '@citrineos/reporting';
 import {
   InternalSmartCharging,
@@ -565,7 +565,9 @@ export class CitrineOSServer {
       this._idGenerator,
     );
     await this.initHandlersAndAddModule(module);
-    this.apis.push(new EVDriverModuleApi(module, this._server, this._logger));
+    this.apis.push(new EVDriverOcpp201MessageApi(module, this._server, this._logger));
+    this.apis.push(new EVDriverOcpp16MessageApi(module, this._server, this._logger));
+    this.apis.push(new EVDriverDataApi(module, this._server, this._logger));
   }
 
   private async initMonitoringModule() {


### PR DESCRIPTION
## Context
Implement RemoteStopTransaction endpoint and ensure Citrine to support apis of 2 OCPP versions. 

## Changes
1. Update `AbstractModuleApi`: 
    - add `SystemConfig` endpoints only for data apis. 
    - add ocpp version in the message endpoint path, e.g., `/ocpp/1.6/evdriver/remoteStopTransaction`
2. Split `api.ts` in `EVDriver` module into 3 api files for ocpp 2.0.1 message, ocpp 1.6 message and data endpoints respectively
3. Init all 3 Apis in the Server index.ts

## Tests
### Case 1: Call OCPP 1.6 endpoint
<img width="1173" alt="Screenshot 2025-02-04 at 5 40 16 PM" src="https://github.com/user-attachments/assets/30b69c1a-a013-4755-bd77-a2e473599720" />
<img width="911" alt="Screenshot 2025-02-04 at 5 40 26 PM" src="https://github.com/user-attachments/assets/b3ffeca8-f591-4b2e-a65d-0d8ccac4976a" />

### Case 2: Call OCPP 2.0.1 endpoint
<img width="1169" alt="Screenshot 2025-02-04 at 5 39 01 PM" src="https://github.com/user-attachments/assets/5c570702-3575-4799-baa3-e5c75d1cfacc" />
<img width="907" alt="Screenshot 2025-02-04 at 5 39 52 PM" src="https://github.com/user-attachments/assets/13d0af0c-6dc4-4d5c-95a2-7c1141c98a22" />

### Case 3: The endpoint ocpp version doesn't match the connection protocol version
Charge connects to Citrine with protocol 2.0.1 but send a 1.6 call
<img width="1181" alt="Screenshot 2025-02-04 at 5 39 39 PM" src="https://github.com/user-attachments/assets/29dc2ac6-3157-4698-9f83-e22511ea6bb0" />