### PR TITLE
Introduce ability to use sync

### DIFF
--- a/00_Base/src/config/bootstrap.config.ts
+++ b/00_Base/src/config/bootstrap.config.ts
@@ -20,6 +20,7 @@ export const bootstrapConfigSchema = z.object({
     password: z.string().default('citrine'),
     sync: z.boolean().default(false),
     alter: z.boolean().default(false),
+    force: z.boolean().default(false),
     maxRetries: z.number().int().positive().default(3),
     retryDelay: z.number().int().positive().default(1000),
   }),
@@ -113,6 +114,7 @@ export function loadBootstrapConfig(): BootstrapConfig {
       password: getEnvVarValue('database_password'),
       sync: getEnvVarValue('database_sync') && parseEnvValue(getEnvVarValue('database_sync')!),
       alter: getEnvVarValue('database_alter') && parseEnvValue(getEnvVarValue('database_alter')!),
+      force: getEnvVarValue('database_force') && parseEnvValue(getEnvVarValue('database_force')!),
       maxRetries:
         getEnvVarValue('database_max_retries') &&
         parseInt(getEnvVarValue('database_max_retries')!, 10),

--- a/01_Data/src/layers/sequelize/util.ts
+++ b/01_Data/src/layers/sequelize/util.ts
@@ -110,13 +110,23 @@ export class DefaultSequelizeInstance {
     }
   }
 
