### PR TITLE
feat(local-auth): port OCPP 1.6 Local Authorization List onto monorep…

### DIFF
--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -100,6 +100,7 @@ export {
   HUBJECT_DEFAULT_TOKENURL,
   OCPP_VERSION_LIST,
   RbacRulesSchema,
+  systemConfigInputSchema,
   systemConfigSchema,
 } from './src/config/types.js';
 export type { RbacRules, SystemConfig, WebsocketServerConfig } from './src/config/types.js';

--- a/packages/base/src/config/defineConfig.ts
+++ b/packages/base/src/config/defineConfig.ts
@@ -4,7 +4,7 @@
 
 import { z } from 'zod';
 import type { SystemConfig, SystemConfigInput } from './types.js';
-import { systemConfigSchema } from './types.js';
+import { systemConfigInputSchema, systemConfigSchema } from './types.js';
 
 const args = typeof process !== 'undefined' && process.argv ? process.argv.slice(2) : [];
 
@@ -141,12 +141,80 @@ function mergeConfigFromEnvVars<T extends Record<string, any>>(
 }
 
 /**
- * Validates the  system configuration to ensure required properties are set.
+ * Validates the system configuration.
+ *
+ * Two-pass:
+ *   1. Parse with `systemConfigInputSchema` so any defaults declared on the input
+ *      schema (e.g. `websocketServers[*].protocols = ['ocpp2.0.1']`) are filled in.
+ *      This lets stored configs that predate a newer optional-with-default field
+ *      auto-heal instead of crashing strict validation.
+ *   2. Re-parse with the strict `systemConfigSchema` to enforce the final shape.
+ *
+ * Zod's `z.object()` strips unknown keys by default. Some optional top-level
+ * fields (e.g. `oidcClient`) only live on the strict schema, so we must NOT
+ * replace `finalConfig` with the parse output — that would silently drop them.
+ * Instead the parsed form is used as a defaults-source that the original
+ * config is overlaid onto, preserving every original key/leaf and only
+ * filling values where the original was missing.
+ *
+ * If pass 1 fails (truly malformed config), fall back to the strict schema so
+ * the original error surface is preserved for genuinely broken configs.
+ *
  * @param finalConfig The final system configuration.
  * @throws Error if required properties are not set.
  */
 function validateFinalConfig(finalConfig: SystemConfigInput): SystemConfig {
-  return systemConfigSchema.parse(finalConfig);
+  const inputResult = systemConfigInputSchema.safeParse(finalConfig);
+  const withDefaults = inputResult.success
+    ? (mergePreservingOriginal(inputResult.data, finalConfig) as SystemConfigInput)
+    : finalConfig;
+  return systemConfigSchema.parse(withDefaults);
+}
+
+/**
+ * Merge `original` over `defaults` so the result has every leaf from
+ * `original` where defined, falling back to `defaults` only where `original`
+ * is missing the key. Unknown keys on `original` are preserved (Zod's
+ * default strip would otherwise have removed them). Arrays merge by index;
+ * if one side is longer, extra elements come through as-is.
+ *
+ * Kept inline rather than shared from the Server package so 00_Base has no
+ * upward dependencies.
+ */
+function mergePreservingOriginal(defaults: unknown, original: unknown): unknown {
+  if (original === undefined) {
+    return defaults;
+  }
+  if (defaults === undefined) {
+    return original;
+  }
+  if (Array.isArray(defaults) && Array.isArray(original)) {
+    const length = Math.max(defaults.length, original.length);
+    const out: unknown[] = [];
+    for (let i = 0; i < length; i++) {
+      out.push(mergePreservingOriginal(defaults[i], original[i]));
+    }
+    return out;
+  }
+  if (
+    typeof defaults === 'object' &&
+    defaults !== null &&
+    !Array.isArray(defaults) &&
+    typeof original === 'object' &&
+    original !== null &&
+    !Array.isArray(original)
+  ) {
+    const out: Record<string, unknown> = { ...(defaults as Record<string, unknown>) };
+    for (const key of Object.keys(original as Record<string, unknown>)) {
+      out[key] = mergePreservingOriginal(
+        (defaults as Record<string, unknown>)[key],
+        (original as Record<string, unknown>)[key],
+      );
+    }
+    return out;
+  }
+  // Primitive or type mismatch: original wins.
+  return original;
 }
 
 /**

--- a/packages/base/src/config/types.ts
+++ b/packages/base/src/config/types.ts
@@ -193,14 +193,18 @@ export const systemConfigInputSchema = z.object({
         memory: z.boolean().optional(),
         redis: z
           .union([
-            z.object({
-              host: z.string().default('localhost').optional(),
-              port: z.number().int().min(1).default(6379).optional(),
-            }),
+            // URL form must be tried first: the host/port form has all-optional
+            // fields with defaults, so zod would parse any input (including
+            // {url: ...}) as that branch and silently drop the url, defaulting
+            // to localhost.
             z.object({
               url: z.url().refine((v) => v.startsWith('redis://') || v.startsWith('rediss://'), {
                 message: 'Redis URL must start with redis:// or rediss://',
               }),
+            }),
+            z.object({
+              host: z.string().default('localhost').optional(),
+              port: z.number().int().min(1).default(6379).optional(),
             }),
           ])
           .optional(),

--- a/packages/base/src/ocpp/persistence/namespace.ts
+++ b/packages/base/src/ocpp/persistence/namespace.ts
@@ -71,6 +71,7 @@ export enum OCPP2_Namespace {
 export enum OCPP1_6_Namespace {
   ChangeConfiguration = 'ChangeConfiguration',
   Connector = 'Connector',
+  LocalListVersion = 'LocalListVersion',
   StartTransaction = 'StartTransaction',
   StopTransaction = 'StopTransaction',
 }

--- a/packages/core/src/dal/interfaces/repositories.ts
+++ b/packages/core/src/dal/interfaces/repositories.ts
@@ -196,6 +196,18 @@ export interface ILocalAuthListRepository extends CrudRepository<LocalListVersio
     localAuthorizationList?: OCPP2_common_types.AuthorizationData[],
   ): Promise<SendLocalList>;
   /**
+   * OCPP 1.6 variant. Resolves Authorization rows by flat idTag (no IdTokenEnumType).
+   * For DIFFERENTIAL deletes, an entry without idTagInfo is allowed and recorded as a tombstone.
+   */
+  createSendLocalListFromRequestData16(
+    tenantId: number,
+    stationId: string,
+    correlationId: string,
+    updateType: OCPP1_6.SendLocalListRequestUpdateType,
+    versionNumber: number,
+    localAuthorizationList?: NonNullable<OCPP1_6.SendLocalListRequest['localAuthorizationList']>,
+  ): Promise<SendLocalList>;
+  /**
    * Used to process GetLocalListVersionResponse, if version is unknown it will create or update LocalListVersion with the new version and an empty localAuthorizationList.
    * @param tenantId
    * @param versionNumber

--- a/packages/core/src/dal/layers/sequelize/mapper/1.6/LocalAuthListMapper.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/1.6/LocalAuthListMapper.ts
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AuthorizationStatusEnum, OCPP1_6 } from '@citrineos/base';
+import type { AuthorizationStatusEnumType } from '@citrineos/base';
+import type { Authorization } from '../../model/Authorization/Authorization.js';
+import type { LocalListAuthorization } from '../../model/Authorization/LocalListAuthorization.js';
+
+export type Ocpp16AuthorizationData = NonNullable<
+  OCPP1_6.SendLocalListRequest['localAuthorizationList']
+>[number];
+
+export class LocalAuthListMapper {
+  static toIdTagStatus(
+    status: AuthorizationStatusEnumType | undefined,
+  ): OCPP1_6.SendLocalListRequestStatus {
+    switch (status) {
+      case AuthorizationStatusEnum.Accepted:
+      case undefined:
+        return OCPP1_6.SendLocalListRequestStatus.Accepted;
+      case AuthorizationStatusEnum.Blocked:
+        return OCPP1_6.SendLocalListRequestStatus.Blocked;
+      case AuthorizationStatusEnum.Expired:
+        return OCPP1_6.SendLocalListRequestStatus.Expired;
+      case AuthorizationStatusEnum.ConcurrentTx:
+        return OCPP1_6.SendLocalListRequestStatus.ConcurrentTx;
+      default:
+        return OCPP1_6.SendLocalListRequestStatus.Invalid;
+    }
+  }
+
+  static fromIdTagStatus(status: OCPP1_6.SendLocalListRequestStatus): AuthorizationStatusEnumType {
+    switch (status) {
+      case OCPP1_6.SendLocalListRequestStatus.Accepted:
+        return AuthorizationStatusEnum.Accepted;
+      case OCPP1_6.SendLocalListRequestStatus.Blocked:
+        return AuthorizationStatusEnum.Blocked;
+      case OCPP1_6.SendLocalListRequestStatus.Expired:
+        return AuthorizationStatusEnum.Expired;
+      case OCPP1_6.SendLocalListRequestStatus.ConcurrentTx:
+        return AuthorizationStatusEnum.ConcurrentTx;
+      case OCPP1_6.SendLocalListRequestStatus.Invalid:
+      default:
+        return AuthorizationStatusEnum.Invalid;
+    }
+  }
+
+  /**
+   * Build a 1.6 AuthorizationData entry for an authorization row.
+   * Mirrors STEVE OcppTagService.getAuthData semantics.
+   */
+  static toOcpp16AuthorizationData(
+    auth: Authorization,
+    parentIdTag?: string | null,
+  ): Ocpp16AuthorizationData {
+    return {
+      idTag: auth.idToken,
+      idTagInfo: {
+        status: LocalAuthListMapper.toIdTagStatus(auth.status),
+        expiryDate: auth.cacheExpiryDateTime ?? undefined,
+        parentIdTag: parentIdTag ?? undefined,
+      },
+    };
+  }
+
+  /**
+   * Build a 1.6 AuthorizationData entry from a persisted LocalListAuthorization row.
+   */
+  static toOcpp16AuthorizationDataFromLocal(
+    local: LocalListAuthorization,
+    parentIdTag?: string | null,
+  ): Ocpp16AuthorizationData {
+    return {
+      idTag: local.idToken,
+      idTagInfo: {
+        status: LocalAuthListMapper.toIdTagStatus(
+          local.status as AuthorizationStatusEnumType | undefined,
+        ),
+        expiryDate: local.cacheExpiryDateTime ?? undefined,
+        parentIdTag: parentIdTag ?? undefined,
+      },
+    };
+  }
+}

