### PR TITLE
fix: ensuring to use idToken.type for authorization query string

### DIFF
--- a/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -95,7 +95,7 @@ export class TransactionService {
     const idToken = transactionEvent.idToken!;
     const authorizations = await this._authorizeRepository.readAllByQuerystring(tenantId, {
       idToken: idToken.idToken,
-      type: idToken as unknown as IdTokenEnumType,
+      type: idToken.type,
     });
 
     const response: OCPP2_0_1.TransactionEventResponse = {


### PR DESCRIPTION
Minor fix to authorization query string to ensure idToken.type is passed in properly