### PR TITLE
Fix ReDoS vulnerability in certificate chain parsing (#127)

### DIFF
--- a/02_Util/src/certificate/CertificateUtil.ts
+++ b/02_Util/src/certificate/CertificateUtil.ts
@@ -35,9 +35,19 @@ export function createPemBlock(content: string) {
  */
 export function parseCertificateChainPem(pem: string): string[] {
   const certs: string[] = [];
-  pem
-    .match(/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g)
-    ?.forEach((certPem) => certs.push(certPem));
+  const beginMarker = '-----BEGIN CERTIFICATE-----';
+  const endMarker = '-----END CERTIFICATE-----';
+
+  let startIndex = pem.indexOf(beginMarker);
+  while (startIndex !== -1) {
+    const endIndex = pem.indexOf(endMarker, startIndex + beginMarker.length);
+    if (endIndex === -1) {
+      break;
+    }
+    certs.push(pem.substring(startIndex, endIndex + endMarker.length));
+    startIndex = pem.indexOf(beginMarker, endIndex + endMarker.length);
+  }
+
   return certs;
 }
 


### PR DESCRIPTION
## Summary
- **Security fix**: Replaces vulnerable regex in `parseCertificateChainPem()` with linear-time `indexOf()`-based parsing
- The original regex (`/-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g`) was susceptible to catastrophic backtracking
- A ~1.15 MB crafted payload could block the Node.js event loop for ~25 seconds, making the entire CSMS unresponsive
- The attack requires no authentication — malicious payload can be sent via an OCPP Authorize message through a connected charging station
- New implementation runs in O(n) time regardless of input and produces identical output for all valid inputs

## Files changed
- `02_Util/src/certificate/CertificateUtil.ts` — replaced regex with `indexOf()`-based string parsing

## Test plan
- [ ] Run existing certificate-related tests
- [ ] Parse valid single and multi-certificate PEM chains — verify identical output
- [ ] Test with the ReDoS payload from issue #127 — verify it completes instantly instead of blocking
- [ ] Test with malformed PEM (missing END marker) — verify graceful handling

Fixes citrineos/citrineos#127