### PR TITLE
Fix: Migrate Column concurrentTransaction in Table Authorization

### DIFF
--- a/Server/hasura-metadata/databases/default/tables/public_Authorizations.yaml
+++ b/Server/hasura-metadata/databases/default/tables/public_Authorizations.yaml
@@ -31,6 +31,7 @@ select_permissions:
         - tenantId
         - createdAt
         - updatedAt
+        - concurrentTransaction
       filter:
         tenantId:
           _eq: x-hasura-tenant-id

--- a/migrations/20250618150000-update-authorizations-to-include-concurrenttransaction.ts
+++ b/migrations/20250618150000-update-authorizations-to-include-concurrenttransaction.ts
@@ -1,0 +1,28 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface } from 'sequelize';
+import { DataType } from 'sequelize-typescript';
+
+const TABLE_NAME = 'Authorizations';
+const COLUMN_NAME = 'concurrentTransaction';
+
+export = {
+  up: async (queryInterface: QueryInterface) => {
+    const tableDescription = await queryInterface.describeTable(TABLE_NAME);
+    if (!tableDescription[COLUMN_NAME]) {
+      await queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
+        type: DataType.BOOLEAN,
+        allowNull: true,
+        defaultValue: false,
+      });
+    }
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    const tableDescription = await queryInterface.describeTable(TABLE_NAME);
+    if (tableDescription[COLUMN_NAME]) {
+      await queryInterface.removeColumn(TABLE_NAME, COLUMN_NAME);
+    }
+  },
+};


### PR DESCRIPTION
This PR is to fix the error in UI when loading the Authorization tab due to the missing column, `concurrentTransaction`. A new migration file is added. 
```
field 'concurrentTransaction' not found in type: 'Authorizations': {"response":{"errors":[{"message":"field 'concurrentTransaction' not found in type: 'Authorizations'","extensions":{"path":"$.selectionSet.Authorizations.selectionSet.concurrentTransaction","code":"validation-failed"}}],"status":200,"headers":{}},"request":{"query":"query AuthorizationsList($offset: Int!, $limit: Int!, $order_by: [Authorizations_order_by!], $where: Authorizations_bool_exp) {\n Authorizations(\n offset: $offset\n limit: $limit\n order_by: $order_by\n where: $where\n ) {\n id\n allowedConnectorTypes\n disallowedEvseIdPrefixes\n idTokenId\n idTokenInfoId\n concurrentTransaction\n IdToken {\n createdAt\n id\n idToken\n type\n updatedAt\n }\n IdTokenInfo {\n cacheExpiryDateTime\n chargingPriority\n createdAt\n groupIdTokenId\n id\n language1\n language2\n personalMessage\n status\n updatedAt\n }\n }\n Authorizations_aggregate(where: $where) {\n aggregate {\n count\n }\n }\n}\n","variables":{"limit":10,"offset":0,"order_by":{"updatedAt":"desc"},"where":{"_and":[]}}}}
``` 

This is the log for the successful migration. 
```
== 20250618150000-update-authorizations-to-include-concurrenttransaction: migrating =======
Executing (default): SELECT pk.constraint_type as "Constraint",c.column_name as "Field", c.column_default as "Default",c.is_nullable as "Null", (CASE WHEN c.udt_name = 'hstore' THEN c.udt_name ELSE c.data_type END) || (CASE WHEN c.character_maximum_length IS NOT NULL THEN '(' || c.character_maximum_length || ')' ELSE '' END) as "Type", (SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special", (SELECT pgd.description FROM pg_catalog.pg_statio_all_tables AS st INNER JOIN pg_catalog.pg_description pgd on (pgd.objoid=st.relid) WHERE c.ordinal_position=pgd.objsubid AND c.table_name=st.relname) AS "Comment" FROM information_schema.columns c LEFT JOIN (SELECT tc.table_schema, tc.table_name, cu.column_name, tc.constraint_type FROM information_schema.TABLE_CONSTRAINTS tc JOIN information_schema.KEY_COLUMN_USAGE  cu ON tc.table_schema=cu.table_schema and tc.table_name=cu.table_name and tc.constraint_name=cu.constraint_name and tc.constraint_type='PRIMARY KEY') pk ON pk.table_schema=c.table_schema AND pk.table_name=c.table_name AND pk.column_name=c.column_name WHERE c.table_name = 'Authorizations' AND c.table_schema = 'public'
Executing (default): ALTER TABLE "public"."Authorizations" ADD COLUMN "concurrentTransaction" BOOLEAN DEFAULT false;
Executing (default): SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'SequelizeMeta'
Executing (default): SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND t.relkind = 'r' and t.relname = 'SequelizeMeta' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;
Executing (default): INSERT INTO "SequelizeMeta" ("name") VALUES ($1) RETURNING "name";
== 20250618150000-update-authorizations-to-include-concurrenttransaction: migrated (0.244s)
``` 
The Authorization data is loaded successfully.<img width="1689" alt="Screenshot 2025-06-18 at 4 50 06 PM" src="https://github.com/user-attachments/assets/6b3f69ac-05b9-49e4-9485-8b353e500f82" />