### PR TITLE
Feature/tc 33 as a developer i need to represent ocpi

### DIFF
--- a/01_Data/src/index.ts
+++ b/01_Data/src/index.ts
@@ -47,6 +47,7 @@ export {
   ChargingStationSecurityInfo,
   ChargingStationNetworkProfile,
   Tenant,
+  TenantPartner,
   SignatureAlgorithmEnumType,
   SequelizeAuthorizationRepository,
   SequelizeBootRepository,

--- a/01_Data/src/interfaces/ocpi.ts
+++ b/01_Data/src/interfaces/ocpi.ts
@@ -25,7 +25,7 @@ export interface Endpoint {
 
 export interface CredentialRole {
   role: 'CPO' | 'EMSP' | 'HUB' | 'NAP' | 'NSP' | 'SCSP';
-  business_details?: BusinessDetails;
+  businessDetails?: BusinessDetails;
 }
 
 export interface Credentials {

--- a/01_Data/src/interfaces/ocpi.ts
+++ b/01_Data/src/interfaces/ocpi.ts
@@ -1,0 +1,37 @@
+export interface BusinessDetails {
+  name: string;
+  website?: string;
+  logo?: Image;
+}
+
+export interface Image {
+  url: string;
+  category?: string;
+  type?: string;
+  width?: number;
+  height?: number;
+}
+
+export interface Version {
+  version: string;
+  url: string;
+}
+
+export interface VersionEndpoint {
+  identifier: string;
+  url: string;
+  role: 'SENDER' | 'RECEIVER';
+}
+
+export interface CredentialRole {
+  role: 'CPO' | 'EMSP' | 'HUB' | 'NAP' | 'NSP' | 'SCSP';
+  business_details?: BusinessDetails;
+  party_id: string;
+  country_code: string;
+}
+
+export interface Credentials {
+  token: string;
+  url: string;
+  roles: CredentialRole[];
+}

--- a/01_Data/src/interfaces/ocpi.ts
+++ b/01_Data/src/interfaces/ocpi.ts
@@ -17,21 +17,19 @@ export interface Version {
   url: string;
 }
 
-export interface VersionEndpoint {
-  identifier: string;
+export interface Endpoint {
+  module: string;
   url: string;
-  role: 'SENDER' | 'RECEIVER';
+  roles: string[];
 }
 
 export interface CredentialRole {
   role: 'CPO' | 'EMSP' | 'HUB' | 'NAP' | 'NSP' | 'SCSP';
   business_details?: BusinessDetails;
-  party_id: string;
-  country_code: string;
 }
 
 export interface Credentials {
-  token: string;
-  url: string;
-  roles: CredentialRole[];
+  token?: string;
+  connectionUrl?: string;
+  certificateRef?: string;
 }

--- a/01_Data/src/layers/sequelize/index.ts
+++ b/01_Data/src/layers/sequelize/index.ts
@@ -64,6 +64,7 @@ export { Reservation } from './model/Reservation';
 export { ChargingStationSecurityInfo } from './model/ChargingStationSecurityInfo';
 export { ChangeConfiguration } from './model/ChangeConfiguration';
 export { Tenant } from './model/Tenant';
+export { TenantPartner } from './model/TenantPartner';
 
 // Sequelize Repositories
 export { SequelizeRepository } from './repository/Base';

--- a/01_Data/src/layers/sequelize/model/Tenant.ts
+++ b/01_Data/src/layers/sequelize/model/Tenant.ts
@@ -53,6 +53,7 @@ import { SecurityEvent } from './SecurityEvent';
 import { LatestStatusNotification } from './Location/LatestStatusNotification';
 import { Subscription } from './Subscription';
 import { Tariff } from './Tariff';
+import { TenantPartner } from './TenantPartner';
 
 export enum TenantAttributeProps {
   id = 'id',
@@ -82,6 +83,12 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> {
 
   @Column(DataType.STRING)
   declare name: string;
+
+  @Column(DataType.JSONB)
+  declare serverCredentialsRoles: object;
+
+  @Column(DataType.JSONB)
+  declare serverVersions: object;
 
   /**
    * Relationships
@@ -224,4 +231,7 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> {
 
   @HasMany(() => SendLocalListAuthorization)
   declare sendLocalListAuthorizations: SendLocalListAuthorization[];
+
+  @HasMany(() => TenantPartner)
+  declare tenantPartners: TenantPartner[];
 }

--- a/01_Data/src/layers/sequelize/model/Tenant.ts
+++ b/01_Data/src/layers/sequelize/model/Tenant.ts
@@ -54,7 +54,7 @@ import { LatestStatusNotification } from './Location/LatestStatusNotification';
 import { Subscription } from './Subscription';
 import { Tariff } from './Tariff';
 import { TenantPartner } from './TenantPartner';
-import { CredentialRole, Version } from '../../../interfaces/ocpi';
+import { CredentialRole, Version, Credentials } from '../../../interfaces/ocpi';
 import { JSONB } from '../util';
 
 export enum TenantAttributeProps {
@@ -85,12 +85,6 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> {
 
   @Column(DataType.STRING)
   declare name: string;
-
-  @Column(DataType.JSONB)
-  declare serverCredentialsRoles: JSONB<CredentialRole[]>;
-
-  @Column(DataType.JSONB)
-  declare serverVersions: JSONB<Version[]>;
 
   /**
    * Relationships
@@ -236,4 +230,19 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> {
 
   @HasMany(() => TenantPartner)
   declare tenantPartners: TenantPartner[];
+
+  @Column(DataType.STRING)
+  declare partyId: string;
+
+  @Column(DataType.STRING)
+  declare countryCode: string;
+
+  @Column(DataType.JSONB)
+  declare serverCredentialsRoles: JSONB<CredentialRole[]>;
+
+  @Column(DataType.JSONB)
+  declare serverVersions: JSONB<Version[]>;
+
+  @Column(DataType.JSONB)
+  declare serverCredential: JSONB<Credentials>;
 }

--- a/01_Data/src/layers/sequelize/model/Tenant.ts
+++ b/01_Data/src/layers/sequelize/model/Tenant.ts
@@ -54,6 +54,8 @@ import { LatestStatusNotification } from './Location/LatestStatusNotification';
 import { Subscription } from './Subscription';
 import { Tariff } from './Tariff';
 import { TenantPartner } from './TenantPartner';
+import { CredentialRole, Version } from '../../../interfaces/ocpi';
+import { JSONB } from '../util';
 
 export enum TenantAttributeProps {
   id = 'id',
@@ -85,10 +87,10 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> {
   declare name: string;
 
   @Column(DataType.JSONB)
-  declare serverCredentialsRoles: object;
+  declare serverCredentialsRoles: JSONB<CredentialRole[]>;
 
   @Column(DataType.JSONB)
-  declare serverVersions: object;
+  declare serverVersions: JSONB<Version[]>;
 
   /**
    * Relationships

--- a/01_Data/src/layers/sequelize/model/TenantPartner.ts
+++ b/01_Data/src/layers/sequelize/model/TenantPartner.ts
@@ -8,6 +8,8 @@ import {
   BelongsTo,
 } from 'sequelize-typescript';
 import { Tenant } from './Tenant';
+import { CredentialRole, Version, VersionEndpoint } from '../../../interfaces/ocpi';
+import { JSONB } from '../util';
 
 @Table
 export class TenantPartner extends Model {
@@ -22,31 +24,21 @@ export class TenantPartner extends Model {
   @BelongsTo(() => Tenant)
   declare tenant: Tenant;
 
-  // OCPI/Protocol-agnostic partner details
   @Column(DataType.JSONB)
-  declare businessDetails: object;
+  declare clientCredentialsRoles: JSONB<CredentialRole[]>;
 
   @Column(DataType.JSONB)
-  declare clientCredentialsRoles: object;
+  declare clientVersions: JSONB<Version[]>;
 
   @Column(DataType.JSONB)
-  declare clientInformations: object;
+  declare cpoTenants: JSONB;
 
   @Column(DataType.JSONB)
-  declare clientVersions: object;
+  declare endpoints: JSONB;
 
   @Column(DataType.JSONB)
-  declare cpoTenants: object;
+  declare versions: JSONB<Version[]>;
 
   @Column(DataType.JSONB)
-  declare endpoints: object;
-
-  @Column(DataType.JSONB)
-  declare images: object;
-
-  @Column(DataType.JSONB)
-  declare versions: object;
-
-  @Column(DataType.JSONB)
-  declare versionEndpoints: object;
+  declare versionEndpoints: JSONB<VersionEndpoint[]>;
 }

--- a/01_Data/src/layers/sequelize/model/TenantPartner.ts
+++ b/01_Data/src/layers/sequelize/model/TenantPartner.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  DataType,
+  ForeignKey,
+  Model,
+  PrimaryKey,
+  Table,
+  BelongsTo,
+} from 'sequelize-typescript';
+import { Tenant } from './Tenant';
+
+@Table
+export class TenantPartner extends Model {
+  @PrimaryKey
+  @Column(DataType.INTEGER)
+  declare id: number;
+
+  @ForeignKey(() => Tenant)
+  @Column(DataType.INTEGER)
+  declare tenantId: number;
+
+  @BelongsTo(() => Tenant)
+  declare tenant: Tenant;
+
+  // OCPI/Protocol-agnostic partner details
+  @Column(DataType.JSONB)
+  declare businessDetails: object;
+
+  @Column(DataType.JSONB)
+  declare clientCredentialsRoles: object;
+
+  @Column(DataType.JSONB)
+  declare clientInformations: object;
+
+  @Column(DataType.JSONB)
+  declare clientVersions: object;
+
+  @Column(DataType.JSONB)
+  declare cpoTenants: object;
+
+  @Column(DataType.JSONB)
+  declare endpoints: object;
+
+  @Column(DataType.JSONB)
+  declare images: object;
+
+  @Column(DataType.JSONB)
+  declare versions: object;
+
+  @Column(DataType.JSONB)
+  declare versionEndpoints: object;
+}

--- a/01_Data/src/layers/sequelize/model/TenantPartner.ts
+++ b/01_Data/src/layers/sequelize/model/TenantPartner.ts
@@ -8,8 +8,8 @@ import {
   BelongsTo,
 } from 'sequelize-typescript';
 import { Tenant } from './Tenant';
-import { CredentialRole, Version, VersionEndpoint } from '../../../interfaces/ocpi';
 import { JSONB } from '../util';
+import { CredentialRole, Credentials, Endpoint, Version } from '../../../interfaces/ocpi';
 
 @Table
 export class TenantPartner extends Model {
@@ -25,20 +25,18 @@ export class TenantPartner extends Model {
   declare tenant: Tenant;
 
   @Column(DataType.JSONB)
-  declare clientCredentialsRoles: JSONB<CredentialRole[]>;
-
-  @Column(DataType.JSONB)
-  declare clientVersions: JSONB<Version[]>;
-
-  @Column(DataType.JSONB)
-  declare cpoTenants: JSONB;
-
-  @Column(DataType.JSONB)
-  declare endpoints: JSONB;
-
-  @Column(DataType.JSONB)
-  declare versions: JSONB<Version[]>;
-
-  @Column(DataType.JSONB)
-  declare versionEndpoints: JSONB<VersionEndpoint[]>;
+  declare partnerProfile: JSONB<{
+    protocol: string;
+    version: string;
+    party_id: string;
+    country_code: string;
+    roles: CredentialRole[];
+    credentials?: Credentials;
+    endpoints?: Endpoint[];
+    versionEndpoints?: Version[];
+    relatedPartners?: Array<{
+      partnerId: number;
+      relationshipType?: string;
+    }>;
+  }>;
 }

--- a/01_Data/src/layers/sequelize/model/TenantPartner.ts
+++ b/01_Data/src/layers/sequelize/model/TenantPartner.ts
@@ -17,6 +17,12 @@ export class TenantPartner extends Model {
   @Column(DataType.INTEGER)
   declare id: number;
 
+  @Column(DataType.STRING)
+  declare partyId: string;
+
+  @Column(DataType.STRING)
+  declare countryCode: string;
+
   @ForeignKey(() => Tenant)
   @Column(DataType.INTEGER)
   declare tenantId: number;
@@ -28,8 +34,6 @@ export class TenantPartner extends Model {
   declare partnerProfile: JSONB<{
     protocol: string;
     version: string;
-    party_id: string;
-    country_code: string;
     roles: CredentialRole[];
     credentials?: Credentials;
     endpoints?: Endpoint[];

--- a/01_Data/src/layers/sequelize/model/index.ts
+++ b/01_Data/src/layers/sequelize/model/index.ts
@@ -18,3 +18,4 @@ export * from './Tariff';
 export * from './Tenant';
 export * from './TransactionEvent';
 export * from './VariableMonitoring';
+export * from './TenantPartner';

--- a/01_Data/src/layers/sequelize/util.ts
+++ b/01_Data/src/layers/sequelize/util.ts
@@ -178,3 +178,5 @@ export class DefaultSequelizeInstance {
     });
   }
 }
+
+export type JSONB<T = any> = T | Record<string, unknown>;


### PR DESCRIPTION
##  Summary

This PR implements the data models for representing OCPI objects in Core, aligned with both OCPI 2.2.1 and OCPI 3.0 specifications, in order to persist tenant-specific and partner-specific information. This supports the OCPI handshake flow and future multi-tenant topology requirements.

##  Scope

- Added `Tenant` data structure with:
  - Server credentials and roles
  - Supported versions

- Added `TenantPartner` data structure with:
  - Partner credentials and roles
  - Supported OCPI versions
  - Supported endpoints and version endpoints
  - `relatedPartners` for multi-partner trust relationships

- JSONB-based columns to allow flexible nesting or flattening as required
- Extensible design for future OCPI protocol extensions or other standards

