### PR TITLE
FIX: Update charge session password API

### DIFF
--- a/03_Modules/Configuration/src/module/DataApi.ts
+++ b/03_Modules/Configuration/src/module/DataApi.ts
@@ -120,7 +120,7 @@ export class ConfigurationDataApi
     }
     const password = request.body.password || generatePassword();
 
-    if (!request.body.setOnCharger) {
+    if (request.body.setOnCharger) {
       try {
         await this.updatePasswordOnStation(password, stationId, request.query.callbackUrl);
       } catch (error) {


### PR DESCRIPTION
If set on charger, do not update password on charger (this logic is backwards).
It should be: If set on charger, update password on charger.