### PR TITLE
fix(transactions): set Connector FK fields on OCPP 1.6 StatusNotification (#160)

### DIFF
--- a/core/src/dal/interfaces/repositories.ts
+++ b/core/src/dal/interfaces/repositories.ts
@@ -266,6 +266,18 @@ export interface ILocationRepository extends CrudRepository<Location> {
     chargingStation: ChargingStation,
   ): Promise<ChargingStation>;
   createOrUpdateConnector(tenantId: number, connector: Connector): Promise<Connector | undefined>;
+  /**
+   * Commissions a default evse + evseTypeConnector record for an OCPP 1.6 connector.
+   * Used in ad-hoc/`allowUnknownChargingStations` flows where the charge point arrives
+   * uncommissioned (OCPP 1.6 has no native EVSE concept). Conservative default:
+   * one connector → one evse. Returns the FK ids the caller should stamp on the
+   * Connector record being upserted.
+   */
+  commissionEvseForOcpp16Connector(
+    tenantId: number,
+    ocppConnectionName: string,
+    connectorId: number,
+  ): Promise<{ evseId: number; evseTypeConnectorId: number }>;
   updateAllConnectorsByQuery(
     tenantId: number,
     value: Partial<Connector>,

--- a/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/core/src/dal/layers/sequelize/repository/Location.ts
@@ -9,6 +9,7 @@ import { Sequelize } from 'sequelize-typescript';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { type ILocationRepository } from '../../../interfaces/repositories.js';
+import { EvseType } from '../model/DeviceModel/EvseType.js';
 import { ChargingStation } from '../model/Location/ChargingStation.js';
 import { Connector } from '../model/Location/Connector.js';
 import { Evse } from '../model/Location/Evse.js';
@@ -341,6 +342,32 @@ export class SequelizeLocationRepository
     query: object,
   ): Promise<Connector[]> {
     return await this.connector.updateAllByQuery(tenantId, value, query);
+  }
+
+  async commissionEvseForOcpp16Connector(
+    tenantId: number,
+    ocppConnectionName: string,
+    connectorId: number,
+  ): Promise<{ evseId: number; evseTypeConnectorId: number }> {
+    return await this.s.transaction(async (sequelizeTransaction) => {
+      // OCPP 1.6 has no native EVSE concept. Conservative default: each connector
+      // maps to its own (Evse, EvseType) pair using the 1.6 connectorId as the
+      // OCPP 2.0.1 evse id. EvseType.connectorId stays null because the EVSE
+      // is implicit (single-connector hardware abstraction). The Evse's
+      // stationId FK is auto-resolved from ocppConnectionName by the
+      // BeforeCreate hook on the Evse model.
+      const [evseType] = await EvseType.findOrCreate({
+        where: { tenantId, id: connectorId, connectorId: null },
+        defaults: { tenantId, id: connectorId, connectorId: null },
+        transaction: sequelizeTransaction,
+      });
+      const [evse] = await Evse.findOrCreate({
+        where: { tenantId, ocppConnectionName, evseTypeId: connectorId },
+        defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
+        transaction: sequelizeTransaction,
+      });
+      return { evseId: evse.id, evseTypeConnectorId: evseType.databaseId };
+    });
   }
 
   async updateChargingStationTimestamp(

--- a/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -169,24 +169,15 @@ export class StatusNotificationService {
           (connector) => connector.connectorId === statusNotificationRequest.connectorId,
         ),
       );
-      const statusNotificationInput: Partial<StatusNotification> = {
-        tenantId,
-        ...statusNotificationRequest,
-        ocppConnectionName: ocppConnectionName,
-        connectorStatus: statusNotificationRequest.status,
-      };
-      if (matchingEvse) {
-        statusNotificationInput.evseId = matchingEvse.evseTypeId;
-      }
-      const statusNotification = StatusNotification.build(statusNotificationInput);
-      await this._locationRepository.addStatusNotificationToChargingStation(
-        tenantId,
-        ocppConnectionName,
-        statusNotification,
+      const matchingConnector = matchingEvse?.connectors?.find(
+        (connector) => connector.connectorId === statusNotificationRequest.connectorId,
       );
 
+      // We upsert the Connector BEFORE saving the StatusNotification because
+      // StatusNotifications.connectorId has an FK to Connectors.connectorId.
       const connector = {
         tenantId,
+        stationId: chargingStation.id,
         connectorId: statusNotificationRequest.connectorId,
         ocppConnectionName: ocppConnectionName,
         status: OCPP1_6_Mapper.LocationMapper.mapStatusNotificationRequestStatusToConnectorStatus(
@@ -205,7 +196,8 @@ export class StatusNotificationService {
       } as Connector;
 
       if (chargingStation.use16StatusNotification0 && statusNotificationRequest.connectorId === 0) {
-        // update all connectors
+        // update all connectors at this station — connectorId stripped so we
+        // don't overwrite the per-row connectorId values
         await this._locationRepository.updateAllConnectorsByQuery(
           tenantId,
           {
@@ -213,32 +205,60 @@ export class StatusNotificationService {
             connectorId: undefined,
           },
           {
-            where: {
-              ocppConnectionName: ocppConnectionName,
-              tenantId,
-            },
+            where: { stationId: chargingStation.id, tenantId },
           },
         );
       } else if (statusNotificationRequest.connectorId !== 0) {
-        const connectionJson = await this._cache.get<string>(
-          createIdentifier(tenantId, ocppConnectionName),
-          CacheNamespace.Connections,
-        );
-        const connection: IWebsocketConnection | null = connectionJson
-          ? JSON.parse(connectionJson)
-          : null;
-        if (!connection?.allowUnknownChargingStations) {
-          const connectorExists = chargingStation.evses?.some((evse) =>
-            evse.connectors?.some((c) => c.connectorId === statusNotificationRequest.connectorId),
+        // Connector model declares evseId and evseTypeConnectorId as allowNull:false.
+        // For commissioned stations these come from the matching evse/connector;
+        // for ad-hoc 1.6 stations we auto-commission below (citrineos/citrineos#160).
+        if (!matchingEvse) {
+          const connectionJson = await this._cache.get<string>(
+            createIdentifier(tenantId, ocppConnectionName),
+            CacheNamespace.Connections,
           );
-          if (!connectorExists) {
+          const connection: IWebsocketConnection | null = connectionJson
+            ? JSON.parse(connectionJson)
+            : null;
+          if (!connection?.allowUnknownChargingStations) {
             throw new Error(
               `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is false`,
             );
           }
+          const commissioned = await this._locationRepository.commissionEvseForOcpp16Connector(
+            tenantId,
+            ocppConnectionName,
+            statusNotificationRequest.connectorId,
+          );
+          connector.evseId = commissioned.evseId;
+          connector.evseTypeConnectorId = commissioned.evseTypeConnectorId;
+        } else {
+          // matchingConnector is found via the same predicate as matchingEvse,
+          // so it is guaranteed to be defined when matchingEvse is.
+          connector.evseId = matchingEvse.id as number;
+          connector.evseTypeConnectorId = matchingConnector!.evseTypeConnectorId as number;
         }
+
         await this._locationRepository.createOrUpdateConnector(tenantId, connector);
       }
+
+      // Now that the Connector record exists (upserted above, or pre-existing in
+      // the broadcast path), save the StatusNotification record.
+      const statusNotificationInput: Partial<StatusNotification> = {
+        tenantId,
+        ...statusNotificationRequest,
+        ocppConnectionName: ocppConnectionName,
+        connectorStatus: statusNotificationRequest.status,
+      };
+      if (matchingEvse) {
+        statusNotificationInput.evseId = matchingEvse.evseTypeId;
+      }
+      const statusNotification = StatusNotification.build(statusNotificationInput);
+      await this._locationRepository.addStatusNotificationToChargingStation(
+        tenantId,
+        ocppConnectionName,
+        statusNotification,
+      );
     } else {
       this._logger.warn(
         `Charging station ${ocppConnectionName} not found. Status notification cannot be associated with a charging station.`,

--- a/core/src/modules/Transactions/test/module/StatusNotificationService.integration.test.ts
+++ b/core/src/modules/Transactions/test/module/StatusNotificationService.integration.test.ts
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { BootstrapConfig, ICache, IWebsocketConnection } from '@citrineos/base';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  Evse,
+  SequelizeLocationRepository,
+  Tenant,
+} from '@dal/index.js';
+import { StatusNotificationService } from '../../src/module/StatusNotificationService.js';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let locationRepository: SequelizeLocationRepository;
+let cache: ICache;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  locationRepository = new SequelizeLocationRepository(
+    {} as BootstrapConfig,
+    undefined,
+    sequelizeInstance,
+  );
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance.close();
+  await pgContainer.stop();
+});
+
+beforeEach(async () => {
+  await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+  await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'default' } as Tenant);
+});
+
+describe('SequelizeLocationRepository.commissionEvseForOcpp16Connector (#160 integration)', () => {
+  it('creates an Evse and returns ids that satisfy the Connector FK constraints', async () => {
+    const ocppConnectionName = 'CS-1.6-clean-db';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    } as ChargingStation);
+
+    const { evseId, evseTypeConnectorId } =
+      await locationRepository.commissionEvseForOcpp16Connector(
+        DEFAULT_TENANT_ID,
+        ocppConnectionName,
+        1,
+      );
+
+    expect(evseId).toBeGreaterThan(0);
+    expect(evseTypeConnectorId).toBeGreaterThan(0);
+
+    // Confirm the Evse row exists and is linked to the right station
+    const evse = await Evse.findOne({ where: { id: evseId } });
+    expect(evse).not.toBeNull();
+    expect(evse?.ocppConnectionName).toBe(ocppConnectionName);
+
+    // Critical: verify the returned ids satisfy whatever FK rules the live DB enforces
+    // by actually inserting a Connector row.
+    const dbConnector = await Connector.create({
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      connectorId: 1,
+      evseId,
+      evseTypeConnectorId,
+      status: 'Available',
+      timestamp: new Date(),
+      errorCode: 'NoError',
+    } as unknown as Connector);
+    expect(dbConnector.id).toBeGreaterThan(0);
+  });
+
+  it('is idempotent: a second call for the same station+connector returns the same evseId', async () => {
+    const ocppConnectionName = 'CS-1.6-idempotent';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    } as ChargingStation);
+
+    const first = await locationRepository.commissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      2,
+    );
+    const second = await locationRepository.commissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      2,
+    );
+
+    expect(second.evseId).toBe(first.evseId);
+  });
+});
+
+describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (#160 integration)', () => {
+  it('processes a 1.6 StatusNotification against a clean DB without crashing (auto-commission path)', async () => {
+    const ocppConnectionName = 'CS-1.6-e2e-clean';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    } as ChargingStation);
+
+    const websocketConnection: IWebsocketConnection = {
+      id: 'test-server',
+      protocol: 'ocpp1.6',
+      allowUnknownChargingStations: true,
+    };
+    cache = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(websocketConnection)),
+    } as unknown as ICache;
+
+    // The service needs ComponentRepository and DeviceModelRepository, but the
+    // 1.6 path doesn't use them. Stubs are sufficient.
+    const service = new StatusNotificationService(
+      { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+      locationRepository,
+      cache,
+    );
+
+    await expect(
+      service.processOcpp16StatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        connectorId: 1,
+        status: 'Available',
+        errorCode: 'NoError',
+        timestamp: new Date().toISOString(),
+      } as any),
+    ).resolves.not.toThrow();
+
+    // Connector should now exist in the DB.
+    const connector = await Connector.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName, connectorId: 1 },
+    });
+    expect(connector).not.toBeNull();
+    expect(connector?.evseId).toBeDefined();
+    expect(connector?.evseTypeConnectorId).toBeDefined();
+
+    // Reporter's "cascade" concern: StartTransaction must be able to find
+    // this connector via readConnectorByStationIdAndOcpp16ConnectorId.
+    const lookedUp = await locationRepository.readConnectorByStationIdAndOcpp16ConnectorId(
+      DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      1,
+    );
+    expect(lookedUp).toBeDefined();
+    expect(lookedUp?.id).toBe(connector?.id);
+  });
+
+  it('processes a 1.6 StatusNotification for a commissioned station (matching evse path)', async () => {
+    const ocppConnectionName = 'CS-1.6-e2e-commissioned';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    } as ChargingStation);
+    // Use the commission helper for a clean pre-existing setup, then upsert
+    // a Connector tied to it so the matching-evse branch fires in the handler.
+    const { evseId, evseTypeConnectorId } =
+      await locationRepository.commissionEvseForOcpp16Connector(
+        DEFAULT_TENANT_ID,
+        ocppConnectionName,
+        1,
+      );
+    await Connector.create({
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      connectorId: 1,
+      evseId,
+      evseTypeConnectorId,
+      status: 'Available',
+      timestamp: new Date(),
+      errorCode: 'NoError',
+    } as unknown as Connector);
+
+    const websocketConnection: IWebsocketConnection = {
+      id: 'test-server',
+      protocol: 'ocpp1.6',
+      allowUnknownChargingStations: false, // strict — relies on commissioned record
+    };
+    cache = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(websocketConnection)),
+    } as unknown as ICache;
+
+    const service = new StatusNotificationService(
+      { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+      locationRepository,
+      cache,
+    );
+
+    await expect(
+      service.processOcpp16StatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        connectorId: 1,
+        status: 'Charging',
+        errorCode: 'NoError',
+        timestamp: new Date().toISOString(),
+      } as any),
+    ).resolves.not.toThrow();
+
+    const connector = await Connector.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName, connectorId: 1 },
+    });
+    expect(connector?.status).toBe('Charging');
+    expect(connector?.evseId).toBe(evseId);
+  });
+});

