### PR TITLE
fix: properly handle same-station reconnect by cleaning up old connec…

### DIFF
--- a/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
+++ b/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
@@ -556,8 +556,17 @@ export class WebsocketNetworkConnection implements INetworkConnection {
           pingInterval * 2,
         );
         ws.ping();
+
+        // If no pong comes back within pingInterval, the connection is dead.
+        // Terminate the socket to trigger the close handler and clean up.
+        const pongTimeout = setTimeout(() => {
+          this._logger.warn('No pong received from', identifier, '- terminating dead connection');
+          ws.terminate();
+        }, pingInterval * 1000);
+
+        ws.once('pong', () => clearTimeout(pongTimeout));
       } else {
-        ws.close(1011, 'Client is not alive');
+        ws.terminate();
       }
     }, pingInterval * 1000);
   }

--- a/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
+++ b/02_Util/src/networkconnection/WebsocketNetworkConnection.ts
@@ -358,6 +358,20 @@ export class WebsocketNetworkConnection implements INetworkConnection {
 
       const identifier = createIdentifier(tenantId, stationId);
 
+      // If the same station is already connected, clean up the old connection
+      // before registering the new one. This handles chargers that reconnect
+      // after a network drop before the server detects the disconnect.
+      const existingWs = this._identifierConnections.get(identifier);
+      if (existingWs) {
+        this._logger.info(
+          `Station ${identifier} is already connected, closing old connection to allow reconnect`,
+        );
+        this._identifierConnections.delete(identifier);
+        await this._cache.remove(identifier, CacheNamespace.Connections);
+        await this._router.deregisterConnection(tenantId, stationId);
+        existingWs.close(1012, 'Replaced by new connection');
+      }
+
       // Enforce optional per-tenant connection limit if configured
       const maxConnections = websocketServerConfig.maxConnectionsPerTenant;
       if (typeof maxConnections === 'number' && maxConnections > 0) {
@@ -441,7 +455,14 @@ export class WebsocketNetworkConnection implements INetworkConnection {
     };
 
     ws.once('close', () => {
-      // Unregister client
+      // Unregister client — but only if this ws is still the active connection
+      // for this identifier. If a newer connection replaced us, skip cleanup
+      // since it was already handled during the reconnect.
+      const currentWs = this._identifierConnections.get(identifier);
+      if (currentWs !== ws) {
+        this._logger.info('Connection closed for', identifier, '(already replaced, skipping cleanup)');
+        return;
+      }
       this._logger.info('Connection closed for', identifier);
       this._cache.remove(identifier, CacheNamespace.Connections);
       this._identifierConnections.delete(identifier);


### PR DESCRIPTION
This is to address [#](https://github.com/citrineos/citrineos/issues/190)

**Problem 1**
When a charger dirty-disconnects (network drop, no close frame), the old WebSocket stays in _identifierConnections as a zombie. When the charger tries to reconnect, the maxConnectionsPerTenant check in _onConnection counts the zombie and rejects the new connection with close code 1013.

The tenant limit check runs BEFORE the existing connection for the same station ID is evicted:
With maxConnectionsPerTenant: 1, a single dirty disconnect permanently blocks that charger from reconnecting.

**Problem 2**
also current ping/pong logics seems no timeout if no pong is back

The ping/pong cycle works like a chain:

```
_registerWebsocketEvents calls _ping(60s timer)
    → _ping fires, sends ws.ping()
    → charger sends pong back
    → pong handler calls _ping(60s timer)  ← this is the ONLY place _ping gets re-scheduled
        → _ping fires, sends ws.ping()
        → charger sends pong back
        → pong handler calls _ping(60s timer)
        → ... and so on forever
```
Now when the charger dirty-disconnects:
```
_ping fires, sends ws.ping()
→ charger is dead, no pong comes back
→ pong handler never runs
→ _ping is never called again  ← chain is broken here
→ nothing else happens, ever
```
The else branch in _ping that calls ws.close():
```
if (clientConnection) {
  // send ping
} else {
  ws.close(1011, 'Client is not alive'); 
}
```
This would clean up the zombie, but it only runs when _ping is called AND the cache is empty. Since _ping is never called again after a missed pong, this code is unreachable. The cache expires on its own, but nobody checks it.

So the zombie websocket just sits in _identifierConnections forever because the only thing that could detect it's dead (the ping cycle) stopped running.

**Fix 1**
Before the tenant limit check, detect and clean up any existing connection for the same station identifier:
Additionally, the close event handler in _registerWebsocketEvents now checks if the closing websocket is still the active connection for that identifier. If it was already replaced, it skips cleanup to prevent double-deregistration.

**Fix 2**
After ws.ping(), sets a timeout of pingInterval seconds
If pong comes back → clears the timeout, normal flow continues (pong handler schedules next _ping)
If pong doesn't come back → ws.terminate() force-kills the socket → triggers the close event → cleanup runs (_identifierConnections.delete, deregisterConnection, etc.)
Also changed the else branch from ws.close() to ws.terminate() — if the cache is already gone, don't try a graceful close on a dead socket, just kill it

Testing
Test 1 — Same-station reconnect (Fix 1)

Open a websocket connection for station test-charger-001
Open a second connection with the same station ID without closing the first (simulating dirty disconnect + reconnect)
Before fix: connection 2 rejected with 1013 (or fails with 1011 at broker subscription)
After fix: connection 2 succeeds, old connection cleanly closed with 1012

Test 2 — Pong timeout cleanup (Fix 2)
Connect a websocket client with autoPong: false (suppresses pong responses)
Server pings at T+60s, client does not respond
At T+120s server logs: "No pong received from 1:test-pong-timeout - terminating dead connection"
Close handler fires, _identifierConnections entry deleted, RabbitMQ queues cleaned up
Connection closed with code 1006
```
13:00:17 DEBUG Pinging client 1:test-pong-timeout
13:01:17 WARN  No pong received from 1:test-pong-timeout - terminating dead connection
13:01:17 INFO  Connection closed for 1:test-pong-timeout
13:01:17 INFO  Queue 1:test-pong-timeout deleted with 0 messages remaining.
```
