### PR TITLE
#164 Allow "no auth header" for local development - default to dummy header

### DIFF
--- a/00_Base/src/interfaces/api/auth/IApiAuthProvider.ts
+++ b/00_Base/src/interfaces/api/auth/IApiAuthProvider.ts
@@ -14,6 +14,12 @@ import { ApiAuthenticationResult } from './ApiAuthenticationResult';
  */
 export interface IApiAuthProvider {
   /**
+   * Extracts the authentication token from the request
+   * @param request
+   */
+  extractToken(request: FastifyRequest): Promise<string | null>;
+
+  /**
    * Authenticates a token and extracts user information
    *
    * @param token JWT or other token to authenticate

--- a/02_Util/src/authorization/ApiAuthPlugin.ts
+++ b/02_Util/src/authorization/ApiAuthPlugin.ts
@@ -101,19 +101,15 @@ const apiAuthPlugin: FastifyPluginAsync<{
   // Authentication decorator - validates token from Authorization header
   fastify.decorate('authenticate', async function (request: FastifyRequest, reply: FastifyReply) {
     try {
-      // Extract Authorization header
-      const authHeader = request.headers.authorization;
-
-      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      // Extract token
+      const token = await provider.extractToken(request);
+      if (!token) {
         reply.code(HttpStatus.UNAUTHORIZED).send({
           error: 'Unauthorized',
           message: 'Missing or invalid authorization header',
         });
         return;
       }
-
-      // Extract token
-      const token = authHeader.split('Bearer ')[1];
 
       // Authenticate token
       const authResult = await provider.authenticateToken(token);

--- a/02_Util/src/authorization/provider/LocalByPassAuthProvider.ts
+++ b/02_Util/src/authorization/provider/LocalByPassAuthProvider.ts
@@ -41,14 +41,22 @@ export class LocalBypassAuthProvider implements IApiAuthProvider {
     );
   }
 
+  async extractToken(_request: FastifyRequest): Promise<string> {
+    // Always return a dummy token for local bypass
+    this._logger.debug('LocalBypassAuthProvider.authenticateToken: Returning dummy token');
+    return 'local-bypass-token';
+  }
+
   /**
    * Always returns a successful authentication with admin user
    *
    * @param token Ignored, can be any string
    * @returns Authentication result with admin user info
    */
-  async authenticateToken(token: string): Promise<ApiAuthenticationResult> {
-    this._logger.debug('LocalBypassAuthProvider.authenticateToken: Bypassing authentication');
+  async authenticateToken(_token: string): Promise<ApiAuthenticationResult> {
+    this._logger.debug(
+      'LocalBypassAuthProvider.authenticateToken: Bypassing authentication, using dummy user',
+    );
 
     // Create a default admin user
     const user: UserInfo = {

--- a/02_Util/src/authorization/provider/OIDCAuthProvider.ts
+++ b/02_Util/src/authorization/provider/OIDCAuthProvider.ts
@@ -79,6 +79,20 @@ export class OIDCAuthProvider implements IApiAuthProvider {
     this._logger.info(`OIDC auth provider setup with jwksUri: ${this._config.jwksUri}`);
   }
 
+  async extractToken(request: FastifyRequest): Promise<string | null> {
+    // Extract the Authorization header
+    const authHeader = request.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      this._logger.warn('No Bearer token found in request headers');
+      return null;
+    }
+
+    // Return the token without the "Bearer " prefix
+    const token = authHeader.slice(7).trim();
+    this._logger.debug('Extracted token from request:', token);
+    return token;
+  }
+
   /**
    * Authenticates a JWT token from and OIDC provider
    *


### PR DESCRIPTION
feature: move auth header to not being needed for local bypass during…development. Also adds support for accepting customer headers, instead of only `Authorization` allowing for static api keys

This should address issue [#164](https://github.com/citrineos/citrineos/issues/146)