--- a/core/src/modules/Transactions/test/module/StatusNotificationService.test.ts
+++ b/core/src/modules/Transactions/test/module/StatusNotificationService.test.ts
@@ -75,6 +75,8 @@ describe('StatusNotificationService', () => {
       addStatusNotificationToChargingStation: vi.fn(),
       readChargingStationByStationId: vi.fn(),
       createOrUpdateConnector: vi.fn(),
+      commissionEvseForOcpp16Connector: vi.fn(),
+      updateAllConnectorsByQuery: vi.fn(),
     } as unknown as Mocked<ILocationRepository>;
 
     const mockConnection: IWebsocketConnection = {
@@ -197,8 +199,12 @@ describe('StatusNotificationService', () => {
   });
 
   describe('Test process OCPP 1.6 StatusNotification', () => {
-    it('should save StatusNotification and connector when Charging Station exists', async () => {
-      locationRepository.readChargingStationByStationId.mockResolvedValue(aChargingStation());
+    it('should save StatusNotification and connector when Charging Station exists with a matching evse', async () => {
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [aEvse()];
+        }),
+      );
       vi.spyOn(StatusNotification, 'build').mockImplementation(() => {
         return aStatusNotification();
       });
@@ -223,6 +229,124 @@ describe('StatusNotificationService', () => {
       );
 
       expect(locationRepository.addStatusNotificationToChargingStation).not.toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateConnector).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Test process OCPP 1.6 StatusNotification sets FK fields on Connector record (#160)', () => {
+    it('should stamp evseId on the Connector record when matching evse exists', async () => {
+      // Regression for citrineos/citrineos#160 — Connector model declares evseId
+      // as allowNull:false, so the upsert must include the FK or it crashes with
+      // "notNull Violation: Connector.evseId cannot be null".
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [aEvse()];
+        }),
+      );
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+
+      await statusNotificationService.processOcpp16StatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aOcpp16StatusNotificationRequest((req) => {
+          req.connectorId = MOCK_CONNECTOR_ID;
+        }),
+      );
+
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ evseId: MOCK_EVSE_ID }),
+      );
+    });
+
+    it('should stamp evseTypeConnectorId on the Connector record when matching evse exists', async () => {
+      // Connector model also requires evseTypeConnectorId (FK to EvseType, allowNull:false).
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [aEvse()];
+        }),
+      );
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+
+      await statusNotificationService.processOcpp16StatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aOcpp16StatusNotificationRequest((req) => {
+          req.connectorId = MOCK_CONNECTOR_ID;
+        }),
+      );
+
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ evseTypeConnectorId: MOCK_CONNECTOR_ID }),
+      );
+    });
+
+    it('should auto-commission an evse and stamp its FKs onto the Connector when allowUnknownChargingStations is true and no matching evse exists', async () => {
+      // Reporter's repro (clean DB + 1.6 charger): the station exists from BootNotification
+      // but no EVSE/Connector records exist. With ad-hoc mode enabled, the handler should
+      // commission a new evse on demand (1 connector → 1 evse for OCPP 1.6) instead of
+      // crashing with an FK violation.
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [];
+        }),
+      );
+      const newEvseId = 99;
+      const newEvseTypeConnectorId = 1;
+      locationRepository.commissionEvseForOcpp16Connector.mockResolvedValue({
+        evseId: newEvseId,
+        evseTypeConnectorId: newEvseTypeConnectorId,
+      });
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+
+      await statusNotificationService.processOcpp16StatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aOcpp16StatusNotificationRequest((req) => {
+          req.connectorId = 7;
+        }),
+      );
+
+      expect(locationRepository.commissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        7,
+      );
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({
+          evseId: newEvseId,
+          evseTypeConnectorId: newEvseTypeConnectorId,
+          connectorId: 7,
+        }),
+      );
+    });
+
+    it('should throw and not upsert connector when allowUnknownChargingStations is false and no connector exists', async () => {
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [];
+        }),
+      );
+      const strictConnection: IWebsocketConnection = {
+        id: 'test-server',
+        protocol: 'ocpp1.6',
+        allowUnknownChargingStations: false,
+      };
+      cache.get = vi.fn().mockResolvedValue(JSON.stringify(strictConnection));
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+
+      await expect(
+        statusNotificationService.processOcpp16StatusNotification(
+          DEFAULT_TENANT_ID,
+          MOCK_STATION_ID,
+          aOcpp16StatusNotificationRequest((req) => {
+            req.connectorId = 9;
+          }),
+        ),
+      ).rejects.toThrow(/does not exist and allowUnknownChargingStations is false/);
+
       expect(locationRepository.createOrUpdateConnector).not.toHaveBeenCalled();
     });
   });
