### PR TITLE
fix: error with 1.6 StopTransaction with IdToken

### DIFF
--- a/03_Modules/Transactions/src/module/module.ts
+++ b/03_Modules/Transactions/src/module/module.ts
@@ -584,8 +584,9 @@ export class TransactionsModule extends AbstractModule {
     const request = message.payload;
 
     const authorization: Authorization | undefined = request.idTag
-      ? await this._authorizeRepository.readOnlyOneByQuery({
+      ? await this._authorizeRepository.readOnlyOneByQuerystring({
           idToken: request.idTag,
+          type: null, //explicitly ignore type
         })
       : undefined;
 


### PR DESCRIPTION
- fix: error with 1.6 StopTransaction incorrectly fetching authorization resulting in `More than one value found for query: {\"idToken\":\"IDTOKENVALUE\"}` error

I was able to reproduce the issue locally and with this adjustment, the error goes away
![Screenshot 2025-04-11 at 11 30 24 AM](https://github.com/user-attachments/assets/7255f29c-95a7-4edf-b0af-5fba3a4dfd8b)
<img width="2056" alt="Screenshot 2025-04-11 at 11 30 15 AM" src="https://github.com/user-attachments/assets/d0498424-4255-4877-8832-f853b56eb0b4" />

After fix
![Screenshot 2025-04-11 at 11 32 44 AM](https://github.com/user-attachments/assets/bda307ae-d47d-45bc-9f14-e5366339ddb6)
