### PR TITLE
Fix invalid OCPP messages being forwarded

### DIFF
--- a/03_Modules/OcppRouter/src/module/router.ts
+++ b/03_Modules/OcppRouter/src/module/router.ts
@@ -442,7 +442,8 @@ export class MessageRouterImpl
               { error: error },
             ];
       const rawMessage = JSON.stringify(callError, (k, v) => v ?? undefined);
-      this._sendMessage(identifier, rawMessage);
+      await this._sendMessage(identifier, rawMessage);
+      return;
     }
 
     try {


### PR DESCRIPTION
Invalid message is still getting put on the message bus. We should not be doing that, as it causes issues down the line.