### PR TITLE
Fix: GetTransactionStatus Not Update The Transaction

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -47,10 +47,10 @@ import {
   InstalledCertificate,
   ChangeConfiguration,
   OCPPMessage,
+  StopTransaction,
 } from '../layers/sequelize';
 import { type AuthorizationRestrictions, type VariableAttributeQuerystring } from '.';
 import { TariffQueryString } from './queries/Tariff';
-import { StopTransaction } from '../layers/sequelize/model/TransactionEvent';
 
 export interface IAuthorizationRepository extends CrudRepository<Authorization> {
   createOrUpdateByQuerystring: (
@@ -257,6 +257,11 @@ export interface ITransactionEventRepository extends CrudRepository<TransactionE
     reason?: string,
     idTokenDatabaseId?: number,
   ): Promise<StopTransaction>;
+  updateTransactionByStationIdAndTransactionId(
+    transaction: Partial<Transaction>,
+    transactionId: string,
+    stationId: string,
+  ): Promise<Transaction | undefined>;
 }
 
 export interface IVariableMonitoringRepository

--- a/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
+++ b/01_Data/src/layers/sequelize/repository/TransactionEvent.ts
@@ -624,4 +624,19 @@ export class SequelizeTransactionEventRepository
 
     return stopTransaction;
   }
+
+  async updateTransactionByStationIdAndTransactionId(
+    transaction: Partial<Transaction>,
+    transactionId: string,
+    stationId: string,
+  ): Promise<Transaction | undefined> {
+    const transactions = await this.transaction.updateAllByQuery(transaction, {
+      where: {
+        // unique constraint
+        transactionId,
+        stationId,
+      },
+    });
+    return transactions.length > 0 ? transactions[0] : undefined;
+  }
 }

--- a/03_Modules/Transactions/test/module/TransactionService.test.ts
+++ b/03_Modules/Transactions/test/module/TransactionService.test.ts
@@ -1,5 +1,6 @@
 import {
   IAuthorizationRepository,
+  IOCPPMessageRepository,
   IReservationRepository,
   ITransactionEventRepository,
 } from '@citrineos/data';
@@ -18,6 +19,7 @@ describe('TransactionService', () => {
   let authorizationRepository: jest.Mocked<IAuthorizationRepository>;
   let transactionEventRepository: jest.Mocked<ITransactionEventRepository>;
   let reservationRepository: jest.Mocked<IReservationRepository>;
+  let ocppMessageRepository: jest.Mocked<IOCPPMessageRepository>;
   let authorizer: jest.Mocked<IAuthorizer>;
 
   beforeEach(() => {
@@ -32,6 +34,8 @@ describe('TransactionService', () => {
 
     reservationRepository = {} as unknown as jest.Mocked<IReservationRepository>;
 
+    ocppMessageRepository = {} as unknown as jest.Mocked<IOCPPMessageRepository>;
+
     authorizer = {
       authorize: jest.fn(),
     } as jest.Mocked<IAuthorizer>;
@@ -40,6 +44,7 @@ describe('TransactionService', () => {
       transactionEventRepository,
       authorizationRepository,
       reservationRepository,
+      ocppMessageRepository,
       [authorizer],
     );
   });

--- a/Server/src/index.ts
+++ b/Server/src/index.ts
@@ -612,6 +612,7 @@ export class CitrineOSServer {
       this._repositoryStore.locationRepository,
       this._repositoryStore.tariffRepository,
       this._repositoryStore.reservationRepository,
+      this._repositoryStore.ocppMessageRepository,
     );
     await this.initHandlersAndAddModule(module);
     this.apis.push(


### PR DESCRIPTION
## Content
This PR is to fix the issue that the transaction doesn't get updated when receiving GetTransactionStatusResponse with transaction specific `ongoingIndicator` value.

## Test
1. prepare an active transaction <img width="882" alt="Screenshot 2025-04-24 at 9 40 38 AM" src="https://github.com/user-attachments/assets/319ab981-f6f5-4c22-a011-78509d11366e" />
2. send GetTransactionStatusRequest <img width="996" alt="Screenshot 2025-04-24 at 9 50 01 AM" src="https://github.com/user-attachments/assets/44b0ca28-5edc-4c65-91aa-f0d84a8799a1" />
3. charger sends back the response <img width="916" alt="Screenshot 2025-04-24 at 9 50 57 AM" src="https://github.com/user-attachments/assets/3facea5a-a7fd-4181-bc3e-0c9ce88a7cef" />
4. The transaction is updated. <img width="893" alt="Screenshot 2025-04-24 at 9 41 22 AM" src="https://github.com/user-attachments/assets/7b3e9472-fe33-4309-97f8-651e082795f7" />
