### PR TITLE
Fix case-sensitive apps/Server paths in docker compose files

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,7 +10,7 @@ services:
   citrine:
     build:
       context: .
-      dockerfile: ./apps/server/deploy.Dockerfile
+      dockerfile: ./apps/Server/deploy.Dockerfile
     environment:
       APP_NAME: "all"
       APP_ENV: "docker"
@@ -73,7 +73,7 @@ services:
       RABBITMQ_DEFAULT_USER: "guest"
       RABBITMQ_DEFAULT_PASS: "guest"
     volumes:
-      - ./apps/server/data/rabbitmq:/var/lib/rabbitmq
+      - ./apps/Server/data/rabbitmq:/var/lib/rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics -q check_port_connectivity
       interval: 10s
@@ -86,7 +86,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./apps/server/data/postgresql/pgdata:/var/lib/postgresql/data
+      - ./apps/Server/data/postgresql/pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: citrine
       POSTGRES_USER: citrine
@@ -109,7 +109,7 @@ services:
       MINIO_BROWSER_REDIRECT_URL: http://localhost:9001
       MINIO_SERVER_URL: http://localhost:9000
     volumes:
-      - ./apps/server/data/minio:/data
+      - ./apps/Server/data/minio:/data
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -132,7 +132,7 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.3.cli-migrations-v3
     volumes:
-      - ./apps/server/hasura-metadata:/hasura-metadata
+      - ./apps/Server/hasura-metadata:/hasura-metadata
     ports:
       - 8090:8080
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.3.cli-migrations-v3
     volumes:
-      - ./apps/server/hasura-metadata:/hasura-metadata
+      - ./apps/Server/hasura-metadata:/hasura-metadata
     ports:
       - 8090:8080
     restart: always


### PR DESCRIPTION
## Problem

Both root-level compose files reference `./apps/server` (lowercase) while the actual directory in the repository is `apps/Server`. On case-sensitive filesystems (Linux), this breaks the Quick Start flow from the README in two ways:

1. **`docker-compose.local.yml`**  the `citrine` service fails to build:
   ```
   resolve : lstat /<repo>/apps/server: no such file or directory
   ```
   The same applies to the rabbitmq/postgres/minio volume mounts, which end up creating a new `apps/server` directory instead of reusing `apps/Server/data`.

2. **`docker-compose.yml`**  more subtle: Docker silently creates an empty `apps/server/hasura-metadata` directory and bind-mounts it into the `graphql-engine` container, so the Hasura metadata never loads (no error is raised).

On macOS and Windows the mismatch goes unnoticed because the default filesystems are case-insensitive, which is likely why this hasn't surfaced in CI or for most contributors.

## Fix

Reference `apps/Server` with the correct casing in both files (6 occurrences). Verified with `docker compose config` and a full `docker compose -f docker-compose.local.yml up -d --build` on Linux (Ubuntu, kernel 6.17).
