### PR TITLE
Create Interfaces of the DTO

### DIFF
--- a/00_Base/src/interfaces/dto/authorization.dto.ts
+++ b/00_Base/src/interfaces/dto/authorization.dto.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IIdTokenDto } from './id.token.dto';
+import { IIdTokenInfoDto } from './id.token.info.dto';
+
+export interface IAuthorizationDto extends IBaseDto {
+  id: number;
+  allowedConnectorTypes: any[];
+  disallowedEvseIdPrefixes: any[];
+  idTokenId: number;
+  idToken?: IIdTokenDto;
+  idTokenInfoId: number;
+  idTokenInfo?: IIdTokenInfoDto;
+  concurrentTransaction?: boolean;
+}
+
+export enum AuthorizationDtoProps {
+  id = 'id',
+  allowedConnectorTypes = 'allowedConnectorTypes',
+  disallowedEvseIdPrefixes = 'disallowedEvseIdPrefixes',
+  idTokenId = 'idTokenId',
+  idToken = 'idToken',
+  idTokenInfoId = 'idTokenInfoId',
+  idTokenInfo = 'idTokenInfo',
+  concurrentTransaction = 'concurrentTransaction',
+}

--- a/00_Base/src/interfaces/dto/base.dto.ts
+++ b/00_Base/src/interfaces/dto/base.dto.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export interface IBaseDto {
+  updatedAt?: Date;
+  createdAt?: Date;
+}
+
+export enum BaseDtoProps {
+  updatedAt = 'updatedAt',
+  createdAt = 'createdAt',
+}

--- a/00_Base/src/interfaces/dto/charging.station.dto.ts
+++ b/00_Base/src/interfaces/dto/charging.station.dto.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { IBaseDto } from './base.dto';
+import { ILocationDto } from './location.dto';
+import { ITransactionDto } from './transaction.dto';
+import { IStatusNotificationDto } from './status.notification.dto';
+import { ILatestStatusNotificationDto } from './latest.status.notification.dto';
+import { IEvseDto } from './evse.dto';
+
+export interface IChargingStationDto extends IBaseDto {
+  id: string;
+  isOnline: boolean;
+  protocol?: string;
+  locationId?: string;
+  statusNotifications?: IStatusNotificationDto[];
+  latestStatusNotifications?: ILatestStatusNotificationDto[];
+  evses?: IEvseDto[];
+  connectorTypes?: string[];
+  transactions?: ITransactionDto[];
+  ocppLogs?: any[];
+  location?: ILocationDto;
+  chargePointVendor?: string;
+  chargePointModel?: string;
+  chargePointSerialNumber?: string;
+  chargeBoxSerialNumber?: string;
+  firmwareVersion?: string;
+  iccid?: string;
+  imsi?: string;
+  meterSerialNumber?: string;
+}
+
+export enum ChargingStationDtoProps {
+  id = 'id',
+  isOnline = 'isOnline',
+  protocol = 'protocol',
+  locationId = 'locationId',
+  statusNotifications = 'statusNotifications',
+  latestStatusNotifications = 'latestStatusNotifications',
+  evses = 'evses',
+  transactions = 'transactions',
+  ocppLogs = 'ocppLogs',
+  location = 'Location',
+  chargePointVendor = 'chargePointVendor',
+  chargePointModel = 'chargePointModel',
+  chargePointSerialNumber = 'chargePointSerialNumber',
+  chargeBoxSerialNumber = 'chargeBoxSerialNumber',
+  firmwareVersion = 'firmwareVersion',
+  iccid = 'iccid',
+  imsi = 'imsi',
+  meterSerialNumber = 'meterSerialNumber',
+}

--- a/00_Base/src/interfaces/dto/charging.station.sequence.dto.ts
+++ b/00_Base/src/interfaces/dto/charging.station.sequence.dto.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IChargingStationSequenceDto extends IBaseDto {
+  stationId: string;
+  type: string;
+  value: number;
+}

--- a/00_Base/src/interfaces/dto/component.dto.ts
+++ b/00_Base/src/interfaces/dto/component.dto.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IComponentDto extends IBaseDto {
+  id: number;
+  name: string;
+  instance?: string | null;
+  evseDatabaseId?: number;
+  evseId?: number;
+  connectorId?: number;
+}

