### PR TITLE
Feature/total kwh calc

### DIFF
--- a/00_Base/src/util/MeterValueUtils.ts
+++ b/00_Base/src/util/MeterValueUtils.ts
@@ -11,7 +11,7 @@ export class MeterValueUtils {
    * Calculate the total Kwh
    *
    * @param {array} meterValues - meterValues of a transaction.
-   * @return {number} total Kwh based on the overall values (i.e., without phase) in the simpledValues.
+   * @return {number} total Kwh based on the best available energy measurement.
    */
   public static getTotalKwh(meterValues: OCPP2_0_1.MeterValueType[]): number {
     const filteredValues = this.filterValidMeterValues(meterValues);
@@ -34,43 +34,162 @@ export class MeterValueUtils {
     meterValues: OCPP2_0_1.MeterValueType[],
   ): Map<number, number> {
     const valuesMap = new Map<number, number>();
+
     for (const meterValue of meterValues) {
-      const overallValue = this.findOverallValue(meterValue.sampledValue);
-      if (overallValue) {
-        const timestamp = Date.parse(meterValue.timestamp);
-        const normalizedValue = this.normalizeToKwh(overallValue);
-        if (normalizedValue !== null) {
-          valuesMap.set(timestamp, normalizedValue);
-        }
+      const timestamp = Date.parse(meterValue.timestamp);
+      let energyValue = null;
+
+      // Try strategies in order of preference
+
+      // 1. Overall Energy.Active.Import.Register
+      energyValue = this.findMeasurandValue(
+        meterValue.sampledValue,
+        OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Register,
+        false,
+      );
+
+      // 2. Energy.Active.Import.Interval
+      if (energyValue === null) {
+        energyValue = this.findMeasurandValue(
+          meterValue.sampledValue,
+          OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Interval,
+          false,
+        );
+      }
+
+      // 3. Energy.Active.Net
+      if (energyValue === null) {
+        energyValue = this.findMeasurandValue(
+          meterValue.sampledValue,
+          OCPP2_0_1.MeasurandEnumType.Energy_Active_Net,
+          false,
+        );
+      }
+
+      // 4. Sum of phased Energy.Active.Import.Register values
+      if (energyValue === null) {
+        energyValue = this.sumPhasedValues(
+          meterValue.sampledValue,
+          OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Register,
+        );
+      }
+
+      // 5. Sum of phased Energy.Active.Import.Interval values
+      if (energyValue === null) {
+        energyValue = this.sumPhasedValues(
+          meterValue.sampledValue,
+          OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Interval,
+        );
+      }
+
+      // Store the value if we found one
+      if (energyValue !== null) {
+        valuesMap.set(timestamp, energyValue);
       }
     }
+
     return valuesMap;
   }
 
-  private static findOverallValue(
+  /**
+   * Find a specific measurand value from sampledValues
+   * @param sampledValues Array of sampled values
+   * @param measurand The measurand type to look for
+   * @param phased Whether to look for phased values (true) or non-phased values (false)
+   * @returns The normalized value in kWh, or null if not found
+   */
+  private static findMeasurandValue(
     sampledValues: OCPP2_0_1.SampledValueType[],
-  ): OCPP2_0_1.SampledValueType | undefined {
-    return sampledValues.find(
-      (sv) =>
-        !sv.phase && sv.measurand === OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Register,
-    );
+    measurand: OCPP2_0_1.MeasurandEnumType,
+    phased: boolean,
+  ): number | null {
+    const value = sampledValues.find((sv) => sv.measurand === measurand && !phased === !sv.phase);
+
+    if (value) {
+      return this.normalizeToKwh(value);
+    }
+
+    return null;
   }
 
-  private static normalizeToKwh(overallValue: OCPP2_0_1.SampledValueType): number | null {
-    let powerOfTen = overallValue.unitOfMeasure?.multiplier ?? 0;
-    const unit = overallValue.unitOfMeasure?.unit?.toUpperCase();
+  /**
+   * Sum phased values for a specific measurand
+   * @param sampledValues Array of sampled values
+   * @param measurand The measurand type to sum
+   * @returns The sum of phase values in kWh, or null if no valid phase values found
+   */
+  private static sumPhasedValues(
+    sampledValues: OCPP2_0_1.SampledValueType[],
+    measurand: OCPP2_0_1.MeasurandEnumType,
+  ): number | null {
+    // Find all values for this measurand that have individual phases L1, L2, or L3
+    const phaseValues = sampledValues.filter(
+      (sv) =>
+        sv.measurand === measurand &&
+        sv.phase && // Must have a phase specified
+        (sv.phase === OCPP2_0_1.PhaseEnumType.L1 ||
+          sv.phase === OCPP2_0_1.PhaseEnumType.L2 ||
+          sv.phase === OCPP2_0_1.PhaseEnumType.L3),
+    );
+
+    // If no phase values found, try phase-to-neutral as a last resort
+    if (phaseValues.length === 0) {
+      const phaseNeutralValues = sampledValues.filter(
+        (sv) =>
+          sv.measurand === measurand &&
+          sv.phase && // Must have a phase specified
+          (sv.phase === OCPP2_0_1.PhaseEnumType.L1_N ||
+            sv.phase === OCPP2_0_1.PhaseEnumType.L2_N ||
+            sv.phase === OCPP2_0_1.PhaseEnumType.L3_N),
+      );
+
+      if (phaseNeutralValues.length === 0) {
+        return null;
+      }
+
+      let sum = 0;
+      for (const value of phaseNeutralValues) {
+        const normalizedValue = this.normalizeToKwh(value);
+        if (normalizedValue !== null) {
+          sum += normalizedValue;
+        }
+      }
+
+      return sum;
+    }
+
+    // Sum all the normalized phase values
+    let sum = 0;
+    for (const value of phaseValues) {
+      const normalizedValue = this.normalizeToKwh(value);
+      if (normalizedValue !== null) {
+        sum += normalizedValue;
+      }
+    }
+
+    return sum;
+  }
+
+  private static normalizeToKwh(value: OCPP2_0_1.SampledValueType): number | null {
+    let powerOfTen = value.unitOfMeasure?.multiplier ?? 0;
+    const unit = value.unitOfMeasure?.unit?.toUpperCase();
+
     switch (unit) {
       case 'KWH':
+      case 'KVARH': // For reactive energy
+      case 'KVAH': // For apparent energy
         break;
       case 'WH':
+      case 'VARH': // For reactive energy
+      case 'VAH': // For apparent energy
       case undefined:
         powerOfTen -= 3;
         break;
       default:
-        throw new Error('Unknown unit for Energy.Active.Import.Register: ' + unit);
+        throw new Error(`Unknown unit for energy measurement: ${unit}`);
     }
 
-    return overallValue.value * 10 ** powerOfTen;
+    return value.value * 10 ** powerOfTen;
   }
 
   private static getSortedKwhByTimestampAscending(valuesMap: Map<number, number>): number[] {

--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -512,6 +512,17 @@ export class SequelizeTransactionEventRepository
         this.meterValue.emit('created', [meterValue]);
       }),
     );
+
+    // Update transaction total kWh
+    const allMeterValues = await this.meterValue.readAllByQuery({
+      where: {
+        transactionDatabaseId: transaction.id,
+      },
+    });
+    const meterValueTypes = allMeterValues.map((meterValue) =>
+      MeterValueMapper.toMeterValueType(meterValue),
+    );
+    await transaction.update({ totalKwh: MeterValueUtils.getTotalKwh(meterValueTypes) });
   }
 
   async createTransactionByStartTransaction(


### PR DESCRIPTION
fixes issues with total kwh calc:

- OCPP 1.6 MeterValues now update Transaction.totalKwh
- If unphased Energy.Active.Import is not sent, L1, L2, and L3 are summed
- If Energy.Active.Import.Register is not sent, Energy.Active.Import.Interval or Energy.Active.Import.Net are used (in that order of preference)