### PR TITLE
C20: Cancelation after start of transaction, before costs have been incurred

### DIFF
--- a/apps/Server/migrations/20260507000000-add-transaction-limit-to-transactions.ts
+++ b/apps/Server/migrations/20260507000000-add-transaction-limit-to-transactions.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addColumn('Transactions', 'transactionLimit', {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeColumn('Transactions', 'transactionLimit');
+  },
+};

--- a/packages/base/src/interfaces/schema/MappingSchema.ts
+++ b/packages/base/src/interfaces/schema/MappingSchema.ts
@@ -156,6 +156,7 @@ export const OCPP2_1_CALL_SCHEMA_RECORD: Record<string, object> = {
   [OCPP_CallAction.NotifyEvent]: OCPP2_1.NotifyEventRequestSchema,
   [OCPP_CallAction.NotifyMonitoringReport]: OCPP2_1.NotifyMonitoringReportRequestSchema,
   [OCPP_CallAction.NotifyReport]: OCPP2_1.NotifyReportRequestSchema,
+  [OCPP_CallAction.NotifySettlement]: OCPP2_1.NotifySettlementRequestSchema,
   [OCPP_CallAction.PublishFirmware]: OCPP2_1.PublishFirmwareRequestSchema,
   [OCPP_CallAction.PublishFirmwareStatusNotification]:
     OCPP2_1.PublishFirmwareStatusNotificationRequestSchema,
@@ -331,6 +332,7 @@ export const OCPP2_1_CALL_RESULT_SCHEMA_RECORD: Record<string, object> = {
   [OCPP_CallAction.NotifyEvent]: OCPP2_1.NotifyEventResponseSchema,
   [OCPP_CallAction.NotifyMonitoringReport]: OCPP2_1.NotifyMonitoringReportResponseSchema,
   [OCPP_CallAction.NotifyReport]: OCPP2_1.NotifyReportResponseSchema,
+  [OCPP_CallAction.NotifySettlement]: OCPP2_1.NotifySettlementResponseSchema,
   [OCPP_CallAction.PublishFirmware]: OCPP2_1.PublishFirmwareResponseSchema,
   [OCPP_CallAction.PublishFirmwareStatusNotification]:
     OCPP2_1.PublishFirmwareStatusNotificationResponseSchema,

--- a/packages/core/src/modules/Transactions/src/module/module.ts
+++ b/packages/core/src/modules/Transactions/src/module/module.ts
@@ -70,7 +70,6 @@ import { CostCalculator } from './CostCalculator.js';
 import { CostNotifier } from './CostNotifier.js';
 import { StatusNotificationService } from './StatusNotificationService.js';
 import { TransactionService } from './TransactionService.js';
-import { TriggerReasonEnumType } from '@citrineos/base/dist/src/ocpp/model/2.1/index.js';
 
 /**
  * Component that handles transaction related messages.
@@ -661,8 +660,8 @@ export class TransactionsModule extends AbstractModule {
       if (
         isOcpp21 &&
         transactionEvent.eventType === TransactionEventEnum.Ended &&
-        (transactionEvent.triggerReason === TriggerReasonEnumType.StopAuthorized ||
-          transactionEvent.triggerReason === TriggerReasonEnumType.EVConnectTimeout) &&
+        (transactionEvent.triggerReason === OCPP2_1.TriggerReasonEnumType.StopAuthorized ||
+          transactionEvent.triggerReason === OCPP2_1.TriggerReasonEnumType.EVConnectTimeout) &&
         (!transaction.totalKwh || transaction.totalKwh <= 0)
       ) {
         const tariffEnabled: VariableAttribute[] =

--- a/packages/core/src/modules/Transactions/src/module/module.ts
+++ b/packages/core/src/modules/Transactions/src/module/module.ts
@@ -70,6 +70,7 @@ import { CostCalculator } from './CostCalculator.js';
 import { CostNotifier } from './CostNotifier.js';
 import { StatusNotificationService } from './StatusNotificationService.js';
 import { TransactionService } from './TransactionService.js';
+import { TriggerReasonEnumType } from '@citrineos/base/dist/src/ocpp/model/2.1/index.js';
 
 /**
  * Component that handles transaction related messages.
@@ -654,6 +655,30 @@ export class TransactionsModule extends AbstractModule {
           transaction.connectorId,
           transaction.totalKwh,
         );
+      }
+
+      // OCPP 2.1 C20 Cancel transaction after start of transaction before costs has been incurred
+      if (
+        isOcpp21 &&
+        transactionEvent.eventType === TransactionEventEnum.Ended &&
+        (transactionEvent.triggerReason === TriggerReasonEnumType.StopAuthorized ||
+          transactionEvent.triggerReason === TriggerReasonEnumType.EVConnectTimeout) &&
+        (!transaction.totalKwh || transaction.totalKwh <= 0)
+      ) {
+        const tariffEnabled: VariableAttribute[] =
+          await this._deviceModelRepository.readAllByQuerystring(tenantId, {
+            tenantId,
+            ocppConnectionName: message.context.ocppConnectionName,
+            component_name: 'TariffCostCtrlr',
+            variable_name: 'Enabled',
+            variable_instance: 'Tariff',
+            type: AttributeEnum.Actual,
+          });
+        // C20.FR.03
+        if (tariffEnabled.length == 0 || !Boolean(tariffEnabled[0].value)) {
+          this._logger.info(`Central cost calculation is used for transaction ${transactionId}`);
+          response.totalCost = 0;
+        }
       }
 
       // Store total cost in db

--- a/packages/core/src/modules/Transactions/src/module/module.ts
+++ b/packages/core/src/modules/Transactions/src/module/module.ts
@@ -53,10 +53,7 @@ import { OCPP2_0_1_Mapper } from '@dal/index.js';
 import { Authorization } from '@dal/layers/sequelize/model/Authorization/index.js';
 import { Component, VariableAttribute } from '@dal/layers/sequelize/model/DeviceModel/index.js';
 import { Tariff } from '@dal/layers/sequelize/model/Tariff/Tariffs.js';
-import {
-  ChargingProfile,
-  ChargingSchedule,
-} from '@dal/layers/sequelize/model/ChargingProfile/index.js';
+import { ChargingSchedule } from '@dal/layers/sequelize/model/ChargingProfile/index.js';
 import {
   StartTransaction,
   Transaction,
@@ -674,7 +671,7 @@ export class TransactionsModule extends AbstractModule {
             type: AttributeEnum.Actual,
           });
         // C20.FR.03
-        if (tariffEnabled.length == 0 || !Boolean(tariffEnabled[0].value)) {
+        if (tariffEnabled.length == 0 || !tariffEnabled[0].value) {
           this._logger.info(`Central cost calculation is used for transaction ${transactionId}`);
           response.totalCost = 0;
         }


### PR DESCRIPTION
### Changes
1. Implement OCPP 2.1 C20
2. Fix issues finding during the test

### Tests
1. Charger sends a TransactionEventRequest (Started) and get response <img width="1001" height="143" alt="Screenshot 2026-05-07 at 4 22 12 PM" src="https://github.com/user-attachments/assets/cda1ce96-7144-4e9d-a275-75ae5f425dc2" />
2. Charger sends a TransactionEventRequest (Ended) and get response with totalCost 0 <img width="998" height="143" alt="Screenshot 2026-05-07 at 4 22 36 PM" src="https://github.com/user-attachments/assets/ea17f064-d95c-4269-972d-d32fab82d7f7" />
3. Charger sends a  NotifySettlementRequest and get response <img width="998" height="94" alt="Screenshot 2026-05-07 at 4 22 55 PM" src="https://github.com/user-attachments/assets/7e964fdb-edf0-4caf-8487-6f21dd0b2fbe" />