### PR TITLE
feat: add configuration option to enable/disable GetChargingProfiles …

### DIFF
--- a/Server/src/config/envs/docker.ts
+++ b/Server/src/config/envs/docker.ts
@@ -80,6 +80,7 @@ export function createDockerConfig() {
       },
       evdriver: {
         endpointPrefix: '/evdriver',
+        enableGetChargingProfilesOnStartTransaction: true,
         responses: [
           OCPP_CallAction.CancelReservation,
           OCPP_CallAction.ClearCache,

--- a/Server/src/config/envs/local.ts
+++ b/Server/src/config/envs/local.ts
@@ -80,6 +80,7 @@ export function createLocalConfig() {
       },
       evdriver: {
         endpointPrefix: '/evdriver',
+        enableGetChargingProfilesOnStartTransaction: true,
         responses: [
           OCPP_CallAction.CancelReservation,
           OCPP_CallAction.ClearCache,

--- a/Server/src/config/envs/swarm.docker.ts
+++ b/Server/src/config/envs/swarm.docker.ts
@@ -93,6 +93,7 @@ export function createDockerConfig() {
         endpointPrefix: 'evdriver',
         host: '0.0.0.0',
         port: 8085,
+        enableGetChargingProfilesOnStartTransaction: true,
         responses: [
           OCPP_CallAction.CancelReservation,
           OCPP_CallAction.ClearCache,

--- a/base/src/config/types.ts
+++ b/base/src/config/types.ts
@@ -131,6 +131,7 @@ export const systemConfigInputSchema = z.object({
       port: z.number().int().min(1).default(8081).optional(),
       requests: z.array(CallActionSchema),
       responses: z.array(CallActionSchema),
+      enableGetChargingProfilesOnStartTransaction: z.boolean().default(true).optional(),
     }),
     monitoring: z.object({
       endpointPrefix: z.string().default(EventGroup.Monitoring).optional(),
@@ -379,6 +380,7 @@ export const systemConfigSchema = z
         port: z.number().int().min(1).optional(),
         requests: z.array(CallActionSchema),
         responses: z.array(CallActionSchema),
+        enableGetChargingProfilesOnStartTransaction: z.boolean().optional(),
       }),
       configuration: z
         .object({

--- a/core/src/modules/Certificates/test/providers/SystemConfig.ts
+++ b/core/src/modules/Certificates/test/providers/SystemConfig.ts
@@ -86,6 +86,7 @@ export function aSystemConfig(override?: Partial<SystemConfig>): SystemConfig {
       },
       evdriver: {
         endpointPrefix: '/evdriver',
+        enableGetChargingProfilesOnStartTransaction: true,
         responses: [
           OCPP_CallAction.CancelReservation,
           OCPP_CallAction.ClearCache,

--- a/core/src/modules/EVDriver/src/module/module.ts
+++ b/core/src/modules/EVDriver/src/module/module.ts
@@ -586,24 +586,30 @@ export class EVDriverModule extends AbstractModule {
           returning: false,
         },
       );
-      // 2. Request charging profiles to get the latest data
-      await this.sendCall(
-        stationId,
-        message.context.tenantId,
-        message.protocol,
-        OCPP_CallAction.GetChargingProfiles,
-        {
-          requestId: await this._idGenerator.generateRequestId(
-            message.context.tenantId,
-            message.context.stationId,
-            ChargingStationSequenceTypeEnum.getChargingProfiles,
-          ),
-          chargingProfile: {
-            chargingProfilePurpose: ChargingProfilePurposeEnum.TxProfile,
-            chargingLimitSource: [ChargingLimitSourceEnum.CSO],
-          } as OCPP2_common_types.ChargingProfileCriterionType,
-        } as OCPP2_request_types.GetChargingProfilesRequest,
-      );
+      // 2. Request charging profiles to get the latest data (if configured)
+      if (this._config.modules.evdriver.enableGetChargingProfilesOnStartTransaction !== false) {
+        await this.sendCall(
+          stationId,
+          message.context.tenantId,
+          message.protocol,
+          OCPP_CallAction.GetChargingProfiles,
+          {
+            requestId: await this._idGenerator.generateRequestId(
+              message.context.tenantId,
+              message.context.stationId,
+              ChargingStationSequenceTypeEnum.getChargingProfiles,
+            ),
+            chargingProfile: {
+              chargingProfilePurpose: ChargingProfilePurposeEnum.TxProfile,
+              chargingLimitSource: [ChargingLimitSourceEnum.CSO],
+            } as OCPP2_common_types.ChargingProfileCriterionType,
+          } as OCPP2_request_types.GetChargingProfilesRequest,
+        );
+      } else {
+        this._logger.info(
+          `Skipping GetChargingProfiles after RequestStartTransaction for station ${stationId} (disabled by enableGetChargingProfilesOnStartTransaction configuration)`,
+        );
+      }
     } else {
       this._logger.error(`RequestStartTransaction failed: ${JSON.stringify(message.payload)}`);
     }


### PR DESCRIPTION
This pull request introduces a new configuration option to control whether the EVDriver module should request charging profiles after a start transaction. The change is implemented in the configuration schemas, module logic, and all relevant environment configuration files. By default, this feature is enabled, but it can be explicitly disabled through configuration.

**Configuration changes:**

* Added a new boolean configuration option, `enableGetChargingProfilesOnStartTransaction`, to the `evdriver` module in both the input and runtime config schemas, with a default value of `true`. 

**Module logic updates:**

* Updated the `EVDriverModule` to only request charging profiles after a start transaction if `enableGetChargingProfilesOnStartTransaction` is not set to `false`. If disabled, a log message is generated to indicate the request is being skipped. 

**Environment configuration updates:**

* Set `enableGetChargingProfilesOnStartTransaction: true` by default in the local, docker, and swarm docker environment config files (`local.ts`, `docker.ts`, `swarm.docker.ts`). 
* Updated the system config test provider to include the new option with a value of `true`.…on StartTransaction