### PR TITLE
Adding new boolean field to Authorization, validating before hasConcurrent check in authorizeIdToken function

### DIFF
--- a/01_Data/src/layers/sequelize/model/Authorization/Authorization.ts
+++ b/01_Data/src/layers/sequelize/model/Authorization/Authorization.ts
@@ -4,7 +4,15 @@
 // SPDX-License-Identifier: Apache 2.0
 
 import { Namespace } from '@citrineos/base';
-import { BelongsTo, Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  Default,
+  ForeignKey,
+  Model,
+  Table,
+} from 'sequelize-typescript';
 import { type AuthorizationRestrictions } from '../../../../interfaces';
 import { IdToken, IdTokenInfo } from '.';
 
@@ -34,6 +42,10 @@ export class Authorization extends Model implements AuthorizationRestrictions {
 
   @BelongsTo(() => IdTokenInfo)
   declare idTokenInfo?: IdTokenInfo;
+
+  @Default(false)
+  @Column(DataType.BOOLEAN)
+  declare concurrentTransaction?: boolean;
 
   declare customData?: any | null;
 }

--- a/03_Modules/Transactions/src/module/TransactionService.ts
+++ b/03_Modules/Transactions/src/module/TransactionService.ts
@@ -113,10 +113,12 @@ export class TransactionService {
         authorization,
         messageContext,
       );
-      if (transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started) {
-        const hasConcurrent = await this._hasConcurrentTransactions(idToken);
-        if (hasConcurrent) {
-          response.idTokenInfo.status = OCPP2_0_1.AuthorizationStatusEnumType.ConcurrentTx;
+      if (authorization.concurrentTransaction === true) {
+        if (transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started) {
+          const hasConcurrent = await this._hasConcurrentTransactions(idToken);
+          if (hasConcurrent) {
+            response.idTokenInfo.status = OCPP2_0_1.AuthorizationStatusEnumType.ConcurrentTx;
+          }
         }
       }
     }


### PR DESCRIPTION
- Adding concurrentTx bool field to Authorization Model
- Validating Authorization.concurrentTx before the whole segment for hasConcurrent.