### PR TITLE
[UI] Populate Events for OCPP 1.6

### DIFF
--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
@@ -20,7 +20,11 @@ import { useMemo, useState } from 'react';
 
 const VALID_CONTEXTS = new Set(['Transaction.Begin', 'Sample.Periodic', 'Transaction.End']);
 
-export const MeterValuesList = ({ transactionEventId, transactionDatabaseId, meterValueTimestamps }: any) => {
+export const MeterValuesList = ({
+  transactionEventId,
+  transactionDatabaseId,
+  meterValueTimestamps,
+}: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const columns = useMemo(() => getMeterValueColumns(), []);
 
@@ -53,9 +57,7 @@ export const MeterValuesList = ({ transactionEventId, transactionDatabaseId, met
               select: (data: any) => ({
                 ...data,
                 data: (data.data ?? []).filter((mv: any) =>
-                  (mv.sampledValue as any[])?.some((sv: any) =>
-                    VALID_CONTEXTS.has(sv.context),
-                  ),
+                  (mv.sampledValue as any[])?.some((sv: any) => VALID_CONTEXTS.has(sv.context)),
                 ),
               }),
             }

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
@@ -9,6 +9,7 @@ import { getMeterValueColumns } from '@lib/client/pages/transactions/detail/mete
 import { SampledValuesListView } from '@lib/client/pages/transactions/detail/meter-values/sampled.values.list';
 import { TransactionEventClass } from '@lib/cls/transaction.event.dto';
 import {
+  GET_METER_VALUES_FOR_TRANSACTION,
   GET_METER_VALUES_FOR_TRANSACTION_EVENT,
   METER_VALUE_LIST_QUERY,
 } from '@lib/queries/meter.values';
@@ -17,7 +18,9 @@ import { getPlainToInstanceOptions } from '@lib/utils/tables';
 import type { ExpandedState } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 
-export const MeterValuesList = ({ transactionEventId }: any) => {
+const VALID_CONTEXTS = new Set(['Transaction.Begin', 'Sample.Periodic', 'Transaction.End']);
+
+export const MeterValuesList = ({ transactionEventId, transactionDatabaseId, meterValueTimestamps }: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
   const columns = useMemo(() => getMeterValueColumns(), []);
 
@@ -31,10 +34,32 @@ export const MeterValuesList = ({ transactionEventId }: any) => {
         meta: {
           gqlQuery: transactionEventId
             ? GET_METER_VALUES_FOR_TRANSACTION_EVENT
-            : METER_VALUE_LIST_QUERY,
-          gqlVariables: transactionEventId ? { transactionEventId } : undefined,
+            : transactionDatabaseId
+              ? GET_METER_VALUES_FOR_TRANSACTION
+              : METER_VALUE_LIST_QUERY,
+          gqlVariables: transactionEventId
+            ? { transactionEventId }
+            : transactionDatabaseId
+              ? {
+                  transactionDatabaseId,
+                  ...(meterValueTimestamps?.length
+                    ? { where: { timestamp: { _in: meterValueTimestamps } } }
+                    : {}),
+                }
+              : undefined,
         },
-        queryOptions: getPlainToInstanceOptions(TransactionEventClass),
+        queryOptions: transactionDatabaseId
+          ? {
+              select: (data: any) => ({
+                ...data,
+                data: (data.data ?? []).filter((mv: any) =>
+                  (mv.sampledValue as any[])?.some((sv: any) =>
+                    VALID_CONTEXTS.has(sv.context),
+                  ),
+                ),
+              }),
+            }
+          : getPlainToInstanceOptions(TransactionEventClass),
       }}
       expandable={{
         expandedRowKeys: expanded,

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
@@ -23,7 +23,11 @@ import React, { useMemo, useState } from 'react';
 import type { ExpandedState } from '@tanstack/react-table';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
-export const TransactionEventsList = ({ transactionDatabaseId, ocppTransactionId, ocppConnectionName }: any) => {
+export const TransactionEventsList = ({
+  transactionDatabaseId,
+  ocppTransactionId,
+  ocppConnectionName,
+}: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const tenantId = useTenantId();
@@ -161,7 +165,9 @@ export const TransactionEventsList = ({ transactionDatabaseId, ocppTransactionId
             <div className="border-t bg-muted/20 p-4">
               <MeterValuesList
                 transactionEventId={record.id != null && record.id > 0 ? record.id : undefined}
-                transactionDatabaseId={record.id != null && record.id < 0 ? transactionDatabaseId : undefined}
+                transactionDatabaseId={
+                  record.id != null && record.id < 0 ? transactionDatabaseId : undefined
+                }
                 meterValueTimestamps={(record as any)._meterValueTimestamps}
               />
             </div>

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
@@ -23,7 +23,7 @@ import React, { useMemo, useState } from 'react';
 import type { ExpandedState } from '@tanstack/react-table';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
-export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
+export const TransactionEventsList = ({ transactionDatabaseId, ocppTransactionId, ocppConnectionName }: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const tenantId = useTenantId();
@@ -50,7 +50,7 @@ export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
     sorters: [{ field: 'timestamp', order: 'desc' }],
     meta: {
       gqlQuery: GET_OCPP_MESSAGES_FOR_TRANSACTION_LIST_QUERY,
-      gqlVariables: { transactionDatabaseId },
+      gqlVariables: { ocppTransactionId, ocppConnectionName },
     },
     queryOptions: getPlainToInstanceOptions(OCPPMessageClass),
     pagination: { pageSize: 1000 },
@@ -58,25 +58,48 @@ export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
 
   const merged = useMemo<TransactionEventDto[]>(() => {
     const events = eventsData?.data || [];
-    const messages = messagesData?.data || [];
+    const messages = (messagesData?.data || []) as any[];
 
-    const messageRows: TransactionEventDto[] = messages.map((m: any) => ({
-      id: -m.id,
-      ocppConnectionName: String(m.ocppConnectionName ?? ''),
-      evseId: m.message?.connectorId ?? null,
-      transactionDatabaseId: transactionDatabaseId,
-      eventType: 'OCPPMessage' as TransactionEventDto['eventType'],
-      meterValues: [],
-      timestamp: String(m.timestamp),
-      triggerReason: m.action as TransactionEventDto['triggerReason'],
-      seqNo: -1 as TransactionEventDto['seqNo'],
-      offline: false as TransactionEventDto['offline'],
-      numberOfPhasesUsed: 0 as TransactionEventDto['numberOfPhasesUsed'],
-      cableMaxCurrent: 0 as TransactionEventDto['cableMaxCurrent'],
-      reservationId: 0 as TransactionEventDto['reservationId'],
-      tenantId,
-    }));
-    return [...events, ...messageRows];
+    const sortedMessages = [...messages].sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+    );
+
+    const messageRows: TransactionEventDto[] = sortedMessages.map((m, index) => {
+      const payload = m.message?.[3];
+      const triggerReason: string = m.action === 'StopTransaction' ? (payload?.reason ?? '') : '';
+
+      const innerMeterValues: any[] =
+        m.action === 'MeterValues'
+          ? (payload?.meterValue ?? [])
+          : m.action === 'StopTransaction'
+            ? (payload?.transactionData ?? [])
+            : [];
+
+      const meterValueTimestamps: string[] = innerMeterValues
+        .map((mv: any) => mv.timestamp)
+        .filter(Boolean);
+
+      return {
+        id: -m.id,
+        ocppConnectionName: String(m.ocppConnectionName ?? ''),
+        evseId: payload?.connectorId ?? null,
+        transactionDatabaseId: transactionDatabaseId,
+        eventType: m.action as TransactionEventDto['eventType'],
+        meterValues: innerMeterValues,
+        timestamp: String(m.timestamp),
+        triggerReason: triggerReason as TransactionEventDto['triggerReason'],
+        seqNo: (index + 1) as TransactionEventDto['seqNo'],
+        offline: false as TransactionEventDto['offline'],
+        numberOfPhasesUsed: 0 as TransactionEventDto['numberOfPhasesUsed'],
+        cableMaxCurrent: 0 as TransactionEventDto['cableMaxCurrent'],
+        reservationId: 0 as TransactionEventDto['reservationId'],
+        tenantId,
+        _meterValueTimestamps: meterValueTimestamps,
+      } as any;
+    });
+    return [...events, ...messageRows].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    );
   }, [eventsData?.data, messagesData?.data, transactionDatabaseId, tenantId]);
 
   const columns = [
@@ -87,7 +110,8 @@ export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
       accessorKey={TransactionEventProps.meterValue}
       header=""
       cell={({ row }) =>
-        row.original.eventType! in TransactionEventEnum ? (
+        row.original.eventType! in TransactionEventEnum ||
+        (row.original.meterValues as any[])?.length > 0 ? (
           <div
             className="flex items-center justify-end cursor-pointer hover:text-primary"
             onClick={(e) => {
@@ -135,7 +159,11 @@ export const TransactionEventsList = ({ transactionDatabaseId }: any) => {
           },
           expandedRowRender: (record: TransactionEventDto) => (
             <div className="border-t bg-muted/20 p-4">
-              <MeterValuesList transactionEventId={record.id} />
+              <MeterValuesList
+                transactionEventId={record.id != null && record.id > 0 ? record.id : undefined}
+                transactionDatabaseId={record.id != null && record.id < 0 ? transactionDatabaseId : undefined}
+                meterValueTimestamps={(record as any)._meterValueTimestamps}
+              />
             </div>
           ),
           expandedRowClassName: 'bg-muted/10',

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.tabs.card.tsx
@@ -165,7 +165,13 @@ export const TransactionDetailTabsCard = ({ transaction }: { transaction: Transa
                 accessType: TransactionAccessType.EVENTS,
               }}
             >
-              <TransactionEventsList transactionDatabaseId={transaction.id} />
+              <TransactionEventsList
+                transactionDatabaseId={transaction.id}
+                ocppTransactionId={
+                  transaction.transactionId ? Number(transaction.transactionId) : undefined
+                }
+                ocppConnectionName={transaction.ocppConnectionName}
+              />
             </CanAccess>
           </TabsContent>
 

--- a/apps/operator-ui/src/lib/queries/meter.values.ts
+++ b/apps/operator-ui/src/lib/queries/meter.values.ts
@@ -63,12 +63,13 @@ export const GET_METER_VALUES_FOR_TRANSACTION = gql`
     $offset: Int!
     $limit: Int!
     $order_by: [MeterValues_order_by!]
+    $where: MeterValues_bool_exp! = {}
   ) {
     MeterValues(
       offset: $offset
       limit: $limit
       order_by: $order_by
-      where: { transactionDatabaseId: { _eq: $transactionDatabaseId } }
+      where: { transactionDatabaseId: { _eq: $transactionDatabaseId }, _and: [$where] }
     ) {
       id
       transactionDatabaseId
@@ -78,7 +79,7 @@ export const GET_METER_VALUES_FOR_TRANSACTION = gql`
       createdAt
       updatedAt
     }
-    MeterValues_aggregate(where: { transactionDatabaseId: { _eq: $transactionDatabaseId } }) {
+    MeterValues_aggregate(where: { transactionDatabaseId: { _eq: $transactionDatabaseId }, _and: [$where] }) {
       aggregate {
         count
       }

--- a/apps/operator-ui/src/lib/queries/meter.values.ts
+++ b/apps/operator-ui/src/lib/queries/meter.values.ts
@@ -79,7 +79,9 @@ export const GET_METER_VALUES_FOR_TRANSACTION = gql`
       createdAt
       updatedAt
     }
-    MeterValues_aggregate(where: { transactionDatabaseId: { _eq: $transactionDatabaseId }, _and: [$where] }) {
+    MeterValues_aggregate(
+      where: { transactionDatabaseId: { _eq: $transactionDatabaseId }, _and: [$where] }
+    ) {
       aggregate {
         count
       }

--- a/apps/operator-ui/src/lib/queries/ocpp.messages.ts
+++ b/apps/operator-ui/src/lib/queries/ocpp.messages.ts
@@ -39,7 +39,8 @@ export const GET_OCPP_MESSAGES_LIST_FOR_STATION = gql`
 
 export const GET_OCPP_MESSAGES_FOR_TRANSACTION_LIST_QUERY = gql`
   query OCPPMessageList(
-    $transactionDatabaseId: Int!
+    $ocppTransactionId: Int
+    $ocppConnectionName: String
     $offset: Int!
     $limit: Int!
     $order_by: [OCPPMessages_order_by!]
@@ -51,7 +52,8 @@ export const GET_OCPP_MESSAGES_FOR_TRANSACTION_LIST_QUERY = gql`
       order_by: $order_by
       where: {
         _and: [
-          { message: { _contains: [{ transactionId: $transactionDatabaseId }] } }
+          { message: { _contains: [{ transactionId: $ocppTransactionId }] } }
+          { ocppConnectionName: { _eq: $ocppConnectionName } }
           {
             _or: [
               {
@@ -91,7 +93,8 @@ export const GET_OCPP_MESSAGES_FOR_TRANSACTION_LIST_QUERY = gql`
     OCPPMessages_aggregate(
       where: {
         _and: [
-          { message: { _contains: [{ transactionId: $transactionDatabaseId }] } }
+          { message: { _contains: [{ transactionId: $ocppTransactionId }] } }
+          { ocppConnectionName: { _eq: $ocppConnectionName } }
           {
             _or: [
               {


### PR DESCRIPTION
### Changes
1. Fix GET_OCPP_MESSAGES_FOR_TRANSACTION_LIST_QUERY to filter by OCPP-level transactionId instead of DB primary key
2. Make sure always add ocppConnectionName filter for uniqueness together with OCPP transaction ID
3. Column mapping changes: eventType now shows action name, triggerReason shows StopTransaction.reason only, meterValues populated from payload
4. Filter expanded meter values client-side to Transaction.Begin, Sample.Periodic, Transaction.End contexts only
### Tests
1. OCPP 1.6 events <img width="1694" height="678" alt="Screenshot 2026-06-02 at 3 10 44 PM" src="https://github.com/user-attachments/assets/96395e49-f66a-4ead-919d-ffd8c760cd92" />
2. Details in a event <img width="1705" height="700" alt="Screenshot 2026-06-02 at 3 11 18 PM" src="https://github.com/user-attachments/assets/5108f87e-1662-46d4-a3be-9a5c58f3b145" />
3. Regression: OCPP 2.0.1 events <img width="1695" height="453" alt="Screenshot 2026-06-02 at 3 11 40 PM" src="https://github.com/user-attachments/assets/0de351b5-2574-422e-af66-6e1c8f2dcab1" />
4. Regression: OCPP 2.0.1 Details in a event <img width="1704" height="687" alt="Screenshot 2026-06-02 at 3 12 17 PM" src="https://github.com/user-attachments/assets/ceb89b6b-2027-4dbd-a93e-0ee2cf0ffbe3" />