### PR TITLE
UI: Allow Manual Input for Get/Set Variables

### DIFF
--- a/apps/Server/deploy.Dockerfile
+++ b/apps/Server/deploy.Dockerfile
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 # Use a specific base image with platform support
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24.16.0 AS build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24.4.1 AS build
 
 RUN corepack enable
 
@@ -15,7 +15,7 @@ RUN pnpm --filter "@citrineos/server..." build
 
 # The final stage, which copies built files and prepares the run environment
 # Using a slim image to reduce the final image size
-FROM node:24.16.0-slim
+FROM node:24.4.1-slim
 
 RUN corepack enable
 

--- a/apps/Server/deploy.Dockerfile
+++ b/apps/Server/deploy.Dockerfile
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 
 # Use a specific base image with platform support
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24.4.1 AS build
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24.16.0 AS build
 
 RUN corepack enable
 
@@ -15,7 +15,7 @@ RUN pnpm --filter "@citrineos/server..." build
 
 # The final stage, which copies built files and prepares the run environment
 # Using a slim image to reduce the final image size
-FROM node:24.4.1-slim
+FROM node:24.16.0-slim
 
 RUN corepack enable
 

--- a/apps/operator-ui/src/lib/client/components/combobox/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/combobox/index.tsx
@@ -69,9 +69,7 @@ export function Combobox<T>({
   const showManualEntry =
     allowManualEntry &&
     trimmedInput !== '' &&
-    !options.some(
-      (o) => o.label.toLowerCase() === trimmedInput.toLowerCase(),
-    );
+    !options.some((o) => o.label.toLowerCase() === trimmedInput.toLowerCase());
 
   return (
     <Popover

--- a/apps/operator-ui/src/lib/client/components/combobox/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/combobox/index.tsx
@@ -28,6 +28,7 @@ export interface ComboboxProps<T> {
   isLoading?: boolean;
   skipValue?: boolean;
   disabled?: boolean;
+  allowManualEntry?: boolean;
 }
 
 export function Combobox<T>({
@@ -41,8 +42,10 @@ export function Combobox<T>({
   isLoading = false,
   skipValue = false,
   disabled = false,
+  allowManualEntry = false,
 }: ComboboxProps<T>) {
   const [open, setOpen] = useState<boolean>(false);
+  const [inputValue, setInputValue] = useState('');
   const [selectedOption, setSelectedOption] = useState<{ label: string; value: T } | undefined>(
     undefined,
   );
@@ -50,14 +53,34 @@ export function Combobox<T>({
   useEffect(() => {
     if (value) {
       const matchingOption = options.find((option) => option.value === value);
-      setSelectedOption(matchingOption ? { ...matchingOption } : undefined);
+      if (matchingOption) {
+        setSelectedOption({ ...matchingOption });
+      } else if (allowManualEntry && typeof value === 'string') {
+        setSelectedOption({ label: value, value });
+      } else {
+        setSelectedOption(undefined);
+      }
     } else {
       setSelectedOption(undefined);
     }
-  }, [value, options]);
+  }, [value, options, allowManualEntry]);
+
+  const trimmedInput = inputValue.trim();
+  const showManualEntry =
+    allowManualEntry &&
+    trimmedInput !== '' &&
+    !options.some(
+      (o) => o.label.toLowerCase() === trimmedInput.toLowerCase(),
+    );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (!isOpen) setInputValue('');
+      }}
+    >
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -74,10 +97,34 @@ export function Combobox<T>({
         <Command shouldFilter={!onSearch}>
           <CommandInput
             placeholder={searchPlaceholder ?? 'Search'}
-            onValueChange={(val: string) => onSearch?.(val)}
+            onValueChange={(val) => {
+              setInputValue(val);
+              onSearch?.(val);
+            }}
           />
           <CommandList>
             <CommandEmpty>{isLoading ? 'Loading...' : emptyMessage}</CommandEmpty>
+            {showManualEntry && (
+              <CommandGroup>
+                <CommandItem
+                  value={`__manual__${trimmedInput}`}
+                  onSelect={() => {
+                    const manualOption = {
+                      label: trimmedInput,
+                      value: trimmedInput as unknown as T,
+                    };
+                    if (!skipValue) {
+                      setSelectedOption(manualOption);
+                    }
+                    onSelect?.(trimmedInput as unknown as T, trimmedInput);
+                    setOpen(false);
+                    setInputValue('');
+                  }}
+                >
+                  Use &quot;{trimmedInput}&quot;
+                </CommandItem>
+              </CommandGroup>
+            )}
             <CommandGroup>
               {options.map((option, index) => (
                 <CommandItem
@@ -89,6 +136,7 @@ export function Combobox<T>({
                     }
                     onSelect?.(option.value, option.label);
                     setOpen(false);
+                    setInputValue('');
                   }}
                 >
                   <CheckIcon

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
@@ -43,8 +43,16 @@ export interface GetVariablesModalProps {
   station: any;
 }
 
+const requiredIdOrName = (label: string) =>
+  z.custom<number | string>(
+    (val) =>
+      (typeof val === 'number' && val > 0) ||
+      (typeof val === 'string' && val.trim().length > 0),
+    `${label} is required`,
+  );
+
 const GetVariableDataSchema = z.object({
-  componentId: z.coerce.number<number>().min(1, 'Component is required'),
+  componentId: requiredIdOrName('Component'),
   variableId: z.string().optional(),
   componentInstance: z.string().max(50).optional(),
   variableInstance: z.string().max(50).optional(),
@@ -123,6 +131,9 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
   const variableSelects = fields.map((field, index) => {
     const componentId = form.watch(`getVariableData.${index}.componentId`);
 
+    const numericComponentId =
+      typeof componentId === 'number' && componentId > 0 ? componentId : 0;
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const { options, onSearch, query } = useSelect({
       resource: ResourceType.VARIABLES,
@@ -130,15 +141,15 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
       optionValue: 'name',
       meta: {
         gqlQuery: VARIABLE_LIST_BY_COMPONENT_QUERY,
-        gqlVariables: componentId
-          ? { componentId, offset: 0, limit: 100, mutability: '' }
+        gqlVariables: numericComponentId
+          ? { componentId: numericComponentId, offset: 0, limit: 100, mutability: '' }
           : undefined,
       },
       pagination: { mode: 'off' },
-      queryOptions: { enabled: !!componentId && componentId > 0 },
+      queryOptions: { enabled: numericComponentId > 0 },
     });
 
-    if (componentId > 0 && options.length > 0 && variableOptionsMap[index] !== options) {
+    if (numericComponentId > 0 && options.length > 0 && variableOptionsMap[index] !== options) {
       setVariableOptionsMap((prev) => ({ ...prev, [index]: options }));
     }
 
@@ -152,8 +163,11 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
     }
 
     const getVariableData = values.getVariableData.map((item) => {
-      const component = componentOptions.find((c) => c.value === item.componentId);
-      const componentName = (component as any)?.label || '';
+      const componentName =
+        typeof item.componentId === 'string'
+          ? item.componentId
+          : (componentOptions.find((c) => c.value === item.componentId) as any)
+          ?.label || '';
 
       const data: any = {
         component: {
@@ -247,6 +261,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
                 searchPlaceholder="Search Components"
                 isLoading={componentQuery.isLoading}
                 required
+                allowManualEntry
               />
 
               <ComboboxFormField
@@ -260,6 +275,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
                 isLoading={variableLoading}
                 required
                 disabled={!componentId || componentId === 0}
+                allowManualEntry
               />
 
               <FormField

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
@@ -46,8 +46,7 @@ export interface GetVariablesModalProps {
 const requiredIdOrName = (label: string) =>
   z.custom<number | string>(
     (val) =>
-      (typeof val === 'number' && val > 0) ||
-      (typeof val === 'string' && val.trim().length > 0),
+      (typeof val === 'number' && val > 0) || (typeof val === 'string' && val.trim().length > 0),
     `${label} is required`,
   );
 
@@ -131,8 +130,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
   const variableSelects = fields.map((field, index) => {
     const componentId = form.watch(`getVariableData.${index}.componentId`);
 
-    const numericComponentId =
-      typeof componentId === 'number' && componentId > 0 ? componentId : 0;
+    const numericComponentId = typeof componentId === 'number' && componentId > 0 ? componentId : 0;
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const { options, onSearch, query } = useSelect({
@@ -166,8 +164,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
       const componentName =
         typeof item.componentId === 'string'
           ? item.componentId
-          : (componentOptions.find((c) => c.value === item.componentId) as any)
-          ?.label || '';
+          : (componentOptions.find((c) => c.value === item.componentId) as any)?.label || '';
 
       const data: any = {
         component: {

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-network-profile/set.network.profile.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-network-profile/set.network.profile.modal.tsx
@@ -139,7 +139,7 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
     query: serverNetworkProfileQuery,
   } = useSelect({
     resource: ResourceType.SERVER_NETWORK_PROFILES,
-    optionLabel: 'host',
+    optionLabel: (item: any) => `${item.host}:${item.port}`,
     optionValue: 'id',
     meta: {
       gqlQuery: SERVER_NETWORK_PROFILE_LIST_QUERY,

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
@@ -46,8 +46,7 @@ interface SetVariablesModalProps {
 const requiredIdOrName = (label: string) =>
   z.custom<number | string>(
     (val) =>
-      (typeof val === 'number' && val > 0) ||
-      (typeof val === 'string' && val.trim().length > 0),
+      (typeof val === 'number' && val > 0) || (typeof val === 'string' && val.trim().length > 0),
     `${label} is required`,
   );
 
@@ -124,8 +123,7 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
 
   const variableSelects = fields.map((field, index) => {
     const componentId = form.watch(`setVariableData.${index}.componentId`);
-    const numericComponentId =
-      typeof componentId === 'number' && componentId > 0 ? componentId : 0;
+    const numericComponentId = typeof componentId === 'number' && componentId > 0 ? componentId : 0;
 
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const { options, onSearch, query } = useSelect({
@@ -159,14 +157,12 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
       const componentName =
         typeof item.componentId === 'string'
           ? item.componentId
-          : (componentOptions.find((c) => c.value === item.componentId) as any)
-          ?.label || '';
+          : (componentOptions.find((c) => c.value === item.componentId) as any)?.label || '';
 
       const variableName =
         typeof item.variableId === 'string'
           ? item.variableId
-          : variableOptionsMap[index]?.find((v) => v.value === item.variableId)
-          ?.label || '';
+          : variableOptionsMap[index]?.find((v) => v.value === item.variableId)?.label || '';
 
       return {
         component: {

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
@@ -43,9 +43,17 @@ interface SetVariablesModalProps {
   station: any;
 }
 
+const requiredIdOrName = (label: string) =>
+  z.custom<number | string>(
+    (val) =>
+      (typeof val === 'number' && val > 0) ||
+      (typeof val === 'string' && val.trim().length > 0),
+    `${label} is required`,
+  );
+
 const SetVariableDataSchema = z.object({
-  componentId: z.coerce.number<number>().min(1, 'Component is required'),
-  variableId: z.coerce.number<number>().min(1, 'Variable is required'),
+  componentId: requiredIdOrName('Component'),
+  variableId: requiredIdOrName('Variable'),
   value: z.string().min(1, 'Value is required'),
   attributeType: z.enum(OCPP2_0_1.AttributeEnumType).optional(),
 });
@@ -116,6 +124,9 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
 
   const variableSelects = fields.map((field, index) => {
     const componentId = form.watch(`setVariableData.${index}.componentId`);
+    const numericComponentId =
+      typeof componentId === 'number' && componentId > 0 ? componentId : 0;
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const { options, onSearch, query } = useSelect({
       resource: ResourceType.VARIABLES,
@@ -123,15 +134,15 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
       optionValue: 'id',
       meta: {
         gqlQuery: VARIABLE_LIST_BY_COMPONENT_QUERY,
-        gqlVariables: componentId
-          ? { componentId, offset: 0, limit: 100, mutability: 'ReadOnly' }
+        gqlVariables: numericComponentId
+          ? { componentId: numericComponentId, offset: 0, limit: 100, mutability: 'ReadOnly' }
           : undefined,
       },
       pagination: { mode: 'off' },
-      queryOptions: { enabled: !!componentId && componentId > 0 },
+      queryOptions: { enabled: numericComponentId > 0 },
     });
 
-    if (componentId > 0 && options.length > 0 && variableOptionsMap[index] !== options) {
+    if (numericComponentId > 0 && options.length > 0 && variableOptionsMap[index] !== options) {
       setVariableOptionsMap((prev) => ({ ...prev, [index]: options }));
     }
 
@@ -145,17 +156,24 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
     }
 
     const setVariableData = values.setVariableData.map((item, index) => {
-      const component = componentOptions.find((c) => c.value === item.componentId);
-      const componentName = (component as any)?.label || '';
+      const componentName =
+        typeof item.componentId === 'string'
+          ? item.componentId
+          : (componentOptions.find((c) => c.value === item.componentId) as any)
+          ?.label || '';
 
-      const variable = variableOptionsMap[index]?.find((v) => v.value === item.variableId);
+      const variableName =
+        typeof item.variableId === 'string'
+          ? item.variableId
+          : variableOptionsMap[index]?.find((v) => v.value === item.variableId)
+          ?.label || '';
 
       return {
         component: {
           name: componentName,
         },
         variable: {
-          name: variable?.label || '',
+          name: variableName,
         },
         attributeValue: item.value,
         ...(item.attributeType && { attributeType: item.attributeType }),
@@ -225,6 +243,7 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
                 placeholder="Select Component"
                 searchPlaceholder="Search Component"
                 isLoading={componentQuery.isLoading}
+                allowManualEntry
               />
 
               <ComboboxFormField
@@ -238,6 +257,7 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
                 isLoading={variableLoading}
                 required
                 disabled={!componentId || componentId === 0}
+                allowManualEntry
               />
 
               <FormField

--- a/apps/operator-ui/src/lib/queries/server.network.profiles.ts
+++ b/apps/operator-ui/src/lib/queries/server.network.profiles.ts
@@ -16,7 +16,7 @@ export const SERVER_NETWORK_PROFILE_LIST_QUERY = gql`
       host
       port
       pingInterval
-      protocol
+      protocols
       messageTimeout
       securityProfile
       allowUnknownChargingStations
@@ -42,7 +42,7 @@ export const SERVER_NETWORK_PROFILE_GET_QUERY = gql`
       host
       port
       pingInterval
-      protocol
+      protocols
       messageTimeout
       securityProfile
       allowUnknownChargingStations


### PR DESCRIPTION
### Changes
- This PR is to allow customer to input component and variable manually in Get/Set Variables
- Additionally, fix issues found in `Set Network Profile`: 
   - correct the col name mismatch 
   - extend the label `host` in dropdown list otherwise they can be the same

### Tests
1. Get Variables  <img width="1217" height="388" alt="Screenshot 2026-05-29 at 12 14 52 PM" src="https://github.com/user-attachments/assets/8ab953b2-3eb1-4d77-bd55-2c4c1d2da3bd" /> <img width="1129" height="360" alt="Screenshot 2026-05-29 at 12 33 31 PM" src="https://github.com/user-attachments/assets/e8da680d-c89d-4866-8ac5-df152bae8050" />
2. Set Variables  <img width="1225" height="388" alt="Screenshot 2026-05-29 at 12 28 10 PM" src="https://github.com/user-attachments/assets/b10f6de4-4c59-42f5-ac50-650a3e40de3d" /> <img width="1037" height="405" alt="Screenshot 2026-05-29 at 12 33 03 PM" src="https://github.com/user-attachments/assets/af64c0fe-5dc7-40d1-a919-ec5fd80a9e8f" />
3. Set Network Profile <img width="1648" height="311" alt="Screenshot 2026-05-29 at 2 37 56 PM" src="https://github.com/user-attachments/assets/d1b47437-c92e-4808-b22b-d81ba3db0bbf" />
