### PR TITLE
Making the charging station dto ID optional again

### DIFF
--- a/packages/base/src/interfaces/dto/charging.station.dto.ts
+++ b/packages/base/src/interfaces/dto/charging.station.dto.ts
@@ -14,7 +14,7 @@ import { PointSchema } from './types/location.js';
 import { OCPPVersionSchema } from './types/ocpp.message.js';
 
 export const ChargingStationSchema = BaseSchema.extend({
-  id: z.number().int(),
+  id: z.number().int().optional(),
   ocppConnectionName: z.string().max(36),
   isOnline: z.boolean(),
   protocol: OCPPVersionSchema.nullable().optional(),


### PR DESCRIPTION
We changed this erroneously. Need this to be optional for CREATE dtos.