--- a/packages/core/src/dal/layers/sequelize/mapper/1.6/index.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/1.6/index.ts
@@ -7,3 +7,4 @@ export { AuthorizationMapper } from './AuthorizationMapper.js';
 export { LocationMapper } from './LocationMapper.js';
 export { MeterValueMapper } from './MeterValueMapper.js';
 export { ChargingProfileMapper } from './ChargingProfileMapper.js';
+export { LocalAuthListMapper } from './LocalAuthListMapper.js';

--- a/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type { BootstrapConfig } from '@citrineos/base';
-import { CrudRepository, OCPP2_0_1 } from '@citrineos/base';
+import { CrudRepository, OCPP1_6, OCPP2_0_1 } from '@citrineos/base';
 import { Sequelize } from 'sequelize-typescript';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
@@ -11,6 +11,7 @@ import type {
   ILocalAuthListRepository,
 } from '../../../interfaces/repositories.js';
 import { AuthorizationMapper } from '../mapper/2.0.1/AuthorizationMapper.js';
+import { LocalAuthListMapper } from '../mapper/1.6/LocalAuthListMapper.js';
 import { Authorization } from '../model/Authorization/Authorization.js';
 import { LocalListAuthorization } from '../model/Authorization/LocalListAuthorization.js';
 import { LocalListVersion } from '../model/Authorization/LocalListVersion.js';
