### PR TITLE
Feature/set variables now updates device model

### DIFF
--- a/01_Data/src/interfaces/repositories.ts
+++ b/01_Data/src/interfaces/repositories.ts
@@ -125,6 +125,7 @@ export interface IDeviceModelRepository extends CrudRepository<OCPP2_0_1.Variabl
     result: OCPP2_0_1.SetVariableResultType,
     stationId: string,
     isoTimestamp: string,
+    existingVariableAttribute?: VariableAttribute,
   ): Promise<VariableAttribute | undefined>;
   readAllSetVariableByStationId(
     tenantId: number,

--- a/01_Data/src/layers/sequelize/repository/DeviceModel.ts
+++ b/01_Data/src/layers/sequelize/repository/DeviceModel.ts
@@ -371,54 +371,57 @@ export class SequelizeDeviceModelRepository
     result: OCPP2_0_1.SetVariableResultType,
     stationId: string,
     isoTimestamp: string,
+    existingVariableAttribute?: VariableAttribute,
   ): Promise<VariableAttribute | undefined> {
-    const savedVariableAttribute = await super.readOnlyOneByQuery(tenantId, {
-      where: { stationId, type: result.attributeType ?? OCPP2_0_1.AttributeEnumType.Actual },
-      include: [
-        {
-          model: Component,
-          where: {
-            name: result.component.name,
-            instance: result.component.instance ? result.component.instance : null,
+    if (!existingVariableAttribute) {
+      existingVariableAttribute = await super.readOnlyOneByQuery(tenantId, {
+        where: { stationId, type: result.attributeType ?? OCPP2_0_1.AttributeEnumType.Actual },
+        include: [
+          {
+            model: Component,
+            where: {
+              name: result.component.name,
+              instance: result.component.instance ? result.component.instance : null,
+            },
           },
-        },
-        {
-          model: Variable,
-          where: {
-            name: result.variable.name,
-            instance: result.variable.instance ? result.variable.instance : null,
+          {
+            model: Variable,
+            where: {
+              name: result.variable.name,
+              instance: result.variable.instance ? result.variable.instance : null,
+            },
           },
-        },
-      ],
-    });
-    if (savedVariableAttribute) {
+        ],
+      });
+    }
+    if (existingVariableAttribute) {
       await this.variableStatus.create(
         tenantId,
         VariableStatus.build({
           tenantId,
-          value: savedVariableAttribute.value,
+          value: existingVariableAttribute.value,
           status: result.attributeStatus,
           statusInfo: result.attributeStatusInfo,
-          variableAttributeId: savedVariableAttribute.get('id'),
+          variableAttributeId: existingVariableAttribute.get('id'),
         }),
       );
       if (result.attributeStatus !== OCPP2_0_1.SetVariableStatusEnumType.Accepted) {
         const mostRecentAcceptedStatus = (
           await this.variableStatus.readAllByQuery(tenantId, {
             where: {
-              variableAttributeId: savedVariableAttribute.get('id'),
+              variableAttributeId: existingVariableAttribute.get('id'),
               status: OCPP2_0_1.SetVariableStatusEnumType.Accepted,
             },
             limit: 1,
             order: [['createdAt', 'DESC']],
           })
         )[0];
-        savedVariableAttribute.setDataValue('value', mostRecentAcceptedStatus?.value);
+        existingVariableAttribute.setDataValue('value', mostRecentAcceptedStatus?.value);
       }
-      savedVariableAttribute.set('generatedAt', isoTimestamp);
-      await savedVariableAttribute.save();
+      existingVariableAttribute.set('generatedAt', isoTimestamp);
+      await existingVariableAttribute.save();
       // Reload in order to include the statuses
-      return await savedVariableAttribute.reload({
+      return await existingVariableAttribute.reload({
         include: [VariableStatus],
       });
     } else {

--- a/03_Modules/Monitoring/src/module/2.0.1/MessageApi.ts
+++ b/03_Modules/Monitoring/src/module/2.0.1/MessageApi.ts
@@ -260,15 +260,6 @@ export class MonitoringOcpp201Api
     for (const id of identifier) {
       try {
         const setVariableData = request.setVariableData as OCPP2_0_1.SetVariableDataType[];
-
-        // Store variable data in local DB so that the response can find them
-        await this._module.deviceModelRepository.createOrUpdateBySetVariablesDataAndStationId(
-          tenantId,
-          setVariableData,
-          id,
-          new Date().toISOString(),
-        );
-
         // Determine how many items to send per message
         const itemsPerMessage =
           (await this._module._deviceModelService.getItemsPerMessageByComponentAndVariableInstanceAndStationId(

--- a/03_Modules/Monitoring/src/module/module.ts
+++ b/03_Modules/Monitoring/src/module/module.ts
@@ -1,37 +1,44 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type {
-  BootstrapConfig,
-  CallAction,
-  HandlerProperties,
-  ICache,
-  IMessage,
-  IMessageHandler,
-  IMessageSender,
-  SystemConfig,
-} from '@citrineos/base';
 import {
   AbstractModule,
   AsHandler,
+  type BootstrapConfig,
+  type CallAction,
   ChargingStationSequenceTypeEnum,
   EventGroup,
+  type HandlerProperties,
+  type ICache,
+  type IMessage,
+  type IMessageHandler,
+  type IMessageSender,
+  MessageOrigin,
   OCPP2_0_1,
   OCPP2_0_1_CallAction,
   OCPPValidator,
   OCPPVersion,
+  type SystemConfig,
 } from '@citrineos/base';
-import type { IDeviceModelRepository, IVariableMonitoringRepository } from '@citrineos/data';
 import {
+  Component,
+  type IDeviceModelRepository,
+  type IOCPPMessageRepository,
+  type IVariableMonitoringRepository,
   SequelizeChargingStationSequenceRepository,
   SequelizeDeviceModelRepository,
+  SequelizeOCPPMessageRepository,
   SequelizeVariableMonitoringRepository,
+  Variable,
+  type VariableAttribute,
 } from '@citrineos/data';
 import { IdGenerator } from '@citrineos/util';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { MonitoringService } from './MonitoringService.js';
 import { DeviceModelService } from './services.js';
+
+type SetVariableDataMap = { [key: string]: OCPP2_0_1.SetVariableDataType };
 
 /**
  * Component that handles monitoring related messages.
@@ -46,6 +53,7 @@ export class MonitoringModule extends AbstractModule {
 
   protected _deviceModelRepository: IDeviceModelRepository;
   protected _variableMonitoringRepository: IVariableMonitoringRepository;
+  protected _ocppMessageRepository: IOCPPMessageRepository;
   private _idGenerator: IdGenerator;
 
   /**
@@ -84,6 +92,7 @@ export class MonitoringModule extends AbstractModule {
     ocppValidator?: OCPPValidator,
     deviceModelRepository?: IDeviceModelRepository,
     variableMonitoringRepository?: IVariableMonitoringRepository,
+    ocppMessageRepository?: IOCPPMessageRepository,
     idGenerator?: IdGenerator,
   ) {
     super(config, cache, handler, sender, EventGroup.Monitoring, logger, ocppValidator);
@@ -96,6 +105,8 @@ export class MonitoringModule extends AbstractModule {
     this._variableMonitoringRepository =
       variableMonitoringRepository ||
       new SequelizeVariableMonitoringRepository(config, this._logger);
+    this._ocppMessageRepository =
+      ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
 
     this._deviceModelService = new DeviceModelService(this._deviceModelRepository);
     this._monitoringService = new MonitoringService(
@@ -310,14 +321,172 @@ export class MonitoringModule extends AbstractModule {
     props?: HandlerProperties,
   ): Promise<void> {
     this._logger.debug('SetVariables response received:', message, props);
-
+    const tenantId = message.context.tenantId;
+    const stationId = message.context.stationId;
+    const correlationId = message.context.correlationId;
+    const setVariablesDataMap: SetVariableDataMap =
+      await this.getSetVariablesDataMapFromOriginalSetVariablesRequest(
+        tenantId,
+        stationId,
+        correlationId,
+      );
     for (const setVariableResultType of message.payload.setVariableResult) {
-      await this._deviceModelRepository.updateResultByStationId(
-        message.context.tenantId,
+      await this.handleSetVariableResultType(
+        tenantId,
+        stationId,
         setVariableResultType,
-        message.context.stationId,
+        setVariablesDataMap,
         message.context.timestamp,
       );
     }
+  }
+
+  protected async getSetVariablesDataMapFromOriginalSetVariablesRequest(
+    tenantId: number,
+    stationId: string,
+    correlationId: string,
+  ) {
+    // map where key is `${component}-${componentInstance}-${variable}-${variableInstance}` and value is the SetVariableData
+    const setVariablesDataMap: SetVariableDataMap = {};
+    const requestOcppMessage = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        tenantId,
+        stationId,
+        correlationId,
+        origin: MessageOrigin.ChargingStationManagementSystem,
+      },
+    });
+
+    if (requestOcppMessage) {
+      const setVariablesRequest = requestOcppMessage.message[3] as OCPP2_0_1.SetVariablesRequest;
+      const setVariableData = setVariablesRequest.setVariableData;
+      setVariableData.forEach((setVariableData) => {
+        const component = setVariableData.component.name;
+        const variable = setVariableData.variable.name;
+        const componentInstance = setVariableData.component.instance || 'null';
+        const variableInstance = setVariableData.variable.instance || 'null';
+        setVariablesDataMap[
+          this.getSetVariableDataMapKey(component, componentInstance, variable, variableInstance)
+        ] = setVariableData;
+      });
+    }
+
+    return setVariablesDataMap;
+  }
+
+  protected async handleSetVariableResultType(
+    tenantId: number,
+    stationId: string,
+    setVariableResultType: OCPP2_0_1.SetVariableResultType,
+    setVariablesDataMap: SetVariableDataMap,
+    timestamp: string,
+  ) {
+    const componentName = setVariableResultType.component.name;
+    const variableName = setVariableResultType.variable.name;
+    const componentInstance = setVariableResultType.component.instance || null;
+    const variableInstance = setVariableResultType.variable.instance || null;
+    const applicableSetVariableData =
+      setVariablesDataMap[
+        this.getSetVariableDataMapKey(
+          componentName,
+          componentInstance,
+          variableName,
+          variableInstance,
+        )
+      ];
+    if (applicableSetVariableData) {
+      const variableValue = applicableSetVariableData.attributeValue;
+      const attributeType =
+        applicableSetVariableData.attributeType ?? OCPP2_0_1.AttributeEnumType.Actual;
+      const existingVariableAttribute = await this.getExistingOrCreateVariableAttribute(
+        tenantId,
+        stationId,
+        componentName,
+        componentInstance,
+        variableName,
+        variableInstance,
+        variableValue,
+        attributeType,
+      );
+      if (setVariableResultType.attributeStatus === OCPP2_0_1.SetVariableStatusEnumType.Accepted) {
+        existingVariableAttribute?.setDataValue('value', variableValue);
+      }
+      await this._deviceModelRepository.updateResultByStationId(
+        tenantId,
+        setVariableResultType,
+        stationId,
+        timestamp,
+        existingVariableAttribute || undefined,
+      );
+    }
+  }
+
+  protected async getExistingOrCreateVariableAttribute(
+    tenantId: number,
+    stationId: string,
+    componentName: string,
+    componentInstance: string | null,
+    variableName: string,
+    variableInstance: string | null,
+    variableValue: string,
+    attributeType: OCPP2_0_1.AttributeEnumType,
+  ): Promise<VariableAttribute> {
+    let existingVariableAttribute = (await this.deviceModelRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        stationId,
+        type: attributeType,
+      },
+      include: [
+        {
+          model: Component,
+          where: {
+            name: componentName,
+            instance: componentInstance ? componentInstance : null,
+          },
+        },
+        {
+          model: Variable,
+          where: {
+            name: variableName,
+            instance: variableInstance ? variableInstance : null,
+          },
+        },
+      ],
+    })) as VariableAttribute;
+    if (!existingVariableAttribute) {
+      const createdVariableAttributes =
+        await this.deviceModelRepository.createOrUpdateBySetVariablesDataAndStationId(
+          tenantId,
+          [
+            {
+              attributeType: attributeType,
+              attributeValue: variableValue,
+              component: {
+                name: componentName,
+                instance: componentInstance ? componentInstance : null,
+              },
+              variable: {
+                name: variableName,
+                instance: variableInstance ? variableInstance : null,
+              },
+            },
+          ],
+          stationId,
+          new Date().toISOString(),
+        );
+      if (createdVariableAttributes && createdVariableAttributes.length === 1) {
+        existingVariableAttribute = createdVariableAttributes[0];
+      }
+    }
+    return existingVariableAttribute;
+  }
+
+  protected getSetVariableDataMapKey(
+    componentName: string,
+    componentInstance: string | null,
+    variableName: string,
+    variableInstance: string | null,
+  ) {
+    return `${componentName}-${componentInstance}-${variableName}-${variableInstance}`;
   }
 }

--- a/03_Modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
+++ b/03_Modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
@@ -1,0 +1,786 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { BootstrapConfig } from '@citrineos/base';
+import {
+  DEFAULT_TENANT_ID,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPPVersion,
+} from '@citrineos/base';
+import {
+  ChargingStation,
+  Component,
+  DefaultSequelizeInstance,
+  OCPPMessage,
+  SequelizeDeviceModelRepository,
+  SequelizeOCPPMessageRepository,
+  SequelizeVariableMonitoringRepository,
+  Tenant,
+  Variable,
+  VariableAttribute,
+  VariableStatus,
+} from '@citrineos/data';
+import { MonitoringModule } from '../../src/module/module.js';
+import {
+  aSetVariableData,
+  aSetVariableResult,
+  aSetVariablesResponse,
+  aSetVariablesResponseMessage,
+} from '../providers/Monitoring.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TENANT_ID = DEFAULT_TENANT_ID;
+const STATION_ID = 'CS-001';
+const CORRELATION_ID = 'corr-abc-123';
+
+// ---------------------------------------------------------------------------
+// Container & DB lifecycle
+// ---------------------------------------------------------------------------
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance.close();
+  await pgContainer.stop();
+});
+
+beforeEach(async () => {
+  await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+});
+
+// ---------------------------------------------------------------------------
+// Repository / module factory
+// ---------------------------------------------------------------------------
+
+function makeRepos() {
+  const config = {} as BootstrapConfig;
+  return {
+    deviceModelRepo: new SequelizeDeviceModelRepository(config, undefined, sequelizeInstance),
+    ocppMessageRepo: new SequelizeOCPPMessageRepository(config, undefined, sequelizeInstance),
+    variableMonitoringRepo: new SequelizeVariableMonitoringRepository(
+      config,
+      undefined,
+      sequelizeInstance,
+    ),
+  };
+}
+
+function makeModule(): MonitoringModule {
+  const { deviceModelRepo, ocppMessageRepo, variableMonitoringRepo } = makeRepos();
+
+  const mockConfig = { modules: { monitoring: { requests: [], responses: [] } } } as any;
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    getSubLogger: vi.fn().mockReturnThis(),
+  } as any;
+
+  return new MonitoringModule(
+    mockConfig,
+    /* cache */ {} as any,
+    /* sender */ {} as any,
+    /* handler */ { module: null } as any,
+    mockLogger,
+    /* ocppValidator */ { validate: vi.fn().mockResolvedValue(undefined) } as any,
+    deviceModelRepo,
+    variableMonitoringRepo,
+    ocppMessageRepo,
+    /* idGenerator */ { generateRequestId: vi.fn().mockResolvedValue(1) } as any,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+async function seedBase(): Promise<void> {
+  await Tenant.create({ id: TENANT_ID as any });
+  await ChargingStation.create({ id: STATION_ID, isOnline: false, tenantId: TENANT_ID });
+}
+
+async function seedComponent(name: string, instance: string | null = null): Promise<Component> {
+  return Component.create({ name, instance, tenantId: TENANT_ID });
+}
+
+async function seedVariable(name: string, instance: string | null = null): Promise<Variable> {
+  return Variable.create({ name, instance, tenantId: TENANT_ID });
+}
+
+async function seedVariableAttribute(
+  componentId: number,
+  variableId: number,
+  value: string,
+  type: OCPP2_0_1.AttributeEnumType = OCPP2_0_1.AttributeEnumType.Actual,
+): Promise<VariableAttribute> {
+  return VariableAttribute.create({
+    stationId: STATION_ID,
+    componentId,
+    variableId,
+    type,
+    value,
+    generatedAt: new Date(),
+    tenantId: TENANT_ID,
+  });
+}
+
+async function seedVariableStatus(
+  variableAttributeId: number,
+  value: string,
+  status: OCPP2_0_1.SetVariableStatusEnumType,
+): Promise<VariableStatus> {
+  return VariableStatus.create({ variableAttributeId, value, status, tenantId: TENANT_ID });
+}
+
+/**
+ * Seeds an OCPPMessage as the CSMS-originated SetVariables request.
+ * Stored in raw OCPP array format: [messageTypeId, correlationId, action, payload].
+ */
+async function seedSetVariablesRequest(
+  setVariableData: OCPP2_0_1.SetVariableDataType[],
+  correlationId: string = CORRELATION_ID,
+): Promise<OCPPMessage> {
+  return OCPPMessage.create({
+    stationId: STATION_ID,
+    correlationId,
+    origin: MessageOrigin.ChargingStationManagementSystem,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_0_1,
+    action: 'SetVariables',
+    message: [
+      2,
+      correlationId,
+      'SetVariables',
+      { setVariableData } as OCPP2_0_1.SetVariablesRequest,
+    ],
+    tenantId: TENANT_ID,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MonitoringModule – SetVariables response handling', () => {
+  // -------------------------------------------------------------------------
+  // getSetVariablesDataMapFromOriginalSetVariablesRequest
+  // -------------------------------------------------------------------------
+
+  describe('getSetVariablesDataMapFromOriginalSetVariablesRequest', () => {
+    it('returns an empty map when no OCPPMessage exists for the correlation id', async () => {
+      await seedBase();
+      // No OCPPMessage seeded
+      const module = makeModule();
+
+      const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
+        TENANT_ID,
+        STATION_ID,
+        CORRELATION_ID,
+      );
+
+      expect(map).toEqual({});
+    });
+
+    it('builds a keyed map from the SetVariables request stored in the DB', async () => {
+      await seedBase();
+      const data1 = aSetVariableData((d) => {
+        d.component = { name: 'Connector', instance: null };
+        d.variable = { name: 'MaxVoltage', instance: null };
+        d.attributeValue = '240';
+        d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+      });
+      const data2 = aSetVariableData((d) => {
+        d.component = { name: 'EVSE', instance: '1' };
+        d.variable = { name: 'Power', instance: 'A' };
+        d.attributeValue = '7200';
+        d.attributeType = undefined;
+      });
+      await seedSetVariablesRequest([data1, data2]);
+
+      const module = makeModule();
+
+      const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
+        TENANT_ID,
+        STATION_ID,
+        CORRELATION_ID,
+      );
+
+      expect(map['Connector-null-MaxVoltage-null']).toEqual(data1);
+      expect(map['EVSE-1-Power-A']).toEqual(data2);
+    });
+
+    it('treats missing component/variable instance as the "null" string key segment', async () => {
+      await seedBase();
+      const data = aSetVariableData((d) => {
+        d.component = { name: 'Clock' };
+        d.variable = { name: 'NtpSource' };
+        d.attributeValue = 'pool.ntp.org';
+        d.attributeType = undefined;
+      });
+      await seedSetVariablesRequest([data]);
+
+      const module = makeModule();
+
+      const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
+        TENANT_ID,
+        STATION_ID,
+        CORRELATION_ID,
+      );
+
+      // undefined instance → falls back to 'null' string segment
+      expect(map['Clock-null-NtpSource-null']).toEqual(data);
+    });
+
+    it('only returns entries matching the given correlationId', async () => {
+      await seedBase();
+      const data = aSetVariableData((d) => {
+        d.component = { name: 'Connector' };
+        d.variable = { name: 'MaxVoltage' };
+        d.attributeValue = '240';
+      });
+      await seedSetVariablesRequest([data], 'other-corr-id');
+      // No message seeded for CORRELATION_ID
+
+      const module = makeModule();
+
+      const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
+        TENANT_ID,
+        STATION_ID,
+        CORRELATION_ID, // different from 'other-corr-id'
+      );
+
+      expect(map).toEqual({});
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getExistingOrCreateVariableAttribute
+  // -------------------------------------------------------------------------
+
+  describe('getExistingOrCreateVariableAttribute', () => {
+    it('returns the existing VariableAttribute from the DB without creating a new one', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const seeded = await seedVariableAttribute(component.id, variable.id, '120');
+
+      const module = makeModule();
+
+      const result = await (module as any).getExistingOrCreateVariableAttribute(
+        TENANT_ID,
+        STATION_ID,
+        'Connector',
+        null,
+        'MaxVoltage',
+        null,
+        '240',
+        OCPP2_0_1.AttributeEnumType.Actual,
+      );
+
+      expect(result.id).toBe(seeded.id);
+      // Only the one we seeded exists
+      const allAttrs = await VariableAttribute.findAll({ where: { stationId: STATION_ID } });
+      expect(allAttrs).toHaveLength(1);
+    });
+
+    it('creates a new VariableAttribute in the DB when none exists', async () => {
+      await seedBase();
+      // No Component, Variable, or VariableAttribute seeded
+
+      const module = makeModule();
+
+      const result = await (module as any).getExistingOrCreateVariableAttribute(
+        TENANT_ID,
+        STATION_ID,
+        'Connector',
+        null,
+        'MaxVoltage',
+        null,
+        '240',
+        OCPP2_0_1.AttributeEnumType.Actual,
+      );
+
+      expect(result).toBeDefined();
+      const inDb = await VariableAttribute.findOne({
+        where: { stationId: STATION_ID, type: OCPP2_0_1.AttributeEnumType.Actual },
+        include: [
+          { model: Component, where: { name: 'Connector' } },
+          { model: Variable, where: { name: 'MaxVoltage' } },
+        ],
+      });
+      expect(inDb).not.toBeNull();
+    });
+
+    it('finds the attribute matching the specific component and variable instance', async () => {
+      await seedBase();
+      const comp = await seedComponent('EVSE', '1');
+      const varA = await seedVariable('Power', 'A');
+      const seeded = await seedVariableAttribute(
+        comp.id,
+        varA.id,
+        '7200',
+        OCPP2_0_1.AttributeEnumType.Actual,
+      );
+
+      const module = makeModule();
+
+      const result = await (module as any).getExistingOrCreateVariableAttribute(
+        TENANT_ID,
+        STATION_ID,
+        'EVSE',
+        '1',
+        'Power',
+        'A',
+        '9600',
+        OCPP2_0_1.AttributeEnumType.Actual,
+      );
+
+      expect(result.id).toBe(seeded.id);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleSetVariableResultType
+  // -------------------------------------------------------------------------
+
+  describe('handleSetVariableResultType', () => {
+    it('updates VariableAttribute.value and creates an Accepted VariableStatus when status is Accepted', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+
+      const dataMap = {
+        'Connector-null-MaxVoltage-null': aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '240';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      };
+      const result = aSetVariableResult((r) => {
+        r.component = { name: 'Connector' };
+        r.variable = { name: 'MaxVoltage' };
+        r.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+        r.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+      });
+
+      const module = makeModule();
+      await (module as any).handleSetVariableResultType(
+        TENANT_ID,
+        STATION_ID,
+        result,
+        dataMap,
+        new Date().toISOString(),
+      );
+
+      const updated = await VariableAttribute.findByPk(varAttr.id);
+      expect(updated?.value).toBe('240');
+
+      const statuses = await VariableStatus.findAll({ where: { variableAttributeId: varAttr.id } });
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0].status).toBe(OCPP2_0_1.SetVariableStatusEnumType.Accepted);
+      expect(statuses[0].value).toBe('240');
+    });
+
+    it('does NOT update VariableAttribute.value when status is Rejected, restoring the last Accepted value', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      // Current value is the last accepted value
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+      await seedVariableStatus(varAttr.id, '120', OCPP2_0_1.SetVariableStatusEnumType.Accepted);
+
+      const dataMap = {
+        'Connector-null-MaxVoltage-null': aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '999'; // attempted but rejected
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      };
+      const result = aSetVariableResult((r) => {
+        r.component = { name: 'Connector' };
+        r.variable = { name: 'MaxVoltage' };
+        r.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Rejected;
+        r.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+      });
+
+      const module = makeModule();
+      await (module as any).handleSetVariableResultType(
+        TENANT_ID,
+        STATION_ID,
+        result,
+        dataMap,
+        new Date().toISOString(),
+      );
+
+      const updated = await VariableAttribute.findByPk(varAttr.id);
+      // Restored to last Accepted value, not the attempted '999'
+      expect(updated?.value).toBe('120');
+
+      const statuses = await VariableStatus.findAll({
+        where: { variableAttributeId: varAttr.id },
+        order: [['createdAt', 'ASC']],
+      });
+      expect(statuses).toHaveLength(2);
+      expect(statuses[1].status).toBe(OCPP2_0_1.SetVariableStatusEnumType.Rejected);
+    });
+
+    it('does nothing to the DB when the result component/variable is not in the data map', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+
+      const dataMap = {
+        'Connector-null-MaxVoltage-null': aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '240';
+        }),
+      };
+      const result = aSetVariableResult((r) => {
+        r.component = { name: 'Unknown' };
+        r.variable = { name: 'Unknown' };
+        r.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+      });
+
+      const module = makeModule();
+      await (module as any).handleSetVariableResultType(
+        TENANT_ID,
+        STATION_ID,
+        result,
+        dataMap,
+        new Date().toISOString(),
+      );
+
+      const unchanged = await VariableAttribute.findByPk(varAttr.id);
+      expect(unchanged?.value).toBe('120');
+
+      const statuses = await VariableStatus.findAll({ where: { variableAttributeId: varAttr.id } });
+      expect(statuses).toHaveLength(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // _handleSetVariables (full end-to-end with real DB)
+  // -------------------------------------------------------------------------
+
+  describe('_handleSetVariables', () => {
+    it('updates VariableAttribute.value in the DB when the response status is Accepted', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+
+      await seedSetVariablesRequest([
+        aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '240';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      ]);
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'Connector' };
+                res.variable = { name: 'MaxVoltage' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      const updated = await VariableAttribute.findByPk(varAttr.id);
+      expect(updated?.value).toBe('240');
+    });
+
+    it('creates a VariableStatus record with Accepted status and the new value', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+
+      await seedSetVariablesRequest([
+        aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '240';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      ]);
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'Connector' };
+                res.variable = { name: 'MaxVoltage' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      const statuses = await VariableStatus.findAll({ where: { variableAttributeId: varAttr.id } });
+      expect(statuses).toHaveLength(1);
+      expect(statuses[0].status).toBe(OCPP2_0_1.SetVariableStatusEnumType.Accepted);
+      expect(statuses[0].value).toBe('240');
+    });
+
+    it('does NOT update VariableAttribute.value when status is Rejected, and restores the last Accepted value', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+      await seedVariableStatus(varAttr.id, '120', OCPP2_0_1.SetVariableStatusEnumType.Accepted);
+
+      await seedSetVariablesRequest([
+        aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '999'; // attempted but charger rejects it
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      ]);
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'Connector' };
+                res.variable = { name: 'MaxVoltage' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Rejected;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      // Value reverted to last accepted, not the rejected attempt
+      const updated = await VariableAttribute.findByPk(varAttr.id);
+      expect(updated?.value).toBe('120');
+
+      const statuses = await VariableStatus.findAll({
+        where: { variableAttributeId: varAttr.id },
+        order: [['createdAt', 'ASC']],
+      });
+      expect(statuses).toHaveLength(2);
+      expect(statuses[1].status).toBe(OCPP2_0_1.SetVariableStatusEnumType.Rejected);
+    });
+
+    it('leaves VariableAttribute.value unchanged when no OCPP request is found for the correlation id', async () => {
+      await seedBase();
+      const component = await seedComponent('Connector');
+      const variable = await seedVariable('MaxVoltage');
+      const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
+      // Intentionally do NOT seed an OCPPMessage
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'Connector' };
+                res.variable = { name: 'MaxVoltage' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      const unchanged = await VariableAttribute.findByPk(varAttr.id);
+      expect(unchanged?.value).toBe('120');
+
+      const statuses = await VariableStatus.findAll({ where: { variableAttributeId: varAttr.id } });
+      expect(statuses).toHaveLength(0);
+    });
+
+    it('creates a new VariableAttribute when none exists and the response status is Accepted', async () => {
+      await seedBase();
+      // No Component, Variable, or VariableAttribute seeded
+
+      await seedSetVariablesRequest([
+        aSetVariableData((d) => {
+          d.component = { name: 'Connector' };
+          d.variable = { name: 'MaxVoltage' };
+          d.attributeValue = '240';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      ]);
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'Connector' };
+                res.variable = { name: 'MaxVoltage' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      const created = await VariableAttribute.findOne({
+        where: { stationId: STATION_ID, type: OCPP2_0_1.AttributeEnumType.Actual },
+        include: [
+          { model: Component, where: { name: 'Connector' } },
+          { model: Variable, where: { name: 'MaxVoltage' } },
+        ],
+      });
+      expect(created).not.toBeNull();
+      expect(created?.value).toBe('240');
+    });
+
+    it('updates only the Accepted variable in a multi-result response; the Rejected one stays at its last Accepted value', async () => {
+      await seedBase();
+
+      const compA = await seedComponent('CompA');
+      const varA = await seedVariable('VarA');
+      const attrA = await seedVariableAttribute(compA.id, varA.id, 'old-A');
+
+      const compB = await seedComponent('CompB');
+      const varB = await seedVariable('VarB');
+      const attrB = await seedVariableAttribute(compB.id, varB.id, 'current-B');
+      await seedVariableStatus(attrB.id, 'current-B', OCPP2_0_1.SetVariableStatusEnumType.Accepted);
+
+      await seedSetVariablesRequest([
+        aSetVariableData((d) => {
+          d.component = { name: 'CompA' };
+          d.variable = { name: 'VarA' };
+          d.attributeValue = 'new-A';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+        aSetVariableData((d) => {
+          d.component = { name: 'CompB' };
+          d.variable = { name: 'VarB' };
+          d.attributeValue = 'attempted-B';
+          d.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+        }),
+      ]);
+
+      await (makeModule() as any)._handleSetVariables(
+        aSetVariablesResponseMessage(
+          aSetVariablesResponse((r) => {
+            r.setVariableResult = [
+              aSetVariableResult((res) => {
+                res.component = { name: 'CompA' };
+                res.variable = { name: 'VarA' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+              aSetVariableResult((res) => {
+                res.component = { name: 'CompB' };
+                res.variable = { name: 'VarB' };
+                res.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Rejected;
+                res.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
+              }),
+            ];
+          }),
+          { correlationId: CORRELATION_ID, stationId: STATION_ID, tenantId: TENANT_ID },
+        ),
+      );
+
+      const updatedA = await VariableAttribute.findByPk(attrA.id);
+      const updatedB = await VariableAttribute.findByPk(attrB.id);
+
+      expect(updatedA?.value).toBe('new-A');
+      expect(updatedB?.value).toBe('current-B');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getSetVariableDataMapKey  (pure logic – no DB needed)
+  // -------------------------------------------------------------------------
+
+  describe('getSetVariableDataMapKey', () => {
+    it('produces consistent keys for the same inputs', () => {
+      const module = makeModule();
+      const key1 = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
+      const key2 = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
+      expect(key1).toBe(key2);
+    });
+
+    it('differentiates keys by instance value', () => {
+      const module = makeModule();
+      const keyNoInstance = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
+      const keyWithInstance = (module as any).getSetVariableDataMapKey('Comp', '1', 'Var', null);
+      expect(keyNoInstance).not.toBe(keyWithInstance);
+    });
+
+    it('returns a string in the expected format', () => {
+      const module = makeModule();
+      const key = (module as any).getSetVariableDataMapKey(
+        'MyComponent',
+        'inst',
+        'MyVariable',
+        'v1',
+      );
+      expect(key).toBe('MyComponent-inst-MyVariable-v1');
+    });
+  });
+});

--- a/03_Modules/Monitoring/test/providers/Monitoring.ts
+++ b/03_Modules/Monitoring/test/providers/Monitoring.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { OCPP2_0_1 } from '@citrineos/base';
+import { DEFAULT_TENANT_ID, MessageOrigin, OCPP2_0_1 } from '@citrineos/base';
 import { applyUpdateFunction, UpdateFunction } from '../utils/UpdateUtil.js';
 
 export const aClearMonitoringResult = (
@@ -14,3 +14,79 @@ export const aClearMonitoringResult = (
 
   return applyUpdateFunction(clear, updateFunction);
 };
+
+export const aSetVariableData = (
+  updateFunction?: UpdateFunction<OCPP2_0_1.SetVariableDataType>,
+): OCPP2_0_1.SetVariableDataType => {
+  const data: OCPP2_0_1.SetVariableDataType = {
+    component: { name: 'TestComponent' },
+    variable: { name: 'TestVariable' },
+    attributeValue: 'test-value',
+    attributeType: OCPP2_0_1.AttributeEnumType.Actual,
+  };
+  return applyUpdateFunction(data, updateFunction);
+};
+
+export const aSetVariableResult = (
+  updateFunction?: UpdateFunction<OCPP2_0_1.SetVariableResultType>,
+): OCPP2_0_1.SetVariableResultType => {
+  const result: OCPP2_0_1.SetVariableResultType = {
+    component: { name: 'TestComponent' },
+    variable: { name: 'TestVariable' },
+    attributeStatus: OCPP2_0_1.SetVariableStatusEnumType.Accepted,
+    attributeType: OCPP2_0_1.AttributeEnumType.Actual,
+  };
+  return applyUpdateFunction(result, updateFunction);
+};
+
+export const aSetVariablesRequest = (
+  updateFunction?: UpdateFunction<OCPP2_0_1.SetVariablesRequest>,
+): OCPP2_0_1.SetVariablesRequest => {
+  const request: OCPP2_0_1.SetVariablesRequest = {
+    setVariableData: [aSetVariableData()],
+  };
+  return applyUpdateFunction(request, updateFunction);
+};
+
+export const aSetVariablesResponse = (
+  updateFunction?: UpdateFunction<OCPP2_0_1.SetVariablesResponse>,
+): OCPP2_0_1.SetVariablesResponse => {
+  const response: OCPP2_0_1.SetVariablesResponse = {
+    setVariableResult: [aSetVariableResult()],
+  };
+  return applyUpdateFunction(response, updateFunction);
+};
+
+/**
+ * Builds the raw OCPP message array as stored in the DB for a SetVariables request.
+ * Format: [messageTypeId, correlationId, action, payload]
+ */
+export const aStoredSetVariablesOcppMessage = (
+  correlationId: string,
+  setVariableData: OCPP2_0_1.SetVariableDataType[],
+  origin: MessageOrigin = MessageOrigin.ChargingStationManagementSystem,
+) => ({
+  message: [2, correlationId, 'SetVariables', { setVariableData } as OCPP2_0_1.SetVariablesRequest],
+  origin,
+});
+
+/**
+ * Builds a minimal IMessage-shaped object for a SetVariablesResponse, as the handler receives it.
+ */
+export const aSetVariablesResponseMessage = (
+  payload: OCPP2_0_1.SetVariablesResponse,
+  overrides: Partial<{
+    correlationId: string;
+    tenantId: number;
+    stationId: string;
+    timestamp: string;
+  }> = {},
+) => ({
+  context: {
+    correlationId: overrides.correlationId ?? 'corr-default',
+    tenantId: overrides.tenantId ?? DEFAULT_TENANT_ID,
+    stationId: overrides.stationId ?? 'CS-001',
+    timestamp: overrides.timestamp ?? '2025-01-01T00:00:00.000Z',
+  },
+  payload,
+});

--- a/Server/src/citrineOSServer.ts
+++ b/Server/src/citrineOSServer.ts
@@ -583,6 +583,7 @@ export class CitrineOSServer {
       this._ocppValidator,
       this._repositoryStore.deviceModelRepository,
       this._repositoryStore.variableMonitoringRepository,
+      this._repositoryStore.ocppMessageRepository,
       this._idGenerator,
     );
     await this.initHandlersAndAddModule(module);


### PR DESCRIPTION
Current:
It was discovered that when SetVariables is sent directly to the charger via RabbitMQ, the device model in the DB never gets updated with the latest value if it is accepted. Instead, in the message API, the record is created when the SetVariables endpoint is hit. 

New:
This adjustment removes the previous logic to create device model variables in the DB in the message API, and instead, when the SetVariables response confirmation from the charger is received, we now get the original SetVariables request using the OCPPMessage table and use that to update / create the variable attribute record in the DB. This way, no matter how the SetVariables request originally entered the system, the SetVariables confirmation will handle updating the values in the DB.