@@ -253,12 +377,18 @@ describe('StatusNotificationService', () => {
       expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
     });
 
-    it('should not set evseId when no matching evse is found for the connector', async () => {
+    it('should not set evseId on StatusNotification record when no matching evse is found, then auto-commission for the Connector record', async () => {
+      // The StatusNotification record itself is saved without evseId (audit trail),
+      // and the Connector record gets FKs from a freshly-commissioned evse.
       locationRepository.readChargingStationByStationId.mockResolvedValue(
         aChargingStation((cs) => {
           cs.evses = [aEvse()];
         }),
       );
+      locationRepository.commissionEvseForOcpp16Connector.mockResolvedValue({
+        evseId: 50,
+        evseTypeConnectorId: 1,
+      });
 
       const buildSpy = vi.spyOn(StatusNotification, 'build').mockImplementation((input: any) => {
         expect(input.evseId).toBeUndefined();
@@ -274,6 +404,16 @@ describe('StatusNotificationService', () => {
       );
 
       expect(buildSpy).toHaveBeenCalled();
+      expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
+      expect(locationRepository.commissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        404,
+      );
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ evseId: 50, evseTypeConnectorId: 1, connectorId: 404 }),
+      );
     });
   });
 });


### PR DESCRIPTION
- Stamps `evseId` and `evseTypeConnectorId` on the Connector record from the matching evse/connector for commissioned stations.
- Auto-commissions a default evse (1 connector → 1 evse for OCPP 1.6) when `allowUnknownChargingStations: true` and no matching evse exists.
- Strict mode preserved: throws when commissioning is required but the flag is off — matches PR #567 maintainer feedback (no nullable FKs).
- Tests: 4 new cases (FK stamping, auto-commission, strict-mode throw, audit-trail behavior); 2 existing tests refactored.

Fixes citrineos/citrineos#160