### PR TITLE
Patch: Transaction properties shadowed by Public Class Fields causing `undefined` DB queries in CostNotifier

### DIFF
--- a/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
+++ b/01_Data/src/layers/sequelize/model/TransactionEvent/Transaction.ts
@@ -41,7 +41,7 @@ export class Transaction extends Model implements TransactionDto {
 
   @Column(DataType.INTEGER)
   @ForeignKey(() => Location)
-  locationId?: number;
+  declare locationId?: number;
 
   @BelongsTo(() => Location)
   location?: LocationType;
@@ -51,7 +51,7 @@ export class Transaction extends Model implements TransactionDto {
     unique: 'stationId_transactionId',
   })
   @ForeignKey(() => ChargingStation)
-  stationId!: string;
+  declare stationId: string;
 
   @BelongsTo(() => ChargingStation)
   station!: ChargingStationType;
@@ -72,14 +72,14 @@ export class Transaction extends Model implements TransactionDto {
 
   @Column(DataType.INTEGER)
   @ForeignKey(() => Authorization)
-  authorizationId?: number;
+  declare authorizationId?: number;
 
   @BelongsTo(() => Authorization)
   authorization?: Authorization;
 
   @Column(DataType.INTEGER)
   @ForeignKey(() => Tariff)
-  tariffId?: number;
+  declare tariffId?: number;
 
   @BelongsTo(() => Tariff)
   tariff?: Tariff;

--- a/03_Modules/Transactions/src/module/CostNotifier.ts
+++ b/03_Modules/Transactions/src/module/CostNotifier.ts
@@ -89,6 +89,14 @@ export class CostNotifier extends Scheduler {
           transactionId,
         );
 
+      if (!transaction) {
+        this._logger.error(
+          `Transaction NOT FOUND in DB. Searched for stationId: "${stationId}", transactionId: "${transactionId}"`,
+        );
+        this.unschedule(this._key(stationId, transactionId));
+        return;
+      }
+
       if (!transaction?.isActive) {
         this._logger.debug(
           `Unscheduling periodic cost notifications for ${stationId} station, ${transactionId} transaction, ${tenantId} tenant`,
@@ -100,6 +108,7 @@ export class CostNotifier extends Scheduler {
       await this.calculateCostAndNotify(transaction, tenantId);
     } catch (error) {
       this._logger.error(`Failed to send CostUpdated call for ${transactionId} transaction`, error);
+      this.unschedule(this._key(stationId, transactionId));
     }
   }
 


### PR DESCRIPTION

```
2026-02-26 12:33:33.209	ERROR	/usr/local/apps/citrineos/03_Modules/Transactions/dist/module/CostNotifier.js:56	CitrineOS Logger:TransactionsModule:CostNotifier	Failed to send CostUpdated call for 671dae77-399e-452b-a57c-f70b632aa087 transaction

 Error  WHERE parameter "stationId" has invalid "undefined" value
error stack:
  • query-generator.js	PostgresQueryGenerator.whereItemQuery
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1746
  • query-generator.js	
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1737
  • 	
	
  • query-generator.js	PostgresQueryGenerator.whereItemsQuery
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-generator.js:1735
  • query-generator.js	PostgresQueryGenerator.getWhereConditions
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2078
  • query-generator.js	PostgresQueryGenerator.selectQuery
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-generator.js:991
  • query-interface.js	PostgresQueryInterface.select
	/usr/local/apps/citrineos/node_modules/sequelize/lib/dialects/abstract/query-interface.js:407
  • model.js	Tariff.findAll
	/usr/local/apps/citrineos/node_modules/sequelize/lib/model.js:1140
  • task_queues	process.processTicksAndRejections
	internal/process/task_queues:105
  • Base.js	async SequelizeTariffRepository.readAllByQuery
	/usr/local/apps/citrineos/01_Data/dist/layers/sequelize/repository/Base.js:25
```

A critical issue was identified where transaction-related properties (specifically `stationId`) become `undefined` at runtime, despite being present in the database. This leads to a crash in the `CostNotifier` and `CostCalculator` modules when attempting to perform recurring cost calculations, as `Sequelize` generates an invalid PostgreSQL query: `WHERE "stationId" = undefined`.

### **Root Cause**

The `Transaction` model in `@citrineos/data` defines several properties (like `stationId`, `locationId`, etc.) as **Public Class Fields** without the `declare` keyword.

In TypeScript (with `target` set to ESNext or using certain transpilers), class fields are initialized to `undefined` in the constructor. This occurs **after** Sequelize has injected the database values into the instance, effectively "shadowing" or overwriting the real data with `undefined`.

This is a known incompatibility between Sequelize and TypeScript/ES Class Fields (see [Sequelize Issue #14300](https://github.com/sequelize/sequelize/issues/14300)).