### PR TITLE
groupAuthorizationId fix

### DIFF
--- a/Server/hasura-metadata/databases/default/tables/public_Authorizations.yaml
+++ b/Server/hasura-metadata/databases/default/tables/public_Authorizations.yaml
@@ -7,7 +7,7 @@ object_relationships:
       foreign_key_constraint_on: tenantId
   - name: GroupAuthorization
     using:
-      foreign_key_constraint_on: groupIdTokenId
+      foreign_key_constraint_on: groupAuthorizationId
 array_relationships:
   - name: LocalListAuthorizations
     using:
@@ -32,7 +32,7 @@ select_permissions:
         - language1
         - language2
         - personalMessage
-        - groupIdTokenId
+        - groupAuthorizationId
         - concurrentTransaction
         - customData
         - tenantId


### PR DESCRIPTION
This PR corrects the metadata for the Authorizations table by replacing references to groupIdTokenId with the new groupAuthorizationId column in object relationships and select permissions.

Update object relationship foreign key to use groupAuthorizationId
Expose groupAuthorizationId in select permissions