### PR TITLE
Fix concurrent transaction handling for OCPP 2.0.1 and 1.6

### DIFF
--- a/03_Modules/Transactions/src/module/TransactionService.ts
+++ b/03_Modules/Transactions/src/module/TransactionService.ts
@@ -236,11 +236,13 @@ export class TransactionService {
         return response;
       }
 
-      // Check concurrent transactions
-      const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
-      if (hasConcurrent) {
-        response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.ConcurrentTx;
-        return response;
+      // Check concurrent transactions (only reject if not allowed)
+      if (authorization.concurrentTransaction === true) {
+        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
+        if (hasConcurrent) {
+          response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.ConcurrentTx;
+          return response;
+        }
       }
 
       // Check authorizers

--- a/03_Modules/Transactions/src/module/TransactionService.ts
+++ b/03_Modules/Transactions/src/module/TransactionService.ts
@@ -123,7 +123,7 @@ export class TransactionService {
       return response;
     } else {
       if (
-        authorization.concurrentTransaction === true &&
+        !authorization.concurrentTransaction &&
         transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started
       ) {
         const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
@@ -237,7 +237,7 @@ export class TransactionService {
       }
 
       // Check concurrent transactions (only reject if not allowed)
-      if (authorization.concurrentTransaction === true) {
+      if (!authorization.concurrentTransaction) {
         const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
         if (hasConcurrent) {
           response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.ConcurrentTx;


### PR DESCRIPTION
## Summary

Fixed incorrect concurrent transaction logic in `TransactionService.ts` affecting both OCPP 2.0.1 and OCPP 1.6 flows.

## Issues

### OCPP 2.0.1 — Inverted concurrent transaction check

The condition on line 126 was checking `authorization.concurrentTransaction === true` before rejecting concurrent transactions. This means transactions were being rejected with `ConcurrentTx` status only when the authorization *explicitly allowed* concurrent transactions, and were being permitted when concurrent transactions were *not* allowed — the exact opposite of the intended behavior.

### OCPP 1.6 — No respect for concurrentTransaction flag

The `StartTransaction` handler always checked for and rejected concurrent transactions regardless of the `concurrentTransaction` flag on the authorization. This meant OCPP 1.6 chargers could never have concurrent transactions even when the authorization was configured to allow them.

## Fix

- **OCPP 2.0.1:** Changed the condition from `authorization.concurrentTransaction === true` to `!authorization.concurrentTransaction`, so concurrent transactions are only rejected when the flag is `false` or unset.
- **OCPP 1.6:** Wrapped the existing concurrent transaction check inside an `if (!authorization.concurrentTransaction)` guard, matching the corrected 2.0.1 behavior. When the flag allows concurrent transactions, the check is skipped entirely.

## Changed files

- `03_Modules/Transactions/src/module/TransactionService.ts`