### PR TITLE
Fix/rabbitmq receiver reconnect

### DIFF
--- a/core/src/util/queue/rabbit-mq/receiver.ts
+++ b/core/src/util/queue/rabbit-mq/receiver.ts
@@ -30,22 +30,22 @@ import { RabbitMQChannelManager } from './ChannelManager.js';
  * environment variable wired into `SystemConfig.util.messageBroker.amqp.instanceIdentifier`.
  */
 export class RabbitMqReceiver extends AbstractMessageHandler {
-  private static readonly QUEUE_PREFIX = 'rabbit_queue_';
-  private static readonly CHANNEL_ID = 'receiver';
+  protected static readonly QUEUE_PREFIX = 'rabbit_queue_';
+  protected static readonly CHANNEL_ID = 'receiver';
 
   protected _channelManager: RabbitMQChannelManager;
-  private exchange: string;
-  private readonly _isRouterMode: boolean;
+  protected exchange: string;
+  protected readonly _isRouterMode: boolean;
 
   protected _consumerTags = new Map<string, string[]>();
-  private _moduleSubscriptions = new Map<
+  protected _moduleSubscriptions = new Map<
     string,
     Array<{ actions?: CallAction[]; filter?: Record<string, string> }>
   >();
-  private readonly _instanceQueueName?: string;
-  private _instanceQueueReady?: Promise<void>;
-  private _instanceConsumerTags: string[] = [];
-  private _instanceBindings = new Map<string, Array<Record<string, string>>>();
+  protected readonly _instanceQueueName?: string;
+  protected _instanceQueueReady?: Promise<void>;
+  protected _instanceConsumerTags: string[] = [];
+  protected _instanceBindings = new Map<string, Array<Record<string, string>>>();
 
   constructor(
     config: SystemConfig,
@@ -67,16 +67,23 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
       this._instanceQueueName = `rabbit_queue_router_${id}`;
     }
 
-    this._channelManager.getConnectionManager().on('connected', () => {
-      this._onReconnect().catch((err) => {
+    this._channelManager.getConnectionManager().on('connected', async () => {
+      try {
+        await this._onReconnect();
+      } catch (err) {
         this._logger.error('Failed to reinitialize after reconnect:', err);
-      });
+      }
     });
   }
 
-  private _lazyInitInstanceQueue(): Promise<void> {
+  protected _lazyInitInstanceQueue(): Promise<void> {
     if (!this._instanceQueueReady) {
-      this._instanceQueueReady = this.initializeInstanceQueue(this._instanceQueueName!);
+      this._instanceQueueReady = this.initializeInstanceQueue(this._instanceQueueName!).catch(
+        (err) => {
+          this._instanceQueueReady = undefined;
+          throw err;
+        },
+      );
     }
     return this._instanceQueueReady;
   }
@@ -110,7 +117,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     this._logger.info(`[instance-queue] Initialized ${queueName} with 1 consumer`);
   }
 
-  private async _onReconnect(): Promise<void> {
+  protected async _onReconnect(): Promise<void> {
     if (this._isRouterMode) {
       await this._reinitializeInstanceQueue();
     } else {
@@ -122,7 +129,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    * Re-establishes all MODULE MODE queues, bindings, and consumers after a reconnection.
    * No-op when in ROUTER MODE or when no module subscriptions have been registered.
    */
-  private async _reinitializeModuleQueues(): Promise<void> {
+  protected async _reinitializeModuleQueues(): Promise<void> {
     if (this._moduleSubscriptions.size === 0) return;
 
     // Old consumer tags reference a dead channel — reset before re-subscribing
@@ -147,7 +154,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    * Re-adds all currently tracked bindings (idempotent — handles the edge case
    * where the queue was deleted and needs to be fully rebuilt).
    */
-  private async _reinitializeInstanceQueue(): Promise<void> {
+  protected async _reinitializeInstanceQueue(): Promise<void> {
     if (!this._instanceQueueReady) return; // no charger has connected yet, nothing to reinitialize
 
     const queueName = this._instanceQueueName!;
@@ -223,7 +230,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    * ROUTER MODE: adds header bindings to the shared instance queue for this charger.
    * No new queue or consumer is created.
    */
-  private async _bindToInstanceQueue(
+  protected async _bindToInstanceQueue(
     identifier: string,
     actions?: CallAction[],
     filter?: { [k: string]: string },
@@ -257,7 +264,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    * MODULE MODE: creates a dedicated queue per identifier with its own consumer(s).
    * Original behavior, unchanged.
    */
-  private async _subscribePerIdentifierQueue(
+  protected async _subscribePerIdentifierQueue(
     identifier: string,
     actions?: CallAction[],
     filter?: { [k: string]: string },

--- a/core/src/util/queue/rabbit-mq/receiver.ts
+++ b/core/src/util/queue/rabbit-mq/receiver.ts
@@ -29,31 +29,23 @@ import { RabbitMQChannelManager } from './ChannelManager.js';
  * per process (e.g. the ECS task hostname or Kubernetes pod name) via the `INSTANCE_IDENTIFIER`
  * environment variable wired into `SystemConfig.util.messageBroker.amqp.instanceIdentifier`.
  */
-
 export class RabbitMqReceiver extends AbstractMessageHandler {
-  /**
-   * Constants
-   */
   private static readonly QUEUE_PREFIX = 'rabbit_queue_';
   private static readonly CHANNEL_ID = 'receiver';
 
-  /**
-   * Fields
-   */
   protected _channelManager: RabbitMQChannelManager;
+  private exchange: string;
+  private readonly _isRouterMode: boolean;
 
-  // MODULE MODE: tracks consumer tags per identifier for cancellation on unsubscribe
   protected _consumerTags = new Map<string, string[]>();
-
-  // ROUTER MODE: single per-instance queue with fixed consumers and dynamic bindings
-  private _instanceQueueName?: string;
+  private _moduleSubscriptions = new Map<
+    string,
+    Array<{ actions?: CallAction[]; filter?: Record<string, string> }>
+  >();
+  private readonly _instanceQueueName?: string;
+  private _instanceQueueReady?: Promise<void>;
   private _instanceConsumerTags: string[] = [];
   private _instanceBindings = new Map<string, Array<Record<string, string>>>();
-
-  // Lazy-init: set when amqpConfig is provided; fulfilled once initializeInstanceQueue completes
-  private _pendingInstanceQueueName?: string;
-  private _instanceQueueInit?: Promise<void>;
-  private exchange: string;
 
   constructor(
     config: SystemConfig,
@@ -69,27 +61,24 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
       throw new Error('RabbitMQ exchange is not configured');
     }
     this.exchange = exchange;
-    if (routerMode) {
+    this._isRouterMode = !!routerMode;
+    if (this._isRouterMode) {
       const id = config.util.messageBroker.amqp?.instanceIdentifier ?? `router-${Date.now()}`;
-      this._pendingInstanceQueueName = `rabbit_queue_router_${id}`;
+      this._instanceQueueName = `rabbit_queue_router_${id}`;
     }
+
+    this._channelManager.getConnectionManager().on('connected', () => {
+      this._onReconnect().catch((err) => {
+        this._logger.error('Failed to reinitialize after reconnect:', err);
+      });
+    });
   }
 
-  /**
-   * Methods
-   */
-
-  /**
-   * Ensures the instance queue is initialized exactly once, triggered lazily on first subscribe.
-   * No-op if this receiver is not in router mode (no `amqpConfig` was supplied).
-   */
-  private async _lazyInitInstanceQueue(): Promise<void> {
-    if (this._instanceQueueName) return; // already initialized
-    if (!this._pendingInstanceQueueName) return; // not router mode
-    if (!this._instanceQueueInit) {
-      this._instanceQueueInit = this.initializeInstanceQueue(this._pendingInstanceQueueName);
+  private _lazyInitInstanceQueue(): Promise<void> {
+    if (!this._instanceQueueReady) {
+      this._instanceQueueReady = this.initializeInstanceQueue(this._instanceQueueName!);
     }
-    await this._instanceQueueInit;
+    return this._instanceQueueReady;
   }
 
   /**
@@ -109,11 +98,9 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     await channel.assertExchange(this.exchange, 'headers', { durable: false });
     await channel.assertQueue(queueName, {
       durable: true,
-      autoDelete: false,
+      autoDelete: true,
       exclusive: false,
     });
-
-    this._instanceQueueName = queueName;
 
     const { consumerTag } = await channel.consume(queueName, (msg) =>
       this._onMessage(msg, channel),
@@ -121,13 +108,38 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     this._instanceConsumerTags.push(consumerTag);
 
     this._logger.info(`[instance-queue] Initialized ${queueName} with 1 consumer`);
+  }
 
-    // On reconnect: re-assert queue, restore all active bindings, re-create consumers
-    this._channelManager.getConnectionManager().on('connected', () => {
-      this._reinitializeInstanceQueue().catch((err) => {
-        this._logger.error('[instance-queue] Failed to reinitialize after reconnect:', err);
-      });
-    });
+  private async _onReconnect(): Promise<void> {
+    if (this._isRouterMode) {
+      await this._reinitializeInstanceQueue();
+    } else {
+      await this._reinitializeModuleQueues();
+    }
+  }
+
+  /**
+   * Re-establishes all MODULE MODE queues, bindings, and consumers after a reconnection.
+   * No-op when in ROUTER MODE or when no module subscriptions have been registered.
+   */
+  private async _reinitializeModuleQueues(): Promise<void> {
+    if (this._moduleSubscriptions.size === 0) return;
+
+    // Old consumer tags reference a dead channel — reset before re-subscribing
+    this._consumerTags.clear();
+
+    let restored = 0;
+    for (const [identifier, subscriptions] of this._moduleSubscriptions) {
+      for (const { actions, filter } of subscriptions) {
+        await this._subscribePerIdentifierQueue(identifier, actions, filter);
+        restored++;
+      }
+    }
+
+    this._logger.info(
+      `[module-queues] Reinitialized ${this._moduleSubscriptions.size} queue(s) after reconnect ` +
+        `(${restored} subscription(s) restored)`,
+    );
   }
 
   /**
@@ -136,14 +148,15 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    * where the queue was deleted and needs to be fully rebuilt).
    */
   private async _reinitializeInstanceQueue(): Promise<void> {
-    if (!this._instanceQueueName) return;
+    if (!this._instanceQueueReady) return; // no charger has connected yet, nothing to reinitialize
 
+    const queueName = this._instanceQueueName!;
     const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
 
     await channel.assertExchange(this.exchange, 'headers', { durable: false });
-    await channel.assertQueue(this._instanceQueueName, {
+    await channel.assertQueue(queueName, {
       durable: true,
-      autoDelete: false,
+      autoDelete: true,
       exclusive: false,
     });
 
@@ -151,20 +164,20 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     let reboundCount = 0;
     for (const bindings of this._instanceBindings.values()) {
       for (const args of bindings) {
-        await channel.bindQueue(this._instanceQueueName, this.exchange, '', args);
+        await channel.bindQueue(queueName, this.exchange, '', args);
         reboundCount++;
       }
     }
 
     // Re-create the single consumer on the new channel
     this._instanceConsumerTags = [];
-    const { consumerTag } = await channel.consume(this._instanceQueueName, (msg) =>
+    const { consumerTag } = await channel.consume(queueName, (msg) =>
       this._onMessage(msg, channel),
     );
     this._instanceConsumerTags.push(consumerTag);
 
     this._logger.info(
-      `[instance-queue] Reinitialized ${this._instanceQueueName} after reconnect: ` +
+      `[instance-queue] Reinitialized ${queueName} after reconnect: ` +
         `1 consumer, ${reboundCount} binding(s) restored`,
     );
   }
@@ -195,10 +208,13 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
       return true;
     }
 
-    if (this._instanceQueueName || this._pendingInstanceQueueName) {
+    if (this._isRouterMode) {
       await this._lazyInitInstanceQueue();
       return this._bindToInstanceQueue(identifier, actions, filter);
     }
+
+    const existing = this._moduleSubscriptions.get(identifier) ?? [];
+    this._moduleSubscriptions.set(identifier, [...existing, { actions, filter }]);
 
     return this._subscribePerIdentifierQueue(identifier, actions, filter);
   }
@@ -295,7 +311,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
 
   async unsubscribe(identifier: string): Promise<boolean> {
     // ROUTER MODE: remove bindings from shared queue
-    if (this._instanceQueueName) {
+    if (this._isRouterMode) {
       const bindings = this._instanceBindings.get(identifier);
       if (!bindings?.length) {
         this._logger.warn(`No bindings found for ${identifier} during unsubscribe.`);
@@ -309,7 +325,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
         const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
         for (const args of bindings) {
           try {
-            await channel.unbindQueue(this._instanceQueueName, this.exchange, '', args);
+            await channel.unbindQueue(this._instanceQueueName!, this.exchange, '', args);
           } catch {
             this._logger.warn(`Could not unbind ${identifier} binding — may already be gone.`);
           }
@@ -328,6 +344,8 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     }
 
     // MODULE MODE: cancel consumers
+    this._moduleSubscriptions.delete(identifier);
+
     const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
     if (!channel) {
       this._logger.error('RabbitMQ is down: cannot unsubscribe.');
@@ -349,7 +367,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
 
   async shutdown(): Promise<void> {
     // ROUTER MODE: cancel all tracked consumers on the shared queue
-    if (this._instanceQueueName) {
+    if (this._isRouterMode) {
       try {
         const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
         for (const tag of this._instanceConsumerTags) {

--- a/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
+++ b/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
@@ -156,10 +156,14 @@ let receiver: RabbitMqReceiver;
 // Each test uses a unique suffix so durable queues from one test don't affect another.
 let uid: string;
 
-beforeEach(() => {
+beforeEach(async () => {
   uid = Date.now().toString(36);
   connectionManager = new RabbitMQConnectionManager(5_000, amqpUrl);
   channelManager = new RabbitMQChannelManager(connectionManager);
+  // Mirror production startup: connect before any subscribe() calls so the
+  // initial 'connected' event fires while _moduleSubscriptions/_instanceQueueReady
+  // are still empty, and _onReconnect is a no-op on first connect.
+  await connectionManager.connect();
 });
 
 afterEach(async () => {
@@ -282,7 +286,7 @@ describe('RabbitMqReceiver', () => {
 
       expect(queue).not.toBeNull();
       expect(queue!.durable).toBe(true);
-      expect(queue!.auto_delete).toBe(false);
+      expect(queue!.auto_delete).toBe(true);
       expect(queue!.exclusive).toBe(false);
     }, 15_000);
 
@@ -370,16 +374,16 @@ describe('RabbitMqReceiver', () => {
       await waitForConsumerCount(queueName, 1);
     }, 15_000);
 
-    it('should cancel the consumer on shutdown, leaving the durable queue intact', async () => {
+    it('should cancel the consumer on shutdown and auto-delete the queue', async () => {
       const queueName = `rabbit_queue_router_${instanceId}-${uid}`;
 
       await receiver.subscribe('charger-1', undefined, { stationId: 'CS001', tenantId: '1' });
       await receiver.shutdown();
 
-      // Queue must still exist (durable) and have no active consumers
-      const queue = await getQueue(queueName);
-      expect(queue).not.toBeNull(); // durable — queue survives
+      // autoDelete:true — queue is removed once the last consumer is cancelled
       await waitForConsumerCount(queueName, 0);
+      const queue = await getQueue(queueName);
+      expect(queue).toBeNull();
     }, 15_000);
   });
 });

--- a/core/src/util/test/queue/rabbit-mq/receiver.test.ts
+++ b/core/src/util/test/queue/rabbit-mq/receiver.test.ts
@@ -186,7 +186,7 @@ describe('RabbitMqReceiver', () => {
 
         expect(mockChannel.assertQueue).toHaveBeenCalledWith(
           'rabbit_queue_router_pod-1',
-          expect.objectContaining({ durable: true, autoDelete: false, exclusive: false }),
+          expect.objectContaining({ durable: true, autoDelete: true, exclusive: false }),
         );
       });
 


### PR DESCRIPTION
- fix: issue with CitrineOS not re-creating MODULE_MODE queues when reconnecting to RabbitMQ. Adjusted implementeation to keep track of _moduleSubscriptions so that _onReconnect we can _reinitializeModuleQueues and _reinitializeInstanceQueue if in router mode. This ensures that when Connection is somehow terminated between CitrineOS and RabbitMQ, CitrineOS will properly re-establish the needed queues.
- chore: cleaned up implementation in efforts to simplify readability, removed `_pendingInstanceQueueName` in favor of just keeping _instanceQueueName and introducing _instanceQueueReady and _isRouterMode as well as other adjustments to help readability. Ensuring that `this._channelManager.getConnectionManager().on('connected', ...` subscription only exists in one place to reduce the cognitive load as well.
- chore: adjusted all queues to autoDelete true for now since we are not currently implementing logic to persist in flight messages during disconnects, which can be revisited in the future.
- tests: updating tests to account for latest changes
- chore: adjusted RabbitMqReceiver properties to protected access for easier extendability