### PR TITLE
feat: add NotifySettlement action handling for transaction cancellation

### DIFF
--- a/Server/src/config/envs/docker.ts
+++ b/Server/src/config/envs/docker.ts
@@ -157,6 +157,7 @@ export function createDockerConfig() {
           OCPP_CallAction.StatusNotification,
           OCPP_CallAction.StartTransaction,
           OCPP_CallAction.StopTransaction,
+          OCPP_CallAction.NotifySettlement,
         ],
       },
     },

--- a/Server/src/config/envs/local.ts
+++ b/Server/src/config/envs/local.ts
@@ -159,6 +159,7 @@ export function createLocalConfig() {
           OCPP_CallAction.MeterValues,
           OCPP_CallAction.StartTransaction,
           OCPP_CallAction.StopTransaction,
+          OCPP_CallAction.NotifySettlement,
         ],
       },
     },

--- a/Server/src/config/envs/swarm.docker.ts
+++ b/Server/src/config/envs/swarm.docker.ts
@@ -179,6 +179,7 @@ export function createDockerConfig() {
           OCPP_CallAction.MeterValues,
           OCPP_CallAction.StartTransaction,
           OCPP_CallAction.StopTransaction,
+          OCPP_CallAction.NotifySettlement,
         ],
       },
     },

--- a/core/src/modules/Transactions/src/module/module.ts
+++ b/core/src/modules/Transactions/src/module/module.ts
@@ -26,6 +26,7 @@ import {
   ErrorCode,
   EventGroup,
   OCPP1_6,
+  OCPP2_1,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
   OcppError,
@@ -542,6 +543,31 @@ export class TransactionsModule extends AbstractModule {
         response.ongoingIndicator,
       );
     }
+  }
+
+  /**
+   * C19 - Cancellation prior to transaction
+   * Handles NotifySettlementRequest from Charging Station to inform CSMS
+   * that a payment has been canceled or settled.
+   */
+  @AsHandler([OCPPVersion.OCPP2_1], OCPP_CallAction.NotifySettlement)
+  protected async _handleNotifySettlement(
+    message: IMessage<OCPP2_1.NotifySettlementRequest>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug('NotifySettlementRequest received:', message, props);
+
+    const request = message.payload;
+
+    this._logger.info(
+      `NotifySettlement received: pspRef=${request.pspRef}, status=${request.status}, ` +
+        `amount=${request.settlementAmount}, transactionId=${request.transactionId ?? 'none'}`,
+    );
+
+    const response: OCPP2_1.NotifySettlementResponse = {};
+
+    const messageConfirmation = await this.sendCallResultWithMessage(message, response);
+    this._logger.debug('NotifySettlement response sent:', messageConfirmation);
   }
 
   /**


### PR DESCRIPTION
This pull request adds support for handling the `NotifySettlement` OCPP 2.1 action in the Transactions module, and updates configuration files to recognize this new action. The main focus is to enable the system to process settlement notifications from charging stations, which is part of the OCPP 2.1 protocol.

**OCPP 2.1 NotifySettlement support:**

* Added a handler method `_handleNotifySettlement` in the `TransactionsModule` to process `NotifySettlementRequest` messages from charging stations, logging relevant details and sending a confirmation response.
* Imported `OCPP2_1` in `core/src/modules/Transactions/src/module/module.ts` to support the new OCPP 2.1 action.

**Configuration updates for NotifySettlement:**

* Added `OCPP_CallAction.NotifySettlement` to the list of allowed actions in the Docker environment configuration (`Server/src/config/envs/docker.ts`).
* Added `OCPP_CallAction.NotifySettlement` to the list of allowed actions in the local environment configuration (`Server/src/config/envs/local.ts`).
* Added `OCPP_CallAction.NotifySettlement` to the list of allowed actions in the Docker Swarm environment configuration (`Server/src/config/envs/swarm.docker.ts`).