### PR TITLE
Fix BootNotification race condition causing FK violations (#156)

### DIFF
--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -284,16 +284,9 @@ export class ConfigurationModule extends AbstractModule {
     const bootNotificationResponseMessageConfirmation: IMessageConfirmation =
       await this.sendCallResultWithMessage(message, bootNotificationResponse);
 
-    // Update device model and charging station
-    this._deviceModelService
-      .updateDeviceModel(chargingStation, tenantId, stationId, timestamp)
-      .then()
-      .catch((error) => {
-        this._logger.error(
-          `Error updating device model for station ${stationId} with boot info:`,
-          error,
-        );
-      });
+    // Update charging station first, then device model.
+    // Order matters: updateDeviceModel creates VariableAttributes with a FK
+    // reference to the ChargingStation record, so the station must exist first.
     this._locationRepository
       .createOrUpdateChargingStation(
         tenantId,
@@ -308,9 +301,19 @@ export class ConfigurationModule extends AbstractModule {
           imsi: chargingStation.modem?.imsi,
         }),
       )
-      .then()
+      .then(() =>
+        this._deviceModelService.updateDeviceModel(
+          chargingStation,
+          tenantId,
+          stationId,
+          timestamp,
+        ),
+      )
       .catch((error) => {
-        this._logger.error(`Error updating station ${stationId} with boot info:`, error);
+        this._logger.error(
+          `Error updating station ${stationId} or device model with boot info:`,
+          error,
+        );
       });
 
     if (!bootNotificationResponseMessageConfirmation.success) {

--- a/03_Modules/Configuration/src/module/module.ts
+++ b/03_Modules/Configuration/src/module/module.ts
@@ -302,12 +302,7 @@ export class ConfigurationModule extends AbstractModule {
         }),
       )
       .then(() =>
-        this._deviceModelService.updateDeviceModel(
-          chargingStation,
-          tenantId,
-          stationId,
-          timestamp,
-        ),
+        this._deviceModelService.updateDeviceModel(chargingStation, tenantId, stationId, timestamp),
       )
       .catch((error) => {
         this._logger.error(


### PR DESCRIPTION
## Summary
- `_handleBootNotification` fires `createOrUpdateChargingStation()` and `updateDeviceModel()` as parallel fire-and-forget promises
- When `updateDeviceModel()` wins the race, it inserts `VariableAttributes` referencing a `ChargingStation` that doesn't exist yet, causing `SequelizeForeignKeyConstraintError`
- Fix: chain the operations sequentially — create the station record first, then update device model

## Root cause
Both operations used `.then().catch()` (fire-and-forget) with no ordering:
- Line 288: `this._deviceModelService.updateDeviceModel(...)` — creates VariableAttributes (FK → ChargingStations)
- Line 297: `this._locationRepository.createOrUpdateChargingStation(...)` — creates ChargingStation record

The FK target must exist before the FK source is inserted.

## Files changed
- `03_Modules/Configuration/src/module/module.ts` — chain createOrUpdateChargingStation before updateDeviceModel

## Test plan
- [ ] Connect a new (unknown) OCPP 2.0.1 charger with `allowUnknownChargingStations: true`
- [ ] Verify BootNotification succeeds without FK constraint errors
- [ ] Verify VariableAttributes and ChargingStation records are both created
- [ ] Verify existing (known) charger BootNotification still works

Fixes #156
Fixes #158