### PR TITLE
fix/validation-issue-in-data-transfer-not-accepting-data-values

### DIFF
--- a/00_Base/src/ocpp/model/2.0.1/schemas/DataTransferRequest.json
+++ b/00_Base/src/ocpp/model/2.0.1/schemas/DataTransferRequest.json
@@ -27,7 +27,15 @@
       "maxLength": 50
     },
     "data": {
-      "description": "Data without specified length or format. This needs to be decided by both parties (Open to implementation).\r\n"
+      "description": "Data without specified length or format. This needs to be decided by both parties (Open to implementation).\r\n",
+      "oneOf": [
+        { "type": "object", "additionalProperties": true },
+        { "type": "array" },
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" }
+      ]
     },
     "vendorId": {
       "description": "This identifies the Vendor specific implementation\r\n\r\n",

--- a/00_Base/src/ocpp/model/2.0.1/schemas/DataTransferResponse.json
+++ b/00_Base/src/ocpp/model/2.0.1/schemas/DataTransferResponse.json
@@ -58,7 +58,15 @@
       "$ref": "#/definitions/StatusInfoType"
     },
     "data": {
-      "description": "Data without specified length or format, in response to request.\r\n"
+      "description": "Data without specified length or format, in response to request.\r\n",
+      "oneOf": [
+        { "type": "object", "additionalProperties": true },
+        { "type": "array" },
+        { "type": "string" },
+        { "type": "number" },
+        { "type": "boolean" },
+        { "type": "null" }
+      ]
     }
   },
   "required": ["status"]


### PR DESCRIPTION
fix: DataTransfer schema data blocks to be more flexible on validation to resolve schema parsing errors during data transfer request, where previously any values for data seemed to not be accepted