-  private static async syncDb() {
-    if (this.config.database.alter) {
-      await this.instance!.sync({ alter: true });
-      this.logger.info('Database altered');
-    } else if (this.config.database.sync) {
-      await this.instance!.sync({ force: true });
-      this.logger.info('Database synchronized');
+  private static async syncDb(): Promise<void> {
+    if (this.config.database.sync) {
+      const alter = this.config.database.alter;
+      const force = this.config.database.force;
+      if (force) {
+        this.logger.info('Database force synchronizing');
+        await this.instance!.sync({ force: true });
+        this.logger.info('Database force synchronized');
+      } else if (alter) {
+        this.logger.info('Database altering');
+        await this.instance!.sync({ alter: true });
+        this.logger.info('Database altered');
+      } else {
+        this.logger.info('Database synchronizing');
+        await this.instance!.sync();
+        this.logger.info('Database synchronized');
+      }
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ CitrineOS is an open-source project aimed at providing a modular server runtime 
 charging infrastructure. This README will guide you through the process of installing and running CitrineOS.
 
 This is the main part of CitrineOS containing the actual charging station management logic, OCPP message routing and all
-modules.
+await (await sequelize).sync(); // Use { force: true } for dropping and recreating tables
 
 All other documentation and the issue tracking can be found in our main repository
 here: <https://github.com/citrineos/citrineos>.
@@ -30,6 +30,7 @@ here: <https://github.com/citrineos/citrineos>.
 - [Information on Docker setup](#information-on-docker-setup)
 - [Generating OCPP Interfaces](#generating-ocpp-interfaces)
 - [Hasura Metadata](#hasura-metadata)
+- [Database Sync vs. Migration](#database-sync-vs-migration)
 - [Contributing](#contributing)
 - [Licensing](#licensing)
 - [Support and contact](#support-and-contact)
@@ -89,6 +90,17 @@ Before you begin, make sure you have the following installed on your system:
    port for the underlying NodeJS process. A variety of tools can be utilized to establish a debugger connection
    with the exposed localhost 9229 port which is forwarded to the NodeJS service running within docker. The IntelliJ
    `Attach Debugger` Run Configuration was made to attach to a debugging session.
+
+### Database Sync vs. Migration
+
+By default, CitrineOS uses migrations to manage database schema changes. This is the recommended approach for production environments.
+
+For development purposes, you can also use `sync` to automatically synchronize your database schema with the models. There are two sync scripts available:
+
+- `npm run sync-db`: This will synchronize the database schema with the models without altering existing tables. This is useful for development when you want to quickly update the schema without losing data.
+- `npm run force-sync-db`: This will drop all tables and recreate them based on the models. This is useful when you want to start with a fresh database.
+
+**Disclaimer:** Using `sync` in a production environment is not recommended as it can lead to data loss. Always use migrations for production deployments.
 
 ### Runtime configuration
 

--- a/Server/deploy.Dockerfile
+++ b/Server/deploy.Dockerfile
@@ -13,6 +13,8 @@ COPY --from=build /usr/local/apps/citrineos /usr/local/apps/citrineos
 
 WORKDIR /usr/local/apps/citrineos
 
+RUN chmod +x /usr/local/apps/citrineos/entrypoint.sh
+
 EXPOSE ${PORT}
 
-CMD ["npm", "run", "start-docker-cloud"]
+ENTRYPOINT ["/usr/local/apps/citrineos/entrypoint.sh"]

--- a/Server/docker-compose.yml
+++ b/Server/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       # Skip authentication completely - use public access
       AWS_ACCESS_KEY_ID: minioadmin
       AWS_SECRET_ACCESS_KEY: minioadmin
+      # Database Strategy
+      DB_STRATEGY: 'migrate'
       # Bootstrap Configuration Environment Variables
       BOOTSTRAP_CITRINEOS_DATABASE_HOST: 'ocpp-db'
       BOOTSTRAP_CITRINEOS_CONFIG_FILENAME: 'config.json'

--- a/Server/package.json
+++ b/Server/package.json
@@ -17,7 +17,7 @@
     "start:instance1": "cross-env APP_NAME=all APP_ENV=local BOOTSTRAP_INSTANCE1_CONFIG_FILENAME=config.json BOOTSTRAP_INSTANCE1_FILE_ACCESS_TYPE=local BOOTSTRAP_INSTANCE1_FILE_ACCESS_LOCAL_DEFAULT_FILE_PATH=/data nodemon dist/index.js --env-prefix=instance1_",
     "start:instance2": "cross-env APP_NAME=all APP_ENV=local BOOTSTRAP_INSTANCE2_CONFIG_FILENAME=config.json BOOTSTRAP_INSTANCE2_FILE_ACCESS_TYPE=local BOOTSTRAP_INSTANCE2_FILE_ACCESS_LOCAL_DEFAULT_FILE_PATH=/data nodemon dist/index.js --env-prefix=instance2_",
     "start-docker": "nodemon",
-    "start-docker-cloud": "npm run migrate --prefix ../ && node --inspect=0.0.0.0:9229 dist/index.js",
+    "start-docker-cloud": "node --inspect=0.0.0.0:9229 dist/index.js",
     "start-everest": "cd ./everest && cross-env OCPP_VERSION=two EVEREST_IMAGE_TAG=0.0.23 EVEREST_TARGET_URL=ws://host.docker.internal:8081/cp001 docker compose up -d",
     "start-everest-16": "cd ./everest && cross-env OCPP_VERSION=one EVEREST_IMAGE_TAG=0.0.23 EVEREST_TARGET_URL=ws://host.docker.internal:8092/ docker compose up -d"
   },

--- a/db.force-sync.ts
+++ b/db.force-sync.ts
@@ -1,0 +1,24 @@
+'use strict';
+
+process.env.APP_ENV = 'local';
+
+import { DefaultSequelizeInstance } from '@citrineos/data';
+import { loadBootstrapConfig } from '@citrineos/base';
+
+async function initializeDatabase() {
+  const bootstrapConfig = loadBootstrapConfig();
+  return DefaultSequelizeInstance.getInstance(bootstrapConfig);
+}
+
+export const sequelize = initializeDatabase();
+
+const syncDatabase = async () => {
+  await (await sequelize).sync({ force: true }); // Use { force: true } for dropping and recreating tables
+  console.log('Database synchronized successfully');
+};
+
+syncDatabase()
+  .then()
+  .catch((error) => {
+    console.error('Error synchronizing database:', error);
+  });

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Default to migrate if DB_STRATEGY is not set
+DB_STRATEGY=${DB_STRATEGY:-migrate}
+
+echo "Executing DB strategy: $DB_STRATEGY"
+
+if [ "$DB_STRATEGY" = "migrate" ]; then
+    npm run migrate
+elif [ "$DB_STRATEGY" = "sync" ]; then
+    npm run sync-db
+elif [ "$DB_STRATEGY" = "force-sync" ]; then
+    npm run force-sync-db
+elif [ "$DB_STRATEGY" = "none" ]; then
+    echo "Skipping DB initialization."
+else
+    echo "Unknown DB_STRATEGY: $DB_STRATEGY. Defaulting to migrate."
+    npm run migrate
+fi
+
+echo "Starting application..."
+# The start-docker-cloud script in Server/package.json will be used, but without the migration part.
+exec npm run start-docker-cloud --prefix ./Server
+

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prettier": "prettier --write .",
     "fi": "npm run fresh && npm run install-all",
     "sync-db": "ts-node ./db.sync.ts",
+    "force-sync-db": "ts-node ./db.force-sync.ts",
     "start-everest": "npm run start-everest --prefix ./Server",
     "test": "jest --config jest.config.ts",
     "coverage": "jest --config jest.config.ts --coverage",


### PR DESCRIPTION
### Summary
This PR introduces support for database schema synchronization in addition to migrations. It provides developers with new options to manage database schema changes more efficiently during local development and testing.

- Added support for three database strategies:
  - `migrate` → Default option, runs Sequelize migrations.
  - `sync` → Synchronizes models with the database without altering existing tables.
  - `force-sync` → Drops and recreates all tables based on current models.
- Entrypoint Updates
  - Added logic to select the database strategy via DB_STRATEGY env variable.
  - Introduced conditional execution of migrate, sync-db, or force-sync-db.