@@ -36,7 +37,14 @@ export class SequelizeLocalAuthListRepository
     localListAuthorization?: CrudRepository<LocalListAuthorization>,
     sendLocalList?: CrudRepository<SendLocalList>,
   ) {
-    super(config, Authorization.MODEL_NAME, logger, sequelizeInstance);
+    // The repo's primary model is LocalListVersion (matches the
+    // ILocalAuthListRepository<LocalListVersion> contract). Earlier code passed
+    // Authorization.MODEL_NAME here, which made readOnlyOneByQuery/readAllByQuery
+    // query the Authorization model — and any include like
+    // `include: [LocalListAuthorization]` then threw
+    // "LocalListAuthorization is not associated to Authorization!" because no such
+    // association exists on Authorization.
+    super(config, LocalListVersion.MODEL_NAME, logger, sequelizeInstance);
     this.authorization = authorization
       ? authorization
       : new SequelizeAuthorizationRepository(config, logger);
@@ -133,6 +141,102 @@ export class SequelizeLocalAuthListRepository
     return sendLocalList;
   }
 
+  async createSendLocalListFromRequestData16(
+    tenantId: number,
+    stationId: string,
+    correlationId: string,
+    updateType: OCPP1_6.SendLocalListRequestUpdateType,
+    versionNumber: number,
+    localAuthorizationList?: NonNullable<OCPP1_6.SendLocalListRequest['localAuthorizationList']>,
+  ): Promise<SendLocalList> {
+    const sendLocalList = await this.sendLocalList.create(
+      tenantId,
+      SendLocalList.build({
+        tenantId,
+        ocppConnectionName: stationId,
+        correlationId,
+        versionNumber,
+        // The SendLocalList.updateType column is a plain string. Both 1.6 and 2.0.1
+        // use the values 'Full' and 'Differential', so coercion across enums is safe.
+        updateType: updateType as unknown as OCPP2_0_1.UpdateEnumType,
+      }),
+    );
+
+    for (const authData of localAuthorizationList ?? []) {
+      if (!authData.idTag) {
+        continue;
+      }
+
+      // For DIFFERENTIAL deletes the spec allows entries with no idTagInfo.
+      // These are recorded as tombstones (status Invalid) so the response handler
+      // can drop the matching authorization from LocalListVersion.
+      const isDelete =
+        updateType === OCPP1_6.SendLocalListRequestUpdateType.Differential && !authData.idTagInfo;
+
+      const auth = await Authorization.findOne({
+        where: { idToken: authData.idTag },
+      });
+
+      if (!auth && !isDelete) {
+        throw new Error(
+          `Authorization not found for idTag '${authData.idTag}' (create the Authorization before adding it to a local auth list)`,
+        );
+      }
+
+      let groupAuthorizationId: number | undefined;
+      if (authData.idTagInfo?.parentIdTag) {
+        const parent = await Authorization.findOne({
+          where: { idToken: authData.idTagInfo.parentIdTag },
+        });
+        if (!parent) {
+          throw new Error(
+            `Parent authorization not found for parentIdTag '${authData.idTagInfo.parentIdTag}'`,
+          );
+        }
+        groupAuthorizationId = parent.id;
+      }
+
+      const baseFields = auth
+        ? (() => {
+            const { id: _id, ...rest } = auth;
+            return rest;
+          })()
+        : {
+            idToken: authData.idTag,
+            idTokenType: null,
+          };
+
+      const localListAuthorization = await this.localListAuthorization.create(
+        tenantId,
+        LocalListAuthorization.build({
+          ...baseFields,
+          idToken: authData.idTag,
+          idTokenType: null,
+          status: isDelete
+            ? 'Invalid'
+            : LocalAuthListMapper.fromIdTagStatus(
+                authData.idTagInfo?.status ?? OCPP1_6.SendLocalListRequestStatus.Accepted,
+              ),
+          cacheExpiryDateTime: authData.idTagInfo?.expiryDate ?? null,
+          groupAuthorizationId: groupAuthorizationId ?? null,
+          authorizationId: auth?.id,
+        }),
+      );
+
+      await SendLocalListAuthorization.create({
+        tenantId,
+        sendLocalListId: sendLocalList.id,
+        authorizationId: localListAuthorization.id,
+      });
+    }
+
+    await sendLocalList.reload({ include: [LocalListAuthorization] });
+
+    this.sendLocalList.emit('created', [sendLocalList]);
+
+    return sendLocalList;
+  }
+
   async validateOrReplaceLocalListVersionForStation(
     tenantId: number,
     versionNumber: number,
@@ -171,8 +275,15 @@ export class SequelizeLocalAuthListRepository
     ocppConnectionName: string,
     correlationId: string,
   ): Promise<SendLocalList | undefined> {
+    // Eager-load the LocalListAuthorization rows that the SendLocalList row was
+    // created with. The Accept-path of replaceLocalListVersion / updateLocal-
+    // ListVersion iterates sendLocalList.localAuthorizationList to populate the
+    // LocalListVersionAuthorization junction; without the include the relation
+    // is undefined and both paths early-return, so the new LocalListVersion is
+    // saved with zero entries and the UI shows an empty list after Accept.
     return this.sendLocalList.readOnlyOneByQuery(tenantId, {
       where: { ocppConnectionName: ocppConnectionName, correlationId },
+      include: [LocalListAuthorization],
     });
   }
 
