### PR TITLE
E-17: implement transaction resumption handling after power loss

### DIFF
--- a/core/src/modules/Transactions/src/module/module.ts
+++ b/core/src/modules/Transactions/src/module/module.ts
@@ -293,6 +293,7 @@ export class TransactionsModule extends AbstractModule {
     this._logger.debug('Transaction event received:', message, props);
     const tenantId: number = message.context.tenantId;
     const ocppConnectionName: string = message.context.ocppConnectionName;
+    const isOcpp21 = message.protocol === OCPPVersion.OCPP2_1;
 
     const transactionEvent = message.payload;
     const transactionId = transactionEvent.transactionInfo.transactionId;
@@ -351,42 +352,19 @@ export class TransactionsModule extends AbstractModule {
 
     if (response) {
       // Include transactionLimit in TransactionEventResponse when setting/changing a limit.
-      if (message.protocol === OCPPVersion.OCPP2_1 && transaction) {
+      if (isOcpp21 && transaction) {
         const ocpp21Response = response as OCPP2_1.TransactionEventResponse;
         const stationTransactionLimit = (
           message.payload as unknown as OCPP2_1.TransactionEventRequest
         ).transactionInfo?.transactionLimit;
-        const dbTransactionLimit = transaction.transactionLimit;
 
-        if (dbTransactionLimit) {
-          // If station didn't report a limit, or reported a different one, include it in response.
-          const limitsMatch =
-            stationTransactionLimit &&
-            stationTransactionLimit.maxCost === dbTransactionLimit.maxCost &&
-            stationTransactionLimit.maxEnergy === dbTransactionLimit.maxEnergy &&
-            stationTransactionLimit.maxTime === dbTransactionLimit.maxTime &&
-            stationTransactionLimit.maxSoC === dbTransactionLimit.maxSoC;
-
-          if (!limitsMatch) {
-            ocpp21Response.transactionLimit = {};
-            if (dbTransactionLimit.maxCost !== undefined) {
-              ocpp21Response.transactionLimit.maxCost = dbTransactionLimit.maxCost;
-            }
-            if (dbTransactionLimit.maxEnergy !== undefined) {
-              ocpp21Response.transactionLimit.maxEnergy = dbTransactionLimit.maxEnergy;
-            }
-            if (dbTransactionLimit.maxTime !== undefined) {
-              ocpp21Response.transactionLimit.maxTime = dbTransactionLimit.maxTime;
-            }
-            if (dbTransactionLimit.maxSoC !== undefined) {
-              ocpp21Response.transactionLimit.maxSoC = dbTransactionLimit.maxSoC;
-            }
-            this._logger.info(
-              `Including transactionLimit in response for station ${ocppConnectionName}, ` +
-                `transaction ${transactionId}: ${JSON.stringify(ocpp21Response.transactionLimit)}`,
-            );
-          }
-        }
+        this.syncTransactionLimitToResponse(
+          ocpp21Response,
+          transaction,
+          stationTransactionLimit,
+          ocppConnectionName,
+          transactionId,
+        );
       }
 
       // For DirectPayment tokens on Started events, include transactionLimit.
@@ -395,7 +373,7 @@ export class TransactionsModule extends AbstractModule {
       if (
         transactionEvent.eventType === TransactionEventEnum.Started &&
         response.idTokenInfo?.status === AuthorizationStatusEnum.Accepted &&
-        message.protocol === OCPPVersion.OCPP2_1 &&
+        isOcpp21 &&
         transactionEvent.idToken?.type === OCPP2_1.IdTokenEnumType.DirectPayment
       ) {
         const ocpp21Response = response as OCPP2_1.TransactionEventResponse;
@@ -475,27 +453,14 @@ export class TransactionsModule extends AbstractModule {
       // E16.FR.02: Persist the CSMS-set transactionLimit to the DB so that subsequent
       // TransactionEventRequests can have the limit echoed back via the E16 sync logic.
       // This covers limits set by C17 (prepaid), C25 (QR web payment), and E16 itself.
-      if (message.protocol === OCPPVersion.OCPP2_1 && transaction) {
+      if (isOcpp21 && transaction) {
         const ocpp21Response = response as OCPP2_1.TransactionEventResponse;
-        if (ocpp21Response.transactionLimit) {
-          try {
-            await this._transactionEventRepository.updateTransactionByStationIdAndTransactionId(
-              tenantId,
-              { transactionLimit: ocpp21Response.transactionLimit } as Partial<Transaction>,
-              transactionId,
-              ocppConnectionName,
-            );
-            this._logger.debug(
-              `Persisted transactionLimit to DB for station ${ocppConnectionName}, ` +
-                `transaction ${transactionId}: ${JSON.stringify(ocpp21Response.transactionLimit)}`,
-            );
-          } catch (error) {
-            this._logger.error(
-              `Failed to persist transactionLimit for transaction ${transactionId}`,
-              error,
-            );
-          }
-        }
+        await this.persistTransactionLimitToDb(
+          tenantId,
+          ocpp21Response,
+          transactionId,
+          ocppConnectionName,
+        );
       }
 
       const messageConfirmation = await this.sendCallResultWithMessage(message, response);
@@ -519,42 +484,19 @@ export class TransactionsModule extends AbstractModule {
       };
 
       // E16.FR.02: Include transactionLimit in TransactionEventResponse when setting/changing a limit.
-      if (message.protocol === OCPPVersion.OCPP2_1 && transaction) {
+      if (isOcpp21 && transaction) {
         const ocpp21Response = response as OCPP2_1.TransactionEventResponse;
         const stationTransactionLimit = (
           message.payload as unknown as OCPP2_1.TransactionEventRequest
         ).transactionInfo?.transactionLimit;
-        const dbTransactionLimit = transaction.transactionLimit;
 
-        if (dbTransactionLimit) {
-          // If station didn't report a limit, or reported a different one, include it in response.
-          const limitsMatch =
-            stationTransactionLimit &&
-            stationTransactionLimit.maxCost === dbTransactionLimit.maxCost &&
-            stationTransactionLimit.maxEnergy === dbTransactionLimit.maxEnergy &&
-            stationTransactionLimit.maxTime === dbTransactionLimit.maxTime &&
-            stationTransactionLimit.maxSoC === dbTransactionLimit.maxSoC;
-
-          if (!limitsMatch) {
-            ocpp21Response.transactionLimit = {};
-            if (dbTransactionLimit.maxCost !== undefined) {
-              ocpp21Response.transactionLimit.maxCost = dbTransactionLimit.maxCost;
-            }
-            if (dbTransactionLimit.maxEnergy !== undefined) {
-              ocpp21Response.transactionLimit.maxEnergy = dbTransactionLimit.maxEnergy;
-            }
-            if (dbTransactionLimit.maxTime !== undefined) {
-              ocpp21Response.transactionLimit.maxTime = dbTransactionLimit.maxTime;
-            }
-            if (dbTransactionLimit.maxSoC !== undefined) {
-              ocpp21Response.transactionLimit.maxSoC = dbTransactionLimit.maxSoC;
-            }
-            this._logger.info(
-              `Including transactionLimit in response for station ${ocppConnectionName}, ` +
-                `transaction ${transactionId}: ${JSON.stringify(ocpp21Response.transactionLimit)}`,
-            );
-          }
-        }
+        this.syncTransactionLimitToResponse(
+          ocpp21Response,
+          transaction,
+          stationTransactionLimit,
+          ocppConnectionName,
+          transactionId,
+        );
       }
 
       if (message.payload.eventType === TransactionEventEnum.Updated) {
@@ -575,7 +517,7 @@ export class TransactionsModule extends AbstractModule {
         // C23: Increasing authorization amount
         // When CS sends TransactionEventRequest(Updated) with triggerReason=LimitSet (OCPP 2.1),
         // it indicates the authorization amount has been increased and transactionLimit.maxCost updated.
-        if (message.protocol === OCPPVersion.OCPP2_1 && transaction && transaction.isActive) {
+        if (isOcpp21 && transaction && transaction.isActive) {
           const ocpp21Payload = message.payload as unknown as OCPP2_1.TransactionEventRequest;
           if (
             ocpp21Payload.triggerReason === OCPP2_1.TriggerReasonEnumType.LimitSet &&
@@ -633,7 +575,7 @@ export class TransactionsModule extends AbstractModule {
         // When CS sends TransactionEventRequest(Updated) with triggerReason=TxResumed,
         // it indicates the transaction has resumed after a power loss or reboot.
         // CSMS should re-send any applicable TxProfile charging profiles for this transaction.
-        if (message.protocol === OCPPVersion.OCPP2_1 && transaction && transaction.isActive) {
+        if (isOcpp21 && transaction && transaction.isActive) {
           const ocpp21Payload = message.payload as unknown as OCPP2_1.TransactionEventRequest;
           if (ocpp21Payload.triggerReason === OCPP2_1.TriggerReasonEnumType.TxResumed) {
             this._logger.info(
@@ -775,27 +717,14 @@ export class TransactionsModule extends AbstractModule {
 
       // E16.FR.02: Persist the CSMS-set transactionLimit to the DB so that subsequent
       // TransactionEventRequests can have the limit echoed back via the E16 sync logic.
-      if (message.protocol === OCPPVersion.OCPP2_1 && transaction) {
+      if (isOcpp21 && transaction) {
         const ocpp21Response = response as OCPP2_1.TransactionEventResponse;
-        if (ocpp21Response.transactionLimit) {
-          try {
-            await this._transactionEventRepository.updateTransactionByStationIdAndTransactionId(
-              tenantId,
-              { transactionLimit: ocpp21Response.transactionLimit } as Partial<Transaction>,
-              transactionId,
-              ocppConnectionName,
-            );
-            this._logger.debug(
-              `Persisted transactionLimit to DB for station ${ocppConnectionName}, ` +
-                `transaction ${transactionId}: ${JSON.stringify(ocpp21Response.transactionLimit)}`,
-            );
-          } catch (error) {
-            this._logger.error(
-              `Failed to persist transactionLimit for transaction ${transactionId}`,
-              error,
-            );
-          }
-        }
+        await this.persistTransactionLimitToDb(
+          tenantId,
+          ocpp21Response,
+          transactionId,
+          ocppConnectionName,
+        );
       }
 
       const messageConfirmation = await this.sendCallResultWithMessage(message, response);
@@ -1450,5 +1379,87 @@ export class TransactionsModule extends AbstractModule {
       ocppConnectionName,
       request.connectorId,
     );
+  }
+
+  /**
+   * Helper method to sync transactionLimit between DB and station for OCPP 2.1.
+   * Adds transactionLimit to response if DB limit differs from station's reported limit.
+   */
+  private syncTransactionLimitToResponse(
+    response: OCPP2_1.TransactionEventResponse,
+    transaction: Transaction,
+    stationTransactionLimit: OCPP2_1.TransactionLimitType | null | undefined,
+    ocppConnectionName: string,
+    transactionId: string,
+  ): void {
+    const dbTransactionLimit = transaction.transactionLimit;
+    if (!dbTransactionLimit) {
+      return;
+    }
+
+    // Check if station's limit matches DB limit
+    const limitsMatch =
+      stationTransactionLimit &&
+      stationTransactionLimit.maxCost === dbTransactionLimit.maxCost &&
+      stationTransactionLimit.maxEnergy === dbTransactionLimit.maxEnergy &&
+      stationTransactionLimit.maxTime === dbTransactionLimit.maxTime &&
+      stationTransactionLimit.maxSoC === dbTransactionLimit.maxSoC;
+
+    if (limitsMatch) {
+      return; // No need to include in response
+    }
+
+    // Build response transactionLimit with only defined fields
+    response.transactionLimit = {};
+    if (dbTransactionLimit.maxCost !== undefined) {
+      response.transactionLimit.maxCost = dbTransactionLimit.maxCost;
+    }
+    if (dbTransactionLimit.maxEnergy !== undefined) {
+      response.transactionLimit.maxEnergy = dbTransactionLimit.maxEnergy;
+    }
+    if (dbTransactionLimit.maxTime !== undefined) {
+      response.transactionLimit.maxTime = dbTransactionLimit.maxTime;
+    }
+    if (dbTransactionLimit.maxSoC !== undefined) {
+      response.transactionLimit.maxSoC = dbTransactionLimit.maxSoC;
+    }
+
+    this._logger.info(
+      `Including transactionLimit in response for station ${ocppConnectionName}, ` +
+        `transaction ${transactionId}: ${JSON.stringify(response.transactionLimit)}`,
+    );
+  }
+
+  /**
+   * Helper method to persist transactionLimit from response to DB for OCPP 2.1.
+   * This ensures subsequent requests can sync the limit via E16 logic.
+   */
+  private async persistTransactionLimitToDb(
+    tenantId: number,
+    response: OCPP2_1.TransactionEventResponse,
+    transactionId: string,
+    ocppConnectionName: string,
+  ): Promise<void> {
+    if (!response.transactionLimit) {
+      return;
+    }
+
+    try {
+      await this._transactionEventRepository.updateTransactionByStationIdAndTransactionId(
+        tenantId,
+        { transactionLimit: response.transactionLimit } as Partial<Transaction>,
+        transactionId,
+        ocppConnectionName,
+      );
+      this._logger.debug(
+        `Persisted transactionLimit to DB for station ${ocppConnectionName}, ` +
+          `transaction ${transactionId}: ${JSON.stringify(response.transactionLimit)}`,
+      );
+    } catch (error) {
+      this._logger.error(
+        `Failed to persist transactionLimit for transaction ${transactionId}`,
+        error,
+      );
+    }
   }
 }

--- a/core/src/modules/Transactions/src/module/module.ts
+++ b/core/src/modules/Transactions/src/module/module.ts
@@ -39,6 +39,7 @@ import {
 import { sequelize } from '@dal/index.js';
 import type {
   IAuthorizationRepository,
+  IChargingProfileRepository,
   IDeviceModelRepository,
   ILocationRepository,
   IOCPPMessageRepository,
@@ -48,9 +49,14 @@ import type {
 } from '@dal/interfaces/repositories.js';
 import { SequelizeOCPPMessageRepository } from '@dal/layers/sequelize/index.js';
 import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
+import { OCPP2_0_1_Mapper } from '@dal/index.js';
 import { Authorization } from '@dal/layers/sequelize/model/Authorization/index.js';
 import { Component, VariableAttribute } from '@dal/layers/sequelize/model/DeviceModel/index.js';
 import { Tariff } from '@dal/layers/sequelize/model/Tariff/Tariffs.js';
+import {
+  ChargingProfile,
+  ChargingSchedule,
+} from '@dal/layers/sequelize/model/ChargingProfile/index.js';
 import {
   StartTransaction,
   Transaction,
@@ -80,6 +86,7 @@ export class TransactionsModule extends AbstractModule {
   protected _tariffRepository: ITariffRepository;
   protected _reservationRepository: IReservationRepository;
   protected _ocppMessageRepository: IOCPPMessageRepository;
+  protected _chargingProfileRepository: IChargingProfileRepository;
 
   protected _transactionService: TransactionService;
   protected _statusNotificationService: StatusNotificationService;
@@ -179,6 +186,7 @@ export class TransactionsModule extends AbstractModule {
     ocppMessageRepository?: IOCPPMessageRepository,
     realTimeAuthorizer?: IAuthorizer,
     authorizers?: IAuthorizer[],
+    chargingProfileRepository?: IChargingProfileRepository,
   ) {
     super(config, cache, handler, sender, EventGroup.Transactions, logger, ocppValidator);
 
@@ -205,6 +213,9 @@ export class TransactionsModule extends AbstractModule {
       reservationRepository || new sequelize.SequelizeReservationRepository(config, logger);
     this._ocppMessageRepository =
       ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
+    this._chargingProfileRepository =
+      chargingProfileRepository ||
+      new sequelize.SequelizeChargingProfileRepository(config, this._logger);
 
     this._authorizers = authorizers || [];
     this._realTimeAuthorizer =
@@ -617,6 +628,82 @@ export class TransactionsModule extends AbstractModule {
           );
           // TODO: checks if there is updated tariff information available and set it in the PersonalMessage field.
         }
+
+        // E17 - Transaction resumption after power loss
+        // When CS sends TransactionEventRequest(Updated) with triggerReason=TxResumed,
+        // it indicates the transaction has resumed after a power loss or reboot.
+        // CSMS should re-send any applicable TxProfile charging profiles for this transaction.
+        if (message.protocol === OCPPVersion.OCPP2_1 && transaction && transaction.isActive) {
+          const ocpp21Payload = message.payload as unknown as OCPP2_1.TransactionEventRequest;
+          if (ocpp21Payload.triggerReason === OCPP2_1.TriggerReasonEnumType.TxResumed) {
+            this._logger.info(
+              `Transaction ${transactionId} resumed after power loss on station ${ocppConnectionName}. ` +
+                `Checking for TxProfile charging profiles to re-send.`,
+            );
+
+            try {
+              // Query active TxProfile charging profiles associated with this transaction
+              const txProfiles = await this._chargingProfileRepository.readAllByQuery(tenantId, {
+                where: {
+                  tenantId,
+                  ocppConnectionName,
+                  chargingProfilePurpose: OCPP2_1.ChargingProfilePurposeEnumType.TxProfile,
+                  transactionDatabaseId: transaction.id,
+                  isActive: true,
+                },
+                include: [{ model: ChargingSchedule, as: 'chargingSchedule' }],
+              });
+
+              if (txProfiles.length > 0) {
+                this._logger.info(
+                  `Found ${txProfiles.length} active TxProfile(s) to re-send for ` +
+                    `transaction ${transactionId} on station ${ocppConnectionName}.`,
+                );
+
+                for (const profile of txProfiles) {
+                  try {
+                    const chargingProfileType =
+                      OCPP2_0_1_Mapper.ChargingProfileMapper.toChargingProfileType(
+                        profile,
+                        transactionId,
+                      );
+                    await this.sendCall(
+                      ocppConnectionName,
+                      tenantId,
+                      OCPPVersion.OCPP2_1,
+                      OCPP_CallAction.SetChargingProfile,
+                      {
+                        evseId: profile.evseId ?? transaction.evseId,
+                        chargingProfile: chargingProfileType,
+                      } as OCPP2_request_types.SetChargingProfileRequest,
+                    );
+                    this._logger.info(
+                      `Re-sent TxProfile id=${profile.id} for transaction ${transactionId} ` +
+                        `on station ${ocppConnectionName}.`,
+                    );
+                  } catch (sendError) {
+                    this._logger.error(
+                      `Failed to re-send TxProfile id=${profile.id} for ` +
+                        `transaction ${transactionId} on station ${ocppConnectionName}`,
+                      sendError,
+                    );
+                  }
+                }
+              } else {
+                this._logger.debug(
+                  `No active TxProfile charging profiles found for ` +
+                    `transaction ${transactionId} on station ${ocppConnectionName}.`,
+                );
+              }
+            } catch (error) {
+              this._logger.error(
+                `Failed to query TxProfile charging profiles for ` +
+                  `transaction ${transactionId} on station ${ocppConnectionName}`,
+                error,
+              );
+            }
+          }
+        }
       }
 
       if (message.payload.eventType === TransactionEventEnum.Ended && transaction.totalKwh) {
@@ -655,7 +742,7 @@ export class TransactionsModule extends AbstractModule {
           if (settlementByCSMS) {
             const totalCost = response.totalCost ?? transaction.totalCost;
             this._logger.info(
-              `C21.FR.05: SettlementByCSMS is true for station ${ocppConnectionName}, ` +
+              `SettlementByCSMS is true for station ${ocppConnectionName}, ` +
                 `transaction ${transaction.transactionId}. ` +
                 `CSMS should settle totalCost=${totalCost} with PSP. ` +
                 `This requires external PSP integration.`,

--- a/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
+++ b/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
@@ -163,6 +163,10 @@ describe('TransactionsModule - E16 Transaction Limits', () => {
       {
         authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
       } as unknown as IAuthorizer,
+      undefined, // authorizers
+      {
+        readAllByQuery: vi.fn().mockResolvedValue([]),
+      } as unknown as any, // chargingProfileRepository
     );
 
     sendCallResultSpy = vi

--- a/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
+++ b/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
@@ -187,6 +187,10 @@ describe('TransactionsModule - _handleTransactionEvent and _handleOcpp16StartTra
         readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
       } as unknown as IOCPPMessageRepository,
       mockRealTimeAuthorizer,
+      /* authorizers */ undefined,
+      /* chargingProfileRepository */ {
+        readAllByQuery: vi.fn().mockResolvedValue([]),
+      } as unknown as any,
     );
 
     vi.spyOn(module, 'sendCallResultWithMessage').mockResolvedValue({ success: true });


### PR DESCRIPTION
This pull request adds support for resuming transactions after a power loss in OCPP 2.1 by automatically re-sending any applicable TxProfile charging profiles to the charging station. It introduces a new `IChargingProfileRepository` dependency to the `TransactionsModule` and implements logic to handle the `TxResumed` trigger reason. Several supporting imports and repository initializations are also included.

**OCPP 2.1 Transaction Resumption and Charging Profile Handling:**

* Implements logic to detect when a transaction is resumed after power loss (triggerReason=`TxResumed`) and automatically re-sends active TxProfile charging profiles to the station using the `SetChargingProfile` call. This ensures charging behavior is restored correctly after interruptions.

**Repository and Dependency Injection Enhancements:**

* Adds `IChargingProfileRepository` as a dependency to `TransactionsModule`, including constructor injection and initialization with a Sequelize implementation if not provided. 
* Imports related models (`ChargingProfile`, `ChargingSchedule`) and the OCPP 2.0.1 mapper to support charging profile operations.