### PR TITLE
C-21: implement settlement handling at the end of transaction with op…

### DIFF
--- a/base/src/config/types.ts
+++ b/base/src/config/types.ts
@@ -180,6 +180,8 @@ export const systemConfigInputSchema = z.object({
           signingMethod: z.enum(['RSASSA-PKCS1-v1_5', 'ECDSA']),
         })
         .optional(),
+      /** Base URL for generating receipt URLs when ReceiptByCSMS is true (C21). */
+      receiptBaseUrl: z.string().optional(),
     }),
   }),
   util: z.object({
@@ -481,6 +483,8 @@ export const systemConfigSchema = z
               signingMethod: z.enum(['RSASSA-PKCS1-v1_5', 'ECDSA']),
             })
             .optional(),
+          /** Base URL for generating receipt URLs when ReceiptByCSMS is true (C21). */
+          receiptBaseUrl: z.string().optional(),
         })
         .refine(
           (obj) =>

--- a/core/src/modules/Transactions/src/module/module.ts
+++ b/core/src/modules/Transactions/src/module/module.ts
@@ -400,6 +400,42 @@ export class TransactionsModule extends AbstractModule {
         );
       }
 
+      // C21.FR.05/FR.06: If SettlementByCSMS is true and transaction ended, CSMS should settle with PSP
+      if (message.payload.eventType === TransactionEventEnum.Ended && transaction) {
+        try {
+          const settlementByCSMSAttributes: VariableAttribute[] =
+            await this._deviceModelRepository.readAllByQuerystring(tenantId, {
+              tenantId,
+              stationId,
+              component_name: 'PaymentCtrlr',
+              variable_name: 'SettlementByCSMS',
+              type: AttributeEnum.Actual,
+            });
+
+          const settlementByCSMS =
+            settlementByCSMSAttributes.length > 0 &&
+            settlementByCSMSAttributes[0].value?.toLowerCase() === 'true';
+
+          if (settlementByCSMS) {
+            const totalCost = response.totalCost ?? transaction.totalCost;
+            this._logger.info(
+              `C21.FR.05: SettlementByCSMS is true for station ${stationId}, ` +
+                `transaction ${transaction.transactionId}. ` +
+                `CSMS should settle totalCost=${totalCost} with PSP. ` +
+                `This requires external PSP integration.`,
+            );
+            // PSP settlement integration point:
+            // Implementers should extend this to call their PSP API to settle
+            // the payment using the pspRef from the authorization's idToken.
+          }
+        } catch (error) {
+          this._logger.error(
+            'Failed to check PaymentCtrlr.SettlementByCSMS from device model',
+            error,
+          );
+        }
+      }
+
       if (transactionEvent.meterValue) {
         const meterValuesValid = await this._signedMeterValuesUtil.validateMeterValues(
           tenantId,
@@ -547,8 +583,13 @@ export class TransactionsModule extends AbstractModule {
 
   /**
    * C19 - Cancellation prior to transaction
+   * C21 - Settlement at end of transaction
    * Handles NotifySettlementRequest from Charging Station to inform CSMS
    * that a payment has been canceled or settled.
+   *
+   * C21.FR.02: CS sends NotifySettlementRequest with status, amount, time, transId, and pspRef.
+   * C21.FR.03: If PaymentCtrlr.ReceiptByCSMS = true, CSMS responds with receiptUrl.
+   * C21.FR.04: If ReceiptByCSMS = false, CS includes receiptUrl/receiptId in the request (no action needed from CSMS).
    */
   @AsHandler([OCPPVersion.OCPP2_1], OCPP_CallAction.NotifySettlement)
   protected async _handleNotifySettlement(
@@ -557,6 +598,8 @@ export class TransactionsModule extends AbstractModule {
   ): Promise<void> {
     this._logger.debug('NotifySettlementRequest received:', message, props);
 
+    const tenantId = message.context.tenantId;
+    const stationId = message.context.stationId;
     const request = message.payload;
 
     this._logger.info(
@@ -564,7 +607,71 @@ export class TransactionsModule extends AbstractModule {
         `amount=${request.settlementAmount}, transactionId=${request.transactionId ?? 'none'}`,
     );
 
+    // Store settlement data on the transaction if a transactionId is provided
+    if (request.transactionId) {
+      try {
+        await this._transactionEventRepository.updateTransactionByStationIdAndTransactionId(
+          tenantId,
+          {
+            customData: {
+              settlement: {
+                pspRef: request.pspRef,
+                status: request.status,
+                settlementAmount: request.settlementAmount,
+                settlementTime: request.settlementTime,
+                receiptId: request.receiptId,
+                receiptUrl: request.receiptUrl,
+                vatNumber: request.vatNumber,
+              },
+            },
+          } as any,
+          request.transactionId,
+          stationId,
+        );
+      } catch (error) {
+        this._logger.error(
+          `Failed to store settlement data for transaction ${request.transactionId}`,
+          error,
+        );
+      }
+    }
+
     const response: OCPP2_1.NotifySettlementResponse = {};
+
+    // C21.FR.03: If PaymentCtrlr.ReceiptByCSMS is true, generate and include receiptUrl in response
+    try {
+      const receiptByCSMSAttributes: VariableAttribute[] =
+        await this._deviceModelRepository.readAllByQuerystring(tenantId, {
+          tenantId,
+          stationId,
+          component_name: 'PaymentCtrlr',
+          variable_name: 'ReceiptByCSMS',
+          type: AttributeEnum.Actual,
+        });
+
+      const receiptByCSMS =
+        receiptByCSMSAttributes.length > 0 &&
+        receiptByCSMSAttributes[0].value?.toLowerCase() === 'true';
+
+      if (receiptByCSMS) {
+        const receiptBaseUrl = this.config.modules.transactions.receiptBaseUrl;
+        if (receiptBaseUrl) {
+          const receiptId = request.transactionId
+            ? `${stationId}-${request.transactionId}-${request.pspRef}`
+            : `${stationId}-${request.pspRef}`;
+          response.receiptUrl = `${receiptBaseUrl}/${encodeURIComponent(receiptId)}`;
+          response.receiptId = receiptId;
+          this._logger.info(`ReceiptByCSMS is true, generated receiptUrl=${response.receiptUrl}`);
+        } else {
+          this._logger.warn(
+            'ReceiptByCSMS is true but no receiptBaseUrl configured in transactions module config. ' +
+              'Cannot generate receiptUrl.',
+          );
+        }
+      }
+    } catch (error) {
+      this._logger.error('Failed to read PaymentCtrlr.ReceiptByCSMS from device model', error);
+    }
 
     const messageConfirmation = await this.sendCallResultWithMessage(message, response);
     this._logger.debug('NotifySettlement response sent:', messageConfirmation);


### PR DESCRIPTION
This pull request introduces enhancements to the settlement and receipt handling logic for transactions, particularly around the OCPP 2.1 NotifySettlement flow. It adds configuration options for receipt URL generation, updates the settlement process to support CSMS-driven settlement and receipt issuance, and ensures settlement data is stored with transactions.

**Settlement and Receipt Handling Enhancements:**

* Added support for CSMS-driven settlement: When a transaction ends and `SettlementByCSMS` is enabled, the system now logs that settlement with the PSP should occur, providing an integration point for implementers to connect to their PSP APIs.
* Settlement data persistence: On receiving a `NotifySettlementRequest`, the system stores settlement details (such as `pspRef`, `status`, `settlementAmount`, etc.) in the transaction record if a `transactionId` is present.

**Receipt URL Generation and Configuration:**

* Receipt URL generation: If `ReceiptByCSMS` is enabled, the system generates a `receiptUrl` and `receiptId` in the response to the charging station, using a configurable base URL. If the base URL is missing, a warning is logged.
* Configuration schema update: Added an optional `receiptBaseUrl` property to the transactions module configuration schema to support receipt URL generation. 

**Documentation and Comments:**

* Expanded comments and documentation in the `TransactionsModule` to clarify the flow and requirements for settlement and receipt handling according to C21 functional requirements.