--- a/00_Base/src/interfaces/dto/connector.dto.ts
+++ b/00_Base/src/interfaces/dto/connector.dto.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IConnectorDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  connectorId: number;
+  status?: any;
+  errorCode?: any;
+  info?: string;
+  vendorId?: string;
+  vendorErrorCode?: string;
+}
+
+export enum ConnectorDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  connectorId = 'connectorId',
+}

--- a/00_Base/src/interfaces/dto/evse.dto.ts
+++ b/00_Base/src/interfaces/dto/evse.dto.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IEvseDto extends IBaseDto {
+  databaseId: number;
+  id: number;
+  connectorId?: number | null;
+  // customData?: CustomDataType | null; // Uncomment and define if needed
+}
+
+export enum EvseDtoProps {
+  databaseId = 'databaseId',
+  id = 'id',
+  connectorId = 'connectorId',
+}

--- a/00_Base/src/interfaces/dto/id.token.dto.ts
+++ b/00_Base/src/interfaces/dto/id.token.dto.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IIdTokenDto extends IBaseDto {
+  id: number;
+  idToken: string;
+  type?: any;
+}
+
+export enum IdTokenDtoProps {
+  id = 'id',
+  idToken = 'idToken',
+  type = 'type',
+}

--- a/00_Base/src/interfaces/dto/id.token.info.dto.ts
+++ b/00_Base/src/interfaces/dto/id.token.info.dto.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IIdTokenInfoDto extends IBaseDto {
+  id: number;
+  status: any;
+  cacheExpiryDateTime?: Date;
+  chargingPriority?: number;
+  language1?: string;
+  language2?: string;
+  groupIdTokenId?: number;
+  personalMessage?: string;
+}
+
+export enum IdTokenInfoDtoProps {
+  id = 'id',
+  status = 'status',
+  cacheExpiryDateTime = 'cacheExpiryDateTime',
+  chargingPriority = 'chargingPriority',
+  language1 = 'language1',
+  language2 = 'language2',
+  groupIdTokenId = 'groupIdTokenId',
+  personalMessage = 'personalMessage',
+}

--- a/00_Base/src/interfaces/dto/latest.status.notification.dto.ts
+++ b/00_Base/src/interfaces/dto/latest.status.notification.dto.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface ILatestStatusNotificationDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  statusNotificationId: number;
+  statusNotification?: any;
+}
+
+export enum LatestStatusNotificationDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  statusNotificationId = 'statusNotificationId',
+  statusNotification = 'statusNotification',
+}

--- a/00_Base/src/interfaces/dto/location.dto.ts
+++ b/00_Base/src/interfaces/dto/location.dto.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IChargingStationDto } from './charging.station.dto';
+
+export interface ILocationDto extends IBaseDto {
+  id: string;
+  name: string;
+  address: string;
+  city: string;
+  postalCode: string;
+  state: string;
+  country: string;
+  coordinates: any;
+  chargingStations: IChargingStationDto[];
+}
+
+export enum LocationDtoProps {
+  id = 'id',
+  name = 'name',
+  address = 'address',
+  city = 'city',
+  postalCode = 'postalCode',
+  state = 'state',
+  country = 'country',
+  coordinates = 'coordinates',
+  chargingStations = 'chargingStations',
+}

--- a/00_Base/src/interfaces/dto/meter.value.dto.ts
+++ b/00_Base/src/interfaces/dto/meter.value.dto.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { ISampledValueDto } from './sampled.value.dto';
+
+export interface IMeterValueDto extends IBaseDto {
+  id: number;
+  transactionEventId?: number | null;
+  transactionDatabaseId?: number | null;
+  sampledValue: ISampledValueDto[];
+  timestamp: Date;
+  connectorId?: number | null;
+}
+
+export enum MeterValueDtoProps {
+  id = 'id',
+  transactionEventId = 'transactionEventId',
+  transactionDatabaseId = 'transactionDatabaseId',
+  sampledValue = 'sampledValue',
+  timestamp = 'timestamp',
+  connectorId = 'connectorId',
+}

--- a/00_Base/src/interfaces/dto/ocpp.message.dto.ts
+++ b/00_Base/src/interfaces/dto/ocpp.message.dto.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IOCPPMessageDto extends IBaseDto {
+  id: string;
+  stationId: string;
+  correlationId: string;
+  origin: any;
+  protocol: any;
+  action?: any;
+  message: any;
+  timestamp: Date;
+}
+
+export enum OCPPMessageDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  correlationId = 'correlationId',
+  origin = 'origin',
+  protocol = 'protocol',
+  action = 'action',
+  message = 'message',
+  timestamp = 'timestamp',
+}