@@ -288,19 +399,31 @@ export class SequelizeLocalAuthListRepository
       }
 
       for (const sendAuth of sendLocalList.localAuthorizationList) {
-        // If there is already an association with the same authorizationId, remove it
-        const oldAuth = localListVersion.localAuthorizationList?.find(
-          (localAuth) => localAuth.authorizationId === sendAuth.authorizationId,
-        );
-        if (oldAuth) {
+        // 1.6 differential delete: tombstone rows have no linked Authorization and status 'Invalid'.
+        // Drop existing entries on the version that match the tombstone's idToken and skip insertion.
+        const isTombstone = !sendAuth.authorizationId && sendAuth.status === 'Invalid';
+
+        const matches =
+          localListVersion.localAuthorizationList?.filter((localAuth) =>
+            isTombstone
+              ? localAuth.idToken === sendAuth.idToken
+              : localAuth.authorizationId === sendAuth.authorizationId,
+          ) ?? [];
+
+        for (const oldAuth of matches) {
           await LocalListVersionAuthorization.destroy({
             where: {
               localListVersionId: localListVersion.id,
-              authorizationId: oldAuth.authorizationId,
+              authorizationId: oldAuth.id,
             },
             transaction,
           });
         }
+
+        if (isTombstone) {
+          continue;
+        }
+
         await LocalListVersionAuthorization.create(
           {
             tenantId,

--- a/packages/core/src/modules/EVDriver/src/module/1.6/MessageApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/1.6/MessageApi.ts
@@ -16,6 +16,7 @@ import {
   OCPPVersion,
   OCPP_CallAction,
 } from '@citrineos/base';
+import { v4 as uuidv4 } from 'uuid';
 
 export class EVDriverOcpp16Api
   extends AbstractModuleApi<EVDriverModule>
@@ -111,6 +112,71 @@ export class EVDriverOcpp16Api
         tenantId,
         OCPPVersion.OCPP1_6,
         OCPP_CallAction.ClearCache,
+        request,
+        callbackUrl,
+      ),
+    );
+    return Promise.all(results);
+  }
+
+  @AsMessageEndpoint(OCPP_CallAction.SendLocalList, OCPP1_6.SendLocalListRequestSchema)
+  async sendLocalList(
+    identifier: string[],
+    request: OCPP1_6.SendLocalListRequest,
+    callbackUrl?: string,
+    tenantId: number = DEFAULT_TENANT_ID,
+  ): Promise<IMessageConfirmation[]> {
+    const results: IMessageConfirmation[] = [];
+
+    for (const i of identifier) {
+      try {
+        const correlationId = uuidv4();
+
+        await this._module.localAuthListService.persistSendLocalListForStationIdAndCorrelationIdAndSendLocalListRequest16(
+          tenantId,
+          i,
+          correlationId,
+          request,
+        );
+
+        const confirmation = await this._module.sendCall(
+          i,
+          tenantId,
+          OCPPVersion.OCPP1_6,
+          OCPP_CallAction.SendLocalList,
+          request,
+          callbackUrl,
+          correlationId,
+        );
+
+        results.push(confirmation);
+      } catch (error) {
+        results.push({
+          success: false,
+          payload: error instanceof Error ? error.message : JSON.stringify(error),
+        });
+      }
+    }
+
+    return results;
+  }
+
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetLocalListVersion,
+    OCPP1_6.GetLocalListVersionRequestSchema,
+  )
+  async getLocalListVersion(
+    identifier: string[],
+    request: OCPP1_6.GetLocalListVersionRequest,
+    callbackUrl?: string,
+    tenantId: number = DEFAULT_TENANT_ID,
+  ): Promise<IMessageConfirmation[]> {
+    const results = identifier.map((id) =>
+      this._module.sendCall(
+        id,
+        tenantId,
+        OCPPVersion.OCPP1_6,
+        OCPP_CallAction.GetLocalListVersion,
         request,
         callbackUrl,
       ),

--- a/packages/core/src/modules/EVDriver/src/module/DataApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/DataApi.ts
@@ -17,7 +17,7 @@ import {
 } from '@citrineos/base';
 import type { ChargingStationKeyQuerystring } from '@dal/interfaces/queries/ChargingStation.js';
 import { ChargingStationKeyQuerySchema } from '@dal/interfaces/queries/ChargingStation.js';
-import { LocalListVersion } from '@dal/index.js';
+import { LocalListAuthorization, LocalListVersion } from '@dal/index.js';
 
 export class EVDriverDataApi
   extends AbstractModuleApi<EVDriverModule>
@@ -40,8 +40,11 @@ export class EVDriverDataApi
   ): Promise<LocalListVersion | undefined> {
     const tenantId = request.query.tenantId;
     return await this._module.localAuthListRepository.readOnlyOneByQuery(tenantId, {
-      tenantId: tenantId,
-      ocppConnectionName: request.query.ocppConnectionName,
+      where: {
+        tenantId: tenantId,
+        ocppConnectionName: request.query.ocppConnectionName,
+      },
+      include: [LocalListAuthorization],
     });
   }
 

--- a/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
+++ b/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { OCPP2_0_1, OCPP2_request_types } from '@citrineos/base';
+import { OCPP1_6, OCPP2_0_1, OCPP2_request_types } from '@citrineos/base';
 import type {
   IDeviceModelRepository,
   ILocalAuthListRepository,
@@ -169,6 +169,52 @@ export class LocalAuthListService {
     } else {
       return Number(itemsPerMessageSendLocalList[0].value);
     }
+  }
+
+  /**
+   * OCPP 1.6 variant: validate and persist a SendLocalListRequest, returning the persisted row.
+   * Mirrors the 2.0.1 path but uses flat idTag and 1.6 update enum. Item-count limits for 1.6
+   * come from the chargepoint via `LocalAuthListMaxLength` configuration; absence is non-fatal.
+   */
+  async persistSendLocalListForStationIdAndCorrelationIdAndSendLocalListRequest16(
+    tenantId: number,
+    stationId: string,
+    correlationId: string,
+    sendLocalListRequest: OCPP1_6.SendLocalListRequest,
+  ): Promise<SendLocalList> {
+    const localListVersion = await this._localAuthListRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName: stationId,
+      },
+      include: [LocalListAuthorization],
+    });
+
+    if (sendLocalListRequest.listVersion <= 0) {
+      throw new Error(`listVersion ${sendLocalListRequest.listVersion} must be greater than 0`);
+    }
+
+    if (localListVersion && localListVersion.versionNumber >= sendLocalListRequest.listVersion) {
+      throw new Error(
+        `Current LocalListVersion for ${stationId} is ${localListVersion.versionNumber}, cannot send LocalListVersion ${sendLocalListRequest.listVersion} (version number must be higher)`,
+      );
+    }
+
+    const list = sendLocalListRequest.localAuthorizationList ?? [];
+    if (list.length > 1) {
+      const idTags = list.map((entry) => entry.idTag);
+      if (new Set(idTags).size !== idTags.length) {
+        throw new Error(`Duplicated idTag in SendLocalListRequest: ${JSON.stringify(idTags)}`);
+      }
+    }
+
+    return await this._localAuthListRepository.createSendLocalListFromRequestData16(
+      tenantId,
+      stationId,
+      correlationId,
+      sendLocalListRequest.updateType,
+      sendLocalListRequest.listVersion,
+      sendLocalListRequest.localAuthorizationList ?? undefined,
+    );
   }
 
   private async getMaxLocalAuthListEntries(tenantId: number): Promise<number | null> {

--- a/packages/core/src/modules/EVDriver/src/module/module.ts
+++ b/packages/core/src/modules/EVDriver/src/module/module.ts
@@ -1239,4 +1239,86 @@ export class EVDriverModule extends AbstractModule {
   ): Promise<void> {
     this._logger.debug('ClearCacheResponse received:', message, props);
   }
+
+  @AsHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.SendLocalList)
+  protected async _handleOcpp16SendLocalList(
+    message: IMessage<OCPP1_6.SendLocalListResponse>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug('OCPP 1.6 SendLocalListResponse received:', message, props);
+
+    const stationId = message.context.ocppConnectionName;
+
+    const sendLocalListRequest =
+      await this._localAuthListRepository.getSendLocalListRequestByStationIdAndCorrelationId(
+        message.context.tenantId,
+        stationId,
+        message.context.correlationId,
+      );
+
+    if (!sendLocalListRequest) {
+      this._logger.error(
+        `Unable to process OCPP 1.6 SendLocalListResponse. SendLocalListRequest not found for StationId ${stationId} by CorrelationId ${message.context.correlationId}.`,
+      );
+      return;
+    }
+
+    switch (message.payload.status) {
+      case OCPP1_6.SendLocalListResponseStatus.Accepted:
+        await this._localAuthListRepository.createOrUpdateLocalListVersionFromStationIdAndSendLocalList(
+          message.context.tenantId,
+          stationId,
+          sendLocalListRequest,
+        );
+        break;
+      case OCPP1_6.SendLocalListResponseStatus.Failed:
+        this._logger.error(
+          `OCPP 1.6 SendLocalListRequest failed for StationId ${stationId}: ${message.context.correlationId}, ${JSON.stringify(sendLocalListRequest)}.`,
+        );
+        break;
+      case OCPP1_6.SendLocalListResponseStatus.VersionMismatch: {
+        this._logger.error(
+          `OCPP 1.6 SendLocalListRequest version mismatch for StationId ${stationId}; firing GetLocalListVersion to resync.`,
+        );
+        const messageConfirmation = await this.sendCall(
+          stationId,
+          message.context.tenantId,
+          OCPPVersion.OCPP1_6,
+          OCPP_CallAction.GetLocalListVersion,
+          {} as OCPP1_6.GetLocalListVersionRequest,
+        );
+        if (!messageConfirmation.success) {
+          this._logger.error(
+            `Unable to send OCPP 1.6 GetLocalListVersion for StationId ${stationId} after version mismatch.`,
+            messageConfirmation,
+          );
+        }
+        break;
+      }
+      case OCPP1_6.SendLocalListResponseStatus.NotSupported:
+        this._logger.error(
+          `OCPP 1.6 SendLocalListRequest reported NotSupported for StationId ${stationId}.`,
+        );
+        break;
+      default:
+        this._logger.error(
+          `Unknown OCPP 1.6 SendLocalListResponseStatus: ${message.payload.status}.`,
+        );
+        break;
+    }
+  }
+
+  @AsHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.GetLocalListVersion)
+  protected async _handleOcpp16GetLocalListVersion(
+    message: IMessage<OCPP1_6.GetLocalListVersionResponse>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug('OCPP 1.6 GetLocalListVersionResponse received:', message, props);
+
+    await this._localAuthListRepository.validateOrReplaceLocalListVersionForStation(
+      message.context.tenantId,
+      message.payload.listVersion,
+      message.context.ocppConnectionName,
+    );
+  }
 }


