### PR TITLE
Fix compatibility issue with linux/amd64 architecture

### DIFF
--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
   ocpp-db:
     image: postgis/postgis:16-3.5
+    platform: linux/amd64
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
### What’s Changed
This PR addresses an issue that prevented the project from working correctly on M-series (Apple Silicon) Macs. The fix ensures that the postgis image targets is  explicitly compatible with this architecture.

### Why
Docker image `postgis/postgis`  does not have builds for the ARM64 architecture

### Changes
- Updated Server/docker-compose.yml to support `linux/amd64`

### Testing
Tested on an Apple silicon chip machine and confirmed successful build.