--- a/00_Base/src/interfaces/dto/sampled.value.dto.ts
+++ b/00_Base/src/interfaces/dto/sampled.value.dto.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface ISampledValueDto extends IBaseDto {
+  value: number;
+  context?: any; // Use ReadingContextEnumType if available
+  measurand?: any; // Use MeasurandEnumType if available
+  phase?: any; // Use PhaseEnumType if available
+  location?: any; // Use LocationEnumType if available
+  signedMeterValue?: any; // Use SignedMeterValue if available
+  unitOfMeasure?: any; // Use UnitOfMeasure if available
+}
+
+export enum SampledValueDtoProps {
+  value = 'value',
+  context = 'context',
+  measurand = 'measurand',
+  phase = 'phase',
+  location = 'location',
+  signedMeterValue = 'signedMeterValue',
+  unitOfMeasure = 'unitOfMeasure',
+}

--- a/00_Base/src/interfaces/dto/start.transaction.dto.ts
+++ b/00_Base/src/interfaces/dto/start.transaction.dto.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IConnectorDto } from './connector.dto';
+import { IIdTokenDto } from './id.token.dto';
+
+export interface IStartTransactionDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  meterStart: number;
+  timestamp: Date;
+  reservationId?: number | null;
+  transactionDatabaseId?: string;
+  idTokenDatabaseId?: number | null;
+  connectorDatabaseId: number;
+  idToken?: IIdTokenDto;
+  connector?: IConnectorDto;
+}
+
+export enum StartTransactionDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  meterStart = 'meterStart',
+  timestamp = 'timestamp',
+  reservationId = 'reservationId',
+  transactionDatabaseId = 'transactionDatabaseId',
+  idTokenDatabaseId = 'idTokenDatabaseId',
+  connectorDatabaseId = 'connectorDatabaseId',
+  idToken = 'IdToken',
+  connector = 'connector',
+}

--- a/00_Base/src/interfaces/dto/status.notification.dto.ts
+++ b/00_Base/src/interfaces/dto/status.notification.dto.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IStatusNotificationDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  evseId?: number;
+  connectorId: number;
+  timestamp: string;
+  connectorStatus: any; // Use ConnectorStatusEnumType if available
+}
+
+export enum StatusNotificationDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  evseId = 'evseId',
+  connectorId = 'connectorId',
+  timestamp = 'timestamp',
+  connectorStatus = 'connectorStatus',
+}

--- a/00_Base/src/interfaces/dto/stop.transaction.dto.ts
+++ b/00_Base/src/interfaces/dto/stop.transaction.dto.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IMeterValueDto } from './meter.value.dto';
+import { IIdTokenDto } from './id.token.dto';
+
+export interface IStopTransactionDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  transactionDatabaseId?: string;
+  meterStop: number;
+  timestamp: Date;
+  idTokenDatabaseId?: number | null;
+  reason?: string;
+  meterValues?: IMeterValueDto[];
+  idToken?: IIdTokenDto;
+}
+
+export enum StopTransactionDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  transactionDatabaseId = 'transactionDatabaseId',
+  meterStop = 'meterStop',
+  timestamp = 'timestamp',
+  idTokenDatabaseId = 'idTokenDatabaseId',
+  reason = 'reason',
+  meterValues = 'meterValues',
+  idToken = 'idToken',
+}