### PR DESCRIPTION
…o layout

Re-applies the local-auth feature from gokabisa/main (PR #730, old pre-monorepo layout) onto the citrineos-core monorepo packages/ structure.

What's included
- ILocalAuthListRepository: createSendLocalListFromRequestData16, validateOrReplaceLocalListVersionForStation, getSendLocalListRequestByStationIdAndCorrelationId, createOrUpdateLocalListVersionFromStationIdAndSendLocalList
- New LocalAuthListMapper (1.6): toIdTagStatus / fromIdTagStatus
- 1.6 MessageApi endpoints: SendLocalList + GetLocalListVersion
- EVDriverModule handlers: _handleOcpp16SendLocalList, _handleOcpp16GetLocalListVersion (Accept/Failed/VersionMismatch/NotSupported)
- DataApi getLocalAuthorizationListVersion: eager-load LocalListAuthorization
- config: split systemConfigInputSchema vs systemConfigSchema (two-pass loader)

Adapted for monorepo
- Old paths 00_Base/, 01_Data/, 03_Modules/ -> packages/base/, packages/core/src/dal/, packages/core/src/modules/
- OCPP1_6_CallAction.* -> OCPP_CallAction.* (unified enum upstream)
- Model column rename: stationId -> ocppConnectionName on SendLocalList, LocalListVersion, IMessageContext (translated at boundary, local variable names kept where logging refers to "Station")
- @AsHandler(OCPPVersion.OCPP1_6, ...) -> @AsHandler([OCPPVersion.OCPP1_6], ...)
- LocalAuthListMapper imports switched from non-existent model barrel to direct file paths
- Dropped dead _updateAuthorizationFromDto (never called)
- Dropped Server/config/envs/* (fork-specific infra, not local-auth scope)

Verified
- pnpm -r run build green across all packages (core, server, operator-ui)

Supersedes #730. Co-authored by ProgrammerDATCH (original feature) and ICantThinkOfAName-tech.