### PR TITLE
script to start everest 1.6

### DIFF
--- a/Server/everest/Dockerfile
+++ b/Server/everest/Dockerfile
@@ -1,21 +1,7 @@
 ARG EVEREST_IMAGE_TAG=0.0.23
-
 FROM --platform=linux/x86_64 ghcr.io/everest/everest-demo/manager:${EVEREST_IMAGE_TAG}
 
-ARG EVEREST_TARGET_URL=host.docker.internal/cp001
-ENV EVEREST_TARGET_URL $EVEREST_TARGET_URL
-
 WORKDIR /workspace
-
-RUN apt-get update && apt-get install -y sqlite3
-RUN sqlite3 /ext/dist/share/everest/modules/OCPP201/device_model_storage.db \
-        "UPDATE VARIABLE_ATTRIBUTE \
-        SET value = '[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}},{\"configurationSlot\": 2, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]' \
-        WHERE \
-        variable_Id IN ( \
-        SELECT id FROM VARIABLE \
-        WHERE name = 'NetworkConnectionProfiles' \
-        );"
 
 RUN npm i -g http-server
 EXPOSE 8888

--- a/Server/everest/docker-compose.yml
+++ b/Server/everest/docker-compose.yml
@@ -11,7 +11,6 @@ services:
     build:
       dockerfile: Dockerfile
       args:
-        - EVEREST_TARGET_URL=${EVEREST_TARGET_URL}
         - EVEREST_IMAGE_TAG=${EVEREST_IMAGE_TAG}
     platform: linux/x86_64
     ports:
@@ -25,6 +24,8 @@ services:
       - mqtt-server
     environment:
       - MQTT_SERVER_ADDRESS=mqtt-server
+      - EVEREST_TARGET_URL=${EVEREST_TARGET_URL}
+      - OCPP_VERSION=${OCPP_VERSION}
     sysctls:
       - net.ipv6.conf.all.disable_ipv6=0
     extra_hosts:

--- a/Server/everest/start.sh
+++ b/Server/everest/start.sh
@@ -1,7 +1,26 @@
 #!/bin/sh
+if [ "$OCPP_VERSION" = "two" ]; then
+    apt-get update && apt-get install -y sqlite3
+    sqlite3 /ext/dist/share/everest/modules/OCPP201/device_model_storage.db \
+            "UPDATE VARIABLE_ATTRIBUTE \
+            SET value = '[{\"configurationSlot\": 1, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}},{\"configurationSlot\": 2, \"connectionData\": {\"messageTimeout\": 30, \"ocppCsmsUrl\": \"$EVEREST_TARGET_URL\", \"ocppInterface\": \"Wired0\", \"ocppTransport\": \"JSON\", \"ocppVersion\": \"OCPP20\", \"securityProfile\": 1}}]' \
+            WHERE \
+            variable_Id IN ( \
+            SELECT id FROM VARIABLE \
+            WHERE name = 'NetworkConnectionProfiles' \
+            );"
+fi
+
 /entrypoint.sh
 http-server /tmp/everest_ocpp_logs -p 8888 &
-rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/EVSE_2.json
-rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/Connector_2_1.json
-chmod +x /ext/build/run-scripts/run-sil-ocpp201-pnc.sh
-/ext/build/run-scripts/run-sil-ocpp201-pnc.sh
+
+if [ "$OCPP_VERSION" = "one" ]; then
+    chmod +x /ext/build/run-scripts/run-sil-ocpp.sh
+    sed -i "0,/127.0.0.1:8180\/steve\/websocket\/CentralSystemService\// s|127.0.0.1:8180/steve/websocket/CentralSystemService/|${EVEREST_TARGET_URL}|" /ext/dist/share/everest/modules/OCPP/config-docker.json
+    /ext/build/run-scripts/run-sil-ocpp.sh
+else
+    rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/EVSE_2.json
+    rm /ext/dist/share/everest/modules/OCPP201/component_config/custom/Connector_2_1.json
+    chmod +x /ext/build/run-scripts/run-sil-ocpp201-pnc.sh
+    /ext/build/run-scripts/run-sil-ocpp201-pnc.sh
+fi

--- a/Server/package.json
+++ b/Server/package.json
@@ -18,7 +18,8 @@
     "start:instance2": "cross-env APP_NAME=all APP_ENV=local CITRINEOS_CONFIG_FILENAME=config.json CITRINEOS_FILE_ACCESS_TYPE=local CITRINEOS_FILE_ACCESS_LOCAL_DEFAULT_FILE_PATH=/data nodemon dist/index.js --env-prefix=instance2_",
     "start-docker": "nodemon",
     "start-docker-cloud": "npm run migrate --prefix ../ && node --inspect=0.0.0.0:9229 dist/index.js",
-    "start-everest": "cd ./everest && cross-env EVEREST_IMAGE_TAG=0.0.23 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker compose up"
+    "start-everest": "cd ./everest && cross-env OCPP_VERSION=two EVEREST_IMAGE_TAG=0.0.23 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker compose up -d",
+    "start-everest-16": "cd ./everest && cross-env OCPP_VERSION=one EVEREST_IMAGE_TAG=0.0.23 EVEREST_TARGET_URL=ws://host.docker.internal:8092/ docker compose up -d"
   },
   "keywords": [
     "ocpp",


### PR DESCRIPTION
added 16 command to start everest

moved logic out of dockerfile and into start.sh to be able to identify either 16 or 201 and correctly configure the everest sim with the correct sil script and inserting the ws url for local

added start-everest-16 script to package.json. modified start-everest script to pass in var for 2.0.1