--- a/00_Base/src/interfaces/dto/transaction.dto.ts
+++ b/00_Base/src/interfaces/dto/transaction.dto.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IEvseDto } from './evse.dto';
+import { IChargingStationDto } from './charging.station.dto';
+import { ITransactionEventDto } from './transaction.event.dto';
+
+export interface ITransactionDto extends IBaseDto {
+  id: number;
+  transactionId: string;
+  stationId: string;
+  transactionEvents?: ITransactionEventDto[];
+  chargingStation?: IChargingStationDto;
+  evse?: IEvseDto;
+  evseDatabaseId?: number;
+  isActive: boolean;
+  meterValues?: any[];
+  startTransaction?: any;
+  stopTransaction?: any;
+  chargingState?: any;
+  timeSpentCharging?: number | null;
+  totalKwh?: number | null;
+  stoppedReason?: any;
+  remoteStartId?: number | null;
+  totalCost?: number;
+}
+
+export enum TransactionDtoProps {
+  id = 'id',
+  transactionId = 'transactionId',
+  stationId = 'stationId',
+  chargingStation = 'ChargingStation',
+  transactionEvents = 'TransactionEvents',
+  evseDatabaseId = 'evseDatabaseId',
+  isActive = 'isActive',
+  meterValues = 'meterValues',
+  startTransaction = 'StartTransaction',
+  stopTransaction = 'stopTransaction',
+  chargingState = 'chargingState',
+  timeSpentCharging = 'timeSpentCharging',
+  totalKwh = 'totalKwh',
+  stoppedReason = 'stoppedReason',
+  remoteStartId = 'remoteStartId',
+  totalCost = 'totalCost',
+  evse = 'evse',
+}

--- a/00_Base/src/interfaces/dto/transaction.event.dto.ts
+++ b/00_Base/src/interfaces/dto/transaction.event.dto.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+import { IIdTokenDto } from './id.token.dto';
+
+export interface ITransactionEventDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  evseId?: number | null;
+  transactionDatabaseId?: string;
+  eventType: any;
+  meterValues?: any[];
+  timestamp: Date;
+  triggerReason: any;
+  seqNo: number;
+  offline?: boolean | null;
+  numberOfPhasesUsed?: number | null;
+  cableMaxCurrent?: number | null;
+  reservationId?: number | null;
+  idTokenId?: number | null;
+  idToken?: IIdTokenDto;
+  // transactionInfo?: any; // Uncomment and type if needed
+}
+
+export enum TransactionEventDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  evseId = 'evseId',
+  transactionDatabaseId = 'transactionDatabaseId',
+  eventType = 'eventType',
+  meterValues = 'meterValues',
+  timestamp = 'timestamp',
+  triggerReason = 'triggerReason',
+  seqNo = 'seqNo',
+  offline = 'offline',
+  numberOfPhasesUsed = 'numberOfPhasesUsed',
+  cableMaxCurrent = 'cableMaxCurrent',
+  reservationId = 'reservationId',
+  idToken = 'IdToken',
+  idTokenId = 'idTokenId',
+}

--- a/00_Base/src/interfaces/dto/variable.attribute.dto.ts
+++ b/00_Base/src/interfaces/dto/variable.attribute.dto.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IVariableAttributeDto extends IBaseDto {
+  id: number;
+  stationId: string;
+  type?: any; // Use AttributeEnumType if available
+  dataType: any; // Use DataEnumType if available
+  value?: string | null;
+  mutability?: any; // Use MutabilityEnumType if available
+  persistent: boolean;
+  constant: boolean;
+  variableId?: any | null; // Use IVariableDto if available
+  componentId?: any | null; // Use IComponentDto if available
+  evseDatabaseId?: number | null;
+  generatedAt?: string;
+}
+
+export enum VariableAttributeDtoProps {
+  id = 'id',
+  stationId = 'stationId',
+  type = 'type',
+  dataType = 'dataType',
+  value = 'value',
+  mutability = 'mutability',
+  persistent = 'persistent',
+  constant = 'constant',
+  variableId = 'variableId',
+  componentId = 'componentId',
+  evseDatabaseId = 'evseDatabaseId',
+  generatedAt = 'generatedAt',
+}

--- a/00_Base/src/interfaces/dto/variable.dto.ts
+++ b/00_Base/src/interfaces/dto/variable.dto.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IBaseDto } from './base.dto';
+
+export interface IVariableDto extends IBaseDto {
+  id: number;
+  name: string;
+  instance?: string | null;
+}
+
+export enum VariableDtoProps {
+  id = 'id',
+  name = 'name',
+  instance = 'instance',
+}


### PR DESCRIPTION
### Description
This PR migrates the CitrineOS core DTO definitions from operator-ui/src/dtos to core/00_Base/src/interfaces/dto to promote reuse across upstream repositories (operator-ui, ocpi, etc).

### Why
This is Part 1 of a broader effort to unify models across the codebase.
No changes were made to the models in 01_Data or pages; they will implement the shared interfaces in later tasks.

### Changes
- Moved all DTO definitions from operator-ui/src/dtos to core/00_Base/src/interfaces/dto.
- Ensured models are exportable and type-safe for consumption across multiple repositories.
