### PR TITLE
chore(ocpp-router): remove empty IAdminApi placeholder

### DIFF
--- a/core/src/modules/OcppRouter/src/index.ts
+++ b/core/src/modules/OcppRouter/src/index.ts
@@ -3,6 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export { AdminApi } from './module/DataApi.js';
-export type { IAdminApi } from './module/interface.js';
 export { MessageRouterImpl } from './module/router.js';
 export { WebhookDispatcher } from './module/webhook.dispatcher.js';

--- a/core/src/modules/OcppRouter/src/module/DataApi.ts
+++ b/core/src/modules/OcppRouter/src/module/DataApi.ts
@@ -51,12 +51,11 @@ import { Subscription } from '@dal/layers/sequelize/model/Subscription/index.js'
 import type { FastifyInstance, FastifyRequest } from 'fastify';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type { IAdminApi } from './interface.js';
 
 /**
  * Admin API for the OcppRouter.
  */
-export class AdminApi extends AbstractModuleApi<IMessageRouter> implements IAdminApi {
+export class AdminApi extends AbstractModuleApi<IMessageRouter> {
   private _networkConnection: INetworkConnection;
   private _subscriptionRepository: ISubscriptionRepository;
   private _serverNetworkProfileRepository: IServerNetworkProfileRepository;

--- a/core/src/modules/OcppRouter/src/module/interface.ts
+++ b/core/src/modules/OcppRouter/src/module/interface.ts
@@ -1,9 +1,0 @@
-// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
-//
-// SPDX-License-Identifier: Apache-2.0
-
-/**
- * TODO: add actual interface
- * Interface for the admin api.
- */
-export interface IAdminApi {}


### PR DESCRIPTION
- `IAdminApi` was empty and had a single implementor; `implements` enforced no contract.
- Deleted the interface file, removed the `implements` clause and the public type export.
- Build and OcppRouter tests pass (81/81).