### PR TITLE
Adding A02 and a03 functionality

### DIFF
--- a/apps/Server/migrations/20260520120000-add-request-id-to-install-certificate-attempts.ts
+++ b/apps/Server/migrations/20260520120000-add-request-id-to-install-certificate-attempts.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { DataTypes, QueryInterface } from 'sequelize';
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.addColumn('InstallCertificateAttempts', 'requestId', {
+    type: DataTypes.INTEGER,
+    allowNull: true,
+  });
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.removeColumn('InstallCertificateAttempts', 'requestId');
+}

--- a/packages/core/src/dal/layers/sequelize/model/Certificate/InstallCertificateAttempt.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Certificate/InstallCertificateAttempt.ts
@@ -59,6 +59,12 @@ export class InstallCertificateAttempt extends Model {
   declare certificate?: CertificateDto;
 
   @Column({
+    type: DataType.INTEGER,
+    allowNull: true,
+  })
+  declare requestId?: number | null;
+
+  @Column({
     type: DataType.STRING,
   })
   declare status?: InstallCertificateStatusEnumType | null;

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -79,6 +79,7 @@ export class InstallCertificateHelperService {
     ocppConnectionName: string,
     certificate: string,
     certificateType: CertificateUseEnumType,
+    requestId?: number | null,
   ) {
     const hash = this.getCertificateHash(certificate);
     const existingPendingInstallCertificateAttempt =
@@ -87,6 +88,7 @@ export class InstallCertificateHelperService {
           ocppConnectionName: ocppConnectionName,
           certificateType: certificateType,
           status: null,
+          ...(requestId != null ? { requestId } : {}),
         },
         include: [
           {
@@ -128,6 +130,9 @@ export class InstallCertificateHelperService {
       installCertificateAttempt.ocppConnectionName = ocppConnectionName;
       installCertificateAttempt.certificateType = certificateType;
       installCertificateAttempt.certificateId = existingCertificate!.id;
+      if (requestId != null) {
+        installCertificateAttempt.requestId = requestId;
+      }
       await installCertificateAttempt.save();
     }
   }
@@ -136,12 +141,14 @@ export class InstallCertificateHelperService {
     tenantId: number,
     ocppConnectionName: string,
     status: InstallCertificateStatusEnumType,
+    requestId?: number,
   ) {
     const existingPendingInstallCertificateAttempt =
       await this.installCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
         where: {
           ocppConnectionName: ocppConnectionName,
           status: null,
+          ...(requestId != null ? { requestId } : {}),
         },
       });
     // should always be true

--- a/packages/core/src/modules/Certificates/src/module/module.ts
+++ b/packages/core/src/modules/Certificates/src/module/module.ts
@@ -33,6 +33,8 @@ import {
   DeleteCertificateStatusEnum,
   CertificateSigningUseEnum,
   AttributeEnum,
+  OCPPVersion,
+  OCPP2_1,
 } from '@citrineos/base';
 import type {
   ICertificateRepository,
@@ -286,6 +288,11 @@ export class CertificatesModule extends AbstractModule {
     const csrString: string = message.payload.csr.replace(/\n/g, '');
     const certificateType: CertificateSigningUseEnumType | undefined | null =
       message.payload.certificateType;
+    let requestId: number | undefined | null;
+    if (message.protocol === OCPPVersion.OCPP2_1) {
+      const payload21 = message.payload as OCPP2_1.SignCertificateRequest;
+      requestId = payload21.requestId;
+    }
 
     // Validate PEM format
     const validationResult = validatePEMEncodedCSR(message.payload.csr);
@@ -344,17 +351,24 @@ export class CertificatesModule extends AbstractModule {
       ocppConnectionName,
       certificateChainPem,
       certificateType as unknown as CertificateUseEnumType,
+      requestId,
     );
+
+    let certSignedRequest = {
+      certificateChain: certificateChainPem,
+      certificateType: certificateType,
+    } as OCPP2_request_types.CertificateSignedRequest;
+
+    if (message.protocol === OCPPVersion.OCPP2_1 && requestId != null) {
+      (certSignedRequest as OCPP2_1.CertificateSignedRequest).requestId = requestId;
+    }
 
     await this.sendCall(
       ocppConnectionName,
       tenantId,
       message.protocol,
       OCPP_CallAction.CertificateSigned,
-      {
-        certificateChain: certificateChainPem,
-        certificateType: certificateType,
-      } as OCPP2_request_types.CertificateSignedRequest,
+      certSignedRequest,
     );
   }
 
@@ -368,10 +382,29 @@ export class CertificatesModule extends AbstractModule {
     props?: HandlerProperties,
   ): Promise<void> {
     this._logger.debug('CertificateSigned received:', message, props);
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+
+    let requestId: number | undefined;
+    if (message.protocol === OCPPVersion.OCPP2_1) {
+      const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+        where: {
+          ocppConnectionName,
+          correlationId: message.context.correlationId,
+          origin: MessageOrigin.ChargingStationManagementSystem,
+        },
+      });
+      if (originalRequest) {
+        const certSignedPayload = originalRequest.message[3] as OCPP2_1.CertificateSignedRequest;
+        requestId = certSignedPayload?.requestId ?? undefined;
+      }
+    }
+
     await this.installCertificateHelperService.finalizeInstalledCertificate(
-      message.context.tenantId,
-      message.context.ocppConnectionName,
+      tenantId,
+      ocppConnectionName,
       message.payload.status as unknown as InstallCertificateStatusEnumType,
+      requestId,
     );
     // TODO: If rejected, retry and/or send to callbackUrl if originally part of a triggered refresh
     // TODO: If accepted, revoke old certificate
@@ -530,6 +563,7 @@ export class CertificatesModule extends AbstractModule {
     if (
       !certificateType ||
       (certificateType !== CertificateSigningUseEnum.V2GCertificate &&
+        certificateType !== CertificateSigningUseEnum.V2G20Certificate &&
         certificateType !== CertificateSigningUseEnum.ChargingStationCertificate)
     ) {
       throw new Error(`Unsupported certificate type: ${certificateType}`);

--- a/packages/core/src/modules/Certificates/src/module/module.ts
+++ b/packages/core/src/modules/Certificates/src/module/module.ts
@@ -354,7 +354,7 @@ export class CertificatesModule extends AbstractModule {
       requestId,
     );
 
-    let certSignedRequest = {
+    const certSignedRequest = {
       certificateChain: certificateChainPem,
       certificateType: certificateType,
     } as OCPP2_request_types.CertificateSignedRequest;

--- a/packages/core/src/modules/Certificates/test/module/installCertificateHelperService.test.ts
+++ b/packages/core/src/modules/Certificates/test/module/installCertificateHelperService.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../../../dal/layers/sequelize/index.js', async (importOriginal) => {
     ocppConnectionName?: string;
     certificateType?: string;
     certificateId?: number;
+    requestId?: number;
     status?: string;
     save = vi.fn().mockResolvedValue(this);
 
@@ -258,6 +259,63 @@ describe('InstallCertificateHelperService', () => {
       expect(savedAttempt.save).toHaveBeenCalled();
     });
 
+    it('should include requestId when checking for existing pending attempt', async () => {
+      const mockExistingAttempt = { id: 1 } as any;
+      mockInstallCertificateAttemptReadOnlyOneByQuery.mockResolvedValue(mockExistingAttempt);
+
+      await service.prepareToInstallCertificate(
+        tenantId,
+        ocppConnectionName,
+        MOCK_CERTIFICATE,
+        MOCK_CERT_TYPE_V2G as any,
+        42,
+      );
+
+      expect(mockInstallCertificateAttemptReadOnlyOneByQuery).toHaveBeenCalledWith(tenantId, {
+        where: {
+          ocppConnectionName,
+          certificateType: MOCK_CERT_TYPE_V2G,
+          status: null,
+          requestId: 42,
+        },
+        include: [
+          {
+            model: Certificate,
+            where: { certificateFileHash: mockHash },
+          },
+        ],
+      });
+    });
+
+    it('should set requestId on new attempt when provided', async () => {
+      const mockCertDetails = {
+        serialNumber: 123456,
+        issuerName: 'Test Issuer',
+        organizationName: 'Test Org',
+        commonName: 'localhost',
+        countryName: 'US',
+        validBefore: new Date('2027-02-17'),
+        signatureAlgorithm: 'SHA256withECDSA' as any,
+      };
+
+      mockInstallCertificateAttemptReadOnlyOneByQuery.mockResolvedValue(undefined);
+      mockExtractCertificateDetails.mockReturnValue(mockCertDetails);
+      vi.spyOn(service, 'createNewCertificate').mockResolvedValue({ id: 100 } as any);
+
+      await service.prepareToInstallCertificate(
+        tenantId,
+        ocppConnectionName,
+        MOCK_CERTIFICATE,
+        MOCK_CERT_TYPE_V2G as any,
+        42,
+      );
+
+      const savedAttempt = createdInstallCertificateAttemptInstances[0];
+      expect(savedAttempt).toBeDefined();
+      expect(savedAttempt.requestId).toBe(42);
+      expect(savedAttempt.save).toHaveBeenCalled();
+    });
+
     it('should use existing certificate if found and create install attempt', async () => {
       vi.spyOn(service, 'createNewCertificate');
 
@@ -385,6 +443,32 @@ describe('InstallCertificateHelperService', () => {
       const savedInstalledCert = createdInstalledCertificateInstances[0];
       expect(savedInstalledCert).toBeDefined();
       expect(savedInstalledCert.save).toHaveBeenCalled();
+    });
+
+    it('should include requestId in lookup query when provided', async () => {
+      const mockAttemptSave = vi.fn().mockResolvedValue(true);
+      const mockAttempt = {
+        id: 1,
+        save: mockAttemptSave,
+      } as any;
+
+      mockInstallCertificateAttemptReadOnlyOneByQuery.mockResolvedValue(mockAttempt);
+      mockInstalledCertificateReadOnlyOneByQuery.mockResolvedValue(undefined);
+
+      await service.finalizeInstalledCertificate(
+        tenantId,
+        ocppConnectionName,
+        MOCK_STATUS_REJECTED as any,
+        42,
+      );
+
+      expect(mockInstallCertificateAttemptReadOnlyOneByQuery).toHaveBeenCalledWith(tenantId, {
+        where: {
+          ocppConnectionName,
+          status: null,
+          requestId: 42,
+        },
+      });
     });
 
     it('should log error and return if file retrieval fails', async () => {

--- a/packages/core/src/util/certificate/CertificateAuthority.ts
+++ b/packages/core/src/util/certificate/CertificateAuthority.ts
@@ -74,7 +74,8 @@ export class CertificateAuthorityService {
     );
 
     switch (certificateType) {
-      case CertificateSigningUseEnum.V2GCertificate: {
+      case CertificateSigningUseEnum.V2GCertificate:
+      case CertificateSigningUseEnum.V2G20Certificate: {
         const signedCert = await this._v2gClient.getSignedCertificate(
           extractEncodedContentFromCSR(csrString),
         );


### PR DESCRIPTION
This adds the functionality described in A02 and A03 of the OCPP 2.1 specification, namely the requestId regarding certificates requests and responses