### PR TITLE
Use better healthcheck to ensure rabbitmq is up before citrine

### DIFF
--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./data/rabbitmq:/var/lib/rabbitmq
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q check_port_connectivity
       interval: 10s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Atleast for me the previous healthcheck of `ping` would cause `citrine` to start before rabbitmq was ready to accept connections, resulting in a crash.

License same as project.