### PR TITLE
Add RBAC rules for new OCPP 1.6 endpoints

### DIFF
--- a/Server/rbac-rules.json
+++ b/Server/rbac-rules.json
@@ -125,6 +125,12 @@
     "/ocpp/1.6/evdriver/remoteStopTransaction": {
       "POST": ["user", "admin"]
     },
+    "/ocpp/1.6/evdriver/unlockConnector": {
+      "POST": ["user", "admin"]
+    },
+    "/ocpp/1.6/evdriver/clearCache": {
+      "POST": ["user", "admin"]
+    },
     "/data/evdriver/authorization": {
       "GET": ["user", "admin"],
       "PUT": ["user", "admin"],
@@ -182,6 +188,9 @@
     "/ocpp/2.0.1/reporting/customerInformation": {
       "POST": ["user", "admin"]
     },
+    "/ocpp/1.6/reporting/getDiagnostics": {
+      "POST": ["user", "admin"]
+    },
     "/ocpp/2.0.1/smartcharging/clearChargingProfile": {
       "POST": ["user", "admin"]
     },
@@ -195,6 +204,15 @@
       "POST": ["user", "admin"]
     },
     "/ocpp/2.0.1/smartcharging/getCompositeSchedule": {
+      "POST": ["user", "admin"]
+    },
+    "/ocpp/1.6/smartcharging/setChargingProfile": {
+      "POST": ["user", "admin"]
+    },
+    "/ocpp/1.6/smartcharging/clearChargingProfile": {
+      "POST": ["user", "admin"]
+    },
+    "/ocpp/1.6/smartcharging/getCompositeSchedule": {
       "POST": ["user", "admin"]
     },
     "/ocpp/2.0.1/transactions/costUpdated": {


### PR DESCRIPTION
## Summary
  - Add RBAC rules for six new OCPP 1.6 endpoints to `Server/rbac-rules.json`
  - Endpoints added: `unlockConnector`, `clearCache` (evdriver), `getDiagnostics` (reporting), `setChargingProfile`, `clearChargingProfile`,
  `getCompositeSchedule` (smartcharging)
  - All endpoints grant access to `user` and `admin` roles, consistent with existing OCPP 1.6 and 2.0.1 entries

  ## Motivation
  Without these RBAC rules, requests to the new OCPP 1.6 endpoints return a 403 Forbidden error:
  ```json
  {
      "error": "Forbidden",
      "message": "Tenant does not have access to this resource /ocpp/1.6/evdriver/clearCache?identifier=abcd&tenantId=1"
  }
 ```

  ### Test plan

  - JSON validity verified
  - Full test suite passed (37/37 files, 1320 tests)
  - No existing behavior affected (data-only change)