### PR TITLE
I08: Receive Driver Tariff

### DIFF
--- a/core/src/modules/EVDriver/src/module/module.ts
+++ b/core/src/modules/EVDriver/src/module/module.ts
@@ -739,8 +739,11 @@ export class EVDriverModule extends AbstractModule {
             authorization.tariffId,
           );
           if (tariff) {
-            (response as OCPP2_1.AuthorizeResponse).tariff =
+            // I08.FR.09: CSMS SHALL NOT provide validFrom in AuthorizeResponse
+            const { validFrom: _, ...tariffForResponse } =
               OCPP2_1_Mapper.TariffMapper.toTariffType(tariff);
+            (response as OCPP2_1.AuthorizeResponse).tariff =
+              tariffForResponse as OCPP2_1.TariffType;
           }
         }
       }


### PR DESCRIPTION
## Context
This PR aims to implement OCPP2.1, I08 Set Default Tariff but most parts have been done in https://github.com/citrineos/citrineos-core/pull/638 and https://github.com/citrineos/citrineos-core/pull/644
⚠️ This branch is branch off of another feature branch (https://github.com/citrineos/citrineos-core/pull/644). Please merge that PR at first and update the destination branch before merging

## Changes
Implement I08.FR.09: exclude validFrom field of tariff in AuthorizeResponse

## Tests
1. prepare a tariff with validFrom value <img width="955" height="46" alt="Screenshot 2026-04-22 at 10 42 36 AM" src="https://github.com/user-attachments/assets/0ff3a5c5-6db9-41c9-bffc-0f825720b793" />
2. charger send authorize request and the response doesn't contain the `validFrom` filed. <img width="909" height="232" alt="Screenshot 2026-04-22 at 10 35 45 AM" src="https://github.com/user-attachments/assets/10af37f9-8b8c-4912-ae9e-f81117cc8bb7" />