### PR TITLE
Fixed typescript error

### DIFF
--- a/02_Util/src/util/directus.ts
+++ b/02_Util/src/util/directus.ts
@@ -136,7 +136,7 @@ export class DirectusUtil implements ConfigStore {
     if (filePath) {
       formData.append('folder', filePath);
     }
-    formData.append('file', new Blob([content]), fileName);
+    formData.append('file', new Blob([content as Buffer<ArrayBuffer>]), fileName);
     try {
       const file = await this._client.request(uploadFiles(formData));
       return file['id'];


### PR DESCRIPTION
Trying to build with ./Server/local.Dockerfile gives this error
```
90.04 02_Util/src/util/directus.ts(139,39): error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'BlobPart'.
90.04   Type 'Buffer<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
90.04     Types of property 'buffer' are incompatible.
90.04       Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
90.04         Type 'SharedArrayBuffer' is missing the following properties from type 'ArrayBuffer': resizable, resize, detached, transfer, transferToFixedLength
```

I believe a new Typescript version created this error.
Thankfully, the solution is a simple type assertion. 