### PR TITLE
feat(operator-ui): add i18n support with pt-BR locale and language switcher

### DIFF
--- a/.reuse/ignore-files.txt
+++ b/.reuse/ignore-files.txt
@@ -103,6 +103,15 @@ apps/operator-ui/public/locales/en/locations.json
 apps/operator-ui/public/locales/en/tariffs.json
 apps/operator-ui/public/locales/en/tenantPartners.json
 apps/operator-ui/public/locales/en/transactions.json
+apps/operator-ui/public/locales/en/overview.json
+apps/operator-ui/public/locales/pt-BR/common.json
+apps/operator-ui/public/locales/pt-BR/authorizations.json
+apps/operator-ui/public/locales/pt-BR/chargingStations.json
+apps/operator-ui/public/locales/pt-BR/locations.json
+apps/operator-ui/public/locales/pt-BR/overview.json
+apps/operator-ui/public/locales/pt-BR/tariffs.json
+apps/operator-ui/public/locales/pt-BR/tenantPartners.json
+apps/operator-ui/public/locales/pt-BR/transactions.json
 apps/operator-ui/public/logo-black.svg
 apps/operator-ui/public/logo-collapsed.svg
 apps/operator-ui/public/logo-white.svg

--- a/apps/operator-ui/README.MD
+++ b/apps/operator-ui/README.MD
@@ -45,6 +45,8 @@ full stack (server + UI + Hasura) together, see the [root README](../../README.m
 - [Working with `@citrineos/base`](#working-with-citrineosbase)
 - [Build & Development Workflow](#build--development-workflow)
 - [Running the Application](#running-the-application)
+- [Internationalization (i18n)](#internationalization-i18n)
+  - [Adding a New Language](#adding-a-new-language)
 - [Bringing a Charging Station Online (End-to-End)](#bringing-a-charging-station-online-end-to-end)
   - [Create a Location](#create-a-location)
   - [Add a Charging Station (Charge Point)](#add-a-charging-station-charge-point)
@@ -212,6 +214,51 @@ pnpm run start
 ```
 
 - Production URL: http://localhost:3000
+
+## Internationalization (i18n)
+
+The Operator UI is fully internationalized using [next-intl](https://next-intl.dev/), integrated with Refine's
+`i18nProvider`. All user-facing strings are resolved through translation keys.
+
+- **Available languages:** English (`en`, default) and Brazilian Portuguese (`pt-BR`)
+- **Language switcher:** available at the bottom of the sidebar, next to the theme toggle
+- **Persistence:** the selected language is stored in the `NEXT_LOCALE` cookie; English is used as a fallback for
+  any key missing in the selected locale
+
+Translation files live in `public/locales/<locale>/`, one JSON file per domain namespace (`common.json`,
+`chargingStations.json`, `locations.json`, `authorizations.json`, `tariffs.json`, `transactions.json`,
+`tenantPartners.json`, `overview.json`). Each file has a single PascalCase root key (e.g. `ChargingStations`)
+with camelCase sub-keys, and supports ICU parameters (e.g. `"noDataFound": "No location found with id {id}."`).
+
+In components, strings are resolved with Refine's `useTranslate` hook, using flat keys from the merged message
+tree:
+
+```tsx
+import { useTranslate } from '@refinedev/core';
+
+const translate = useTranslate();
+translate('Common.save');
+translate('Locations.noDataFound', { id });
+```
+
+### Adding a New Language
+
+1. Copy `public/locales/en/` to `public/locales/<locale>/` (e.g. `public/locales/de/`) and translate the values
+   (keep the keys and ICU parameters unchanged).
+2. Register the locale in `LOCALES` in `src/lib/utils/consts.tsx`:
+
+   ```ts
+   export const LOCALES = [
+     { value: 'en', label: 'English' },
+     { value: 'pt-BR', label: 'Português (Brasil)' },
+     { value: 'de', label: 'Deutsch' },
+   ];
+   ```
+
+3. Add the new files to `.reuse/ignore-files.txt` (repository root) so the REUSE license check passes.
+
+The language switcher picks up new locales automatically from `LOCALES`. Keys missing from the new locale fall
+back to English at runtime, so partial translations are safe to ship incrementally.
 
 ## Bringing a Charging Station Online (End-to-End)
 

--- a/apps/operator-ui/playwright/.auth/admin.json
+++ b/apps/operator-ui/playwright/.auth/admin.json
@@ -1,0 +1,61 @@
+{
+  "cookies": [
+    {
+      "name": "next-auth.csrf-token",
+      "value": "9f9998f86dc40302c47329d61272f78674da72b2aad221bbe4aa4be5505fbcf1%7C0595b9f4198ed7c187f30e2c29100504fd322645a204e499c7448469c56e1ae5",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": true,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "next-auth.callback-url",
+      "value": "http%3A%2F%2Flocalhost%3A3000%2Flogin",
+      "domain": "localhost",
+      "path": "/",
+      "expires": -1,
+      "httpOnly": true,
+      "secure": false,
+      "sameSite": "Lax"
+    },
+    {
+      "name": "next-auth.session-token",
+      "value": "eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..H1G3tTiwSpPdK1iv.pfEa42I1T41uphFy_qWqVDUe5P27jDgFs2o3xZ4PNszFALaEoEDDngeGNJvTD3e5TA3TEAEGs-mbAFqG4TJUF2EFAWTSlZQGNAvJSa1d5CFannWa3KJnSjG84nHcb4kxzEoFhHfohBiITuKKruSEoqzFmJBf1CfiWuzn9V4.y7ow8AI4n3B-QzlVMdB3Xw",
+      "domain": "localhost",
+      "path": "/",
+      "expires": 1783262363.317933,
+      "httpOnly": true,
+      "secure": false,
+      "sameSite": "Lax"
+    }
+  ],
+  "origins": [
+    {
+      "origin": "http://localhost:3000",
+      "localStorage": [
+        {
+          "name": "nextauth.message",
+          "value": "{\"event\":\"session\",\"data\":{\"trigger\":\"getSession\"},\"timestamp\":1780670363}"
+        },
+        {
+          "name": "auth_token",
+          "value": "mock_token_7dg122120tj"
+        },
+        {
+          "name": "persist:citrine",
+          "value": "{\"tablePreferences\":\"{\\\"visibleColumns\\\":{},\\\"pageSize\\\":{}}\",\"_persist\":\"{\\\"version\\\":-1,\\\"rehydrated\\\":true}\"}"
+        },
+        {
+          "name": "firstLoginHelp:1",
+          "value": "true"
+        },
+        {
+          "name": "auth_user",
+          "value": "{\"id\":\"1\",\"name\":\"Admin User\",\"email\":\"admin@citrineos.com\",\"roles\":[\"admin\"]}"
+        }
+      ]
+    }
+  ]
+}

--- a/apps/operator-ui/public/locales/en/authorizations.json
+++ b/apps/operator-ui/public/locales/en/authorizations.json
@@ -2,6 +2,56 @@
   "Authorizations": {
     "Authorizations": "Authorizations",
     "authorization": "Authorization",
-    "noDataFound": "No authorization found with id {id}."
+    "noDataFound": "No authorization found with id {id}.",
+    "noId": "No ID",
+    "allowed": "Allowed",
+    "notAllowed": "Not Allowed",
+    "columns": {
+      "authorizationId": "Authorization ID",
+      "type": "Type",
+      "status": "Status",
+      "concurrentTransactions": "Concurrent Transactions",
+      "allowedTypes": "Allowed Types",
+      "disallowedPrefixes": "Disallowed Prefixes",
+      "createdAt": "Created At",
+      "updatedAt": "Updated At"
+    },
+    "fields": {
+      "idToken": "ID Token",
+      "idTokenType": "ID Token Type",
+      "status": "Status",
+      "cacheExpiryDateTime": "Cache Expiry DateTime",
+      "chargingPriority": "Charging Priority",
+      "language1": "Language 1",
+      "language2": "Language 2",
+      "personalMessage": "Personal Message",
+      "groupAuthorizationId": "Group Authorization ID",
+      "allowedConnectorTypes": "Allowed Connector Types (comma-separated)",
+      "disallowedEvseIdPrefixes": "Disallowed EVSE ID Prefixes (comma-separated)",
+      "realTimeAuth": "Real-Time Authentication",
+      "realTimeAuthUrl": "Real-Time Authentication URL",
+      "realTimeAuthTimeout": "Real-Time Authentication Timeout (seconds)",
+      "concurrentTransaction": "Allow Concurrent Transaction",
+      "additionalInfo": "Additional Info",
+      "additionalIdToken": "Additional Id Token #{index}",
+      "type": "Type",
+      "typeNumbered": "Type #{index}"
+    },
+    "placeholders": {
+      "selectType": "Select Type",
+      "searchTypes": "Search Types",
+      "selectStatus": "Select Status",
+      "searchStatuses": "Search Statuses",
+      "allowedConnectorTypes": "e.g., Type2, CCS",
+      "disallowedEvseIdPrefixes": "e.g., EVSE1, EVSE2",
+      "selectOption": "Select Option",
+      "searchOption": "Search Option",
+      "additionalInfo": "Additional Info",
+      "type": "Type"
+    },
+    "detail": {
+      "partner": "Partner",
+      "realTimeAuthTimeoutSeconds": "{timeout} seconds"
+    }
   }
 }

--- a/apps/operator-ui/public/locales/en/chargingStations.json
+++ b/apps/operator-ui/public/locales/en/chargingStations.json
@@ -23,6 +23,408 @@
     "liveLogDisabledInactivity": "Live log disabled due to inactivity",
     "refreshMessages": "Refresh Messages",
     "noDataFound": "No charging station found with id {id}.",
+    "unsupportedProtocol": "Unsupported protocol version: {protocol}",
+    "fieldRequired": "{field} is required",
+    "exportToCsvError": "Could export to CSV due to error: {error}",
+    "detailCard": {
+      "lastOcppMessage": "Last OCPP Message",
+      "connectorTypes": "Connector Types",
+      "totalEvses": "Total EVSEs"
+    },
+    "tabs": {
+      "evses": "EVSEs",
+      "ocppMessages": "OCPP Messages",
+      "configuration": "Configuration",
+      "aggregatedMeterValuesData": "Aggregated Meter Values Data",
+      "noEvsesPermission": "You don't have permission to view EVSEs.",
+      "noOcppLogsPermission": "You don't have permission to view OCPP logs.",
+      "noConfigurationsPermission": "You don't have permission to view station configurations."
+    },
+    "columns": {
+      "name": "Name",
+      "stationId": "Station ID",
+      "location": "Location",
+      "onlineStatus": "Online status",
+      "protocol": "Protocol",
+      "vendorModel": "Vendor / Model",
+      "vendor": "Vendor",
+      "floorLevel": "Floor Level",
+      "parkingRestrictions": "Parking Restrictions",
+      "capabilities": "Capabilities",
+      "firmwareVersion": "Firmware Version",
+      "createdAt": "Created At",
+      "updatedAt": "Updated At"
+    },
+    "aggregatedData": {
+      "timeRange": "Time Range:",
+      "contexts": "Contexts:",
+      "selectReadingContexts": "Select reading contexts"
+    },
+    "connectors": {
+      "connectorId": "Connector ID",
+      "connectorIdDescription": "The serial integers starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station.",
+      "evseTypeConnectorId": "EVSE Type Connector ID",
+      "evseTypeConnectorIdDescription": "The serial integers starting at 1 used in OCPP 2.0.1 to refer to the connector, unique per EVSE.",
+      "type": "Type",
+      "format": "Format",
+      "powerType": "Power Type",
+      "maxPower": "Max Power",
+      "maximumAmperage": "Maximum Amperage",
+      "maximumVoltage": "Maximum Voltage",
+      "maximumPowerWatts": "Maximum Power Watts",
+      "termsAndConditionsUrl": "Terms and Conditions URL",
+      "tariff": "Tariff",
+      "selectType": "Select Type",
+      "searchTypes": "Search Types",
+      "selectFormat": "Select Format",
+      "selectPowerType": "Select Power Type",
+      "searchPowerTypes": "Search Power Types",
+      "selectTariff": "Select Tariff",
+      "searchTariffs": "Search Tariffs",
+      "noConnectors": "No connectors",
+      "addConnector": "Add Connector",
+      "addNewConnector": "Add New Connector",
+      "editConnector": "Edit Connector"
+    },
+    "evses": {
+      "evseTypeId": "EVSE Type ID",
+      "evseTypeIdDescription": "The serial integers used in OCPP 2.0.1 to refer to the EVSE, unique per Charging Station.",
+      "evseId": "EVSE ID",
+      "evseIdDescription": "The eMI3 compliant EVSE ID, which must be globally unique.",
+      "physicalReference": "Physical Reference",
+      "physicalReferenceDescription": "Any identifier printed on the EVSE used to identify it when physically at the location, e.g. a number or a letter.",
+      "removed": "Removed",
+      "removedDescription": "Marked as REMOVED",
+      "noEvses": "No EVSEs",
+      "viewConnectors": "View Connectors",
+      "addNewEvse": "Add New EVSE",
+      "editEvse": "Edit Evse"
+    },
+    "evseSelector": {
+      "label": "EVSE",
+      "loading": "Loading EVSEs...",
+      "searchPlaceholder": "Search EVSE",
+      "description": "EVSE IDs are serial integers starting at 1"
+    },
+    "connectorSelector": {
+      "label": "Connector",
+      "loading": "Loading Connectors...",
+      "searchPlaceholder": "Search Connectors",
+      "selectConnector": "Select Connector",
+      "selectEvse": "Select an EVSE",
+      "description": "Connector IDs are serial integers starting at 1",
+      "descriptionForEvse": "Connectors for selected EVSE"
+    },
+    "requestId": {
+      "label": "Request ID",
+      "placeholder": "Enter request ID",
+      "positiveError": "Request ID must be a positive number"
+    },
+    "firmwareDiagnostics": {
+      "locationUrl": "Location (URL)",
+      "invalidUrl": "Must be a valid URL",
+      "locationRequired": "Location is required",
+      "retries": "Retries",
+      "retriesPlaceholder": "Number of retries",
+      "retryInterval": "Retry Interval",
+      "retryIntervalPlaceholder": "Retry interval in seconds"
+    },
+    "commands": {
+      "certificateSigned": "Certificate Signed",
+      "changeAvailability": "Change Availability",
+      "changeConfiguration": "Change Configuration",
+      "clearCache": "Clear Cache",
+      "customerInformation": "Customer Information",
+      "dataTransfer": "Data Transfer",
+      "deleteCertificate": "Delete Certificate",
+      "deleteStationNetworkProfiles": "Delete Station Network Profiles",
+      "getBaseReport": "Get Base Report",
+      "getConfiguration": "Get Configuration",
+      "getDiagnostics": "Get Diagnostics",
+      "getInstalledCertificateIds": "Get Installed Certificate IDs",
+      "getLogs": "Get Logs",
+      "getTransactionStatus": "Get Transaction Status",
+      "getVariables": "Get Variables",
+      "installCertificate": "Install Certificate",
+      "setNetworkProfile": "Set Network Profile",
+      "setVariables": "Set Variables",
+      "triggerMessage": "Trigger Message",
+      "unlockConnector": "Unlock Connector",
+      "updateAuthPassword": "Update Auth Password",
+      "updateFirmware": "Update Firmware"
+    },
+    "resetModal": {
+      "resetType": "Reset Type",
+      "selectResetType": "Select Reset Type",
+      "selectResetTypeError": "Please select a reset type"
+    },
+    "remoteStartModal": {
+      "start": "Start",
+      "remoteStartId": "Remote Start ID",
+      "remoteStartIdMin": "Remote Start ID must be at least 0",
+      "idToken": "ID Token",
+      "idTokenRequired": "ID Token is required",
+      "searchIdToken": "Search ID Token",
+      "authorization": "Authorization",
+      "authorizationRequired": "Authorization is required",
+      "selectAuthorization": "Select Authorization",
+      "searchAuthorizations": "Search Authorizations"
+    },
+    "remoteStopModal": {
+      "stop": "Stop",
+      "transactionRequired": "Transaction is required",
+      "noActiveTransactions": "No active transactions found for this charging station.",
+      "activeTransactions": "Active Transactions",
+      "selectTransaction": "Select Transaction",
+      "searchTransactions": "Search Transactions",
+      "unknownEvse": "Unknown"
+    },
+    "dataTransferModal": {
+      "vendorId": "Vendor ID",
+      "vendorIdRequired": "Vendor ID is required",
+      "vendorIdPlaceholder": "Vendor specific implementation identifier",
+      "messageId": "Message ID",
+      "messageIdPlaceholder": "Specific message or implementation identifier",
+      "data": "Data",
+      "dataPlaceholder": "Data to send (freeform text)"
+    },
+    "changeAvailabilityModal": {
+      "availability": "Availability",
+      "selectAvailabilityError": "Please select an availability type",
+      "connectorRequired": "Connector is required",
+      "operationalStatus": "Operational Status",
+      "selectStatus": "Select Status",
+      "selectStatusError": "Please select an operational status"
+    },
+    "changeConfigurationModal": {
+      "key": "Key",
+      "keyRequired": "Key is required",
+      "keyPlaceholder": "Configuration key",
+      "value": "Value",
+      "valueRequired": "Value is required",
+      "valuePlaceholder": "Configuration value"
+    },
+    "getConfigurationModal": {
+      "description": "Optionally specify configuration keys to retrieve. Leave empty to get all configuration values.",
+      "key": "Key",
+      "keyNumber": "Key #{number}",
+      "keyPlaceholder": "Enter configuration key"
+    },
+    "getDiagnosticsModal": {
+      "startTimestamp": "Start Timestamp",
+      "stopTimestamp": "Stop Timestamp"
+    },
+    "triggerMessageModal": {
+      "requestedMessage": "Requested Message",
+      "selectMessage": "Select Message",
+      "selectMessageError": "Please select a message type",
+      "selectMessageType": "Select Message Type",
+      "searchMessageTypes": "Search Message Types"
+    },
+    "updateFirmwareModal": {
+      "retrieveDate": "Retrieve Date",
+      "retrieveDateRequired": "Retrieve date is required",
+      "retrieveDateTime": "Retrieve Date/Time",
+      "installDateTime": "Install Date/Time",
+      "signingCertificate": "Signing Certificate (PEM)",
+      "signingCertificatePlaceholder": "Paste PEM-formatted certificate here",
+      "signature": "Signature",
+      "signaturePlaceholder": "Firmware signature"
+    },
+    "certificateSignedModal": {
+      "certificateFile": "Certificate File",
+      "certificateRequired": "Certificate file is required",
+      "fileTypeError": "File must be one of: {types}",
+      "fileSizeError": "File size must be less than 5MB",
+      "certificateType": "Certificate Type",
+      "selectCertificateType": "Select Certificate Type"
+    },
+    "clearCacheModal": {
+      "description": "This will send a Clear Cache request to the charging station. The station will clear its authorization cache.",
+      "proceed": "Do you want to proceed?",
+      "clearing": "Clearing..."
+    },
+    "customerInformationModal": {
+      "report": "Report",
+      "clear": "Clear",
+      "customerIdentifier": "Customer Identifier",
+      "customerIdentifierPlaceholder": "Enter customer identifier"
+    },
+    "deleteCertificateModal": {
+      "certificateRequired": "Certificate is required",
+      "selectCertificateError": "Please select a certificate",
+      "wrongStationError": "This certificate does not belong to this station",
+      "hashAlgorithm": "Hash Algorithm:",
+      "installedCertificate": "Installed Certificate",
+      "searchCertificates": "Search Certificates by Serial Number"
+    },
+    "deleteStationNetworkProfilesModal": {
+      "slotsRequired": "At least one configuration slot is required",
+      "deleteProfiles": "Delete Profiles",
+      "slot": "Slot",
+      "slotNumber": "Slot #{number}",
+      "slotPlaceholder": "Enter slot number"
+    },
+    "getBaseReportModal": {
+      "reportBase": "Report Base",
+      "reportBaseRequired": "Report Base is required",
+      "selectReportBase": "Select Report Base"
+    },
+    "getInstalledCertificateIdsModal": {
+      "certificateTypes": "Certificate Types",
+      "description": "When certificate types are omitted, all certificate types are requested.",
+      "selectCertificateTypes": "Select Certificate Types",
+      "searchCertificateTypes": "Search Certificate Types"
+    },
+    "getLogsModal": {
+      "remoteLocationUrl": "Remote Location (URL)",
+      "remoteLocationRequired": "Remote Location is required",
+      "logType": "Log Type",
+      "logTypeRequired": "Log Type is required",
+      "selectLogType": "Select Log Type",
+      "oldestTimestamp": "Oldest Timestamp",
+      "latestTimestamp": "Latest Timestamp"
+    },
+    "getTransactionStatusModal": {
+      "transaction": "Transaction",
+      "description": "Optionally select a transaction to get its status. Leave empty to get the status of all transactions."
+    },
+    "getVariablesModal": {
+      "alert": "Send a GetBaseReport to this Charging Station to populate Components and Variables.",
+      "atLeastOneVariable": "At least one variable is required",
+      "componentAndVariableRequired": "Component and Variable are required for each entry",
+      "component": "Component",
+      "variable": "Variable",
+      "componentNumber": "Component #{number}",
+      "variableNumber": "Variable #{number}",
+      "componentInstanceNumber": "Component Instance #{number}",
+      "variableInstanceNumber": "Variable Instance #{number}",
+      "attributeTypeNumber": "Attribute Type #{number}",
+      "instance": "Instance",
+      "selectComponent": "Select Component",
+      "searchComponents": "Search Components",
+      "selectVariable": "Select Variable",
+      "searchVariables": "Search Variables",
+      "selectAttributeType": "Select Attribute Type"
+    },
+    "setVariablesModal": {
+      "valueRequired": "Value is required",
+      "allFieldsRequired": "Component, Variable, and Value are required for each entry",
+      "valueNumber": "Value #{number}",
+      "valuePlaceholder": "Value To Set"
+    },
+    "installCertificateModal": {
+      "certificateRequired": "Certificate is required",
+      "certificateTooLong": "Certificate must be less than 5500 characters",
+      "certificateTypeRequired": "Certificate Type is required",
+      "invalidPem": "Incorrectly formatted PEM certificate",
+      "certificatePem": "Certificate (PEM)"
+    },
+    "setNetworkProfileModal": {
+      "apnRequired": "APN is required",
+      "apnAuthRequired": "APN Authentication is required",
+      "serverRequired": "Server is required",
+      "userRequired": "User is required",
+      "passwordRequired": "Password is required",
+      "keyRequired": "Key is required",
+      "vpnTypeRequired": "VPN Type is required",
+      "ocppVersionRequired": "OCPP Version is required",
+      "ocppTransportRequired": "OCPP Transport is required",
+      "csmsUrlRequired": "CSMS URL is required",
+      "messageTimeoutPositive": "Message timeout must be positive",
+      "securityProfilePositive": "Security profile must be positive",
+      "ocppInterfaceRequired": "OCPP Interface is required",
+      "configurationSlotNonNegative": "Configuration slot must be non-negative",
+      "websocketServerConfig": "Websocket Server Config",
+      "searchServerProfiles": "Search Server Network Profiles",
+      "configurationSlot": "Configuration Slot",
+      "ocppVersion": "OCPP Version",
+      "selectOcppVersion": "Select OCPP Version",
+      "ocppTransport": "OCPP Transport",
+      "selectOcppTransport": "Select OCPP Transport",
+      "ocppCsmsUrl": "OCPP CSMS URL",
+      "messageTimeout": "Message Timeout (seconds)",
+      "securityProfile": "Security Profile",
+      "ocppInterface": "OCPP Interface",
+      "selectOcppInterface": "Select OCPP Interface",
+      "includeApn": "Include APN Configuration",
+      "includeVpn": "Include VPN Configuration",
+      "apn": "APN",
+      "apnPlaceholder": "APN name",
+      "apnAuthentication": "APN Authentication",
+      "selectAuthType": "Select Authentication Type",
+      "apnUsername": "APN Username",
+      "apnPassword": "APN Password",
+      "simPin": "SIM PIN",
+      "preferredNetwork": "Preferred Network",
+      "useOnlyPreferredNetwork": "Use Only Preferred Network",
+      "vpnType": "VPN Type",
+      "selectVpnType": "Select VPN Type",
+      "server": "Server",
+      "serverPlaceholder": "VPN server",
+      "user": "User",
+      "userPlaceholder": "VPN username",
+      "group": "Group",
+      "password": "Password",
+      "passwordPlaceholder": "VPN password",
+      "key": "Key",
+      "keyPlaceholder": "VPN key"
+    },
+    "updateAuthPasswordModal": {
+      "passwordRequired": "Password is required",
+      "updatePassword": "Update Password",
+      "password": "Password",
+      "passwordPlaceholder": "Enter new password",
+      "setOnCharger": "Set On Charger"
+    },
+    "upsert": {
+      "selectLocation": "Select Location",
+      "selectParkingRestrictions": "Select Parking Restrictions",
+      "searchParkingRestrictions": "Search Parking Restrictions",
+      "selectCapabilities": "Select Capabilities",
+      "searchCapabilities": "Search Capabilities",
+      "useLocationCoordinates": "Use Location Coordinates",
+      "latitude": "Latitude",
+      "enterLatitude": "Enter latitude",
+      "longitude": "Longitude",
+      "enterLongitude": "Enter longitude",
+      "image": "Image"
+    },
+    "ocppMessages": {
+      "searchCorrelationId": "Search Correlation ID",
+      "selectActions": "Select Actions",
+      "searchActions": "Search Actions",
+      "filterOrigins": "Filter Origins",
+      "allOrigins": "All Origins",
+      "pickStartDate": "Pick Start Date",
+      "pickEndDate": "Pick End Date",
+      "correlationId": "Correlation ID",
+      "actionOrigin": "Action - Origin",
+      "unknownAction": "Unknown Action",
+      "timestamp": "Timestamp",
+      "content": "Content",
+      "findRelatedMessage": "Find related message",
+      "copyCorrelationId": "Copy Correlation ID"
+    },
+    "configuration": {
+      "key": "Key",
+      "value": "Value",
+      "type": "Type",
+      "componentNameInstance": "Component Name:Instance",
+      "variableNameInstance": "Variable Name:Instance",
+      "evseConnectorId": "EVSE ID:Connector ID",
+      "stationId": "Station Id",
+      "action": "Action",
+      "noData": "No data",
+      "noDataForDownload": "No data available for download",
+      "loadAttributesError": "Failed to load variable attributes",
+      "loadConfigurationsError": "Failed to load change configurations",
+      "selectOcppVersion": "Select OCPP Version",
+      "downloadCsv": "Download CSV",
+      "searchPlaceholder": "Search...",
+      "addConfiguration": "Add Configuration",
+      "editConfiguration": "Edit Configuration"
+    },
     "connectionModal": {
       "welcomeTitle": "Welcome to CitrineOS Operator UI",
       "connectionTitle": "Charging Station Connection",
@@ -61,6 +463,13 @@
           "description": "Both the Charging Station and CSMS authenticate themselves using certificates."
         }
       }
+    },
+    "exportDialog": {
+      "correlationId": "Correlation ID",
+      "actions": "Actions",
+      "origin": "Origin",
+      "startDate": "Start Date",
+      "endDate": "End Date"
     }
   }
 }

--- a/apps/operator-ui/public/locales/en/common.json
+++ b/apps/operator-ui/public/locales/en/common.json
@@ -1,13 +1,133 @@
 {
+  "Common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "create": "Create",
+    "edit": "Edit",
+    "clear": "Clear",
+    "search": "Search",
+    "searchOptions": "Search Options",
+    "searchColumns": "Search Columns",
+    "export": "Export",
+    "refresh": "Refresh",
+    "close": "Close",
+    "confirm": "Confirm",
+    "back": "Back",
+    "add": "Add",
+    "remove": "Remove",
+    "ok": "OK",
+    "submit": "Submit",
+    "apply": "Apply",
+    "reset": "Reset",
+    "loading": "Loading",
+    "loadingEllipsis": "Loading...",
+    "yes": "Yes",
+    "no": "No",
+    "actions": "Actions",
+    "status": "Status",
+    "online": "Online",
+    "offline": "Offline",
+    "active": "Active",
+    "inactive": "Inactive",
+    "unknown": "Unknown",
+    "time": "Time",
+    "copiedToClipboard": "Copied to clipboard.",
+    "copiedValueToClipboard": "Copied {value} to clipboard.",
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "noResults": "No results found",
+    "noDataFound": "No Data Found",
+    "nothingFound": "Nothing found.",
+    "error": "Error",
+    "success": "Success",
+    "select": "Select",
+    "selectItem": "Select Item",
+    "selectOption": "Select an option",
+    "selectOptions": "Select options...",
+    "selected": "selected",
+    "openMenu": "Open menu",
+    "filters": "Filters",
+    "activeFilters": "Active filters",
+    "addFilter": "Add a filter",
+    "addFilterButton": "Add filter",
+    "clearAll": "Clear all",
+    "searchField": "Search {field}…",
+    "atMost": "at most {value}",
+    "after": "after {value}",
+    "rowsSelected": "{selected} of {total} row(s) selected.",
+    "pageOf": "Page {page} of {total}",
+    "pickDateRange": "Pick a date range",
+    "startTypingAddress": "Start typing an address...",
+    "useValue": "Use \"{value}\"",
+    "removeFilter": "Remove filter: {field}"
+  },
+  "filters": {
+    "valueOrLess": "{unit} or less",
+    "previewText": "\"{label}\" includes \"{value}\"",
+    "previewNumber": "\"{label}\" is at most {value}",
+    "previewDate": "\"{label}\" within {preset}",
+    "previewEnum": "\"{label}\" is {value}",
+    "previewYes": "\"{label}\" is Yes",
+    "previewNo": "\"{label}\" is No"
+  },
+  "filterPresets": {
+    "today": "Today",
+    "last7Days": "Last 7 days",
+    "last30Days": "Last 30 days",
+    "last3Months": "Last 3 months",
+    "thisYear": "This year"
+  },
+  "openingHours": {
+    "title": "Opening Hours",
+    "twentyFourSeven": "24/7 Operation",
+    "twentyFourSevenDescription": "This location is open 24 hours a day, 7 days a week",
+    "regularHours": "Regular Hours",
+    "noRegularHours": "No regular hours specified",
+    "exceptionalOpenings": "Exceptional Openings",
+    "exceptionalClosings": "Exceptional Closings",
+    "specialOpening": "Special Opening",
+    "closed": "Closed",
+    "form": {
+      "addHours": "Add Hours",
+      "addOpening": "Add Opening",
+      "addClosing": "Add Closing",
+      "selectDay": "Select day",
+      "exceptionalOpeningsDescription": "Special dates when the location is open",
+      "exceptionalClosingsDescription": "Special dates when the location is closed",
+      "removeTimeSlot": "Remove time slot?",
+      "removeTimeSlotConfirm": "Are you sure you want to remove this time slot?",
+      "removeOpening": "Remove exceptional opening?",
+      "removeOpeningConfirm": "Are you sure you want to remove this exceptional opening?",
+      "removeClosing": "Remove exceptional closing?",
+      "removeClosingConfirm": "Are you sure you want to remove this exceptional closing?"
+    },
+    "weekdays": {
+      "monday": "Monday",
+      "tuesday": "Tuesday",
+      "wednesday": "Wednesday",
+      "thursday": "Thursday",
+      "friday": "Friday",
+      "saturday": "Saturday",
+      "sunday": "Sunday"
+    }
+  },
   "pages": {
     "login": {
       "title": "Sign in to your account",
+      "description": "Enter your credentials to access the dashboard",
       "signin": "Sign in",
+      "signingIn": "Signing in...",
       "signup": "Sign up",
       "divider": "or",
+      "invalidCredentials": "Invalid email or password",
       "fields": {
         "email": "Email",
         "password": "Password"
+      },
+      "placeholders": {
+        "email": "admin@example.com",
+        "password": "Enter your password"
       },
       "errors": {
         "validEmail": "Invalid email address",
@@ -67,12 +187,16 @@
     },
     "error": {
       "info": "You may have forgotten to add the {action} component to {resource} resource.",
+      "title": "Page not found.",
+      "description": "The page you're looking for does not exist.",
       "404": "Sorry, the page you visited does not exist.",
       "resource404": "Are you sure you have created the {resource} resource.",
-      "backHome": "Back Home"
+      "backHome": "Back to homepage"
     },
     "redirectingToLogin": "Redirecting to login...",
-    "checkingAuth": "Checking authentication..."
+    "checkingAuth": "Checking authentication...",
+    "redirectingToKeycloak": "Redirecting to Keycloak...",
+    "redirectingToKeycloakLogin": "Redirecting to Keycloak login..."
   },
   "actions": {
     "create": "Create",
@@ -120,6 +244,25 @@
     "editError": "Error when editing {resource} (status code: {statusCode})",
     "importProgress": "Importing: {processed}/{total}"
   },
+  "notificationProvider": {
+    "notAllowed": "Not allowed",
+    "missingRequiredParameter": "Missing required Parameter: {parameter}",
+    "noPermission": "You do not have permission to access this resource.",
+    "contactAdministrator": "Please contact your administrator if you believe this is a mistake."
+  },
+  "messages": {
+    "requestSuccessful": "The request was successful {payload}",
+    "requestFailed": "Request Failed",
+    "noSuccessfulResponse": "The request did not receive a successful response.",
+    "requestFailedWithMessage": "The request failed with message: {message}"
+  },
+  "auth": {
+    "loginFailed": "Login failed"
+  },
+  "confirmDialog": {
+    "title": "Are you sure?",
+    "description": "This action cannot be undone."
+  },
   "accessDenied": "Access Denied",
   "imageUploadFailed": "Image upload failed.",
   "loading": "Loading",
@@ -159,6 +302,9 @@
   "menu": {
     "overview": "Overview",
     "help": "Help",
+    "language": "Language",
+    "expandSidebar": "Expand sidebar",
+    "collapseSidebar": "Collapse sidebar",
     "themes": {
       "changeTo": "Change to",
       "dark": "Dark",
@@ -171,18 +317,5 @@
     "description": "CitrineOS collects anonymous usage metrics to help us improve the product. Would you like to send these metrics?",
     "reject": "Reject",
     "accept": "Accept"
-  },
-  "overview": {
-    "activeTransactions": "Active Transactions",
-    "chargerActivity": "Charger Activity",
-    "chargerOnlineStatus": "Charger Online Status",
-    "chargers": "Chargers",
-    "errorLoadingData": "Error loading data",
-    "plugInSuccessRate": "Plug-In Success Rate",
-    "noActiveTransactions": "No active transactions.",
-    "noChargersStatus": "No chargers currently have {status} status.",
-    "viewAllChargers": "View all chargers",
-    "viewAllLocations": "View all locations",
-    "viewAllTransactions": "View all transactions"
   }
 }

--- a/apps/operator-ui/public/locales/en/locations.json
+++ b/apps/operator-ui/public/locales/en/locations.json
@@ -2,6 +2,78 @@
   "Locations": {
     "Locations": "Locations",
     "location": "Location",
-    "noDataFound": "No location found with id {id}."
+    "noDataFound": "No location found with id {id}.",
+    "unnamedLocation": "Unnamed Location",
+    "noAddress": "No address",
+    "chargingStations": "Charging Stations",
+    "openingHours": "Opening Hours",
+    "viewStations": "View Stations",
+    "columns": {
+      "name": "Name",
+      "address": "Address",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "timeZone": "Time Zone",
+      "parkingType": "Parking Type",
+      "facilities": "Facilities",
+      "totalStations": "Total Stations",
+      "createdAt": "Created At",
+      "updatedAt": "Updated At"
+    },
+    "detail": {
+      "totalChargers": "Total Chargers",
+      "imageAlt": "{name} image"
+    },
+    "form": {
+      "name": "Name",
+      "streetAddress": "Street Address",
+      "streetAddressRequired": "Street address is required",
+      "addressAutocompletePlaceholder": "Start typing to search, or enter manually below",
+      "city": "City",
+      "cityPlaceholder": "e.g. Berlin",
+      "stateProvinceRegion": "State / Province / Region",
+      "stateProvinceRegionPlaceholder": "e.g. California, Ontario, Bayern",
+      "postalCode": "Postal Code",
+      "postalCodePlaceholder": "e.g. 94105, SW1A 1AA, 10115",
+      "country": "Country",
+      "selectCountry": "Select country",
+      "searchCountries": "Search countries...",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "autoFilledFromAddress": "Auto-filled from address",
+      "timeZone": "Time Zone",
+      "parkingType": "Parking Type",
+      "selectParkingType": "Select Parking Type",
+      "searchParkingTypes": "Search Parking Types",
+      "facilities": "Facilities",
+      "selectFacilities": "Select Facilities",
+      "searchFacilities": "Search Facilities",
+      "image": "Image",
+      "upload": "Upload",
+      "uploadFailedToast": "Failed to update charging stations on location due to error {error}"
+    },
+    "stations": {
+      "searchChargingStation": "Search Charging Station",
+      "noChargingStationsFound": "No Charging Stations found",
+      "noChargingStationsSelected": "No Charging Stations selected",
+      "stationId": "Station ID",
+      "configuration": "Configuration",
+      "needsConfiguration": "Needs configuration",
+      "modelVendor": "Model / Vendor",
+      "needsModel": "Needs model",
+      "needsVendor": "Needs Vendor"
+    },
+    "map": {
+      "viewDetails": "View Details",
+      "networkOverview": "Network Overview",
+      "all": "All",
+      "locations": "Locations",
+      "stations": "Stations",
+      "viewTypeDetails": "View {type} details",
+      "online": "Online",
+      "partial": "Partial",
+      "offline": "Offline",
+      "noChargers": "No chargers."
+    }
   }
 }

--- a/apps/operator-ui/public/locales/en/overview.json
+++ b/apps/operator-ui/public/locales/en/overview.json
@@ -1,0 +1,24 @@
+{
+  "Overview": {
+    "activeTransactions": "Active Transactions",
+    "chargerActivity": "Charger Activity",
+    "chargerOnlineStatus": "Charger Online Status",
+    "chargers": "Chargers",
+    "errorLoadingData": "Error loading data",
+    "plugInSuccessRate": "Plug-In Success Rate",
+    "noActiveTransactions": "No active transactions.",
+    "noChargersStatus": "No chargers currently have {status} status.",
+    "viewAllChargers": "View all chargers",
+    "viewAllLocations": "View all locations",
+    "viewAllTransactions": "View all transactions",
+    "viewAll": "View all",
+    "faultedChargers": "Faulted Chargers",
+    "somethingWentWrong": "Something went wrong!",
+    "station": "Station",
+    "stationLabel": "Station: {value}",
+    "location": "Location:",
+    "totalKwh": "Total kWh: {value}",
+    "totalTime": "Total Time: {value}",
+    "transactionStatus": "Status: {value}"
+  }
+}

--- a/apps/operator-ui/public/locales/en/tariffs.json
+++ b/apps/operator-ui/public/locales/en/tariffs.json
@@ -2,6 +2,36 @@
   "Tariffs": {
     "Tariffs": "Tariffs",
     "tariff": "Tariff",
-    "noDataFound": "No tariff found with id {id}."
+    "noDataFound": "No tariff found with id {id}.",
+    "columns": {
+      "id": "ID",
+      "currency": "Currency",
+      "pricePerKwh": "Price / kWh",
+      "pricePerMin": "Price / min",
+      "pricePerSession": "Price / session"
+    },
+    "fields": {
+      "currency": "Currency (3-letter code)",
+      "pricePerKwh": "Price per kWh",
+      "pricePerMin": "Price per min",
+      "pricePerSession": "Price per session",
+      "authorizationAmount": "Authorization Amount",
+      "paymentFee": "Payment Fee",
+      "taxRate": "Tax Rate (%)",
+      "tariffAltText": "Tariff Alt Text (JSON)"
+    },
+    "placeholders": {
+      "currency": "e.g. USD",
+      "tariffAltText": "{ \"en\": \"Standard tariff\", \"de\": \"Standardtarif\" }"
+    },
+    "detail": {
+      "currency": "Currency",
+      "pricePerKwh": "Price / kWh",
+      "pricePerMin": "Price / min",
+      "pricePerSession": "Price / session",
+      "authorizationAmount": "Authorization Amount",
+      "paymentFee": "Payment Fee",
+      "taxRate": "Tax Rate (%)"
+    }
   }
 }

--- a/apps/operator-ui/public/locales/en/tenantPartners.json
+++ b/apps/operator-ui/public/locales/en/tenantPartners.json
@@ -2,6 +2,66 @@
   "TenantPartners": {
     "TenantPartners": "Partners",
     "tenantPartner": "Partner",
-    "noDataFound": "No partner found with id {id}."
+    "noDataFound": "No partner found with id {id}.",
+    "unnamedBusiness": "Unnamed Business",
+    "loadingPartnerData": "Loading partner data...",
+    "columns": {
+      "name": "Name",
+      "countryCode": "Country Code",
+      "partyId": "Party ID"
+    },
+    "fields": {
+      "countryCode": "Country Code",
+      "partyId": "Party ID",
+      "versionsUrl": "Versions URL",
+      "clientToken": "Client Token",
+      "ocpiVersion": "OCPI Version",
+      "versionDetailsUrl": "Version Details URL",
+      "serverCredentialsVersionsUrl": "(Server Credentials) Versions URL",
+      "serverCredentialsToken": "(Server Credentials) Token",
+      "roles": "Roles",
+      "role": "Role",
+      "businessName": "Business Name",
+      "website": "Website"
+    },
+    "placeholders": {
+      "selectVersion": "Select Version",
+      "selectRole": "Select Role",
+      "businessName": "Business Name",
+      "website": "Website"
+    },
+    "validation": {
+      "countryCodeLength": "Country Code must be exactly 2 characters.",
+      "partyIdLength": "Party ID must be exactly 3 characters."
+    },
+    "notifications": {
+      "createSuccess": "Partner created successfully",
+      "updateSuccess": "Partner updated successfully",
+      "createError": "Error creating partner: {message}",
+      "updateError": "Error updating partner: {message}"
+    },
+    "detail": {
+      "countryCode": "Country Code",
+      "partyId": "Party ID",
+      "website": "Website",
+      "roles": "Roles",
+      "ocpiVersion": "OCPI Version",
+      "versionsUrl": "Versions URL",
+      "logoAlt": "{name} logo"
+    },
+    "tabs": {
+      "endpoints": "Endpoints"
+    },
+    "endpoints": {
+      "endpoint": "Endpoint",
+      "identifier": "Identifier",
+      "url": "URL",
+      "noEndpointsFound": "No endpoints found",
+      "deleteConfirm": "Are you sure you want to delete this endpoint? This action cannot be undone.",
+      "errorIdentifierRequired": "Please input identifier",
+      "errorUrlRequired": "Please input URL",
+      "placeholderIdentifier": "Enter identifier",
+      "placeholderUrl": "Enter URL"
+    }
   }
 }

--- a/apps/operator-ui/public/locales/en/transactions.json
+++ b/apps/operator-ui/public/locales/en/transactions.json
@@ -5,6 +5,72 @@
     "toggleActiveStatus": "Toggle Active Status",
     "toggleActiveWarning": "You are about to mark this transaction as ",
     "toggleActiveCaution": "Warning: This action may cause the UI to be out of sync with the actual transaction status. Only proceed if you are certain.",
-    "noDataFound": "No transaction found with id {id}."
+    "noDataFound": "No transaction found with id {id}.",
+    "columns": {
+      "transactionId": "Transaction ID",
+      "active": "Active",
+      "stationId": "Station ID",
+      "location": "Location",
+      "idToken": "ID Token",
+      "totalKwh": "Total kWh",
+      "status": "Status",
+      "startTime": "Start Time",
+      "endTime": "End Time",
+      "createdAt": "Created At",
+      "updatedAt": "Updated At"
+    },
+    "detail": {
+      "stationId": "Station ID",
+      "location": "Location",
+      "totalKwh": "Total kWh",
+      "chargingState": "Charging State",
+      "startTime": "Start Time",
+      "endTime": "End Time",
+      "tariff": "Tariff"
+    },
+    "tabs": {
+      "meterValueData": "Meter Value Data",
+      "events": "Events",
+      "ocppMessages": "OCPP Messages",
+      "contexts": "Contexts:",
+      "selectReadingContexts": "Select reading contexts",
+      "searchReadingContexts": "Search reading contexts"
+    },
+    "charts": {
+      "timeElapsed": "Time Elapsed",
+      "stateOfChargeLabel": "State of Charge (%)",
+      "stateOfChargeTitle": "State of Charge Over Time",
+      "noStateOfChargeData": "No State of Charge data available",
+      "energyLabel": "Energy (kWh)",
+      "energyTitle": "Energy Over Time",
+      "noEnergyData": "No Energy data available",
+      "voltageLabel": "Voltage (V)",
+      "voltageTitle": "Voltage Over Time",
+      "noVoltageData": "No Voltage data available",
+      "powerLabel": "Power (kW)",
+      "powerTitle": "Power Over Time",
+      "noPowerData": "No Power data available",
+      "currentLabel": "Current (A)",
+      "currentTitle": "Current Over Time",
+      "noCurrentData": "No Current data available"
+    },
+    "events": {
+      "eventType": "Event Type",
+      "timestamp": "Timestamp",
+      "seqNo": "Seq. #",
+      "triggerReason": "Trigger Reason",
+      "viewMeterValues": "View Meter Values"
+    },
+    "meterValues": {
+      "id": "ID",
+      "timestamp": "Timestamp",
+      "sampleValues": "Sample Values",
+      "value": "Value",
+      "context": "Context",
+      "measurand": "Measurand",
+      "phase": "Phase",
+      "location": "Location",
+      "sampledValue": "Sampled Value {index}"
+    }
   }
 }

--- a/apps/operator-ui/public/locales/pt-BR/authorizations.json
+++ b/apps/operator-ui/public/locales/pt-BR/authorizations.json
@@ -1,0 +1,57 @@
+{
+  "Authorizations": {
+    "Authorizations": "Autorizações",
+    "authorization": "Autorização",
+    "noDataFound": "Nenhuma autorização encontrada com o id {id}.",
+    "noId": "Sem ID",
+    "allowed": "Permitido",
+    "notAllowed": "Não Permitido",
+    "columns": {
+      "authorizationId": "ID da Autorização",
+      "type": "Tipo",
+      "status": "Status",
+      "concurrentTransactions": "Transações Simultâneas",
+      "allowedTypes": "Tipos Permitidos",
+      "disallowedPrefixes": "Prefixos Não Permitidos",
+      "createdAt": "Criado em",
+      "updatedAt": "Atualizado em"
+    },
+    "fields": {
+      "idToken": "idToken",
+      "idTokenType": "Tipo de idToken",
+      "status": "Status",
+      "cacheExpiryDateTime": "Data/Hora de Expiração do Cache",
+      "chargingPriority": "Prioridade de Recarga",
+      "language1": "Idioma 1",
+      "language2": "Idioma 2",
+      "personalMessage": "Mensagem Pessoal",
+      "groupAuthorizationId": "ID da Autorização de Grupo",
+      "allowedConnectorTypes": "Tipos de Conector Permitidos (separados por vírgula)",
+      "disallowedEvseIdPrefixes": "Prefixos de EVSE ID Não Permitidos (separados por vírgula)",
+      "realTimeAuth": "Autenticação em Tempo Real",
+      "realTimeAuthUrl": "URL de Autenticação em Tempo Real",
+      "realTimeAuthTimeout": "Tempo Limite de Autenticação em Tempo Real (segundos)",
+      "concurrentTransaction": "Permitir Transação Simultânea",
+      "additionalInfo": "Informações Adicionais",
+      "additionalIdToken": "idToken Adicional #{index}",
+      "type": "Tipo",
+      "typeNumbered": "Tipo #{index}"
+    },
+    "placeholders": {
+      "selectType": "Selecione o Tipo",
+      "searchTypes": "Buscar Tipos",
+      "selectStatus": "Selecione o Status",
+      "searchStatuses": "Buscar Status",
+      "allowedConnectorTypes": "ex.: Type2, CCS",
+      "disallowedEvseIdPrefixes": "ex.: EVSE1, EVSE2",
+      "selectOption": "Selecione a Opção",
+      "searchOption": "Buscar Opção",
+      "additionalInfo": "Informações Adicionais",
+      "type": "Tipo"
+    },
+    "detail": {
+      "partner": "Parceiro",
+      "realTimeAuthTimeoutSeconds": "{timeout} segundos"
+    }
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/chargingStations.json
+++ b/apps/operator-ui/public/locales/pt-BR/chargingStations.json
@@ -1,0 +1,475 @@
+{
+  "ChargingStations": {
+    "ChargingStations": "Estações de Recarga",
+    "chargingStation": "Estação de Recarga",
+    "use16StatusNotification0": "Usar Notificações de Status OCPP 1.6 com Connector Id 0",
+    "toggleOnlineStatus": "Alternar Status Online",
+    "toggleOnlineWarning": "Você está prestes a marcar esta estação de recarga como ",
+    "toggleOnlineCaution": "Atenção: esta ação pode fazer com que a interface fique dessincronizada do status real da estação. Prossiga apenas se tiver certeza.",
+    "commandsUnavailable": "Estação offline - comandos indisponíveis",
+    "forceDisconnect": "Forçar Desconexão",
+    "otherCommands": "Outros Comandos",
+    "remoteStart": "Partida Remota",
+    "remoteStop": "Parada Remota",
+    "reset": "Reiniciar",
+    "startTransaction": "Iniciar Transação",
+    "stopTransaction": "Encerrar Transação",
+    "forceDisconnectMessage": "Tem certeza de que deseja forçar a desconexão desta estação de recarga",
+    "forceDisconnectCaution": "Isso fechará imediatamente a conexão com a estação.",
+    "exportMessagesToCsvHeader": "Exportar Mensagens OCPP para CSV",
+    "downloadAllMessagesToCsv": "Você baixará todas as mensagens OCPP deste carregador.",
+    "downloadMessagesToCsvWithFilters": "Você baixará as mensagens OCPP deste carregador com os seguintes filtros:",
+    "liveLog": "Log ao vivo",
+    "liveLogDisabledInactivity": "Log ao vivo desativado por inatividade",
+    "refreshMessages": "Atualizar Mensagens",
+    "noDataFound": "Nenhuma estação de recarga encontrada com o id {id}.",
+    "unsupportedProtocol": "Versão de protocolo não suportada: {protocol}",
+    "fieldRequired": "{field} é obrigatório",
+    "exportToCsvError": "Não foi possível exportar para CSV devido a um erro: {error}",
+    "detailCard": {
+      "lastOcppMessage": "Última Mensagem OCPP",
+      "connectorTypes": "Tipos de Conector",
+      "totalEvses": "Total de EVSEs"
+    },
+    "tabs": {
+      "evses": "EVSEs",
+      "ocppMessages": "Mensagens OCPP",
+      "configuration": "Configuração",
+      "aggregatedMeterValuesData": "Dados Agregados de Medição",
+      "noEvsesPermission": "Você não tem permissão para visualizar EVSEs.",
+      "noOcppLogsPermission": "Você não tem permissão para visualizar os logs OCPP.",
+      "noConfigurationsPermission": "Você não tem permissão para visualizar as configurações da estação."
+    },
+    "columns": {
+      "name": "Nome",
+      "stationId": "ID da Estação",
+      "location": "Local",
+      "onlineStatus": "Status online",
+      "protocol": "Protocolo",
+      "vendorModel": "Fabricante / Modelo",
+      "vendor": "Fabricante",
+      "floorLevel": "Andar",
+      "parkingRestrictions": "Restrições de Estacionamento",
+      "capabilities": "Capacidades",
+      "firmwareVersion": "Versão do Firmware",
+      "createdAt": "Criado em",
+      "updatedAt": "Atualizado em"
+    },
+    "aggregatedData": {
+      "timeRange": "Intervalo de Tempo:",
+      "contexts": "Contextos:",
+      "selectReadingContexts": "Selecione os contextos de leitura"
+    },
+    "connectors": {
+      "connectorId": "ID do Conector",
+      "connectorIdDescription": "Os inteiros seriais começando em 1 usados no OCPP 1.6 para referenciar o conector, únicos por Estação de Recarga.",
+      "evseTypeConnectorId": "ID do Conector do Tipo EVSE",
+      "evseTypeConnectorIdDescription": "Os inteiros seriais começando em 1 usados no OCPP 2.0.1 para referenciar o conector, únicos por EVSE.",
+      "type": "Tipo",
+      "format": "Formato",
+      "powerType": "Tipo de Potência",
+      "maxPower": "Potência Máxima",
+      "maximumAmperage": "Amperagem Máxima",
+      "maximumVoltage": "Tensão Máxima",
+      "maximumPowerWatts": "Potência Máxima em Watts",
+      "termsAndConditionsUrl": "URL dos Termos e Condições",
+      "tariff": "Tarifa",
+      "selectType": "Selecionar Tipo",
+      "searchTypes": "Pesquisar Tipos",
+      "selectFormat": "Selecionar Formato",
+      "selectPowerType": "Selecionar Tipo de Potência",
+      "searchPowerTypes": "Pesquisar Tipos de Potência",
+      "selectTariff": "Selecionar Tarifa",
+      "searchTariffs": "Pesquisar Tarifas",
+      "noConnectors": "Nenhum conector",
+      "addConnector": "Adicionar Conector",
+      "addNewConnector": "Adicionar Novo Conector",
+      "editConnector": "Editar Conector"
+    },
+    "evses": {
+      "evseTypeId": "ID do Tipo EVSE",
+      "evseTypeIdDescription": "Os inteiros seriais usados no OCPP 2.0.1 para referenciar o EVSE, únicos por Estação de Recarga.",
+      "evseId": "ID do EVSE",
+      "evseIdDescription": "O EVSE ID compatível com eMI3, que deve ser globalmente único.",
+      "physicalReference": "Referência Física",
+      "physicalReferenceDescription": "Qualquer identificador impresso no EVSE usado para identificá-lo fisicamente no local, por exemplo, um número ou uma letra.",
+      "removed": "Removido",
+      "removedDescription": "Marcado como REMOVIDO",
+      "noEvses": "Nenhum EVSE",
+      "viewConnectors": "Ver Conectores",
+      "addNewEvse": "Adicionar Novo EVSE",
+      "editEvse": "Editar EVSE"
+    },
+    "evseSelector": {
+      "label": "EVSE",
+      "loading": "Carregando EVSEs...",
+      "searchPlaceholder": "Pesquisar EVSE",
+      "description": "IDs de EVSE são inteiros seriais começando em 1"
+    },
+    "connectorSelector": {
+      "label": "Conector",
+      "loading": "Carregando Conectores...",
+      "searchPlaceholder": "Pesquisar Conectores",
+      "selectConnector": "Selecionar Conector",
+      "selectEvse": "Selecione um EVSE",
+      "description": "IDs de conector são inteiros seriais começando em 1",
+      "descriptionForEvse": "Conectores do EVSE selecionado"
+    },
+    "requestId": {
+      "label": "ID da Requisição",
+      "placeholder": "Insira o ID da requisição",
+      "positiveError": "O ID da requisição deve ser um número positivo"
+    },
+    "firmwareDiagnostics": {
+      "locationUrl": "Localização (URL)",
+      "invalidUrl": "Deve ser uma URL válida",
+      "locationRequired": "A localização é obrigatória",
+      "retries": "Tentativas",
+      "retriesPlaceholder": "Número de tentativas",
+      "retryInterval": "Intervalo entre Tentativas",
+      "retryIntervalPlaceholder": "Intervalo entre tentativas em segundos"
+    },
+    "commands": {
+      "certificateSigned": "Certificado Assinado",
+      "changeAvailability": "Alterar Disponibilidade",
+      "changeConfiguration": "Alterar Configuração",
+      "clearCache": "Limpar Cache",
+      "customerInformation": "Informações do Cliente",
+      "dataTransfer": "Transferência de Dados",
+      "deleteCertificate": "Excluir Certificado",
+      "deleteStationNetworkProfiles": "Excluir Perfis de Rede da Estação",
+      "getBaseReport": "Obter Relatório Base",
+      "getConfiguration": "Obter Configuração",
+      "getDiagnostics": "Obter Diagnósticos",
+      "getInstalledCertificateIds": "Obter IDs de Certificados Instalados",
+      "getLogs": "Obter Logs",
+      "getTransactionStatus": "Obter Status da Transação",
+      "getVariables": "Obter Variáveis",
+      "installCertificate": "Instalar Certificado",
+      "setNetworkProfile": "Definir Perfil de Rede",
+      "setVariables": "Definir Variáveis",
+      "triggerMessage": "Disparar Mensagem",
+      "unlockConnector": "Desbloquear Conector",
+      "updateAuthPassword": "Atualizar Senha de Autenticação",
+      "updateFirmware": "Atualizar Firmware"
+    },
+    "resetModal": {
+      "resetType": "Tipo de Reinício",
+      "selectResetType": "Selecionar Tipo de Reinício",
+      "selectResetTypeError": "Selecione um tipo de reinício"
+    },
+    "remoteStartModal": {
+      "start": "Iniciar",
+      "remoteStartId": "ID da Partida Remota",
+      "remoteStartIdMin": "O ID da Partida Remota deve ser no mínimo 0",
+      "idToken": "ID Token",
+      "idTokenRequired": "O ID Token é obrigatório",
+      "searchIdToken": "Pesquisar ID Token",
+      "authorization": "Autorização",
+      "authorizationRequired": "A autorização é obrigatória",
+      "selectAuthorization": "Selecionar Autorização",
+      "searchAuthorizations": "Pesquisar Autorizações"
+    },
+    "remoteStopModal": {
+      "stop": "Parar",
+      "transactionRequired": "A transação é obrigatória",
+      "noActiveTransactions": "Nenhuma transação ativa encontrada para esta estação de recarga.",
+      "activeTransactions": "Transações Ativas",
+      "selectTransaction": "Selecionar Transação",
+      "searchTransactions": "Pesquisar Transações",
+      "unknownEvse": "Desconhecido"
+    },
+    "dataTransferModal": {
+      "vendorId": "ID do Fabricante",
+      "vendorIdRequired": "O ID do Fabricante é obrigatório",
+      "vendorIdPlaceholder": "Identificador específico da implementação do fabricante",
+      "messageId": "ID da Mensagem",
+      "messageIdPlaceholder": "Identificador específico de mensagem ou implementação",
+      "data": "Dados",
+      "dataPlaceholder": "Dados a enviar (texto livre)"
+    },
+    "changeAvailabilityModal": {
+      "availability": "Disponibilidade",
+      "selectAvailabilityError": "Selecione um tipo de disponibilidade",
+      "connectorRequired": "O conector é obrigatório",
+      "operationalStatus": "Status Operacional",
+      "selectStatus": "Selecionar Status",
+      "selectStatusError": "Selecione um status operacional"
+    },
+    "changeConfigurationModal": {
+      "key": "Chave",
+      "keyRequired": "A chave é obrigatória",
+      "keyPlaceholder": "Chave de configuração",
+      "value": "Valor",
+      "valueRequired": "O valor é obrigatório",
+      "valuePlaceholder": "Valor de configuração"
+    },
+    "getConfigurationModal": {
+      "description": "Opcionalmente, especifique chaves de configuração para recuperar. Deixe em branco para obter todos os valores de configuração.",
+      "key": "Chave",
+      "keyNumber": "Chave #{number}",
+      "keyPlaceholder": "Insira a chave de configuração"
+    },
+    "getDiagnosticsModal": {
+      "startTimestamp": "Data/Hora Inicial",
+      "stopTimestamp": "Data/Hora Final"
+    },
+    "triggerMessageModal": {
+      "requestedMessage": "Mensagem Solicitada",
+      "selectMessage": "Selecionar Mensagem",
+      "selectMessageError": "Selecione um tipo de mensagem",
+      "selectMessageType": "Selecionar Tipo de Mensagem",
+      "searchMessageTypes": "Pesquisar Tipos de Mensagem"
+    },
+    "updateFirmwareModal": {
+      "retrieveDate": "Data de Recuperação",
+      "retrieveDateRequired": "A data de recuperação é obrigatória",
+      "retrieveDateTime": "Data/Hora de Recuperação",
+      "installDateTime": "Data/Hora de Instalação",
+      "signingCertificate": "Certificado de Assinatura (PEM)",
+      "signingCertificatePlaceholder": "Cole aqui o certificado no formato PEM",
+      "signature": "Assinatura",
+      "signaturePlaceholder": "Assinatura do firmware"
+    },
+    "certificateSignedModal": {
+      "certificateFile": "Arquivo de Certificado",
+      "certificateRequired": "O arquivo de certificado é obrigatório",
+      "fileTypeError": "O arquivo deve ser um dos seguintes: {types}",
+      "fileSizeError": "O tamanho do arquivo deve ser menor que 5MB",
+      "certificateType": "Tipo de Certificado",
+      "selectCertificateType": "Selecionar Tipo de Certificado"
+    },
+    "clearCacheModal": {
+      "description": "Isso enviará uma requisição de Limpar Cache para a estação de recarga. A estação limpará seu cache de autorização.",
+      "proceed": "Deseja prosseguir?",
+      "clearing": "Limpando..."
+    },
+    "customerInformationModal": {
+      "report": "Relatório",
+      "clear": "Limpar",
+      "customerIdentifier": "Identificador do Cliente",
+      "customerIdentifierPlaceholder": "Insira o identificador do cliente"
+    },
+    "deleteCertificateModal": {
+      "certificateRequired": "O certificado é obrigatório",
+      "selectCertificateError": "Selecione um certificado",
+      "wrongStationError": "Este certificado não pertence a esta estação",
+      "hashAlgorithm": "Algoritmo de Hash:",
+      "installedCertificate": "Certificado Instalado",
+      "searchCertificates": "Pesquisar Certificados por Número de Série"
+    },
+    "deleteStationNetworkProfilesModal": {
+      "slotsRequired": "Pelo menos um slot de configuração é obrigatório",
+      "deleteProfiles": "Excluir Perfis",
+      "slot": "Slot",
+      "slotNumber": "Slot #{number}",
+      "slotPlaceholder": "Insira o número do slot"
+    },
+    "getBaseReportModal": {
+      "reportBase": "Base do Relatório",
+      "reportBaseRequired": "A Base do Relatório é obrigatória",
+      "selectReportBase": "Selecionar Base do Relatório"
+    },
+    "getInstalledCertificateIdsModal": {
+      "certificateTypes": "Tipos de Certificado",
+      "description": "Quando os tipos de certificado são omitidos, todos os tipos de certificado são solicitados.",
+      "selectCertificateTypes": "Selecionar Tipos de Certificado",
+      "searchCertificateTypes": "Pesquisar Tipos de Certificado"
+    },
+    "getLogsModal": {
+      "remoteLocationUrl": "Localização Remota (URL)",
+      "remoteLocationRequired": "A Localização Remota é obrigatória",
+      "logType": "Tipo de Log",
+      "logTypeRequired": "O Tipo de Log é obrigatório",
+      "selectLogType": "Selecionar Tipo de Log",
+      "oldestTimestamp": "Data/Hora Mais Antiga",
+      "latestTimestamp": "Data/Hora Mais Recente"
+    },
+    "getTransactionStatusModal": {
+      "transaction": "Transação",
+      "description": "Opcionalmente, selecione uma transação para obter seu status. Deixe em branco para obter o status de todas as transações."
+    },
+    "getVariablesModal": {
+      "alert": "Envie um GetBaseReport para esta Estação de Recarga para preencher Componentes e Variáveis.",
+      "atLeastOneVariable": "Pelo menos uma variável é obrigatória",
+      "componentAndVariableRequired": "Componente e Variável são obrigatórios para cada entrada",
+      "component": "Componente",
+      "variable": "Variável",
+      "componentNumber": "Componente #{number}",
+      "variableNumber": "Variável #{number}",
+      "componentInstanceNumber": "Instância do Componente #{number}",
+      "variableInstanceNumber": "Instância da Variável #{number}",
+      "attributeTypeNumber": "Tipo de Atributo #{number}",
+      "instance": "Instância",
+      "selectComponent": "Selecionar Componente",
+      "searchComponents": "Pesquisar Componentes",
+      "selectVariable": "Selecionar Variável",
+      "searchVariables": "Pesquisar Variáveis",
+      "selectAttributeType": "Selecionar Tipo de Atributo"
+    },
+    "setVariablesModal": {
+      "valueRequired": "O valor é obrigatório",
+      "allFieldsRequired": "Componente, Variável e Valor são obrigatórios para cada entrada",
+      "valueNumber": "Valor #{number}",
+      "valuePlaceholder": "Valor a Definir"
+    },
+    "installCertificateModal": {
+      "certificateRequired": "O certificado é obrigatório",
+      "certificateTooLong": "O certificado deve ter menos de 5500 caracteres",
+      "certificateTypeRequired": "O Tipo de Certificado é obrigatório",
+      "invalidPem": "Certificado PEM com formato incorreto",
+      "certificatePem": "Certificado (PEM)"
+    },
+    "setNetworkProfileModal": {
+      "apnRequired": "O APN é obrigatório",
+      "apnAuthRequired": "A Autenticação APN é obrigatória",
+      "serverRequired": "O servidor é obrigatório",
+      "userRequired": "O usuário é obrigatório",
+      "passwordRequired": "A senha é obrigatória",
+      "keyRequired": "A chave é obrigatória",
+      "vpnTypeRequired": "O Tipo de VPN é obrigatório",
+      "ocppVersionRequired": "A Versão OCPP é obrigatória",
+      "ocppTransportRequired": "O Transporte OCPP é obrigatório",
+      "csmsUrlRequired": "A URL do CSMS é obrigatória",
+      "messageTimeoutPositive": "O tempo limite da mensagem deve ser positivo",
+      "securityProfilePositive": "O perfil de segurança deve ser positivo",
+      "ocppInterfaceRequired": "A Interface OCPP é obrigatória",
+      "configurationSlotNonNegative": "O slot de configuração deve ser não-negativo",
+      "websocketServerConfig": "Configuração do Servidor Websocket",
+      "searchServerProfiles": "Pesquisar Perfis de Rede do Servidor",
+      "configurationSlot": "Slot de Configuração",
+      "ocppVersion": "Versão OCPP",
+      "selectOcppVersion": "Selecionar Versão OCPP",
+      "ocppTransport": "Transporte OCPP",
+      "selectOcppTransport": "Selecionar Transporte OCPP",
+      "ocppCsmsUrl": "URL do CSMS OCPP",
+      "messageTimeout": "Tempo Limite da Mensagem (segundos)",
+      "securityProfile": "Perfil de Segurança",
+      "ocppInterface": "Interface OCPP",
+      "selectOcppInterface": "Selecionar Interface OCPP",
+      "includeApn": "Incluir Configuração de APN",
+      "includeVpn": "Incluir Configuração de VPN",
+      "apn": "APN",
+      "apnPlaceholder": "Nome do APN",
+      "apnAuthentication": "Autenticação APN",
+      "selectAuthType": "Selecionar Tipo de Autenticação",
+      "apnUsername": "Usuário do APN",
+      "apnPassword": "Senha do APN",
+      "simPin": "PIN do SIM",
+      "preferredNetwork": "Rede Preferencial",
+      "useOnlyPreferredNetwork": "Usar Apenas Rede Preferencial",
+      "vpnType": "Tipo de VPN",
+      "selectVpnType": "Selecionar Tipo de VPN",
+      "server": "Servidor",
+      "serverPlaceholder": "Servidor VPN",
+      "user": "Usuário",
+      "userPlaceholder": "Usuário da VPN",
+      "group": "Grupo",
+      "password": "Senha",
+      "passwordPlaceholder": "Senha da VPN",
+      "key": "Chave",
+      "keyPlaceholder": "Chave da VPN"
+    },
+    "updateAuthPasswordModal": {
+      "passwordRequired": "A senha é obrigatória",
+      "updatePassword": "Atualizar Senha",
+      "password": "Senha",
+      "passwordPlaceholder": "Insira a nova senha",
+      "setOnCharger": "Definir no Carregador"
+    },
+    "upsert": {
+      "selectLocation": "Selecionar Local",
+      "selectParkingRestrictions": "Selecionar Restrições de Estacionamento",
+      "searchParkingRestrictions": "Pesquisar Restrições de Estacionamento",
+      "selectCapabilities": "Selecionar Capacidades",
+      "searchCapabilities": "Pesquisar Capacidades",
+      "useLocationCoordinates": "Usar Coordenadas do Local",
+      "latitude": "Latitude",
+      "enterLatitude": "Insira a latitude",
+      "longitude": "Longitude",
+      "enterLongitude": "Insira a longitude",
+      "image": "Imagem"
+    },
+    "ocppMessages": {
+      "searchCorrelationId": "Pesquisar Correlation ID",
+      "selectActions": "Selecionar Ações",
+      "searchActions": "Pesquisar Ações",
+      "filterOrigins": "Filtrar Origens",
+      "allOrigins": "Todas as Origens",
+      "pickStartDate": "Escolher Data Inicial",
+      "pickEndDate": "Escolher Data Final",
+      "correlationId": "Correlation ID",
+      "actionOrigin": "Ação - Origem",
+      "unknownAction": "Ação Desconhecida",
+      "timestamp": "Data/Hora",
+      "content": "Conteúdo",
+      "findRelatedMessage": "Encontrar mensagem relacionada",
+      "copyCorrelationId": "Copiar Correlation ID"
+    },
+    "configuration": {
+      "key": "Chave",
+      "value": "Valor",
+      "type": "Tipo",
+      "componentNameInstance": "Nome do Componente:Instância",
+      "variableNameInstance": "Nome da Variável:Instância",
+      "evseConnectorId": "ID do EVSE:ID do Conector",
+      "stationId": "ID da Estação",
+      "action": "Ação",
+      "noData": "Sem dados",
+      "noDataForDownload": "Nenhum dado disponível para download",
+      "loadAttributesError": "Falha ao carregar atributos de variável",
+      "loadConfigurationsError": "Falha ao carregar alterações de configuração",
+      "selectOcppVersion": "Selecionar Versão OCPP",
+      "downloadCsv": "Baixar CSV",
+      "searchPlaceholder": "Pesquisar...",
+      "addConfiguration": "Adicionar Configuração",
+      "editConfiguration": "Editar Configuração"
+    },
+    "connectionModal": {
+      "welcomeTitle": "Bem-vindo à Operator UI do CitrineOS",
+      "connectionTitle": "Conexão da Estação de Recarga",
+      "welcomeDescription": "Assista a este vídeo rápido de introdução para aprender como conectar estações de recarga. Você pode acessar estas informações a qualquer momento clicando no botão Ajuda.",
+      "connectionDescription": "Use as seguintes URLs de websocket específicas do tenant para conectar-se ao servidor. A conexão pode ser atualizada de Sem Autenticação até o Perfil de Segurança 3, uma de cada vez.",
+      "showConnectionInfo": "Mostrar Informações de Conexão",
+      "showHelpVideo": "Mostrar Vídeo de Ajuda",
+      "gettingStartedVideo": "Vídeo de Introdução",
+      "videoNotSupported": "Seu navegador não suporta a tag de vídeo.",
+      "noVideoAvailable": "Nenhum vídeo disponível",
+      "videoDescription": "Este vídeo demonstra como conectar estações de recarga à plataforma CitrineOS.",
+      "quickSteps": "Passos Rápidos",
+      "step1": "Configure sua estação de recarga com a URL de websocket apropriada",
+      "step2": "Escolha o perfil de segurança que corresponde à sua configuração",
+      "step3": "Copie a URL de conexão da seção de informações de conexão",
+      "step4": "Teste a conexão a partir da sua estação de recarga",
+      "rememberLabel": "Lembre-se:",
+      "rememberText": "Você sempre pode acessar este conteúdo de ajuda clicando no botão Ajuda na barra lateral.",
+      "copied": "Copiado!",
+      "noWebsocketServers": "Nenhum servidor de websocket disponível.",
+      "securityProfiles": {
+        "0": {
+          "label": "Sem Autenticação",
+          "description": "A estação de recarga conecta-se sem credenciais. Configure o usuário/senha usando esta conexão"
+        },
+        "1": {
+          "label": "Perfil de Segurança 1: Transporte Não Seguro com Autenticação Básica",
+          "description": "A autenticação da Estação de Recarga é feita por meio de usuário e senha. Instale o certificado CA na estação de recarga usando esta conexão"
+        },
+        "2": {
+          "label": "Perfil de Segurança 2: TLS com Autenticação Básica",
+          "description": "O CSMS autentica-se usando um certificado de servidor TLS. As Estações de Recarga autenticam-se usando Autenticação HTTP Básica. Assine o certificado da estação de recarga usando esta conexão"
+        },
+        "3": {
+          "label": "Perfil de Segurança 3: TLS com Certificados do Lado do Cliente",
+          "description": "Tanto a Estação de Recarga quanto o CSMS autenticam-se usando certificados."
+        }
+      }
+    },
+    "exportDialog": {
+      "correlationId": "ID de Correlação",
+      "actions": "Ações",
+      "origin": "Origem",
+      "startDate": "Data Inicial",
+      "endDate": "Data Final"
+    }
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/common.json
+++ b/apps/operator-ui/public/locales/pt-BR/common.json
@@ -1,0 +1,321 @@
+{
+  "Common": {
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "delete": "Excluir",
+    "create": "Criar",
+    "edit": "Editar",
+    "clear": "Limpar",
+    "search": "Buscar",
+    "searchOptions": "Buscar Opções",
+    "searchColumns": "Buscar Colunas",
+    "export": "Exportar",
+    "refresh": "Atualizar",
+    "close": "Fechar",
+    "confirm": "Confirmar",
+    "back": "Voltar",
+    "add": "Adicionar",
+    "remove": "Remover",
+    "ok": "OK",
+    "submit": "Enviar",
+    "apply": "Aplicar",
+    "reset": "Redefinir",
+    "loading": "Carregando",
+    "loadingEllipsis": "Carregando...",
+    "yes": "Sim",
+    "no": "Não",
+    "actions": "Ações",
+    "status": "Status",
+    "online": "Online",
+    "offline": "Offline",
+    "active": "Ativo",
+    "inactive": "Inativo",
+    "unknown": "Desconhecido",
+    "time": "Hora",
+    "copiedToClipboard": "Copiado para a área de transferência.",
+    "copiedValueToClipboard": "{value} copiado para a área de transferência.",
+    "enabled": "Habilitado",
+    "disabled": "Desabilitado",
+    "noResults": "Nenhum resultado encontrado",
+    "noDataFound": "Nenhum Dado Encontrado",
+    "nothingFound": "Nada encontrado.",
+    "error": "Erro",
+    "success": "Sucesso",
+    "select": "Selecionar",
+    "selectItem": "Selecionar Item",
+    "selectOption": "Selecione uma opção",
+    "selectOptions": "Selecione opções...",
+    "selected": "selecionado(s)",
+    "openMenu": "Abrir menu",
+    "filters": "Filtros",
+    "activeFilters": "Filtros ativos",
+    "addFilter": "Adicionar um filtro",
+    "addFilterButton": "Adicionar filtro",
+    "clearAll": "Limpar tudo",
+    "searchField": "Buscar {field}…",
+    "atMost": "no máximo {value}",
+    "after": "após {value}",
+    "rowsSelected": "{selected} de {total} linha(s) selecionada(s).",
+    "pageOf": "Página {page} de {total}",
+    "pickDateRange": "Selecione um período",
+    "startTypingAddress": "Comece a digitar um endereço...",
+    "useValue": "Usar \"{value}\"",
+    "removeFilter": "Remover filtro: {field}"
+  },
+  "filters": {
+    "valueOrLess": "{unit} ou menos",
+    "previewText": "\"{label}\" contém \"{value}\"",
+    "previewNumber": "\"{label}\" é no máximo {value}",
+    "previewDate": "\"{label}\" em {preset}",
+    "previewEnum": "\"{label}\" é {value}",
+    "previewYes": "\"{label}\" é Sim",
+    "previewNo": "\"{label}\" é Não"
+  },
+  "filterPresets": {
+    "today": "Hoje",
+    "last7Days": "Últimos 7 dias",
+    "last30Days": "Últimos 30 dias",
+    "last3Months": "Últimos 3 meses",
+    "thisYear": "Este ano"
+  },
+  "openingHours": {
+    "title": "Horário de Funcionamento",
+    "twentyFourSeven": "Funcionamento 24/7",
+    "twentyFourSevenDescription": "Este local está aberto 24 horas por dia, 7 dias por semana",
+    "regularHours": "Horário Regular",
+    "noRegularHours": "Nenhum horário regular especificado",
+    "exceptionalOpenings": "Aberturas Excepcionais",
+    "exceptionalClosings": "Fechamentos Excepcionais",
+    "specialOpening": "Abertura Especial",
+    "closed": "Fechado",
+    "form": {
+      "addHours": "Adicionar Horário",
+      "addOpening": "Adicionar Abertura",
+      "addClosing": "Adicionar Fechamento",
+      "selectDay": "Selecione o dia",
+      "exceptionalOpeningsDescription": "Datas especiais em que o local está aberto",
+      "exceptionalClosingsDescription": "Datas especiais em que o local está fechado",
+      "removeTimeSlot": "Remover faixa de horário?",
+      "removeTimeSlotConfirm": "Tem certeza de que deseja remover esta faixa de horário?",
+      "removeOpening": "Remover abertura excepcional?",
+      "removeOpeningConfirm": "Tem certeza de que deseja remover esta abertura excepcional?",
+      "removeClosing": "Remover fechamento excepcional?",
+      "removeClosingConfirm": "Tem certeza de que deseja remover este fechamento excepcional?"
+    },
+    "weekdays": {
+      "monday": "Segunda-feira",
+      "tuesday": "Terça-feira",
+      "wednesday": "Quarta-feira",
+      "thursday": "Quinta-feira",
+      "friday": "Sexta-feira",
+      "saturday": "Sábado",
+      "sunday": "Domingo"
+    }
+  },
+  "pages": {
+    "login": {
+      "title": "Entre na sua conta",
+      "description": "Insira suas credenciais para acessar o painel",
+      "signin": "Entrar",
+      "signingIn": "Entrando...",
+      "signup": "Cadastrar-se",
+      "divider": "ou",
+      "invalidCredentials": "E-mail ou senha inválidos",
+      "fields": {
+        "email": "E-mail",
+        "password": "Senha"
+      },
+      "placeholders": {
+        "email": "admin@exemplo.com",
+        "password": "Digite sua senha"
+      },
+      "errors": {
+        "validEmail": "Endereço de e-mail inválido",
+        "requiredEmail": "O e-mail é obrigatório",
+        "requiredPassword": "A senha é obrigatória"
+      },
+      "buttons": {
+        "submit": "Entrar",
+        "forgotPassword": "Esqueceu a senha?",
+        "noAccount": "Não tem uma conta?",
+        "rememberMe": "Lembrar de mim"
+      }
+    },
+    "forgotPassword": {
+      "title": "Esqueceu sua senha?",
+      "fields": {
+        "email": "E-mail"
+      },
+      "errors": {
+        "validEmail": "Endereço de e-mail inválido",
+        "requiredEmail": "O e-mail é obrigatório"
+      },
+      "buttons": {
+        "submit": "Enviar instruções de redefinição"
+      }
+    },
+    "register": {
+      "title": "Cadastre-se na sua conta",
+      "fields": {
+        "email": "E-mail",
+        "password": "Senha"
+      },
+      "errors": {
+        "validEmail": "Endereço de e-mail inválido",
+        "requiredEmail": "O e-mail é obrigatório",
+        "requiredPassword": "A senha é obrigatória"
+      },
+      "buttons": {
+        "submit": "Cadastrar",
+        "haveAccount": "Já tem uma conta?"
+      }
+    },
+    "updatePassword": {
+      "title": "Atualizar senha",
+      "fields": {
+        "password": "Nova Senha",
+        "confirmPassword": "Confirmar nova senha"
+      },
+      "errors": {
+        "confirmPasswordNotMatch": "As senhas não coincidem",
+        "requiredPassword": "Senha obrigatória",
+        "requiredConfirmPassword": "A confirmação de senha é obrigatória"
+      },
+      "buttons": {
+        "submit": "Atualizar"
+      }
+    },
+    "error": {
+      "info": "Talvez você tenha esquecido de adicionar o componente {action} ao recurso {resource}.",
+      "title": "Página não encontrada.",
+      "description": "A página que você está procurando não existe.",
+      "404": "Desculpe, a página que você visitou não existe.",
+      "resource404": "Tem certeza de que criou o recurso {resource}.",
+      "backHome": "Voltar à página inicial"
+    },
+    "redirectingToLogin": "Redirecionando para o login...",
+    "checkingAuth": "Verificando autenticação...",
+    "redirectingToKeycloak": "Redirecionando para o Keycloak...",
+    "redirectingToKeycloakLogin": "Redirecionando para o login do Keycloak..."
+  },
+  "actions": {
+    "create": "Criar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "list": "Listar",
+    "show": "Exibir"
+  },
+  "buttons": {
+    "add": "Adicionar",
+    "cancel": "Cancelar",
+    "clear": "Limpar",
+    "clone": "Clonar",
+    "columns": "Colunas",
+    "confirm": "Tem certeza?",
+    "confirmText": "Confirmar",
+    "create": "Criar",
+    "delete": "Excluir",
+    "download": "Baixar",
+    "edit": "Editar",
+    "exportToCsv": "Exportar para CSV",
+    "filter": "Filtrar",
+    "import": "Importar",
+    "logout": "Sair",
+    "notAccessTitle": "Você não tem permissão para acessar este recurso.",
+    "ok": "OK",
+    "refresh": "Atualizar",
+    "save": "Salvar",
+    "saving": "Salvando...",
+    "show": "Exibir",
+    "submit": "Enviar",
+    "undo": "Desfazer",
+    "upload": "Enviar"
+  },
+  "warnWhenUnsavedChanges": "Tem certeza de que deseja sair? Você tem alterações não salvas.",
+  "notifications": {
+    "success": "Sucesso",
+    "error": "Erro (código de status: {statusCode})",
+    "undoable": "Você tem {seconds} segundos para desfazer",
+    "createSuccess": "{resource} criado com sucesso",
+    "createError": "Houve um erro ao criar {resource} (código de status: {statusCode})",
+    "deleteSuccess": "{resource} excluído com sucesso",
+    "deleteError": "Erro ao excluir {resource} (código de status: {statusCode})",
+    "editSuccess": "{resource} editado com sucesso",
+    "editError": "Erro ao editar {resource} (código de status: {statusCode})",
+    "importProgress": "Importando: {processed}/{total}"
+  },
+  "notificationProvider": {
+    "notAllowed": "Não permitido",
+    "missingRequiredParameter": "Parâmetro obrigatório ausente: {parameter}",
+    "noPermission": "Você não tem permissão para acessar este recurso.",
+    "contactAdministrator": "Entre em contato com seu administrador se acreditar que isso é um engano."
+  },
+  "messages": {
+    "requestSuccessful": "A requisição foi bem-sucedida {payload}",
+    "requestFailed": "Falha na Requisição",
+    "noSuccessfulResponse": "A requisição não recebeu uma resposta bem-sucedida.",
+    "requestFailedWithMessage": "A requisição falhou com a mensagem: {message}"
+  },
+  "auth": {
+    "loginFailed": "Falha no login"
+  },
+  "confirmDialog": {
+    "title": "Tem certeza?",
+    "description": "Esta ação não pode ser desfeita."
+  },
+  "accessDenied": "Acesso Negado",
+  "imageUploadFailed": "Falha ao enviar a imagem.",
+  "loading": "Carregando",
+  "noDataFound": "Nenhum Dado Encontrado",
+  "somethingWentWrong": "Algo deu errado.",
+  "loggedOut": "Sessão encerrada! Redirecionando para o login...",
+  "tags": {
+    "clone": "Clonar"
+  },
+  "table": {
+    "actions": "Ações",
+    "bulkActions": "Ações em Massa",
+    "clearFilters": "Limpar filtros",
+    "noResultsFound": "Nenhum resultado encontrado",
+    "selectAll": "Selecionar todos",
+    "selected": "selecionado(s)",
+    "toggleColumns": "Alternar colunas",
+    "resetColumns": "Redefinir Colunas"
+  },
+  "dialogs": {
+    "areYouSure": "Tem certeza?",
+    "thisActionCannotBeUndone": "Esta ação não pode ser desfeita."
+  },
+  "placeholders": {
+    "search": "Buscar",
+    "select": "Selecionar"
+  },
+  "pagination": {
+    "buttons": {
+      "goToFirstPage": "Ir para a primeira página",
+      "goToNextPage": "Ir para a próxima página",
+      "goToPreviousPage": "Ir para a página anterior",
+      "goToLastPage": "Ir para a última página"
+    },
+    "rowsPerPage": "Linhas por página"
+  },
+  "menu": {
+    "overview": "Visão Geral",
+    "help": "Ajuda",
+    "language": "Idioma",
+    "expandSidebar": "Expandir barra lateral",
+    "collapseSidebar": "Recolher barra lateral",
+    "themes": {
+      "changeTo": "Mudar para",
+      "dark": "Escuro",
+      "light": "Claro",
+      "mode": "Modo"
+    }
+  },
+  "telemetryConsentModal": {
+    "title": "Consentimento de Métricas Anônimas",
+    "description": "O CitrineOS coleta métricas de uso anônimas para nos ajudar a melhorar o produto. Você gostaria de enviar essas métricas?",
+    "reject": "Recusar",
+    "accept": "Aceitar"
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/locations.json
+++ b/apps/operator-ui/public/locales/pt-BR/locations.json
@@ -1,0 +1,79 @@
+{
+  "Locations": {
+    "Locations": "Locais",
+    "location": "Local",
+    "noDataFound": "Nenhum local encontrado com o id {id}.",
+    "unnamedLocation": "Local sem nome",
+    "noAddress": "Sem endereço",
+    "chargingStations": "Estações de recarga",
+    "openingHours": "Horário de funcionamento",
+    "viewStations": "Ver estações",
+    "columns": {
+      "name": "Nome",
+      "address": "Endereço",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "timeZone": "Fuso horário",
+      "parkingType": "Tipo de estacionamento",
+      "facilities": "Comodidades",
+      "totalStations": "Total de estações",
+      "createdAt": "Criado em",
+      "updatedAt": "Atualizado em"
+    },
+    "detail": {
+      "totalChargers": "Total de carregadores",
+      "imageAlt": "Imagem de {name}"
+    },
+    "form": {
+      "name": "Nome",
+      "streetAddress": "Endereço",
+      "streetAddressRequired": "O endereço é obrigatório",
+      "addressAutocompletePlaceholder": "Comece a digitar para buscar ou insira manualmente abaixo",
+      "city": "Cidade",
+      "cityPlaceholder": "ex.: Berlim",
+      "stateProvinceRegion": "Estado / Província / Região",
+      "stateProvinceRegionPlaceholder": "ex.: São Paulo, Califórnia, Ontário",
+      "postalCode": "CEP",
+      "postalCodePlaceholder": "ex.: 01001-000, 94105, SW1A 1AA",
+      "country": "País",
+      "selectCountry": "Selecione o país",
+      "searchCountries": "Buscar países...",
+      "latitude": "Latitude",
+      "longitude": "Longitude",
+      "autoFilledFromAddress": "Preenchido automaticamente a partir do endereço",
+      "timeZone": "Fuso horário",
+      "parkingType": "Tipo de estacionamento",
+      "selectParkingType": "Selecione o tipo de estacionamento",
+      "searchParkingTypes": "Buscar tipos de estacionamento",
+      "facilities": "Comodidades",
+      "selectFacilities": "Selecione as comodidades",
+      "searchFacilities": "Buscar comodidades",
+      "image": "Imagem",
+      "upload": "Enviar",
+      "uploadFailedToast": "Falha ao atualizar as estações de recarga do local devido ao erro {error}"
+    },
+    "stations": {
+      "searchChargingStation": "Buscar estação de recarga",
+      "noChargingStationsFound": "Nenhuma estação de recarga encontrada",
+      "noChargingStationsSelected": "Nenhuma estação de recarga selecionada",
+      "stationId": "ID da estação",
+      "configuration": "Configuração",
+      "needsConfiguration": "Requer configuração",
+      "modelVendor": "Modelo / Fabricante",
+      "needsModel": "Requer modelo",
+      "needsVendor": "Requer fabricante"
+    },
+    "map": {
+      "viewDetails": "Ver detalhes",
+      "networkOverview": "Visão geral da rede",
+      "all": "Todos",
+      "locations": "Locais",
+      "stations": "Estações",
+      "viewTypeDetails": "Ver detalhes de {type}",
+      "online": "Online",
+      "partial": "Parcial",
+      "offline": "Offline",
+      "noChargers": "Nenhum carregador."
+    }
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/overview.json
+++ b/apps/operator-ui/public/locales/pt-BR/overview.json
@@ -1,0 +1,24 @@
+{
+  "Overview": {
+    "activeTransactions": "Transações ativas",
+    "chargerActivity": "Atividade dos carregadores",
+    "chargerOnlineStatus": "Status online dos carregadores",
+    "chargers": "Carregadores",
+    "errorLoadingData": "Erro ao carregar os dados",
+    "plugInSuccessRate": "Taxa de sucesso de conexão",
+    "noActiveTransactions": "Nenhuma transação ativa.",
+    "noChargersStatus": "Nenhum carregador está atualmente com o status {status}.",
+    "viewAllChargers": "Ver todos os carregadores",
+    "viewAllLocations": "Ver todos os locais",
+    "viewAllTransactions": "Ver todas as transações",
+    "viewAll": "Ver todos",
+    "faultedChargers": "Carregadores com falha",
+    "somethingWentWrong": "Algo deu errado!",
+    "station": "Estação",
+    "stationLabel": "Estação: {value}",
+    "location": "Local:",
+    "totalKwh": "Total kWh: {value}",
+    "totalTime": "Tempo total: {value}",
+    "transactionStatus": "Status: {value}"
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/tariffs.json
+++ b/apps/operator-ui/public/locales/pt-BR/tariffs.json
@@ -1,0 +1,37 @@
+{
+  "Tariffs": {
+    "Tariffs": "Tarifas",
+    "tariff": "Tarifa",
+    "noDataFound": "Nenhuma tarifa encontrada com o id {id}.",
+    "columns": {
+      "id": "ID",
+      "currency": "Moeda",
+      "pricePerKwh": "Preço / kWh",
+      "pricePerMin": "Preço / min",
+      "pricePerSession": "Preço / sessão"
+    },
+    "fields": {
+      "currency": "Moeda (código de 3 letras)",
+      "pricePerKwh": "Preço por kWh",
+      "pricePerMin": "Preço por min",
+      "pricePerSession": "Preço por sessão",
+      "authorizationAmount": "Valor de Autorização",
+      "paymentFee": "Taxa de Pagamento",
+      "taxRate": "Alíquota de Imposto (%)",
+      "tariffAltText": "Texto Alternativo da Tarifa (JSON)"
+    },
+    "placeholders": {
+      "currency": "ex.: USD",
+      "tariffAltText": "{ \"en\": \"Standard tariff\", \"de\": \"Standardtarif\" }"
+    },
+    "detail": {
+      "currency": "Moeda",
+      "pricePerKwh": "Preço / kWh",
+      "pricePerMin": "Preço / min",
+      "pricePerSession": "Preço / sessão",
+      "authorizationAmount": "Valor de Autorização",
+      "paymentFee": "Taxa de Pagamento",
+      "taxRate": "Alíquota de Imposto (%)"
+    }
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/tenantPartners.json
+++ b/apps/operator-ui/public/locales/pt-BR/tenantPartners.json
@@ -1,0 +1,67 @@
+{
+  "TenantPartners": {
+    "TenantPartners": "Parceiros",
+    "tenantPartner": "Parceiro",
+    "noDataFound": "Nenhum parceiro encontrado com o id {id}.",
+    "unnamedBusiness": "Empresa sem nome",
+    "loadingPartnerData": "Carregando dados do parceiro...",
+    "columns": {
+      "name": "Nome",
+      "countryCode": "Código do País",
+      "partyId": "ID da Parte"
+    },
+    "fields": {
+      "countryCode": "Código do País",
+      "partyId": "ID da Parte",
+      "versionsUrl": "URL de Versões",
+      "clientToken": "Token do Cliente",
+      "ocpiVersion": "Versão OCPI",
+      "versionDetailsUrl": "URL de Detalhes da Versão",
+      "serverCredentialsVersionsUrl": "(Credenciais do Servidor) URL de Versões",
+      "serverCredentialsToken": "(Credenciais do Servidor) Token",
+      "roles": "Papéis",
+      "role": "Papel",
+      "businessName": "Nome da Empresa",
+      "website": "Site"
+    },
+    "placeholders": {
+      "selectVersion": "Selecione a Versão",
+      "selectRole": "Selecione o Papel",
+      "businessName": "Nome da Empresa",
+      "website": "Site"
+    },
+    "validation": {
+      "countryCodeLength": "O Código do País deve ter exatamente 2 caracteres.",
+      "partyIdLength": "O ID da Parte deve ter exatamente 3 caracteres."
+    },
+    "notifications": {
+      "createSuccess": "Parceiro criado com sucesso",
+      "updateSuccess": "Parceiro atualizado com sucesso",
+      "createError": "Erro ao criar parceiro: {message}",
+      "updateError": "Erro ao atualizar parceiro: {message}"
+    },
+    "detail": {
+      "countryCode": "Código do País",
+      "partyId": "ID da Parte",
+      "website": "Site",
+      "roles": "Papéis",
+      "ocpiVersion": "Versão OCPI",
+      "versionsUrl": "URL de Versões",
+      "logoAlt": "logo de {name}"
+    },
+    "tabs": {
+      "endpoints": "Endpoints"
+    },
+    "endpoints": {
+      "endpoint": "Endpoint",
+      "identifier": "Identificador",
+      "url": "URL",
+      "noEndpointsFound": "Nenhum endpoint encontrado",
+      "deleteConfirm": "Tem certeza de que deseja excluir este endpoint? Esta ação não pode ser desfeita.",
+      "errorIdentifierRequired": "Por favor, informe o identificador",
+      "errorUrlRequired": "Por favor, informe a URL",
+      "placeholderIdentifier": "Informe o identificador",
+      "placeholderUrl": "Informe a URL"
+    }
+  }
+}

--- a/apps/operator-ui/public/locales/pt-BR/transactions.json
+++ b/apps/operator-ui/public/locales/pt-BR/transactions.json
@@ -1,0 +1,76 @@
+{
+  "Transactions": {
+    "Transactions": "Transações",
+    "transaction": "Transação",
+    "toggleActiveStatus": "Alternar Status Ativo",
+    "toggleActiveWarning": "Você está prestes a marcar esta transação como ",
+    "toggleActiveCaution": "Atenção: esta ação pode fazer com que a interface fique dessincronizada do status real da transação. Prossiga apenas se tiver certeza.",
+    "noDataFound": "Nenhuma transação encontrada com o id {id}.",
+    "columns": {
+      "transactionId": "ID da Transação",
+      "active": "Ativa",
+      "stationId": "ID da Estação",
+      "location": "Localização",
+      "idToken": "idTag",
+      "totalKwh": "kWh Total",
+      "status": "Status",
+      "startTime": "Início",
+      "endTime": "Término",
+      "createdAt": "Criada em",
+      "updatedAt": "Atualizada em"
+    },
+    "detail": {
+      "stationId": "ID da Estação",
+      "location": "Localização",
+      "totalKwh": "kWh Total",
+      "chargingState": "Estado de Recarga",
+      "startTime": "Início",
+      "endTime": "Término",
+      "tariff": "Tarifa"
+    },
+    "tabs": {
+      "meterValueData": "Dados de Valores de Medição",
+      "events": "Eventos",
+      "ocppMessages": "Mensagens OCPP",
+      "contexts": "Contextos:",
+      "selectReadingContexts": "Selecione os contextos de leitura",
+      "searchReadingContexts": "Buscar contextos de leitura"
+    },
+    "charts": {
+      "timeElapsed": "Tempo Decorrido",
+      "stateOfChargeLabel": "Estado de Carga (%)",
+      "stateOfChargeTitle": "Estado de Carga ao Longo do Tempo",
+      "noStateOfChargeData": "Nenhum dado de estado de carga disponível",
+      "energyLabel": "Energia (kWh)",
+      "energyTitle": "Energia ao Longo do Tempo",
+      "noEnergyData": "Nenhum dado de energia disponível",
+      "voltageLabel": "Tensão (V)",
+      "voltageTitle": "Tensão ao Longo do Tempo",
+      "noVoltageData": "Nenhum dado de tensão disponível",
+      "powerLabel": "Potência (kW)",
+      "powerTitle": "Potência ao Longo do Tempo",
+      "noPowerData": "Nenhum dado de potência disponível",
+      "currentLabel": "Corrente (A)",
+      "currentTitle": "Corrente ao Longo do Tempo",
+      "noCurrentData": "Nenhum dado de corrente disponível"
+    },
+    "events": {
+      "eventType": "Tipo de Evento",
+      "timestamp": "Data/Hora",
+      "seqNo": "Seq. nº",
+      "triggerReason": "Motivo do Disparo",
+      "viewMeterValues": "Ver Valores de Medição"
+    },
+    "meterValues": {
+      "id": "ID",
+      "timestamp": "Data/Hora",
+      "sampleValues": "Valores Amostrados",
+      "value": "Valor",
+      "context": "Contexto",
+      "measurand": "Grandeza Medida",
+      "phase": "Fase",
+      "location": "Localização",
+      "sampledValue": "Valor Amostrado {index}"
+    }
+  }
+}

--- a/apps/operator-ui/src/lib/client/components/combobox/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/combobox/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@lib/client/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@lib/client/components/ui/popover';
 import { cn } from '@lib/utils/cn';
+import { useTranslate } from '@refinedev/core';
 import { CheckIcon, ChevronsUpDownIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -36,14 +37,18 @@ export function Combobox<T>({
   value,
   onSelect,
   onSearch,
-  placeholder = 'Select an option',
-  searchPlaceholder = 'Search',
-  emptyMessage = 'No results found.',
+  placeholder,
+  searchPlaceholder,
+  emptyMessage,
   isLoading = false,
   skipValue = false,
   disabled = false,
   allowManualEntry = false,
 }: ComboboxProps<T>) {
+  const translate = useTranslate();
+  const resolvedPlaceholder = placeholder ?? translate('Common.selectOption');
+  const resolvedSearchPlaceholder = searchPlaceholder ?? translate('Common.search');
+  const resolvedEmptyMessage = emptyMessage ?? translate('Common.noResults') + '.';
   const [open, setOpen] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState('');
   const [selectedOption, setSelectedOption] = useState<{ label: string; value: T } | undefined>(
@@ -87,21 +92,25 @@ export function Combobox<T>({
           className="w-full justify-between"
           disabled={isLoading || disabled}
         >
-          {isLoading ? 'Loading...' : selectedOption?.label || placeholder}
+          {isLoading
+            ? translate('Common.loadingEllipsis')
+            : selectedOption?.label || resolvedPlaceholder}
           <ChevronsUpDownIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-(--radix-popover-trigger-width) p-0" align="start">
         <Command shouldFilter={!onSearch}>
           <CommandInput
-            placeholder={searchPlaceholder ?? 'Search'}
+            placeholder={resolvedSearchPlaceholder}
             onValueChange={(val) => {
               setInputValue(val);
               onSearch?.(val);
             }}
           />
           <CommandList>
-            <CommandEmpty>{isLoading ? 'Loading...' : emptyMessage}</CommandEmpty>
+            <CommandEmpty>
+              {isLoading ? translate('Common.loadingEllipsis') : resolvedEmptyMessage}
+            </CommandEmpty>
             {showManualEntry && (
               <CommandGroup>
                 <CommandItem
@@ -119,7 +128,7 @@ export function Combobox<T>({
                     setInputValue('');
                   }}
                 >
-                  Use &quot;{trimmedInput}&quot;
+                  {translate('Common.useValue', { value: trimmedInput })}
                 </CommandItem>
               </CommandGroup>
             )}

--- a/apps/operator-ui/src/lib/client/components/form/address-autocomplete.tsx
+++ b/apps/operator-ui/src/lib/client/components/form/address-autocomplete.tsx
@@ -8,6 +8,7 @@ import { Input } from '../ui/input';
 import debounce from 'lodash.debounce';
 import { autocompleteAddress } from '@lib/server/actions/map/autocompleteAddress';
 import { getPlaceDetails } from '@lib/server/actions/map/getPlaceDetails';
+import { useTranslate } from '@refinedev/core';
 
 type Prediction = {
   description: string;
@@ -38,9 +39,11 @@ export const AddressAutocomplete: React.FC<Props> = ({
   onChangeAction,
   onSelectPlaceAction,
   countryCode,
-  placeholder = 'Start typing an address...',
+  placeholder,
   sessionToken,
 }) => {
+  const translate = useTranslate();
+  const resolvedPlaceholder = placeholder ?? translate('Common.startTypingAddress');
   const [predictions, setPredictions] = useState<Prediction[]>([]);
   const [loading, setLoading] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -148,7 +151,7 @@ export const AddressAutocomplete: React.FC<Props> = ({
             setShowDropdown(true);
           }
         }}
-        placeholder={placeholder}
+        placeholder={resolvedPlaceholder}
         autoComplete="off"
         data-1p-ignore
         data-lpignore="true"
@@ -157,7 +160,9 @@ export const AddressAutocomplete: React.FC<Props> = ({
       {showDropdown && (predictions.length > 0 || loading) && (
         <ul className="absolute z-50 w-full mt-1 bg-popover text-popover-foreground border border-border rounded-md shadow-md max-h-60 overflow-auto">
           {loading && predictions.length === 0 && (
-            <li className="px-3 py-2 text-sm text-muted-foreground">Loading...</li>
+            <li className="px-3 py-2 text-sm text-muted-foreground">
+              {translate('Common.loadingEllipsis')}
+            </li>
           )}
           {predictions.map((p) => (
             <li

--- a/apps/operator-ui/src/lib/client/components/form/field.tsx
+++ b/apps/operator-ui/src/lib/client/components/form/field.tsx
@@ -23,6 +23,7 @@ import {
 import { Checkbox } from '@lib/client/components/ui/checkbox';
 import { Combobox, type ComboboxProps } from '@lib/client/components/combobox';
 import { MultiSelect, type MultiSelectProps } from '@lib/client/components/multi-select';
+import { useTranslate } from '@refinedev/core';
 
 type Props<
   TFieldValues extends FieldValues = FieldValues,
@@ -107,6 +108,7 @@ export const SelectFormField = <
     placeholder?: string;
   },
 ) => {
+  const translate = useTranslate();
   return (
     <Controller
       name={props.name}
@@ -115,7 +117,7 @@ export const SelectFormField = <
         <FieldWrapper {...{ ...props, field, fieldState }}>
           <Select value={field.value} onValueChange={field.onChange}>
             <SelectTrigger>
-              <SelectValue placeholder={props.placeholder ?? 'Select Item'} />
+              <SelectValue placeholder={props.placeholder ?? translate('Common.selectItem')} />
             </SelectTrigger>
             <SelectContent>
               {props.options.map((o) => (

--- a/apps/operator-ui/src/lib/client/components/locale-switcher/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/locale-switcher/index.tsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+
+import { Button } from '@lib/client/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@lib/client/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@lib/client/components/ui/tooltip';
+import { sidebarIconSize } from '@lib/client/styles/icon';
+import { setUserLocale } from '@lib/server/hooks/getUserLocale';
+import { LOCALES } from '@lib/utils/consts';
+import { Languages } from 'lucide-react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
+
+export const LocaleSwitcher = ({ expanded }: { expanded: boolean }) => {
+  const locale = useLocale();
+  const router = useRouter();
+  const t = useTranslations('menu');
+  const [, startTransition] = useTransition();
+
+  const currentLabel = LOCALES.find((l) => l.value === locale)?.label ?? locale;
+
+  const onSelectLocale = (nextLocale: string) => {
+    if (nextLocale === locale) return;
+    startTransition(() => {
+      setUserLocale(nextLocale).then(() => {
+        router.refresh();
+      });
+    });
+  };
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <DropdownMenu>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                size={expanded ? 'default' : 'icon'}
+                variant="ghost"
+                aria-label={t('language')}
+              >
+                <Languages className={sidebarIconSize} />
+                {expanded && <span>{currentLabel}</span>}
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <DropdownMenuContent align="start" side="right">
+            <DropdownMenuRadioGroup value={locale} onValueChange={onSelectLocale}>
+              {LOCALES.map((l) => (
+                <DropdownMenuRadioItem key={l.value} value={l.value}>
+                  {l.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <TooltipContent side="right">{t('language')}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/apps/operator-ui/src/lib/client/components/main-menu/main.menu.tsx
+++ b/apps/operator-ui/src/lib/client/components/main-menu/main.menu.tsx
@@ -22,6 +22,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Button } from '@lib/client/components/ui/button';
 import { sidebarIconSize } from '@lib/client/styles/icon';
 import { ThemeToggle } from '@lib/client/components/theme-toggle';
+import { LocaleSwitcher } from '@lib/client/components/locale-switcher';
 import { ConnectionModal } from '@lib/client/components/modals/shared/connection-modal/connection.modal';
 import { LogoutButton } from '@lib/client/components/logout-button';
 import { useTranslate } from '@refinedev/core';
@@ -145,7 +146,12 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
         {/* Bottom Menu - Help Link */}
         <div className="border-t border-border p-3 flex flex-col gap-2 items-center">
           <ThemeToggle expanded={!collapsed} />
-          <Button variant="ghost" onClick={() => setIsHelpOpen(true)} title="Help">
+          <LocaleSwitcher expanded={!collapsed} />
+          <Button
+            variant="ghost"
+            onClick={() => setIsHelpOpen(true)}
+            title={translate('menu.help')}
+          >
             <HelpCircle className={sidebarIconSize} />
             {!collapsed && <span>{translate('menu.help')}</span>}
           </Button>
@@ -157,7 +163,9 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
           variant="link"
           onClick={() => setCollapsed(!collapsed)}
           className="absolute top-0 right-0 transform translate-x-1/2 translate-y-[110px] size-8 bg-card text-accent-foreground border-transparent rounded-full shadow-md"
-          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-label={
+            collapsed ? translate('menu.expandSidebar') : translate('menu.collapseSidebar')
+          }
         >
           {collapsed ? (
             <ChevronRight className={sidebarIconSize} />

--- a/apps/operator-ui/src/lib/client/components/map/map.clusters.tsx
+++ b/apps/operator-ui/src/lib/client/components/map/map.clusters.tsx
@@ -10,6 +10,7 @@ import { type Marker, MarkerClusterer } from '@googlemaps/markerclusterer';
 import { MapMarkerV2 } from '@lib/client/components/map/map.clusters.marker';
 import { ChargingStationStatusTag } from '@lib/client/pages/charging-stations/charging.station.status.tag';
 import { MenuSection } from '@lib/client/components/main-menu/main.menu';
+import { useTranslate } from '@refinedev/core';
 
 /**
  * Reference: https://github.com/visgl/react-google-maps/blob/main/examples/marker-clustering/src/clustered-tree-markers.tsx
@@ -17,6 +18,7 @@ import { MenuSection } from '@lib/client/components/main-menu/main.menu';
 export const ClusteredLocationMarkers = ({ locations }: { locations: LocationDto[] }) => {
   const [markers, setMarkers] = useState<{ [id: number]: Marker }>({});
   const [selectedLocationId, setSelectedLocationId] = useState<number | null>(null);
+  const translate = useTranslate();
 
   const selectedLocation = useMemo(
     () =>
@@ -103,7 +105,7 @@ export const ClusteredLocationMarkers = ({ locations }: { locations: LocationDto
                     <span
                       className={`${charger.isOnline ? 'text-success' : 'text-destructive'} text-xs`}
                     >
-                      {charger.isOnline ? 'Online' : 'Offline'}
+                      {charger.isOnline ? translate('Common.online') : translate('Common.offline')}
                     </span>
                   </div>
                   {charger.evses && charger.evses.length > 0 && (
@@ -112,7 +114,7 @@ export const ClusteredLocationMarkers = ({ locations }: { locations: LocationDto
                 </div>
               ))
             ) : (
-              <div className="text-black">No chargers.</div>
+              <div className="text-black">{translate('Locations.map.noChargers')}</div>
             )}
           </div>
         </InfoWindow>

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/change-availability/change.availability.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/change-availability/change.availability.modal.tsx
@@ -13,7 +13,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useMemo, useState } from 'react';
@@ -26,16 +26,10 @@ export interface ChangeAvailabilityModalProps {
   station: ChargingStationDto;
 }
 
-const ChangeAvailabilitySchema = z.object({
-  type: z.enum(OCPP1_6.ChangeAvailabilityRequestType, {
-    message: 'Please select an availability type',
-  }),
-  connectorId: z.number({
-    message: 'Connector is required',
-  }),
-});
-
-type ChangeAvailabilityFormData = z.infer<typeof ChangeAvailabilitySchema>;
+type ChangeAvailabilityFormData = {
+  type: OCPP1_6.ChangeAvailabilityRequestType;
+  connectorId: number;
+};
 
 const availabilityTypes: OCPP1_6.ChangeAvailabilityRequestType[] = Object.keys(
   OCPP1_6.ChangeAvailabilityRequestType,
@@ -43,6 +37,7 @@ const availabilityTypes: OCPP1_6.ChangeAvailabilityRequestType[] = Object.keys(
 
 export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -51,6 +46,19 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const ChangeAvailabilitySchema = useMemo(
+    () =>
+      z.object({
+        type: z.enum(OCPP1_6.ChangeAvailabilityRequestType, {
+          message: translate('ChargingStations.changeAvailabilityModal.selectAvailabilityError'),
+        }),
+        connectorId: z.number({
+          message: translate('ChargingStations.changeAvailabilityModal.connectorRequired'),
+        }),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(ChangeAvailabilitySchema),
@@ -95,6 +103,7 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
     };
 
     await triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/changeAvailability?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -119,20 +128,20 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
     >
       <SelectFormField
         control={form.control}
-        label="Availability"
+        label={translate('ChargingStations.changeAvailabilityModal.availability')}
         name="type"
         options={availabilityTypes}
         required
       />
       <ComboboxFormField
         control={form.control}
-        label="Connector"
+        label={translate('ChargingStations.connectorSelector.label')}
         name="connectorId"
-        description="Connector IDs are serial integers starting at 1"
+        description={translate('ChargingStations.connectorSelector.description')}
         options={options}
         onSearch={onSearch}
-        placeholder="Select Connector"
-        searchPlaceholder="Search Connectors"
+        placeholder={translate('ChargingStations.connectorSelector.selectConnector')}
+        searchPlaceholder={translate('ChargingStations.connectorSelector.searchPlaceholder')}
         isLoading={query.isLoading}
         required
       />

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/change-configuration/change.configuration.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/change-configuration/change.configuration.modal.tsx
@@ -16,16 +16,15 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
-export const ChangeConfigurationSchema = z.object({
-  key: z.string().min(1, 'Key is required'),
-  value: z.string().min(1, 'Value is required'),
-});
-
-export type ChangeConfigurationFormData = z.infer<typeof ChangeConfigurationSchema>;
+export type ChangeConfigurationFormData = {
+  key: string;
+  value: string;
+};
 
 export interface ChangeConfigurationModalProps {
   station: any;
@@ -39,6 +38,7 @@ export const ChangeConfigurationModal = ({
   onFinish,
 }: ChangeConfigurationModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -47,6 +47,17 @@ export const ChangeConfigurationModal = ({
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const ChangeConfigurationSchema = useMemo(
+    () =>
+      z.object({
+        key: z.string().min(1, translate('ChargingStations.changeConfigurationModal.keyRequired')),
+        value: z
+          .string()
+          .min(1, translate('ChargingStations.changeConfigurationModal.valueRequired')),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(ChangeConfigurationSchema),
@@ -70,6 +81,7 @@ export const ChangeConfigurationModal = ({
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/changeConfiguration?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -93,12 +105,24 @@ export const ChangeConfigurationModal = ({
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Key" name="key">
-        <Input placeholder="Configuration key" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.changeConfigurationModal.key')}
+        name="key"
+      >
+        <Input
+          placeholder={translate('ChargingStations.changeConfigurationModal.keyPlaceholder')}
+        />
       </FormField>
 
-      <FormField control={form.control} label="Value" name="value">
-        <Input placeholder="Configuration value" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.changeConfigurationModal.value')}
+        name="value"
+      >
+        <Input
+          placeholder={translate('ChargingStations.changeConfigurationModal.valuePlaceholder')}
+        />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/commands.registry.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/commands.registry.ts
@@ -8,8 +8,10 @@ import { ModalComponentType } from '@lib/client/components/modals/modal.types';
  * Command definition for OCPP 1.6 commands
  */
 export interface CommandDefinition {
-  /** Display name shown in the UI */
+  /** Display name shown in the UI (English fallback) */
   displayName: string;
+  /** i18n key resolving to the localized display name */
+  displayNameKey: string;
   /** Modal component type for registration */
   modalType: ModalComponentType;
 }
@@ -26,30 +28,37 @@ export interface CommandDefinition {
 export const OCPP1_6_COMMANDS_REGISTRY: Record<string, CommandDefinition> = {
   'Change Availability': {
     displayName: 'Change Availability',
+    displayNameKey: 'ChargingStations.commands.changeAvailability',
     modalType: ModalComponentType.changeAvailability16,
   },
   'Data Transfer': {
     displayName: 'Data Transfer',
+    displayNameKey: 'ChargingStations.commands.dataTransfer',
     modalType: ModalComponentType.dataTransfer,
   },
   'Change Configuration': {
     displayName: 'Change Configuration',
+    displayNameKey: 'ChargingStations.commands.changeConfiguration',
     modalType: ModalComponentType.changeConfiguration16,
   },
   'Get Configuration': {
     displayName: 'Get Configuration',
+    displayNameKey: 'ChargingStations.commands.getConfiguration',
     modalType: ModalComponentType.getConfiguration16,
   },
   'Get Diagnostics': {
     displayName: 'Get Diagnostics',
+    displayNameKey: 'ChargingStations.commands.getDiagnostics',
     modalType: ModalComponentType.getDiagnostics16,
   },
   'Trigger Message': {
     displayName: 'Trigger Message',
+    displayNameKey: 'ChargingStations.commands.triggerMessage',
     modalType: ModalComponentType.triggerMessage16,
   },
   'Update Firmware': {
     displayName: 'Update Firmware',
+    displayNameKey: 'ChargingStations.commands.updateFirmware',
     modalType: ModalComponentType.updateFirmware16,
   },
 };

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/get-configuration/get.configuration.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/get-configuration/get.configuration.modal.tsx
@@ -22,6 +22,7 @@ import { RemoveArrayItemButton } from '@lib/client/components/form/remove-array-
 import { useFieldArray } from 'react-hook-form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
+import { useTranslate } from '@refinedev/core';
 
 export interface GetConfigurationModalProps {
   station: any;
@@ -41,6 +42,7 @@ export type GetConfigurationFormData = z.infer<typeof GetConfigurationSchema>;
 
 export const GetConfigurationModal = ({ station }: GetConfigurationModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -82,6 +84,7 @@ export const GetConfigurationModal = ({ station }: GetConfigurationModalProps) =
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/getConfiguration?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -101,8 +104,7 @@ export const GetConfigurationModal = ({ station }: GetConfigurationModalProps) =
       hideCancel
     >
       <div className="text-sm text-muted-foreground">
-        Optionally specify configuration keys to retrieve. Leave empty to get all configuration
-        values.
+        {translate('ChargingStations.getConfigurationModal.description')}
       </div>
 
       <AddArrayItemButton
@@ -111,16 +113,20 @@ export const GetConfigurationModal = ({ station }: GetConfigurationModalProps) =
             configKey: '',
           })
         }
-        itemLabel="Key"
+        itemLabel={translate('ChargingStations.getConfigurationModal.key')}
       />
       {fields.map((field, index) => (
         <div key={field.id} className={nestedFormRowFlex}>
           <FormField
             control={form.control}
-            label={`Key #${index + 1}`}
+            label={translate('ChargingStations.getConfigurationModal.keyNumber', {
+              number: index + 1,
+            })}
             name={`configurationKeys.${index}.configKey`}
           >
-            <Input placeholder="Enter configuration key" />
+            <Input
+              placeholder={translate('ChargingStations.getConfigurationModal.keyPlaceholder')}
+            />
           </FormField>
 
           <RemoveArrayItemButton onRemoveAction={() => remove(index)} />

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/get-diagnostics/get.diagnostics.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/get-diagnostics/get.diagnostics.modal.tsx
@@ -13,6 +13,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { FormField } from '@lib/client/components/form/field';
@@ -24,18 +25,17 @@ interface GetDiagnosticsModalProps {
   station: any;
 }
 
-const GetDiagnosticsSchema = z.object({
-  location: z.url('Must be a valid URL').min(1, 'Location is required').max(512),
-  startTime: z.string().min(1).optional(),
-  stopTime: z.string().min(1).optional(),
-  retries: z.coerce.number<number>().int().min(0).optional(),
-  retryInterval: z.coerce.number<number>().int().min(0).optional(),
-});
-
-type GetDiagnosticsFormData = z.infer<typeof GetDiagnosticsSchema>;
+type GetDiagnosticsFormData = {
+  location: string;
+  startTime?: string;
+  stopTime?: string;
+  retries?: number;
+  retryInterval?: number;
+};
 
 export const GetDiagnosticsModal = ({ station }: GetDiagnosticsModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -46,6 +46,21 @@ export const GetDiagnosticsModal = ({ station }: GetDiagnosticsModalProps) => {
   ) as ChargingStationDto;
 
   const location = 'http://localhost:4566/citrineos-s3-bucket/';
+
+  const GetDiagnosticsSchema = useMemo(
+    () =>
+      z.object({
+        location: z
+          .url(translate('ChargingStations.firmwareDiagnostics.invalidUrl'))
+          .min(1, translate('ChargingStations.firmwareDiagnostics.locationRequired'))
+          .max(512),
+        startTime: z.string().min(1).optional(),
+        stopTime: z.string().min(1).optional(),
+        retries: z.coerce.number<number>().int().min(0).optional(),
+        retryInterval: z.coerce.number<number>().int().min(0).optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(GetDiagnosticsSchema),
@@ -71,6 +86,7 @@ export const GetDiagnosticsModal = ({ station }: GetDiagnosticsModalProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/reporting/getDiagnostics?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -89,23 +105,52 @@ export const GetDiagnosticsModal = ({ station }: GetDiagnosticsModalProps) => {
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Location (URL)" name="location" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.locationUrl')}
+        name="location"
+        required
+      >
         <Input placeholder={location} type="url" />
       </FormField>
-      <FormField control={form.control} label="Start Timestamp" name="startTime">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.getDiagnosticsModal.startTimestamp')}
+        name="startTime"
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Stop Timestamp" name="stopTime">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.getDiagnosticsModal.stopTimestamp')}
+        name="stopTime"
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Retries" name="retries">
-        <Input type="number" placeholder="Number of retries" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retries')}
+        name="retries"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retriesPlaceholder')}
+          min="0"
+        />
       </FormField>
 
-      <FormField control={form.control} label="Retry Interval" name="retryInterval">
-        <Input type="number" placeholder="Retry interval in seconds" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retryInterval')}
+        name="retryInterval"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retryIntervalPlaceholder')}
+          min="0"
+        />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/trigger-message/trigger.message.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/trigger-message/trigger.message.modal.tsx
@@ -13,7 +13,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
@@ -26,19 +26,16 @@ export interface TriggerMessageModalProps {
   station: ChargingStationDto;
 }
 
-const TriggerMessageSchema = z.object({
-  requestedMessage: z.enum(OCPP1_6.TriggerMessageRequestRequestedMessage, {
-    message: 'Please select a message type',
-  }),
-  connectorId: z.number().optional(),
-});
-
-type TriggerMessageFormData = z.infer<typeof TriggerMessageSchema>;
+type TriggerMessageFormData = {
+  requestedMessage: OCPP1_6.TriggerMessageRequestRequestedMessage;
+  connectorId?: number;
+};
 
 const triggerMessages = Object.keys(OCPP1_6.TriggerMessageRequestRequestedMessage);
 
 export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -47,6 +44,17 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const TriggerMessageSchema = useMemo(
+    () =>
+      z.object({
+        requestedMessage: z.enum(OCPP1_6.TriggerMessageRequestRequestedMessage, {
+          message: translate('ChargingStations.triggerMessageModal.selectMessageError'),
+        }),
+        connectorId: z.number().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(TriggerMessageSchema),
@@ -94,6 +102,7 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/triggerMessage?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -115,19 +124,19 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
       <SelectFormField
         control={form.control}
         name="requestedMessage"
-        label="Requested Message"
+        label={translate('ChargingStations.triggerMessageModal.requestedMessage')}
         options={triggerMessages}
-        placeholder="Select Message"
+        placeholder={translate('ChargingStations.triggerMessageModal.selectMessage')}
         required
       />
 
       <ComboboxFormField
         control={form.control}
         name="connectorId"
-        label="Connector"
+        label={translate('ChargingStations.connectorSelector.label')}
         options={options}
         onSearch={onSearch}
-        placeholder="Search Connectors"
+        placeholder={translate('ChargingStations.connectorSelector.searchPlaceholder')}
         isLoading={query.isLoading}
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/1.6/update-firmware/update.firmware.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/1.6/update-firmware/update.firmware.modal.tsx
@@ -17,6 +17,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
@@ -25,17 +26,16 @@ export interface UpdateFirmwareModalProps {
   station: ChargingStationDto;
 }
 
-const UpdateFirmwareSchema = z.object({
-  location: z.url('Must be a valid URL').min(1, 'Location is required').max(512),
-  retrieveDate: z.string().min(1, 'Retrieve date is required'),
-  retries: z.coerce.number<number>().int().min(0).optional(),
-  retryInterval: z.coerce.number<number>().int().min(0).optional(),
-});
-
-type UpdateFirmwareFormData = z.infer<typeof UpdateFirmwareSchema>;
+type UpdateFirmwareFormData = {
+  location: string;
+  retrieveDate: string;
+  retries?: number;
+  retryInterval?: number;
+};
 
 export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -44,6 +44,22 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const UpdateFirmwareSchema = useMemo(
+    () =>
+      z.object({
+        location: z
+          .url(translate('ChargingStations.firmwareDiagnostics.invalidUrl'))
+          .min(1, translate('ChargingStations.firmwareDiagnostics.locationRequired'))
+          .max(512),
+        retrieveDate: z
+          .string()
+          .min(1, translate('ChargingStations.updateFirmwareModal.retrieveDateRequired')),
+        retries: z.coerce.number<number>().int().min(0).optional(),
+        retryInterval: z.coerce.number<number>().int().min(0).optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(UpdateFirmwareSchema),
@@ -71,6 +87,7 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/updateFirmware?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -95,20 +112,46 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Location (URL)" name="location" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.locationUrl')}
+        name="location"
+        required
+      >
         <Input placeholder="https://example.com/firmware.bin" type="url" />
       </FormField>
 
-      <FormField control={form.control} label="Retrieve Date" name="retrieveDate" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateFirmwareModal.retrieveDate')}
+        name="retrieveDate"
+        required
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Retries" name="retries">
-        <Input type="number" placeholder="Number of retries" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retries')}
+        name="retries"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retriesPlaceholder')}
+          min="0"
+        />
       </FormField>
 
-      <FormField control={form.control} label="Retry Interval" name="retryInterval">
-        <Input type="number" placeholder="Retry interval in seconds" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retryInterval')}
+        name="retryInterval"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retryIntervalPlaceholder')}
+          min="0"
+        />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/certificate-signed/certificate.signed.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/certificate-signed/certificate.signed.modal.tsx
@@ -15,6 +15,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -29,27 +30,14 @@ const ACCEPTED_FILE_TYPES = ['.pem', '.id'];
 
 const certificateSigningUses = Object.keys(OCPP2_0_1.CertificateSigningUseEnumType);
 
-export const CertificateSignedSchema = z.object({
-  certificateType: z.enum(OCPP2_0_1.CertificateSigningUseEnumType).optional(),
-  certificate: z
-    .custom<FileList>()
-    .refine((files) => files?.length === 1, 'Certificate file is required')
-    .refine(
-      (files) => {
-        const file = files?.[0];
-        if (!file) return false;
-        const extension = '.' + file.name.split('.').pop()?.toLowerCase();
-        return ACCEPTED_FILE_TYPES.includes(extension);
-      },
-      `File must be one of: ${ACCEPTED_FILE_TYPES.join(', ')}`,
-    )
-    .refine((files) => files?.[0]?.size <= MAX_FILE_SIZE, 'File size must be less than 5MB'),
-});
-
-export type CertificateSignedFormData = z.infer<typeof CertificateSignedSchema>;
+export type CertificateSignedFormData = {
+  certificateType?: OCPP2_0_1.CertificateSigningUseEnumType;
+  certificate: FileList;
+};
 
 export const CertificateSignedModal = ({ station }: CertificateSignedModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -58,6 +46,35 @@ export const CertificateSignedModal = ({ station }: CertificateSignedModalProps)
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const CertificateSignedSchema = useMemo(
+    () =>
+      z.object({
+        certificateType: z.enum(OCPP2_0_1.CertificateSigningUseEnumType).optional(),
+        certificate: z
+          .custom<FileList>()
+          .refine(
+            (files) => files?.length === 1,
+            translate('ChargingStations.certificateSignedModal.certificateRequired'),
+          )
+          .refine(
+            (files) => {
+              const file = files?.[0];
+              if (!file) return false;
+              const extension = '.' + file.name.split('.').pop()?.toLowerCase();
+              return ACCEPTED_FILE_TYPES.includes(extension);
+            },
+            translate('ChargingStations.certificateSignedModal.fileTypeError', {
+              types: ACCEPTED_FILE_TYPES.join(', '),
+            }),
+          )
+          .refine(
+            (files) => files?.[0]?.size <= MAX_FILE_SIZE,
+            translate('ChargingStations.certificateSignedModal.fileSizeError'),
+          ),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(CertificateSignedSchema),
@@ -86,6 +103,7 @@ export const CertificateSignedModal = ({ station }: CertificateSignedModalProps)
         };
 
         triggerMessageAndHandleResponse<MessageConfirmation[]>({
+          translate,
           url: `/certificates/certificateSigned?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
           data,
           setLoading,
@@ -111,16 +129,21 @@ export const CertificateSignedModal = ({ station }: CertificateSignedModalProps)
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Certificate File" name="certificate" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.certificateSignedModal.certificateFile')}
+        name="certificate"
+        required
+      >
         <Input type="file" accept={ACCEPTED_FILE_TYPES.join(',')} {...fileRef} />
       </FormField>
 
       <SelectFormField
         control={form.control}
-        label="Certificate Type"
+        label={translate('ChargingStations.certificateSignedModal.certificateType')}
         name="certificateType"
         options={certificateSigningUses}
-        placeholder="Select Certificate Type"
+        placeholder={translate('ChargingStations.certificateSignedModal.selectCertificateType')}
       />
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/change-availability/change.availability.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/change-availability/change.availability.modal.tsx
@@ -17,6 +17,7 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import { z } from 'zod';
 import { Controller } from 'react-hook-form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -26,15 +27,11 @@ export interface ChangeAvailabilityModalProps {
   station: ChargingStationDto;
 }
 
-const ChangeAvailabilitySchema = z.object({
-  operationalStatus: z.enum(OCPP2_0_1.OperationalStatusEnumType, {
-    message: 'Please select an operational status',
-  }),
-  evse: z.string().optional(), // { id, evseTypeId }
-  connectorId: z.number().optional(),
-});
-
-type ChangeAvailabilityFormData = z.infer<typeof ChangeAvailabilitySchema>;
+type ChangeAvailabilityFormData = {
+  operationalStatus: OCPP2_0_1.OperationalStatusEnumType;
+  evse?: string;
+  connectorId?: number;
+};
 
 const statuses: OCPP2_0_1.OperationalStatusEnumType[] = Object.keys(
   OCPP2_0_1.OperationalStatusEnumType,
@@ -42,6 +39,7 @@ const statuses: OCPP2_0_1.OperationalStatusEnumType[] = Object.keys(
 
 export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -50,6 +48,18 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const ChangeAvailabilitySchema = useMemo(
+    () =>
+      z.object({
+        operationalStatus: z.enum(OCPP2_0_1.OperationalStatusEnumType, {
+          message: translate('ChargingStations.changeAvailabilityModal.selectStatusError'),
+        }),
+        evse: z.string().optional(), // { id, evseTypeId }
+        connectorId: z.number().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(ChangeAvailabilitySchema),
@@ -75,6 +85,7 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/changeAvailability?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -108,12 +119,12 @@ export const ChangeAvailabilityModal = ({ station }: ChangeAvailabilityModalProp
       <ComboboxFormField
         control={form.control}
         name="operationalStatus"
-        label="Operational Status"
+        label={translate('ChargingStations.changeAvailabilityModal.operationalStatus')}
         options={statuses.map((status) => ({
           label: status,
           value: status,
         }))}
-        placeholder="Select Status"
+        placeholder={translate('ChargingStations.changeAvailabilityModal.selectStatus')}
         required
       />
 

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/clear-cache/clear.cache.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/clear-cache/clear.cache.modal.tsx
@@ -12,6 +12,7 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 export interface ClearCacheModalProps {
@@ -20,6 +21,7 @@ export interface ClearCacheModalProps {
 
 export const ClearCacheModal = ({ station }: ClearCacheModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -36,6 +38,7 @@ export const ClearCacheModal = ({ station }: ClearCacheModalProps) => {
     }
 
     await triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/clearCache?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data: {},
       setLoading,
@@ -48,19 +51,18 @@ export const ClearCacheModal = ({ station }: ClearCacheModalProps) => {
   return (
     <div className="space-y-6">
       <div className="text-sm text-muted-foreground">
-        <p>
-          This will send a Clear Cache request to the charging station. The station will clear its
-          authorization cache.
-        </p>
-        <p className="mt-2">Do you want to proceed?</p>
+        <p>{translate('ChargingStations.clearCacheModal.description')}</p>
+        <p className="mt-2">{translate('ChargingStations.clearCacheModal.proceed')}</p>
       </div>
 
       <div className="flex justify-end gap-2">
         <Button type="button" variant="outline" onClick={() => dispatch(closeModal())}>
-          Cancel
+          {translate('Common.cancel')}
         </Button>
         <Button variant="secondary" onClick={handleSubmit} disabled={loading}>
-          {loading ? 'Clearing...' : 'Clear Cache'}
+          {loading
+            ? translate('ChargingStations.clearCacheModal.clearing')
+            : translate('ChargingStations.commands.clearCache')}
         </Button>
       </div>
     </div>

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/commands.registry.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/commands.registry.ts
@@ -8,8 +8,10 @@ import { ModalComponentType } from '@lib/client/components/modals/modal.types';
  * Command definition for OCPP 2.0.1 commands
  */
 export interface CommandDefinition {
-  /** Display name shown in the UI */
+  /** Display name shown in the UI (English fallback) */
   displayName: string;
+  /** i18n key resolving to the localized display name */
+  displayNameKey: string;
   /** Modal component type for registration */
   modalType: ModalComponentType;
 }
@@ -26,78 +28,97 @@ export interface CommandDefinition {
 export const OCPP2_0_1_COMMANDS_REGISTRY: Record<string, CommandDefinition> = {
   'Certificate Signed': {
     displayName: 'Certificate Signed',
+    displayNameKey: 'ChargingStations.commands.certificateSigned',
     modalType: ModalComponentType.certificateSigned,
   },
   'Change Availability': {
     displayName: 'Change Availability',
+    displayNameKey: 'ChargingStations.commands.changeAvailability',
     modalType: ModalComponentType.changeAvailability201,
   },
   'Clear Cache': {
     displayName: 'Clear Cache',
+    displayNameKey: 'ChargingStations.commands.clearCache',
     modalType: ModalComponentType.clearCache,
   },
   'Customer Information': {
     displayName: 'Customer Information',
+    displayNameKey: 'ChargingStations.commands.customerInformation',
     modalType: ModalComponentType.customerInformation,
   },
   'Data Transfer': {
     displayName: 'Data Transfer',
+    displayNameKey: 'ChargingStations.commands.dataTransfer',
     modalType: ModalComponentType.dataTransfer,
   },
   'Delete Certificate': {
     displayName: 'Delete Certificate',
+    displayNameKey: 'ChargingStations.commands.deleteCertificate',
     modalType: ModalComponentType.deleteCertificate,
   },
   'Delete Station Network Profiles': {
     displayName: 'Delete Station Network Profiles',
+    displayNameKey: 'ChargingStations.commands.deleteStationNetworkProfiles',
     modalType: ModalComponentType.deleteStationNetworkProfiles,
   },
   'Get Base Report': {
     displayName: 'Get Base Report',
+    displayNameKey: 'ChargingStations.commands.getBaseReport',
     modalType: ModalComponentType.getBaseReport,
   },
   'Get Installed Certificate IDs': {
     displayName: 'Get Installed Certificate IDs',
+    displayNameKey: 'ChargingStations.commands.getInstalledCertificateIds',
     modalType: ModalComponentType.getInstalledCertificateIds,
   },
   'Get Logs': {
     displayName: 'Get Logs',
+    displayNameKey: 'ChargingStations.commands.getLogs',
     modalType: ModalComponentType.getLogs,
   },
   'Get Transaction Status': {
     displayName: 'Get Transaction Status',
+    displayNameKey: 'ChargingStations.commands.getTransactionStatus',
     modalType: ModalComponentType.getTransactionStatus,
   },
   'Get Variables': {
     displayName: 'Get Variables',
+    displayNameKey: 'ChargingStations.commands.getVariables',
     modalType: ModalComponentType.getVariables,
   },
   'Install Certificate': {
     displayName: 'Install Certificate',
+    displayNameKey: 'ChargingStations.commands.installCertificate',
     modalType: ModalComponentType.installCertificate,
   },
   'Set Network Profile': {
     displayName: 'Set Network Profile',
+    displayNameKey: 'ChargingStations.commands.setNetworkProfile',
     modalType: ModalComponentType.setNetworkProfile,
   },
   'Set Variables': {
     displayName: 'Set Variables',
+    displayNameKey: 'ChargingStations.commands.setVariables',
     modalType: ModalComponentType.setVariables,
   },
   'Trigger Message': {
     displayName: 'Trigger Message',
+    displayNameKey: 'ChargingStations.commands.triggerMessage',
     modalType: ModalComponentType.triggerMessage201,
   },
   'Unlock Connector': {
     displayName: 'Unlock Connector',
+    displayNameKey: 'ChargingStations.commands.unlockConnector',
     modalType: ModalComponentType.unlockConnector,
   },
   'Update Auth Password': {
     displayName: 'Update Auth Password',
+    displayNameKey: 'ChargingStations.commands.updateAuthPassword',
     modalType: ModalComponentType.updateAuthPassword,
   },
   'Update Firmware': {
     displayName: 'Update Firmware',
+    displayNameKey: 'ChargingStations.commands.updateFirmware',
     modalType: ModalComponentType.updateFirmware201,
   },
 };

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/customer-information/customer.information.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/customer-information/customer.information.modal.tsx
@@ -13,7 +13,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useMemo, useState } from 'react';
@@ -27,18 +27,17 @@ export interface CustomerInformationModalProps {
   station: any;
 }
 
-export const CustomerInformationSchema = z.object({
-  requestId: z.coerce.number<number>().int().positive('Request ID must be a positive number'),
-  report: z.boolean(),
-  clear: z.boolean(),
-  customerIdentifier: z.string().optional(),
-  authorization: z.string().optional(),
-});
-
-export type CustomerInformationFormData = z.infer<typeof CustomerInformationSchema>;
+export type CustomerInformationFormData = {
+  requestId: number;
+  report: boolean;
+  clear: boolean;
+  customerIdentifier?: string;
+  authorization?: string;
+};
 
 export const CustomerInformationModal = ({ station }: CustomerInformationModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -47,6 +46,21 @@ export const CustomerInformationModal = ({ station }: CustomerInformationModalPr
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const CustomerInformationSchema = useMemo(
+    () =>
+      z.object({
+        requestId: z.coerce
+          .number<number>()
+          .int()
+          .positive(translate('ChargingStations.requestId.positiveError')),
+        report: z.boolean(),
+        clear: z.boolean(),
+        customerIdentifier: z.string().optional(),
+        authorization: z.string().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(CustomerInformationSchema),
@@ -99,6 +113,7 @@ export const CustomerInformationModal = ({ station }: CustomerInformationModalPr
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/reporting/customerInformation?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data: payload,
       setLoading,
@@ -126,25 +141,46 @@ export const CustomerInformationModal = ({ station }: CustomerInformationModalPr
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Request ID" name="requestId" required>
-        <Input type="number" placeholder="Enter request ID" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.requestId.label')}
+        name="requestId"
+        required
+      >
+        <Input type="number" placeholder={translate('ChargingStations.requestId.placeholder')} />
       </FormField>
 
-      <CheckboxFormField control={form.control} label="Report" name="report" />
+      <CheckboxFormField
+        control={form.control}
+        label={translate('ChargingStations.customerInformationModal.report')}
+        name="report"
+      />
 
-      <CheckboxFormField control={form.control} label="Clear" name="clear" />
+      <CheckboxFormField
+        control={form.control}
+        label={translate('ChargingStations.customerInformationModal.clear')}
+        name="clear"
+      />
 
-      <FormField control={form.control} label="Customer Identifier" name="customerIdentifier">
-        <Input placeholder="Enter customer identifier" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.customerInformationModal.customerIdentifier')}
+        name="customerIdentifier"
+      >
+        <Input
+          placeholder={translate(
+            'ChargingStations.customerInformationModal.customerIdentifierPlaceholder',
+          )}
+        />
       </FormField>
 
       <ComboboxFormField
         control={form.control}
         name="authorization"
-        label="Authorization"
+        label={translate('ChargingStations.remoteStartModal.authorization')}
         options={options}
         onSearch={onSearch}
-        placeholder="Search Authorizations"
+        placeholder={translate('ChargingStations.remoteStartModal.searchAuthorizations')}
         isLoading={query.isLoading}
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/delete-certificate/delete.certificate.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/delete-certificate/delete.certificate.modal.tsx
@@ -16,7 +16,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
@@ -31,14 +31,13 @@ export interface DeleteCertificateModalProps {
   station: any;
 }
 
-export const DeleteCertificateSchema = z.object({
-  certificate: z.string().min(1, 'Certificate is required'),
-});
-
-export type DeleteCertificateFormData = z.infer<typeof DeleteCertificateSchema>;
+export type DeleteCertificateFormData = {
+  certificate: string;
+};
 
 export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -47,6 +46,16 @@ export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps)
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const DeleteCertificateSchema = useMemo(
+    () =>
+      z.object({
+        certificate: z
+          .string()
+          .min(1, translate('ChargingStations.deleteCertificateModal.certificateRequired')),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(DeleteCertificateSchema),
@@ -87,14 +96,14 @@ export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps)
     }
 
     if (!values.certificate) {
-      toast.error('Please select a certificate');
+      toast.error(translate('ChargingStations.deleteCertificateModal.selectCertificateError'));
       return;
     }
 
     const certificate = JSON.parse(values.certificate);
 
     if (parsedStation.ocppConnectionName !== certificate.ocppConnectionName) {
-      toast.error('This certificate does not belong to this station');
+      toast.error(translate('ChargingStations.deleteCertificateModal.wrongStationError'));
       return;
     }
 
@@ -108,6 +117,7 @@ export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps)
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/certificates/deleteCertificate?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -130,7 +140,10 @@ export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps)
     return (
       <div className="flex flex-col gap-2 rounded-md bg-muted p-4 text-sm">
         <span>
-          <span className="font-semibold">Hash Algorithm:</span> {certificate.hashAlgorithm}
+          <span className="font-semibold">
+            {translate('ChargingStations.deleteCertificateModal.hashAlgorithm')}
+          </span>{' '}
+          {certificate.hashAlgorithm}
         </span>
       </div>
     );
@@ -142,16 +155,16 @@ export const DeleteCertificateModal = ({ station }: DeleteCertificateModalProps)
       submitHandler={onFinish}
       loading={loading}
       submitButtonVariant={FormButtonVariants.delete}
-      submitButtonLabel="Delete Certificate"
+      submitButtonLabel={translate('ChargingStations.commands.deleteCertificate')}
       hideCancel
     >
       <ComboboxFormField
         control={form.control}
         name="certificate"
-        label="Installed Certificate"
+        label={translate('ChargingStations.deleteCertificateModal.installedCertificate')}
         options={options}
         onSearch={onSearch}
-        placeholder="Search Certificates by Serial Number"
+        placeholder={translate('ChargingStations.deleteCertificateModal.searchCertificates')}
         isLoading={query.isLoading}
         required
       />

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/delete-station-network-profiles/delete.station.network.profiles.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/delete-station-network-profiles/delete.station.network.profiles.modal.tsx
@@ -15,6 +15,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { useFieldArray } from 'react-hook-form';
@@ -26,30 +27,35 @@ export interface DeleteStationNetworkProfilesModalProps {
   station: any;
 }
 
-export const DeleteStationNetworkProfilesSchema = z.object({
-  configurationSlots: z
-    .array(
-      z.object({
-        slot: z.coerce.number<number>().int().positive(),
-      }),
-    ) // an array of objects to allow react-hook-form useFieldArray to work
-    .min(1, 'At least one configuration slot is required'),
-});
-
-export type DeleteStationNetworkProfilesFormData = z.infer<
-  typeof DeleteStationNetworkProfilesSchema
->;
+export type DeleteStationNetworkProfilesFormData = {
+  configurationSlots: { slot: number }[];
+};
 
 export const DeleteStationNetworkProfilesModal = ({
   station,
 }: DeleteStationNetworkProfilesModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const DeleteStationNetworkProfilesSchema = useMemo(
+    () =>
+      z.object({
+        configurationSlots: z
+          .array(
+            z.object({
+              slot: z.coerce.number<number>().int().positive(),
+            }),
+          ) // an array of objects to allow react-hook-form useFieldArray to work
+          .min(1, translate('ChargingStations.deleteStationNetworkProfilesModal.slotsRequired')),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(DeleteStationNetworkProfilesSchema),
@@ -79,6 +85,7 @@ export const DeleteStationNetworkProfilesModal = ({
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation>({
+      translate,
       url: url,
       data: undefined,
       setLoading,
@@ -96,7 +103,9 @@ export const DeleteStationNetworkProfilesModal = ({
       loading={loading}
       submitHandler={onFinish}
       submitButtonVariant={FormButtonVariants.delete}
-      submitButtonLabel="Delete Profiles"
+      submitButtonLabel={translate(
+        'ChargingStations.deleteStationNetworkProfilesModal.deleteProfiles',
+      )}
       hideCancel
     >
       <AddArrayItemButton
@@ -105,16 +114,24 @@ export const DeleteStationNetworkProfilesModal = ({
             slot: 0,
           })
         }
-        itemLabel="Slot"
+        itemLabel={translate('ChargingStations.deleteStationNetworkProfilesModal.slot')}
       />
       {fields.map((field, index) => (
         <div key={field.id} className={nestedFormRowFlex}>
           <FormField
             control={form.control}
-            label={`Slot #${index + 1}`}
+            label={translate('ChargingStations.deleteStationNetworkProfilesModal.slotNumber', {
+              number: index + 1,
+            })}
             name={`configurationSlots.${index}.slot`}
           >
-            <Input type="number" placeholder="Enter slot number" min="1" />
+            <Input
+              type="number"
+              placeholder={translate(
+                'ChargingStations.deleteStationNetworkProfilesModal.slotPlaceholder',
+              )}
+              min="1"
+            />
           </FormField>
 
           <RemoveArrayItemButton onRemoveAction={() => remove(index)} />

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-base-report/get.base.report.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-base-report/get.base.report.modal.tsx
@@ -12,7 +12,7 @@ import { CHARGING_STATION_SEQUENCES_GET_QUERY } from '@lib/queries/charging.stat
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useApiUrl, useCustom, useGetIdentity } from '@refinedev/core';
+import { useApiUrl, useCustom, useGetIdentity, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useEffect, useMemo, useState } from 'react';
@@ -26,20 +26,31 @@ export interface GetBaseReportModalProps {
   station: any;
 }
 
-const GetBaseReportSchema = z.object({
-  requestId: z.coerce.number<number>().int().positive('Request ID must be a positive number'),
-  reportBase: z.enum(OCPP2_0_1.ReportBaseEnumType, {
-    message: 'Report Base is required',
-  }),
-});
-
-type GetBaseReportFormData = z.infer<typeof GetBaseReportSchema>;
+type GetBaseReportFormData = {
+  requestId: number;
+  reportBase: OCPP2_0_1.ReportBaseEnumType;
+};
 
 const reportBaseTypes = Object.keys(OCPP2_0_1.ReportBaseEnumType);
 
 export const GetBaseReportModal = ({ station }: GetBaseReportModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
+
+  const GetBaseReportSchema = useMemo(
+    () =>
+      z.object({
+        requestId: z.coerce
+          .number<number>()
+          .int()
+          .positive(translate('ChargingStations.requestId.positiveError')),
+        reportBase: z.enum(OCPP2_0_1.ReportBaseEnumType, {
+          message: translate('ChargingStations.getBaseReportModal.reportBaseRequired'),
+        }),
+      }),
+    [translate],
+  );
 
   const tenantId = useTenantId();
 
@@ -95,6 +106,7 @@ export const GetBaseReportModal = ({ station }: GetBaseReportModalProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/reporting/getBaseReport?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -113,16 +125,21 @@ export const GetBaseReportModal = ({ station }: GetBaseReportModalProps) => {
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Request ID" name="requestId" required>
-        <Input type="number" placeholder="Enter request ID" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.requestId.label')}
+        name="requestId"
+        required
+      >
+        <Input type="number" placeholder={translate('ChargingStations.requestId.placeholder')} />
       </FormField>
 
       <SelectFormField
         control={form.control}
-        label="Report Base"
+        label={translate('ChargingStations.getBaseReportModal.reportBase')}
         name="reportBase"
         options={reportBaseTypes}
-        placeholder="Select Report Base"
+        placeholder={translate('ChargingStations.getBaseReportModal.selectReportBase')}
         required
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-installed-certificate-ids/get.installed.certificate.ids.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-installed-certificate-ids/get.installed.certificate.ids.modal.tsx
@@ -14,6 +14,7 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -35,6 +36,7 @@ export const GetInstalledCertificateIdsModal = ({
   station,
 }: GetInstalledCertificateIdsModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -67,6 +69,7 @@ export const GetInstalledCertificateIdsModal = ({
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/certificates/getInstalledCertificateIds?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -89,12 +92,16 @@ export const GetInstalledCertificateIdsModal = ({
     >
       <MultiSelectFormField
         control={form.control}
-        label="Certificate Types"
+        label={translate('ChargingStations.getInstalledCertificateIdsModal.certificateTypes')}
         name="certificateType"
-        description="When certificate types are omitted, all certificate types are requested."
+        description={translate('ChargingStations.getInstalledCertificateIdsModal.description')}
         options={certificateTypeOptions}
-        placeholder="Select Certificate Types"
-        searchPlaceholder="Search Certificate Types"
+        placeholder={translate(
+          'ChargingStations.getInstalledCertificateIdsModal.selectCertificateTypes',
+        )}
+        searchPlaceholder={translate(
+          'ChargingStations.getInstalledCertificateIdsModal.searchCertificateTypes',
+        )}
       />
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-logs/get.logs.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-logs/get.logs.modal.tsx
@@ -14,6 +14,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { FormField } from '@lib/client/components/form/field';
@@ -25,22 +26,21 @@ interface GetLogsModalProps {
   station: any;
 }
 
-const GetLogsSchema = z.object({
-  requestId: z.coerce.number<number>().int().positive('Request ID must be a positive number'),
-  remoteLocation: z.url('Must be a valid URL').min(1, 'Remote Location is required').max(512),
-  oldestTimestamp: z.string().min(1).optional(),
-  latestTimestamp: z.string().min(1).optional(),
-  logType: z.enum(OCPP2_0_1.LogEnumType, { message: 'Log Type is required' }),
-  retries: z.coerce.number<number>().int().min(0).optional(),
-  retryInterval: z.coerce.number<number>().int().min(0).optional(),
-});
-
-type GetLogsFormData = z.infer<typeof GetLogsSchema>;
+type GetLogsFormData = {
+  requestId: number;
+  remoteLocation: string;
+  oldestTimestamp?: string;
+  latestTimestamp?: string;
+  logType: OCPP2_0_1.LogEnumType;
+  retries?: number;
+  retryInterval?: number;
+};
 
 const logTypes = Object.keys(OCPP2_0_1.LogEnumType);
 
 export const GetLogsModal = ({ station }: GetLogsModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -51,6 +51,28 @@ export const GetLogsModal = ({ station }: GetLogsModalProps) => {
   ) as ChargingStationDto;
 
   const remoteLocation = 'http://localhost:4566/citrineos-s3-bucket/';
+
+  const GetLogsSchema = useMemo(
+    () =>
+      z.object({
+        requestId: z.coerce
+          .number<number>()
+          .int()
+          .positive(translate('ChargingStations.requestId.positiveError')),
+        remoteLocation: z
+          .url(translate('ChargingStations.firmwareDiagnostics.invalidUrl'))
+          .min(1, translate('ChargingStations.getLogsModal.remoteLocationRequired'))
+          .max(512),
+        oldestTimestamp: z.string().min(1).optional(),
+        latestTimestamp: z.string().min(1).optional(),
+        logType: z.enum(OCPP2_0_1.LogEnumType, {
+          message: translate('ChargingStations.getLogsModal.logTypeRequired'),
+        }),
+        retries: z.coerce.number<number>().int().min(0).optional(),
+        retryInterval: z.coerce.number<number>().int().min(0).optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(GetLogsSchema),
@@ -85,6 +107,7 @@ export const GetLogsModal = ({ station }: GetLogsModalProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/reporting/getLog?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -103,12 +126,17 @@ export const GetLogsModal = ({ station }: GetLogsModalProps) => {
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Request ID" name="requestId" required>
-        <Input type="number" placeholder="Enter request ID" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.requestId.label')}
+        name="requestId"
+        required
+      >
+        <Input type="number" placeholder={translate('ChargingStations.requestId.placeholder')} />
       </FormField>
       <FormField
         control={form.control}
-        label="Remote Location (URL)"
+        label={translate('ChargingStations.getLogsModal.remoteLocationUrl')}
         name="remoteLocation"
         required
       >
@@ -116,26 +144,50 @@ export const GetLogsModal = ({ station }: GetLogsModalProps) => {
       </FormField>
       <SelectFormField
         control={form.control}
-        label="Log Type"
+        label={translate('ChargingStations.getLogsModal.logType')}
         name="logType"
         options={logTypes}
-        placeholder="Select Log Type"
+        placeholder={translate('ChargingStations.getLogsModal.selectLogType')}
         required
       />
-      <FormField control={form.control} label="Oldest Timestamp" name="oldestTimestamp">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.getLogsModal.oldestTimestamp')}
+        name="oldestTimestamp"
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Latest Timestamp" name="latestTimestamp">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.getLogsModal.latestTimestamp')}
+        name="latestTimestamp"
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Retries" name="retries">
-        <Input type="number" placeholder="Number of retries" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retries')}
+        name="retries"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retriesPlaceholder')}
+          min="0"
+        />
       </FormField>
 
-      <FormField control={form.control} label="Retry Interval" name="retryInterval">
-        <Input type="number" placeholder="Retry interval in seconds" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retryInterval')}
+        name="retryInterval"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retryIntervalPlaceholder')}
+          min="0"
+        />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-transaction-status/get.transaction.status.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-transaction-status/get.transaction.status.modal.tsx
@@ -12,7 +12,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
@@ -34,6 +34,7 @@ export type GetTransactionStatusFormData = z.infer<typeof GetTransactionStatusSc
 
 export const GetTransactionStatusModal = ({ station }: GetTransactionStatusModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -78,6 +79,7 @@ export const GetTransactionStatusModal = ({ station }: GetTransactionStatusModal
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/transactions/getTransactionStatus?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -99,12 +101,12 @@ export const GetTransactionStatusModal = ({ station }: GetTransactionStatusModal
       <ComboboxFormField
         control={form.control}
         name="transactionId"
-        label="Transaction"
-        description="Optionally select a transaction to get its status. Leave empty to get the status of all transactions."
+        label={translate('ChargingStations.getTransactionStatusModal.transaction')}
+        description={translate('ChargingStations.getTransactionStatusModal.description')}
         options={options}
         onSearch={onSearch}
-        placeholder="Select Transaction"
-        searchPlaceholder="Search Transactions"
+        placeholder={translate('ChargingStations.remoteStopModal.selectTransaction')}
+        searchPlaceholder={translate('ChargingStations.remoteStopModal.searchTransactions')}
         isLoading={query.isLoading}
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/get-variables/get.variables.modal.tsx
@@ -26,7 +26,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useFieldArray } from 'react-hook-form';
@@ -43,38 +43,23 @@ export interface GetVariablesModalProps {
   station: any;
 }
 
-const requiredIdOrName = (label: string) =>
-  z.custom<number | string>(
-    (val) =>
-      (typeof val === 'number' && val > 0) || (typeof val === 'string' && val.trim().length > 0),
-    `${label} is required`,
-  );
-
-const GetVariableDataSchema = z.object({
-  componentId: requiredIdOrName('Component'),
-  variableId: z.string().optional(),
-  componentInstance: z.string().max(50).optional(),
-  variableInstance: z.string().max(50).optional(),
-  evseId: z.number().optional(),
-  connectorId: z.number().optional(),
-  attributeType: z.enum(OCPP2_0_1.AttributeEnumType).optional(),
-});
-
-export const GetVariablesSchema = z.object({
-  getVariableData: z
-    .array(GetVariableDataSchema)
-    .min(1, 'At least one variable is required')
-    .refine((data) => data.every((item) => item.componentId && item.variableId), {
-      message: 'Component and Variable are required for each entry',
-    }),
-});
-
-export type GetVariablesFormData = z.infer<typeof GetVariablesSchema>;
+export type GetVariablesFormData = {
+  getVariableData: {
+    componentId: number | string;
+    variableId?: string;
+    componentInstance?: string;
+    variableInstance?: string;
+    evseId?: number;
+    connectorId?: number;
+    attributeType?: OCPP2_0_1.AttributeEnumType;
+  }[];
+};
 
 const attributeTypes = Object.keys(OCPP2_0_1.AttributeEnumType);
 
 export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -86,6 +71,35 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const GetVariablesSchema = useMemo(() => {
+    const requiredIdOrName = (label: string) =>
+      z.custom<number | string>(
+        (val) =>
+          (typeof val === 'number' && val > 0) ||
+          (typeof val === 'string' && val.trim().length > 0),
+        translate('ChargingStations.fieldRequired', { field: label }),
+      );
+
+    const GetVariableDataSchema = z.object({
+      componentId: requiredIdOrName(translate('ChargingStations.getVariablesModal.component')),
+      variableId: z.string().optional(),
+      componentInstance: z.string().max(50).optional(),
+      variableInstance: z.string().max(50).optional(),
+      evseId: z.number().optional(),
+      connectorId: z.number().optional(),
+      attributeType: z.enum(OCPP2_0_1.AttributeEnumType).optional(),
+    });
+
+    return z.object({
+      getVariableData: z
+        .array(GetVariableDataSchema)
+        .min(1, translate('ChargingStations.getVariablesModal.atLeastOneVariable'))
+        .refine((data) => data.every((item) => item.componentId && item.variableId), {
+          message: translate('ChargingStations.getVariablesModal.componentAndVariableRequired'),
+        }),
+    });
+  }, [translate]);
 
   const form = useForm({
     resolver: zodResolver(GetVariablesSchema),
@@ -191,6 +205,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
     });
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/monitoring/getVariables?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data: { getVariableData },
       setLoading,
@@ -208,14 +223,12 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
       loading={loading}
       submitHandler={onFinish}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonlabel="Get Variables"
+      submitButtonlabel={translate('ChargingStations.commands.getVariables')}
       hideCancel
     >
       <Alert className="mb-4">
         <InfoIcon className="h-4 w-4" />
-        <AlertDescription>
-          Send a GetBaseReport to this Charging Station to populate Components and Variables.
-        </AlertDescription>
+        <AlertDescription>{translate('ChargingStations.getVariablesModal.alert')}</AlertDescription>
       </Alert>
       <div className="flex items-start">
         <AddArrayItemButton
@@ -230,7 +243,7 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
               attributeType: undefined,
             })
           }
-          itemLabel="Variable"
+          itemLabel={translate('ChargingStations.getVariablesModal.variable')}
         />
       </div>
       <div className="flex flex-col gap-6 w-full">
@@ -250,12 +263,14 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
             <div key={field.id} className={nestedFormRowFlex}>
               <ComboboxFormField
                 control={form.control}
-                label={`Component #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.componentNumber', {
+                  number: index + 1,
+                })}
                 name={`getVariableData.${index}.componentId`}
                 options={componentOptions}
                 onSearch={onSearch}
-                placeholder="Select Component"
-                searchPlaceholder="Search Components"
+                placeholder={translate('ChargingStations.getVariablesModal.selectComponent')}
+                searchPlaceholder={translate('ChargingStations.getVariablesModal.searchComponents')}
                 isLoading={componentQuery.isLoading}
                 required
                 allowManualEntry
@@ -263,12 +278,14 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
 
               <ComboboxFormField
                 control={form.control}
-                label={`Variable #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.variableNumber', {
+                  number: index + 1,
+                })}
                 name={`getVariableData.${index}.variableId`}
                 options={variableOptions}
                 onSearch={variableOnSearch}
-                placeholder="Select Variable"
-                searchPlaceholder="Search Variables"
+                placeholder={translate('ChargingStations.getVariablesModal.selectVariable')}
+                searchPlaceholder={translate('ChargingStations.getVariablesModal.searchVariables')}
                 isLoading={variableLoading}
                 required
                 disabled={!componentId || componentId === 0}
@@ -277,25 +294,31 @@ export const GetVariablesModal = ({ station }: GetVariablesModalProps) => {
 
               <FormField
                 control={form.control}
-                label={`Component Instance #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.componentInstanceNumber', {
+                  number: index + 1,
+                })}
                 name={`getVariableData.${index}.componentInstance`}
               >
-                <Input placeholder="Instance" />
+                <Input placeholder={translate('ChargingStations.getVariablesModal.instance')} />
               </FormField>
               <FormField
                 control={form.control}
-                label={`Variable Instance #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.variableInstanceNumber', {
+                  number: index + 1,
+                })}
                 name={`getVariableData.${index}.variableInstance`}
               >
-                <Input placeholder="Instance" />
+                <Input placeholder={translate('ChargingStations.getVariablesModal.instance')} />
               </FormField>
 
               <SelectFormField
                 control={form.control}
-                label={`Attribute Type #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.attributeTypeNumber', {
+                  number: index + 1,
+                })}
                 name={`getVariableData.${index}.attributeType`}
                 options={attributeTypes}
-                placeholder="Select Attribute Type"
+                placeholder={translate('ChargingStations.getVariablesModal.selectAttributeType')}
               />
 
               <RemoveArrayItemButton onRemoveAction={() => remove(index)} />

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/install-certificate/install.certificate.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/install-certificate/install.certificate.modal.tsx
@@ -16,6 +16,7 @@ import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { toast } from 'sonner';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Textarea } from '@lib/client/components/ui/textarea';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -25,22 +26,16 @@ interface InstallCertificateModalProps {
   station: any;
 }
 
-const InstallCertificateSchema = z.object({
-  certificate: z
-    .string()
-    .min(1, 'Certificate is required')
-    .max(5500, 'Certificate must be less than 5500 characters'),
-  certificateType: z.enum(OCPP2_0_1.InstallCertificateUseEnumType, {
-    message: 'Certificate Type is required',
-  }),
-});
-
-type InstallCertificateFormData = z.infer<typeof InstallCertificateSchema>;
+type InstallCertificateFormData = {
+  certificate: string;
+  certificateType: OCPP2_0_1.InstallCertificateUseEnumType;
+};
 
 const installCertificateTypes = Object.keys(OCPP2_0_1.InstallCertificateUseEnumType);
 
 export const InstallCertificateModal = ({ station }: InstallCertificateModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -49,6 +44,20 @@ export const InstallCertificateModal = ({ station }: InstallCertificateModalProp
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const InstallCertificateSchema = useMemo(
+    () =>
+      z.object({
+        certificate: z
+          .string()
+          .min(1, translate('ChargingStations.installCertificateModal.certificateRequired'))
+          .max(5500, translate('ChargingStations.installCertificateModal.certificateTooLong')),
+        certificateType: z.enum(OCPP2_0_1.InstallCertificateUseEnumType, {
+          message: translate('ChargingStations.installCertificateModal.certificateTypeRequired'),
+        }),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(InstallCertificateSchema),
@@ -68,7 +77,7 @@ export const InstallCertificateModal = ({ station }: InstallCertificateModalProp
 
     const pemString = formatPem(values.certificate);
     if (pemString == null) {
-      toast.error('Incorrectly formatted PEM certificate');
+      toast.error(translate('ChargingStations.installCertificateModal.invalidPem'));
       return;
     }
 
@@ -78,6 +87,7 @@ export const InstallCertificateModal = ({ station }: InstallCertificateModalProp
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/certificates/installCertificate?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -98,14 +108,19 @@ export const InstallCertificateModal = ({ station }: InstallCertificateModalProp
     >
       <SelectFormField
         control={form.control}
-        label="Certificate Type"
+        label={translate('ChargingStations.certificateSignedModal.certificateType')}
         name="certificateType"
         options={installCertificateTypes}
-        placeholder="Select Certificate Type"
+        placeholder={translate('ChargingStations.certificateSignedModal.selectCertificateType')}
         required
       />
 
-      <FormField control={form.control} label="Certificate (PEM)" name="certificate" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.installCertificateModal.certificatePem')}
+        name="certificate"
+        required
+      >
         <Textarea />
       </FormField>
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-network-profile/set.network.profile.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-network-profile/set.network.profile.modal.tsx
@@ -27,7 +27,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
@@ -38,61 +38,22 @@ export interface SetNetworkProfileModalProps {
   station: any;
 }
 
-// APN Schema
-const ApnSchema = z.object({
-  apn: z.string().min(1, 'APN is required').max(512),
-  apnUserName: z.string().max(20).optional(),
-  apnPassword: z.string().max(20).optional(),
-  simPin: z.coerce.number<number>().int().optional(),
-  preferredNetwork: z.string().max(6).optional(),
-  useOnlyPreferredNetwork: z.boolean().optional(),
-  apnAuthentication: z.enum(OCPP2_0_1.APNAuthenticationEnumType, {
-    message: 'APN Authentication is required',
-  }),
-});
-
-// VPN Schema
-const VpnSchema = z.object({
-  server: z.string().min(1, 'Server is required').max(512),
-  user: z.string().min(1, 'User is required').max(20),
-  group: z.string().max(20).optional(),
-  password: z.string().min(1, 'Password is required').max(20),
-  key: z.string().min(1, 'Key is required').max(255),
-  type: z.enum(OCPP2_0_1.VPNEnumType, {
-    message: 'VPN Type is required',
-  }),
-});
-
-// Network Connection Profile Schema
-const NetworkConnectionProfileSchema = z.object({
-  ocppVersion: z.enum(OCPP2_0_1.OCPPVersionEnumType, {
-    message: 'OCPP Version is required',
-  }),
-  ocppTransport: z.enum(OCPP2_0_1.OCPPTransportEnumType, {
-    message: 'OCPP Transport is required',
-  }),
-  ocppCsmsUrl: z.string().url('Must be a valid URL').min(1, 'CSMS URL is required').max(512),
-  messageTimeout: z.coerce.number<number>().int().min(0, 'Message timeout must be positive'),
-  securityProfile: z.coerce.number<number>().int().min(0, 'Security profile must be positive'),
-  ocppInterface: z.enum(OCPP2_0_1.OCPPInterfaceEnumType, {
-    message: 'OCPP Interface is required',
-  }),
-  apn: ApnSchema.optional(),
-  vpn: VpnSchema.optional(),
-});
-
-const SetNetworkProfileSchema = z.object({
-  websocketServerConfigId: z.string().optional(),
-  configurationSlot: z.coerce
-    .number<number>()
-    .int()
-    .min(0, 'Configuration slot must be non-negative'),
-  connectionData: NetworkConnectionProfileSchema,
-  includeApn: z.boolean(),
-  includeVpn: z.boolean(),
-});
-
-type SetNetworkProfileFormData = z.infer<typeof SetNetworkProfileSchema>;
+type SetNetworkProfileFormData = {
+  websocketServerConfigId?: string;
+  configurationSlot: number;
+  connectionData: {
+    ocppVersion: OCPP2_0_1.OCPPVersionEnumType;
+    ocppTransport: OCPP2_0_1.OCPPTransportEnumType;
+    ocppCsmsUrl: string;
+    messageTimeout: number;
+    securityProfile: number;
+    ocppInterface: OCPP2_0_1.OCPPInterfaceEnumType;
+    apn?: any;
+    vpn?: any;
+  };
+  includeApn: boolean;
+  includeVpn: boolean;
+};
 
 const fieldGrid = 'grid grid-cols-3 sm:grid-cols-2 xl:grid-cols-4 gap-6';
 
@@ -104,6 +65,7 @@ const vpnTypes = Object.keys(OCPP2_0_1.VPNEnumType);
 
 export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -112,6 +74,84 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const SetNetworkProfileSchema = useMemo(() => {
+    const ApnSchema = z.object({
+      apn: z
+        .string()
+        .min(1, translate('ChargingStations.setNetworkProfileModal.apnRequired'))
+        .max(512),
+      apnUserName: z.string().max(20).optional(),
+      apnPassword: z.string().max(20).optional(),
+      simPin: z.coerce.number<number>().int().optional(),
+      preferredNetwork: z.string().max(6).optional(),
+      useOnlyPreferredNetwork: z.boolean().optional(),
+      apnAuthentication: z.enum(OCPP2_0_1.APNAuthenticationEnumType, {
+        message: translate('ChargingStations.setNetworkProfileModal.apnAuthRequired'),
+      }),
+    });
+
+    const VpnSchema = z.object({
+      server: z
+        .string()
+        .min(1, translate('ChargingStations.setNetworkProfileModal.serverRequired'))
+        .max(512),
+      user: z
+        .string()
+        .min(1, translate('ChargingStations.setNetworkProfileModal.userRequired'))
+        .max(20),
+      group: z.string().max(20).optional(),
+      password: z
+        .string()
+        .min(1, translate('ChargingStations.setNetworkProfileModal.passwordRequired'))
+        .max(20),
+      key: z
+        .string()
+        .min(1, translate('ChargingStations.setNetworkProfileModal.keyRequired'))
+        .max(255),
+      type: z.enum(OCPP2_0_1.VPNEnumType, {
+        message: translate('ChargingStations.setNetworkProfileModal.vpnTypeRequired'),
+      }),
+    });
+
+    const NetworkConnectionProfileSchema = z.object({
+      ocppVersion: z.enum(OCPP2_0_1.OCPPVersionEnumType, {
+        message: translate('ChargingStations.setNetworkProfileModal.ocppVersionRequired'),
+      }),
+      ocppTransport: z.enum(OCPP2_0_1.OCPPTransportEnumType, {
+        message: translate('ChargingStations.setNetworkProfileModal.ocppTransportRequired'),
+      }),
+      ocppCsmsUrl: z
+        .string()
+        .url(translate('ChargingStations.firmwareDiagnostics.invalidUrl'))
+        .min(1, translate('ChargingStations.setNetworkProfileModal.csmsUrlRequired'))
+        .max(512),
+      messageTimeout: z.coerce
+        .number<number>()
+        .int()
+        .min(0, translate('ChargingStations.setNetworkProfileModal.messageTimeoutPositive')),
+      securityProfile: z.coerce
+        .number<number>()
+        .int()
+        .min(0, translate('ChargingStations.setNetworkProfileModal.securityProfilePositive')),
+      ocppInterface: z.enum(OCPP2_0_1.OCPPInterfaceEnumType, {
+        message: translate('ChargingStations.setNetworkProfileModal.ocppInterfaceRequired'),
+      }),
+      apn: ApnSchema.optional(),
+      vpn: VpnSchema.optional(),
+    });
+
+    return z.object({
+      websocketServerConfigId: z.string().optional(),
+      configurationSlot: z.coerce
+        .number<number>()
+        .int()
+        .min(0, translate('ChargingStations.setNetworkProfileModal.configurationSlotNonNegative')),
+      connectionData: NetworkConnectionProfileSchema,
+      includeApn: z.boolean(),
+      includeVpn: z.boolean(),
+    });
+  }, [translate]);
 
   const form = useForm({
     resolver: zodResolver(SetNetworkProfileSchema),
@@ -188,6 +228,7 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url,
       data,
       setLoading,
@@ -209,45 +250,49 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
       submitHandler={handleFormSubmit}
       loading={loading}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Set Network Profile"
+      submitButtonLabel={translate('ChargingStations.commands.setNetworkProfile')}
       hideCancel
     >
       <div className={fieldGrid}>
         <ComboboxFormField
           control={form.control}
-          label="Websocket Server Config"
+          label={translate('ChargingStations.setNetworkProfileModal.websocketServerConfig')}
           name="websocketServerConfigId"
           options={serverNetworkProfileOptions}
           onSearch={serverNetworkProfileOnSearch}
-          placeholder="Search Server Network Profiles"
+          placeholder={translate('ChargingStations.setNetworkProfileModal.searchServerProfiles')}
           isLoading={serverNetworkProfileQuery.isLoading}
         />
 
-        <FormField control={form.control} label="Configuration Slot" name="configurationSlot">
+        <FormField
+          control={form.control}
+          label={translate('ChargingStations.setNetworkProfileModal.configurationSlot')}
+          name="configurationSlot"
+        >
           <Input type="number" min="0" />
         </FormField>
 
         <SelectFormField
           control={form.control}
-          label="OCPP Version"
+          label={translate('ChargingStations.setNetworkProfileModal.ocppVersion')}
           name="connectionData.ocppVersion"
           options={ocppVersions}
-          placeholder="Select OCPP Version"
+          placeholder={translate('ChargingStations.setNetworkProfileModal.selectOcppVersion')}
           required
         />
 
         <SelectFormField
           control={form.control}
-          label="OCPP Transport"
+          label={translate('ChargingStations.setNetworkProfileModal.ocppTransport')}
           name="connectionData.ocppTransport"
           options={ocppTransports}
-          placeholder="Select OCPP Transport"
+          placeholder={translate('ChargingStations.setNetworkProfileModal.selectOcppTransport')}
           required
         />
 
         <FormField
           control={form.control}
-          label="OCPP CSMS URL"
+          label={translate('ChargingStations.setNetworkProfileModal.ocppCsmsUrl')}
           name="connectionData.ocppCsmsUrl"
           required
         >
@@ -256,7 +301,7 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
         <FormField
           control={form.control}
-          label="Message Timeout (seconds)"
+          label={translate('ChargingStations.setNetworkProfileModal.messageTimeout')}
           name="connectionData.messageTimeout"
         >
           <Input type="number" min="0" />
@@ -264,7 +309,7 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
         <FormField
           control={form.control}
-          label="Security Profile"
+          label={translate('ChargingStations.setNetworkProfileModal.securityProfile')}
           name="connectionData.securityProfile"
         >
           <Input type="number" min={0} />
@@ -272,16 +317,16 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
         <SelectFormField
           control={form.control}
-          label="OCPP Interface"
+          label={translate('ChargingStations.setNetworkProfileModal.ocppInterface')}
           name="connectionData.ocppInterface"
           options={ocppInterfaces}
-          placeholder="Select OCPP Interface"
+          placeholder={translate('ChargingStations.setNetworkProfileModal.selectOcppInterface')}
           required
         />
 
         <FormField
           control={form.control}
-          label="Security Profile"
+          label={translate('ChargingStations.setNetworkProfileModal.securityProfile')}
           name="connectionData.securityProfile"
         >
           <Input type="number" min={0} />
@@ -292,7 +337,9 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
         {/* Checkbox to show/hide APN section */}
         <Field>
           <FieldLabel className={formLabelWrapperStyle}>
-            <span className={formLabelStyle}>Include APN Configuration</span>
+            <span className={formLabelStyle}>
+              {translate('ChargingStations.setNetworkProfileModal.includeApn')}
+            </span>
           </FieldLabel>
           <Checkbox
             className={formCheckboxStyle}
@@ -313,22 +360,29 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
         {includeApn && (
           <>
-            <FormField control={form.control} label="APN" name="connectionData.apn.apn" required>
-              <Input placeholder="APN name" />
+            <FormField
+              control={form.control}
+              label={translate('ChargingStations.setNetworkProfileModal.apn')}
+              name="connectionData.apn.apn"
+              required
+            >
+              <Input
+                placeholder={translate('ChargingStations.setNetworkProfileModal.apnPlaceholder')}
+              />
             </FormField>
 
             <SelectFormField
               control={form.control}
-              label="APN Authentication"
+              label={translate('ChargingStations.setNetworkProfileModal.apnAuthentication')}
               name="connectionData.apn.apnAuthentication"
               options={apnAuthenticationTypes}
-              placeholder="Select Authentication Type"
+              placeholder={translate('ChargingStations.setNetworkProfileModal.selectAuthType')}
               required
             />
 
             <FormField
               control={form.control}
-              label="APN Username"
+              label={translate('ChargingStations.setNetworkProfileModal.apnUsername')}
               name="connectionData.apn.apnUserName"
             >
               <Input />
@@ -336,19 +390,23 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
             <FormField
               control={form.control}
-              label="APN Password"
+              label={translate('ChargingStations.setNetworkProfileModal.apnPassword')}
               name="connectionData.apn.apnPassword"
             >
               <Input type="password" />
             </FormField>
 
-            <FormField control={form.control} label="SIM PIN" name="connectionData.apn.simPin">
+            <FormField
+              control={form.control}
+              label={translate('ChargingStations.setNetworkProfileModal.simPin')}
+              name="connectionData.apn.simPin"
+            >
               <Input type="number" />
             </FormField>
 
             <FormField
               control={form.control}
-              label="Preferred Network"
+              label={translate('ChargingStations.setNetworkProfileModal.preferredNetwork')}
               name="connectionData.apn.preferredNetwork"
             >
               <Input />
@@ -356,7 +414,7 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
 
             <CheckboxFormField
               control={form.control}
-              label="Use Only Preferred Network"
+              label={translate('ChargingStations.setNetworkProfileModal.useOnlyPreferredNetwork')}
               name="connectionData.apn.useOnlyPreferredNetwork"
             />
           </>
@@ -367,7 +425,9 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
         {/* Checkbox to show/hide VPN section */}
         <Field>
           <FieldLabel className={formLabelWrapperStyle}>
-            <span className={formLabelStyle}>Include VPN Configuration</span>
+            <span className={formLabelStyle}>
+              {translate('ChargingStations.setNetworkProfileModal.includeVpn')}
+            </span>
           </FieldLabel>
           <Checkbox
             className={formCheckboxStyle}
@@ -393,41 +453,67 @@ export const SetNetworkProfileModal = ({ station }: SetNetworkProfileModalProps)
           <>
             <SelectFormField
               control={form.control}
-              label="VPN Type"
+              label={translate('ChargingStations.setNetworkProfileModal.vpnType')}
               name="connectionData.vpn.type"
               options={vpnTypes}
-              placeholder="Select VPN Type"
+              placeholder={translate('ChargingStations.setNetworkProfileModal.selectVpnType')}
               required
             />
 
             <FormField
               control={form.control}
-              label="Server"
+              label={translate('ChargingStations.setNetworkProfileModal.server')}
               name="connectionData.vpn.server"
               required
             >
-              <Input placeholder="VPN server" />
+              <Input
+                placeholder={translate('ChargingStations.setNetworkProfileModal.serverPlaceholder')}
+              />
             </FormField>
 
-            <FormField control={form.control} label="User" name="connectionData.vpn.user" required>
-              <Input placeholder="VPN username" />
+            <FormField
+              control={form.control}
+              label={translate('ChargingStations.setNetworkProfileModal.user')}
+              name="connectionData.vpn.user"
+              required
+            >
+              <Input
+                placeholder={translate('ChargingStations.setNetworkProfileModal.userPlaceholder')}
+              />
             </FormField>
 
-            <FormField control={form.control} label="Group" name="connectionData.vpn.group">
+            <FormField
+              control={form.control}
+              label={translate('ChargingStations.setNetworkProfileModal.group')}
+              name="connectionData.vpn.group"
+            >
               <Input />
             </FormField>
 
             <FormField
               control={form.control}
-              label="Password"
+              label={translate('ChargingStations.setNetworkProfileModal.password')}
               name="connectionData.vpn.password"
               required
             >
-              <Input type="password" placeholder="VPN password" />
+              <Input
+                type="password"
+                placeholder={translate(
+                  'ChargingStations.setNetworkProfileModal.passwordPlaceholder',
+                )}
+              />
             </FormField>
 
-            <FormField control={form.control} label="Key" name="connectionData.vpn.key" required>
-              <Textarea placeholder="VPN key" rows={3} />
+            <FormField
+              control={form.control}
+              label={translate('ChargingStations.setNetworkProfileModal.key')}
+              name="connectionData.vpn.key"
+              required
+            >
+              <Textarea
+                placeholder={translate('ChargingStations.setNetworkProfileModal.keyPlaceholder')}
+                rows={3}
+              />
             </FormField>
           </>
         )}

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/set-variables/set.variables.modal.tsx
@@ -24,7 +24,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useMemo, useState } from 'react';
@@ -43,35 +43,20 @@ interface SetVariablesModalProps {
   station: any;
 }
 
-const requiredIdOrName = (label: string) =>
-  z.custom<number | string>(
-    (val) =>
-      (typeof val === 'number' && val > 0) || (typeof val === 'string' && val.trim().length > 0),
-    `${label} is required`,
-  );
-
-const SetVariableDataSchema = z.object({
-  componentId: requiredIdOrName('Component'),
-  variableId: requiredIdOrName('Variable'),
-  value: z.string().min(1, 'Value is required'),
-  attributeType: z.enum(OCPP2_0_1.AttributeEnumType).optional(),
-});
-
-const SetVariablesSchema = z.object({
-  setVariableData: z
-    .array(SetVariableDataSchema)
-    .min(1, 'At least one variable is required')
-    .refine((data) => data.every((item) => item.componentId && item.variableId && item.value), {
-      message: 'Component, Variable, and Value are required for each entry',
-    }),
-});
-
-type SetVariablesFormData = z.infer<typeof SetVariablesSchema>;
+type SetVariablesFormData = {
+  setVariableData: {
+    componentId: number | string;
+    variableId: number | string;
+    value: string;
+    attributeType?: OCPP2_0_1.AttributeEnumType;
+  }[];
+};
 
 const attributeTypes = Object.keys(OCPP2_0_1.AttributeEnumType);
 
 export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
   const [variableOptionsMap, setVariableOptionsMap] = useState<
     Record<number, { label: string; value: number }[]>
@@ -83,6 +68,32 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const SetVariablesSchema = useMemo(() => {
+    const requiredIdOrName = (label: string) =>
+      z.custom<number | string>(
+        (val) =>
+          (typeof val === 'number' && val > 0) ||
+          (typeof val === 'string' && val.trim().length > 0),
+        translate('ChargingStations.fieldRequired', { field: label }),
+      );
+
+    const SetVariableDataSchema = z.object({
+      componentId: requiredIdOrName(translate('ChargingStations.getVariablesModal.component')),
+      variableId: requiredIdOrName(translate('ChargingStations.getVariablesModal.variable')),
+      value: z.string().min(1, translate('ChargingStations.setVariablesModal.valueRequired')),
+      attributeType: z.enum(OCPP2_0_1.AttributeEnumType).optional(),
+    });
+
+    return z.object({
+      setVariableData: z
+        .array(SetVariableDataSchema)
+        .min(1, translate('ChargingStations.getVariablesModal.atLeastOneVariable'))
+        .refine((data) => data.every((item) => item.componentId && item.variableId && item.value), {
+          message: translate('ChargingStations.setVariablesModal.allFieldsRequired'),
+        }),
+    });
+  }, [translate]);
 
   const form = useForm({
     resolver: zodResolver(SetVariablesSchema),
@@ -177,6 +188,7 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
     });
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/monitoring/setVariables?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data: { setVariableData },
       setLoading,
@@ -193,14 +205,12 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
       loading={loading}
       submitHandler={onFinish}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Set Variables"
+      submitButtonLabel={translate('ChargingStations.commands.setVariables')}
       hideCancel
     >
       <Alert className="mb-4">
         <InfoIcon className="h-4 w-4" />
-        <AlertDescription>
-          Send a GetBaseReport to this Charging Station to populate Components and Variables.
-        </AlertDescription>
+        <AlertDescription>{translate('ChargingStations.getVariablesModal.alert')}</AlertDescription>
       </Alert>
       <div className="flex items-start">
         <AddArrayItemButton
@@ -212,7 +222,7 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
               attributeType: undefined,
             })
           }
-          itemLabel="Variable"
+          itemLabel={translate('ChargingStations.getVariablesModal.variable')}
         />
       </div>
       <div className="flex flex-col gap-6 w-full">
@@ -232,24 +242,28 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
             <div key={field.id} className={nestedFormRowFlex}>
               <ComboboxFormField
                 control={form.control}
-                label={`Component #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.componentNumber', {
+                  number: index + 1,
+                })}
                 name={`setVariableData.${index}.componentId`}
                 options={componentOptions}
                 onSearch={componentOnSearch}
-                placeholder="Select Component"
-                searchPlaceholder="Search Component"
+                placeholder={translate('ChargingStations.getVariablesModal.selectComponent')}
+                searchPlaceholder={translate('ChargingStations.getVariablesModal.searchComponents')}
                 isLoading={componentQuery.isLoading}
                 allowManualEntry
               />
 
               <ComboboxFormField
                 control={form.control}
-                label={`Variable #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.variableNumber', {
+                  number: index + 1,
+                })}
                 name={`setVariableData.${index}.variableId`}
                 options={variableOptions}
                 onSearch={variableOnSearch}
-                placeholder="Select Variable"
-                searchPlaceholder="Search Variables"
+                placeholder={translate('ChargingStations.getVariablesModal.selectVariable')}
+                searchPlaceholder={translate('ChargingStations.getVariablesModal.searchVariables')}
                 isLoading={variableLoading}
                 required
                 disabled={!componentId || componentId === 0}
@@ -258,18 +272,24 @@ export const SetVariablesModal = ({ station }: SetVariablesModalProps) => {
 
               <FormField
                 control={form.control}
-                label={`Value #${index + 1}`}
+                label={translate('ChargingStations.setVariablesModal.valueNumber', {
+                  number: index + 1,
+                })}
                 name={`setVariableData.${index}.value`}
               >
-                <Input placeholder="Value To Set" />
+                <Input
+                  placeholder={translate('ChargingStations.setVariablesModal.valuePlaceholder')}
+                />
               </FormField>
 
               <SelectFormField
                 control={form.control}
-                label={`Attribute Type #${index + 1}`}
+                label={translate('ChargingStations.getVariablesModal.attributeTypeNumber', {
+                  number: index + 1,
+                })}
                 name={`setVariableData.${index}.attributeType`}
                 options={attributeTypes}
-                placeholder="Select Attribute Type"
+                placeholder={translate('ChargingStations.getVariablesModal.selectAttributeType')}
               />
 
               <RemoveArrayItemButton onRemoveAction={() => remove(index)} />

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/trigger-message/trigger.message.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/trigger-message/trigger.message.modal.tsx
@@ -17,6 +17,7 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Controller } from 'react-hook-form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -26,20 +27,17 @@ export interface TriggerMessageModalProps {
   station: ChargingStationDto;
 }
 
-const TriggerMessageSchema = z.object({
-  requestedMessage: z.enum(OCPP2_0_1.MessageTriggerEnumType, {
-    message: 'Please select a message type',
-  }),
-  evse: z.string().optional(), // { id, evseTypeId }
-  connectorId: z.number().optional(),
-});
-
-type TriggerMessageFormData = z.infer<typeof TriggerMessageSchema>;
+type TriggerMessageFormData = {
+  requestedMessage: OCPP2_0_1.MessageTriggerEnumType;
+  evse?: string;
+  connectorId?: number;
+};
 
 const messageTriggers = Object.keys(OCPP2_0_1.MessageTriggerEnumType);
 
 export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -48,6 +46,18 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const TriggerMessageSchema = useMemo(
+    () =>
+      z.object({
+        requestedMessage: z.enum(OCPP2_0_1.MessageTriggerEnumType, {
+          message: translate('ChargingStations.triggerMessageModal.selectMessageError'),
+        }),
+        evse: z.string().optional(), // { id, evseTypeId }
+        connectorId: z.number().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(TriggerMessageSchema),
@@ -73,6 +83,7 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/triggerMessage?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -105,13 +116,13 @@ export const TriggerMessageModal = ({ station }: TriggerMessageModalProps) => {
       <ComboboxFormField
         control={form.control}
         name="requestedMessage"
-        label="Requested Message"
+        label={translate('ChargingStations.triggerMessageModal.requestedMessage')}
         options={messageTriggers.map((mt: string) => ({
           label: mt,
           value: mt,
         }))}
-        placeholder="Select Message Type"
-        searchPlaceholder="Search Message Types"
+        placeholder={translate('ChargingStations.triggerMessageModal.selectMessageType')}
+        searchPlaceholder={translate('ChargingStations.triggerMessageModal.searchMessageTypes')}
         required
       />
 

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/unlock-connector/unlock.connector.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/unlock-connector/unlock.connector.modal.tsx
@@ -15,6 +15,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Form } from '@lib/client/components/form';
 import { Controller } from 'react-hook-form';
@@ -25,19 +26,14 @@ interface UnlockConnectorModalProps {
   station: any;
 }
 
-const UnlockConnectorSchema = z.object({
-  evse: z.string({
-    message: 'EVSE is required',
-  }), // { id, evseTypeId }
-  connectorId: z.number({
-    message: 'Connector is required',
-  }),
-});
-
-type UnlockConnectorFormData = z.infer<typeof UnlockConnectorSchema>;
+type UnlockConnectorFormData = {
+  evse: string;
+  connectorId: number;
+};
 
 export const UnlockConnectorModal = ({ station }: UnlockConnectorModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -46,6 +42,23 @@ export const UnlockConnectorModal = ({ station }: UnlockConnectorModalProps) => 
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const UnlockConnectorSchema = useMemo(
+    () =>
+      z.object({
+        evse: z.string({
+          message: translate('ChargingStations.fieldRequired', {
+            field: translate('ChargingStations.evseSelector.label'),
+          }),
+        }), // { id, evseTypeId }
+        connectorId: z.number({
+          message: translate('ChargingStations.fieldRequired', {
+            field: translate('ChargingStations.connectorSelector.label'),
+          }),
+        }),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(UnlockConnectorSchema),
@@ -69,6 +82,7 @@ export const UnlockConnectorModal = ({ station }: UnlockConnectorModalProps) => 
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/unlockConnector?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -96,7 +110,7 @@ export const UnlockConnectorModal = ({ station }: UnlockConnectorModalProps) => 
       loading={loading}
       submitHandler={onFinish}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Unlock Connector"
+      submitButtonLabel={translate('ChargingStations.commands.unlockConnector')}
       hideCancel
     >
       <Controller

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/update-auth-password/update.auth.password.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/update-auth-password/update.auth.password.modal.tsx
@@ -16,6 +16,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 
@@ -23,21 +24,31 @@ interface UpdateAuthPasswordModalProps {
   station: any;
 }
 
-const UpdateAuthPasswordSchema = z.object({
-  password: z.string().min(1, 'Password is required'),
-  setOnCharger: z.boolean(),
-});
-
-type UpdateAuthPasswordFormData = z.infer<typeof UpdateAuthPasswordSchema>;
+type UpdateAuthPasswordFormData = {
+  password: string;
+  setOnCharger: boolean;
+};
 
 export const UpdateAuthPasswordModal = ({ station }: UpdateAuthPasswordModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const UpdateAuthPasswordSchema = useMemo(
+    () =>
+      z.object({
+        password: z
+          .string()
+          .min(1, translate('ChargingStations.updateAuthPasswordModal.passwordRequired')),
+        setOnCharger: z.boolean(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(UpdateAuthPasswordSchema),
@@ -62,6 +73,7 @@ export const UpdateAuthPasswordModal = ({ station }: UpdateAuthPasswordModalProp
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation>({
+      translate,
       url: `/configuration/password`,
       data,
       setLoading,
@@ -78,16 +90,24 @@ export const UpdateAuthPasswordModal = ({ station }: UpdateAuthPasswordModalProp
       loading={loading}
       submitHandler={handleSubmit}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonlabel="Update Password"
+      submitButtonlabel={translate('ChargingStations.updateAuthPasswordModal.updatePassword')}
       hideCancel
     >
-      <FormField control={form.control} label="Password" name="password" required>
-        <Input type="password" placeholder="Enter new password" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateAuthPasswordModal.password')}
+        name="password"
+        required
+      >
+        <Input
+          type="password"
+          placeholder={translate('ChargingStations.updateAuthPasswordModal.passwordPlaceholder')}
+        />
       </FormField>
 
       <CheckboxFormField
         control={form.control}
-        label="Set On Charger"
+        label={translate('ChargingStations.updateAuthPasswordModal.setOnCharger')}
         name="setOnCharger"
         required
       />

--- a/apps/operator-ui/src/lib/client/components/modals/2.0.1/update-firmware/update.firmware.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/2.0.1/update-firmware/update.firmware.modal.tsx
@@ -13,7 +13,7 @@ import { CHARGING_STATION_SEQUENCES_GET_QUERY } from '@lib/queries/charging.stat
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { formatPem, triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useApiUrl, useCustom } from '@refinedev/core';
+import { useApiUrl, useCustom, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useEffect, useMemo, useState } from 'react';
@@ -28,21 +28,20 @@ export interface UpdateFirmwareModalProps {
   station: ChargingStationDto;
 }
 
-const UpdateFirmwareSchema = z.object({
-  requestId: z.coerce.number<number>().int().min(0),
-  retries: z.coerce.number<number>().int().min(0).optional(),
-  retryInterval: z.coerce.number<number>().int().min(0).optional(),
-  location: z.string().url('Must be a valid URL').min(1).max(512),
-  retrieveDateTime: z.string().min(1, 'Retrieve date is required'),
-  installDateTime: z.string().optional(),
-  signingCertificate: z.string().max(5500).optional(),
-  signature: z.string().max(800).optional(),
-});
-
-type UpdateFirmwareFormData = z.infer<typeof UpdateFirmwareSchema>;
+type UpdateFirmwareFormData = {
+  requestId: number;
+  retries?: number;
+  retryInterval?: number;
+  location: string;
+  retrieveDateTime: string;
+  installDateTime?: string;
+  signingCertificate?: string;
+  signature?: string;
+};
 
 export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
@@ -51,6 +50,27 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
     () => plainToInstance(ChargingStationClass, station),
     [station],
   ) as ChargingStationDto;
+
+  const UpdateFirmwareSchema = useMemo(
+    () =>
+      z.object({
+        requestId: z.coerce.number<number>().int().min(0),
+        retries: z.coerce.number<number>().int().min(0).optional(),
+        retryInterval: z.coerce.number<number>().int().min(0).optional(),
+        location: z
+          .string()
+          .url(translate('ChargingStations.firmwareDiagnostics.invalidUrl'))
+          .min(1)
+          .max(512),
+        retrieveDateTime: z
+          .string()
+          .min(1, translate('ChargingStations.updateFirmwareModal.retrieveDateRequired')),
+        installDateTime: z.string().optional(),
+        signingCertificate: z.string().max(5500).optional(),
+        signature: z.string().max(800).optional(),
+      }),
+    [translate],
+  );
 
   const apiUrl = useApiUrl();
   const {
@@ -96,7 +116,7 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
     if (values.signingCertificate && values.signingCertificate.trim()) {
       const pemString = formatPem(values.signingCertificate);
       if (!pemString) {
-        toast.error('Incorrectly formatted PEM certificate');
+        toast.error(translate('ChargingStations.installCertificateModal.invalidPem'));
         return;
       }
       signingCertificate = pemString;
@@ -120,6 +140,7 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/updateFirmware?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -136,39 +157,88 @@ export const UpdateFirmwareModal = ({ station }: UpdateFirmwareModalProps) => {
       loading={loading || isRequestIdLoading}
       submitHandler={handleSubmit}
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Update Firmware"
+      submitButtonLabel={translate('ChargingStations.commands.updateFirmware')}
       hideCancel
     >
-      <FormField control={form.control} label="Request ID" name="requestId" required>
-        <Input type="number" placeholder="Request ID" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.requestId.label')}
+        name="requestId"
+        required
+      >
+        <Input type="number" placeholder={translate('ChargingStations.requestId.label')} min="0" />
       </FormField>
 
-      <FormField control={form.control} label="Location (URL)" name="location" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.locationUrl')}
+        name="location"
+        required
+      >
         <Input placeholder="https://example.com/firmware.bin" type="url" required />
       </FormField>
 
-      <FormField control={form.control} label="Retrieve Date/Time" name="retrieveDateTime" required>
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateFirmwareModal.retrieveDateTime')}
+        name="retrieveDateTime"
+        required
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Install Date/Time" name="installDateTime">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateFirmwareModal.installDateTime')}
+        name="installDateTime"
+      >
         <Input type="datetime-local" />
       </FormField>
 
-      <FormField control={form.control} label="Retries" name="retries">
-        <Input type="number" placeholder="Number of retries" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retries')}
+        name="retries"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retriesPlaceholder')}
+          min="0"
+        />
       </FormField>
 
-      <FormField control={form.control} label="Retry Interval" name="retryInterval">
-        <Input type="number" placeholder="Retry interval in seconds" min="0" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.firmwareDiagnostics.retryInterval')}
+        name="retryInterval"
+      >
+        <Input
+          type="number"
+          placeholder={translate('ChargingStations.firmwareDiagnostics.retryIntervalPlaceholder')}
+          min="0"
+        />
       </FormField>
 
-      <FormField control={form.control} label="Signing Certificate (PEM)" name="signingCertificate">
-        <Textarea placeholder="Paste PEM-formatted certificate here" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateFirmwareModal.signingCertificate')}
+        name="signingCertificate"
+      >
+        <Textarea
+          placeholder={translate(
+            'ChargingStations.updateFirmwareModal.signingCertificatePlaceholder',
+          )}
+        />
       </FormField>
 
-      <FormField control={form.control} label="Signature" name="signature">
-        <Input placeholder="Firmware signature" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.updateFirmwareModal.signature')}
+        name="signature"
+      >
+        <Input
+          placeholder={translate('ChargingStations.updateFirmwareModal.signaturePlaceholder')}
+        />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/admin/force-disconnect/force.disconnect.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/admin/force-disconnect/force.disconnect.modal.tsx
@@ -30,6 +30,7 @@ export const ForceDisconnectModal = ({ station }: ForceDisconnectModalProps) => 
 
   const onOkay = async () => {
     await triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/ocpprouter/connection?ocppConnectionName=${parsedStation.ocppConnectionName}&tenantId=${parsedStation.tenantId}`,
       data: undefined,
       setLoading,

--- a/apps/operator-ui/src/lib/client/components/modals/data-transfer/data.transfer.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/data-transfer/data.transfer.modal.tsx
@@ -17,6 +17,7 @@ import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
@@ -25,16 +26,15 @@ export interface DataTransferModalProps {
   station: any;
 }
 
-const DataTransferSchema = z.object({
-  vendorId: z.string().min(1, 'Vendor ID is required'),
-  messageId: z.string().optional(),
-  data: z.string().optional(),
-});
-
-type DataTransferFormData = z.infer<typeof DataTransferSchema>;
+type DataTransferFormData = {
+  vendorId: string;
+  messageId?: string;
+  data?: string;
+};
 
 export const DataTransferModal = ({ station }: DataTransferModalProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState(false);
 
   const tenantId = useTenantId();
@@ -45,6 +45,18 @@ export const DataTransferModal = ({ station }: DataTransferModalProps) => {
   ) as ChargingStationDto;
 
   const ocppVersion = parsedStation.protocol;
+
+  const DataTransferSchema = useMemo(
+    () =>
+      z.object({
+        vendorId: z
+          .string()
+          .min(1, translate('ChargingStations.dataTransferModal.vendorIdRequired')),
+        messageId: z.string().optional(),
+        data: z.string().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(DataTransferSchema),
@@ -74,6 +86,7 @@ export const DataTransferModal = ({ station }: DataTransferModalProps) => {
     }
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/dataTransfer?identifier=${parsedStation.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -97,16 +110,29 @@ export const DataTransferModal = ({ station }: DataTransferModalProps) => {
       submitButtonVariant={FormButtonVariants.submit}
       hideCancel
     >
-      <FormField control={form.control} label="Vendor ID" name="vendorId" required>
-        <Input placeholder="Vendor specific implementation identifier" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.dataTransferModal.vendorId')}
+        name="vendorId"
+        required
+      >
+        <Input placeholder={translate('ChargingStations.dataTransferModal.vendorIdPlaceholder')} />
       </FormField>
 
-      <FormField control={form.control} label="Message ID" name="messageId">
-        <Input placeholder="Specific message or implementation identifier" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.dataTransferModal.messageId')}
+        name="messageId"
+      >
+        <Input placeholder={translate('ChargingStations.dataTransferModal.messageIdPlaceholder')} />
       </FormField>
 
-      <FormField control={form.control} label="Data" name="data">
-        <Textarea placeholder="Data to send (freeform text)" />
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.dataTransferModal.data')}
+        name="data"
+      >
+        <Textarea placeholder={translate('ChargingStations.dataTransferModal.dataPlaceholder')} />
       </FormField>
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/other-commands/1.6/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/other-commands/1.6/index.tsx
@@ -12,7 +12,7 @@ import { Button } from '@lib/client/components/ui/button';
 import type { ListCanReturnType } from '@lib/utils/access.types';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
 import { closeModal, openModal } from '@lib/utils/store/modal.slice';
-import { useCan } from '@refinedev/core';
+import { useCan, useTranslate } from '@refinedev/core';
 import { instanceToPlain } from 'class-transformer';
 import { useDispatch } from 'react-redux';
 
@@ -22,11 +22,12 @@ export interface OCPP1_6_CommandsProps {
 
 export const OCPP1_6_Commands = ({ station }: OCPP1_6_CommandsProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
 
   const handleCommandClick = (commandDef: CommandDefinition) => {
     dispatch(
       openModal({
-        title: commandDef.displayName,
+        title: translate(commandDef.displayNameKey),
         modalComponentType: commandDef.modalType,
         modalComponentProps: { station: instanceToPlain(station) },
       }),
@@ -64,7 +65,7 @@ export const OCPP1_6_Commands = ({ station }: OCPP1_6_CommandsProps) => {
           className="w-full"
           onClick={() => handleCommandClick(commandDef)}
         >
-          {commandDef.displayName}
+          {translate(commandDef.displayNameKey)}
         </Button>
       ))}
     </div>

--- a/apps/operator-ui/src/lib/client/components/modals/other-commands/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/other-commands/2.0.1/index.tsx
@@ -12,7 +12,7 @@ import { Button } from '@lib/client/components/ui/button';
 import type { ListCanReturnType } from '@lib/utils/access.types';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
 import { closeModal, openModal } from '@lib/utils/store/modal.slice';
-import { useCan } from '@refinedev/core';
+import { useCan, useTranslate } from '@refinedev/core';
 import { instanceToPlain } from 'class-transformer';
 import { useDispatch } from 'react-redux';
 
@@ -22,11 +22,12 @@ export interface OCPP2_0_1_CommandsProps {
 
 export const OCPP2_0_1_Commands = ({ station }: OCPP2_0_1_CommandsProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
 
   const handleCommandClick = (commandDef: CommandDefinition) => {
     dispatch(
       openModal({
-        title: commandDef.displayName,
+        title: translate(commandDef.displayNameKey),
         modalComponentType: commandDef.modalType,
         modalComponentProps: { station: instanceToPlain(station) },
       }),
@@ -64,7 +65,7 @@ export const OCPP2_0_1_Commands = ({ station }: OCPP2_0_1_CommandsProps) => {
           className="w-full"
           onClick={() => handleCommandClick(commandDef)}
         >
-          {commandDef.displayName}
+          {translate(commandDef.displayNameKey)}
         </Button>
       ))}
     </div>

--- a/apps/operator-ui/src/lib/client/components/modals/other-commands/other.commands.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/other-commands/other.commands.modal.tsx
@@ -10,6 +10,7 @@ import { Loader2 } from 'lucide-react';
 import { plainToInstance } from 'class-transformer';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import { OCPP1_6_Commands } from './1.6';
 import { OCPP2_0_1_Commands } from './2.0.1';
 
@@ -18,6 +19,7 @@ export interface OtherCommandsModalProps {
 }
 
 export const OtherCommandsModal = ({ station }: OtherCommandsModalProps) => {
+  const translate = useTranslate();
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
@@ -40,7 +42,13 @@ export const OtherCommandsModal = ({ station }: OtherCommandsModalProps) => {
       case OCPPVersion.OCPP2_1:
         return <OCPP2_0_1_Commands station={parsedStation} />;
       default:
-        return <div>Unsupported protocol version: {parsedStation.protocol}</div>;
+        return (
+          <div>
+            {translate('ChargingStations.unsupportedProtocol', {
+              protocol: parsedStation.protocol,
+            })}
+          </div>
+        );
     }
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/1.6/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/1.6/index.tsx
@@ -15,9 +15,9 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import z from 'zod';
 import { Controller } from 'react-hook-form';
@@ -28,19 +28,30 @@ export interface OCPP1_6_RemoteStartProps {
   station: ChargingStationDto;
 }
 
-const RemoteStartSchema = z.object({
-  remoteStartId: z.coerce.number<number>().min(0, 'Remote Start ID must be at least 0'),
-  idTag: z.string().min(1, 'ID Token is required'),
-  connectorId: z.number().optional(),
-});
-
-type RemoteStartFormData = z.infer<typeof RemoteStartSchema>;
+type RemoteStartFormData = {
+  remoteStartId: number;
+  idTag: string;
+  connectorId?: number;
+};
 
 export const OCPP1_6_RemoteStart = ({ station }: OCPP1_6_RemoteStartProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const RemoteStartSchema = useMemo(
+    () =>
+      z.object({
+        remoteStartId: z.coerce
+          .number<number>()
+          .min(0, translate('ChargingStations.remoteStartModal.remoteStartIdMin')),
+        idTag: z.string().min(1, translate('ChargingStations.remoteStartModal.idTokenRequired')),
+        connectorId: z.number().optional(),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(RemoteStartSchema),
@@ -100,6 +111,7 @@ export const OCPP1_6_RemoteStart = ({ station }: OCPP1_6_RemoteStartProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/remoteStartTransaction?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       ocppVersion: OCPPVersion.OCPP1_6,
@@ -117,20 +129,24 @@ export const OCPP1_6_RemoteStart = ({ station }: OCPP1_6_RemoteStartProps) => {
       submitHandler={onFinish}
       hideCancel
       submitButtonVariant={FormButtonVariants.confirm}
-      submitButtonLabel="Start"
+      submitButtonLabel={translate('ChargingStations.remoteStartModal.start')}
     >
-      <FormField control={form.control} label="Remote Start ID" name="remoteStartId">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.remoteStartModal.remoteStartId')}
+        name="remoteStartId"
+      >
         <Input type="number" min={0} />
       </FormField>
 
       <ComboboxFormField
         control={form.control}
-        label="ID Token"
+        label={translate('ChargingStations.remoteStartModal.idToken')}
         name="idTag"
         options={authorizationOptions}
         onSelect={handleIdTokenSelection}
         onSearch={authorizationOnSearch}
-        placeholder="Search ID Token"
+        placeholder={translate('ChargingStations.remoteStartModal.searchIdToken')}
         isLoading={authorizationQueryResult.isLoading}
       />
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
@@ -21,10 +21,10 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useCustom, useSelect } from '@refinedev/core';
+import { useCustom, useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import z from 'zod';
 import { Controller } from 'react-hook-form';
@@ -36,18 +36,32 @@ export interface OCPP2_0_1_RemoteStartProps {
   station: ChargingStationDto;
 }
 
-export const RemoteStartSchema = z.object({
-  remoteStartId: z.coerce.number<number>().min(0, 'Remote Start ID must be at least 0'),
-  authorization: z.string().min(1, 'Authorization is required'),
-  evse: z.string().optional(), // { id, evseTypeId }
-});
-export type RemoteStartFormData = z.infer<typeof RemoteStartSchema>;
+export type RemoteStartFormData = {
+  remoteStartId: number;
+  authorization: string;
+  evse?: string;
+};
 
 export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const RemoteStartSchema = useMemo(
+    () =>
+      z.object({
+        remoteStartId: z.coerce
+          .number<number>()
+          .min(0, translate('ChargingStations.remoteStartModal.remoteStartIdMin')),
+        authorization: z
+          .string()
+          .min(1, translate('ChargingStations.remoteStartModal.authorizationRequired')),
+        evse: z.string().optional(), // { id, evseTypeId }
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(RemoteStartSchema),
@@ -141,6 +155,7 @@ export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) =
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/requestStartTransaction?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -158,20 +173,24 @@ export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) =
       submitHandler={onFinish}
       hideCancel
       submitButtonVariant={FormButtonVariants.confirm}
-      submitButtonLabel="Start"
+      submitButtonLabel={translate('ChargingStations.remoteStartModal.start')}
     >
-      <FormField control={form.control} label="Remote Start ID" name="remoteStartId">
+      <FormField
+        control={form.control}
+        label={translate('ChargingStations.remoteStartModal.remoteStartId')}
+        name="remoteStartId"
+      >
         <Input type="number" min={0} />
       </FormField>
 
       <ComboboxFormField
         control={form.control}
-        label="Authorization"
+        label={translate('ChargingStations.remoteStartModal.authorization')}
         name="authorization"
         options={authorizationOptions}
         onSearch={authorizationOnSearch}
-        placeholder="Select Authorization"
-        searchPlaceholder="Search Authorizations"
+        placeholder={translate('ChargingStations.remoteStartModal.selectAuthorization')}
+        searchPlaceholder={translate('ChargingStations.remoteStartModal.searchAuthorizations')}
         required
       />
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
@@ -7,6 +7,7 @@ import { OCPPVersion } from '@citrineos/base';
 import { ChargingStationClass } from '@lib/cls/charging.station.dto';
 import { plainToInstance } from 'class-transformer';
 import { useMemo } from 'react';
+import { useTranslate } from '@refinedev/core';
 import { OCPP1_6_RemoteStart } from './1.6';
 import { OCPP2_0_1_RemoteStart } from './2.0.1';
 
@@ -15,6 +16,7 @@ export interface RemoteStartTransactionModalProps {
 }
 
 export const RemoteStartTransactionModal = ({ station }: RemoteStartTransactionModalProps) => {
+  const translate = useTranslate();
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
@@ -29,7 +31,13 @@ export const RemoteStartTransactionModal = ({ station }: RemoteStartTransactionM
       case OCPPVersion.OCPP2_1:
         return <OCPP2_0_1_RemoteStart station={parsedStation} />;
       default:
-        return <div>Unsupported protocol version: {parsedStation.protocol}</div>;
+        return (
+          <div>
+            {translate('ChargingStations.unsupportedProtocol', {
+              protocol: parsedStation.protocol,
+            })}
+          </div>
+        );
     }
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/1.6/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/1.6/index.tsx
@@ -13,8 +13,9 @@ import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
@@ -23,17 +24,26 @@ export interface OCPP1_6_RemoteStopProps {
   station: ChargingStationWithTransactionsDto;
 }
 
-const RemoteStopSchema = z.object({
-  transactionId: z.string().min(1, 'Transaction is required'),
-});
-
-type RemoteStopFormData = z.infer<typeof RemoteStopSchema>;
+type RemoteStopFormData = {
+  transactionId: string;
+};
 
 export const OCPP1_6_RemoteStop = ({ station }: OCPP1_6_RemoteStopProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const RemoteStopSchema = useMemo(
+    () =>
+      z.object({
+        transactionId: z
+          .string()
+          .min(1, translate('ChargingStations.remoteStopModal.transactionRequired')),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(RemoteStopSchema),
@@ -46,6 +56,7 @@ export const OCPP1_6_RemoteStop = ({ station }: OCPP1_6_RemoteStopProps) => {
     const data = { transactionId: values.transactionId };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/remoteStopTransaction?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       ocppVersion: OCPPVersion.OCPP1_6,
@@ -67,7 +78,7 @@ export const OCPP1_6_RemoteStop = ({ station }: OCPP1_6_RemoteStopProps) => {
   const hasNoActiveTransactions = station.transactions && station.transactions.length === 0;
 
   return hasNoActiveTransactions ? (
-    <div>No active transactions found for this charging station.</div>
+    <div>{translate('ChargingStations.remoteStopModal.noActiveTransactions')}</div>
   ) : (
     <Form
       {...form}
@@ -75,18 +86,18 @@ export const OCPP1_6_RemoteStop = ({ station }: OCPP1_6_RemoteStopProps) => {
       submitHandler={onFinish}
       hideCancel
       submitButtonVariant={FormButtonVariants.delete}
-      submitButtonLabel="Stop"
+      submitButtonLabel={translate('ChargingStations.remoteStopModal.stop')}
     >
       <ComboboxFormField
         control={form.control}
-        label="Active Transactions"
+        label={translate('ChargingStations.remoteStopModal.activeTransactions')}
         name="transactionId"
         options={station.transactions.map((transaction: TransactionDto) => ({
           label: transaction.transactionId,
           value: transaction.transactionId,
         }))}
-        placeholder="Select Transaction"
-        searchPlaceholder="Search Transactions"
+        placeholder={translate('ChargingStations.remoteStopModal.selectTransaction')}
+        searchPlaceholder={translate('ChargingStations.remoteStopModal.searchTransactions')}
         required
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
@@ -14,6 +14,7 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
@@ -22,15 +23,13 @@ export interface OCPP2_0_1_RemoteStopProps {
   station: ChargingStationWithTransactionsDto;
 }
 
-const RemoteStopSchema = z.object({
-  transactionId: z.string().min(1, 'Transaction is required'),
-});
-
-type RemoteStopFormData = z.infer<typeof RemoteStopSchema>;
-
-const unknownEvse = 'Unknown';
+type RemoteStopFormData = {
+  transactionId: string;
+};
 
 export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => {
+  const translate = useTranslate();
+  const unknownEvse = translate('ChargingStations.remoteStopModal.unknownEvse');
   const evseMap: Map<number, EvseDto> = useMemo(() => {
     if (!station.evses) return new Map<number, EvseDto>();
     return new Map(station.evses.map((evse) => [evse.id!, evse]));
@@ -40,6 +39,16 @@ export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => 
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const RemoteStopSchema = useMemo(
+    () =>
+      z.object({
+        transactionId: z
+          .string()
+          .min(1, translate('ChargingStations.remoteStopModal.transactionRequired')),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(RemoteStopSchema),
@@ -52,6 +61,7 @@ export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => 
     const data = { transactionId: values.transactionId };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/evdriver/requestStopTransaction?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       ocppVersion: station.protocol,
@@ -77,7 +87,7 @@ export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => 
   const hasNoActiveTransactions = activeTransactions.length === 0;
 
   return hasNoActiveTransactions ? (
-    <div>No active transactions found for this charging station.</div>
+    <div>{translate('ChargingStations.remoteStopModal.noActiveTransactions')}</div>
   ) : (
     <Form
       {...form}
@@ -85,18 +95,18 @@ export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => 
       submitHandler={onFinish}
       hideCancel
       submitButtonVariant={FormButtonVariants.delete}
-      submitButtonLabel="Stop"
+      submitButtonLabel={translate('ChargingStations.remoteStopModal.stop')}
     >
       <ComboboxFormField
         control={form.control}
-        label="Active Transactions"
+        label={translate('ChargingStations.remoteStopModal.activeTransactions')}
         name="transactionId"
         options={station.transactions.map((transaction: TransactionDto) => ({
           label: `EVSE: ${(transaction.evseId ? evseMap.get(transaction.evseId)?.id : unknownEvse) ?? unknownEvse} - ${transaction.transactionId}`,
           value: transaction.transactionId,
         }))}
-        placeholder="Select Transaction"
-        searchPlaceholder="Search Transactions"
+        placeholder={translate('ChargingStations.remoteStopModal.selectTransaction')}
+        searchPlaceholder={translate('ChargingStations.remoteStopModal.searchTransactions')}
         required
       />
     </Form>

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
@@ -6,6 +6,7 @@ import { ChargingStationSchema, OCPPVersion, TransactionSchema } from '@citrineo
 import { ChargingStationClass } from '@lib/cls/charging.station.dto';
 import { plainToInstance } from 'class-transformer';
 import { useMemo } from 'react';
+import { useTranslate } from '@refinedev/core';
 import type { z } from 'zod';
 import { OCPP1_6_RemoteStop } from './1.6';
 import { OCPP2_0_1_RemoteStop } from './2.0.1';
@@ -22,6 +23,7 @@ export interface RemoteStopTransactionModalProps {
 }
 
 export const RemoteStopTransactionModal = ({ station }: RemoteStopTransactionModalProps) => {
+  const translate = useTranslate();
   const parsedStation: ChargingStationWithTransactionsDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
@@ -36,7 +38,13 @@ export const RemoteStopTransactionModal = ({ station }: RemoteStopTransactionMod
       case OCPPVersion.OCPP2_1:
         return <OCPP2_0_1_RemoteStop station={parsedStation} />;
       default:
-        return <div>Unsupported protocol version: {parsedStation.protocol}</div>;
+        return (
+          <div>
+            {translate('ChargingStations.unsupportedProtocol', {
+              protocol: parsedStation.protocol,
+            })}
+          </div>
+        );
     }
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/reset/1.6/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/reset/1.6/index.tsx
@@ -12,8 +12,9 @@ import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
@@ -22,21 +23,28 @@ export interface OCPP1_6_ResetProps {
   station: ChargingStationDto;
 }
 
-const ResetSchema = z.object({
-  type: z.enum(OCPP1_6.ResetRequestType, {
-    message: 'Please select a reset type',
-  }),
-});
-
-type ResetFormData = z.infer<typeof ResetSchema>;
+type ResetFormData = {
+  type: OCPP1_6.ResetRequestType;
+};
 
 const resetTypes = Object.keys(OCPP1_6.ResetRequestType);
 
 export const OCPP1_6_Reset = ({ station }: OCPP1_6_ResetProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const ResetSchema = useMemo(
+    () =>
+      z.object({
+        type: z.enum(OCPP1_6.ResetRequestType, {
+          message: translate('ChargingStations.resetModal.selectResetTypeError'),
+        }),
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(ResetSchema),
@@ -49,6 +57,7 @@ export const OCPP1_6_Reset = ({ station }: OCPP1_6_ResetProps) => {
     const data = { type: values.type };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/reset?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -66,14 +75,14 @@ export const OCPP1_6_Reset = ({ station }: OCPP1_6_ResetProps) => {
       submitHandler={handleSubmit}
       hideCancel
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Reset"
+      submitButtonLabel={translate('ChargingStations.reset')}
     >
       <SelectFormField
         control={form.control}
-        label="Reset Type"
+        label={translate('ChargingStations.resetModal.resetType')}
         name="type"
         options={resetTypes}
-        placeholder="Select Reset Type"
+        placeholder={translate('ChargingStations.resetModal.selectResetType')}
       />
     </Form>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/reset/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/reset/2.0.1/index.tsx
@@ -12,8 +12,9 @@ import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { Controller } from 'react-hook-form';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
@@ -23,22 +24,30 @@ export interface OCPP2_0_1_ResetProps {
   station: ChargingStationDto;
 }
 
-const ResetSchema = z.object({
-  type: z.enum(OCPP2_0_1.ResetEnumType, {
-    message: 'Please select a reset type',
-  }),
-  evse: z.string().optional(), // { id, evseTypeId }
-});
-
-type ResetFormData = z.infer<typeof ResetSchema>;
+type ResetFormData = {
+  type: OCPP2_0_1.ResetEnumType;
+  evse?: string;
+};
 
 const resetTypes = Object.keys(OCPP2_0_1.ResetEnumType);
 
 export const OCPP2_0_1_Reset = ({ station }: OCPP2_0_1_ResetProps) => {
   const dispatch = useDispatch();
+  const translate = useTranslate();
   const [loading, setLoading] = useState<boolean>(false);
 
   const tenantId = useTenantId();
+
+  const ResetSchema = useMemo(
+    () =>
+      z.object({
+        type: z.enum(OCPP2_0_1.ResetEnumType, {
+          message: translate('ChargingStations.resetModal.selectResetTypeError'),
+        }),
+        evse: z.string().optional(), // { id, evseTypeId }
+      }),
+    [translate],
+  );
 
   const form = useForm({
     resolver: zodResolver(ResetSchema),
@@ -57,6 +66,7 @@ export const OCPP2_0_1_Reset = ({ station }: OCPP2_0_1_ResetProps) => {
     };
 
     triggerMessageAndHandleResponse<MessageConfirmation[]>({
+      translate,
       url: `/configuration/reset?identifier=${station.ocppConnectionName}&tenantId=${tenantId}`,
       data,
       setLoading,
@@ -78,14 +88,14 @@ export const OCPP2_0_1_Reset = ({ station }: OCPP2_0_1_ResetProps) => {
       submitHandler={handleSubmit}
       hideCancel
       submitButtonVariant={FormButtonVariants.submit}
-      submitButtonLabel="Reset"
+      submitButtonLabel={translate('ChargingStations.reset')}
     >
       <SelectFormField
         control={form.control}
-        label="Reset Type"
+        label={translate('ChargingStations.resetModal.resetType')}
         name="type"
         options={resetTypes}
-        placeholder="Select Reset Type"
+        placeholder={translate('ChargingStations.resetModal.selectResetType')}
       />
 
       <Controller

--- a/apps/operator-ui/src/lib/client/components/modals/reset/reset.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/reset/reset.modal.tsx
@@ -7,6 +7,7 @@ import { OCPPVersion } from '@citrineos/base';
 import { ChargingStationClass } from '@lib/cls/charging.station.dto';
 import { plainToInstance } from 'class-transformer';
 import { useMemo } from 'react';
+import { useTranslate } from '@refinedev/core';
 import { OCPP1_6_Reset } from './1.6';
 import { OCPP2_0_1_Reset } from './2.0.1';
 
@@ -15,6 +16,7 @@ export interface ResetModalProps {
 }
 
 export const ResetModal = ({ station }: ResetModalProps) => {
+  const translate = useTranslate();
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
     [station],
@@ -29,7 +31,13 @@ export const ResetModal = ({ station }: ResetModalProps) => {
       case OCPPVersion.OCPP2_1:
         return <OCPP2_0_1_Reset station={parsedStation} />;
       default:
-        return <div>Unsupported protocol version: {parsedStation.protocol}</div>;
+        return (
+          <div>
+            {translate('ChargingStations.unsupportedProtocol', {
+              protocol: parsedStation.protocol,
+            })}
+          </div>
+        );
     }
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/shared/connection-modal/connection.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/connection-modal/connection.modal.tsx
@@ -28,27 +28,9 @@ export interface OperatorConfig {
   defaultTenantId: number;
 }
 
-export const SecurityProfiles: Record<number, { label: string; description: string }> = {
-  0: {
-    label: 'No Authentication',
-    description:
-      'The charging station connects without credentials. Set up the username/password using this connection',
-  },
-  1: {
-    label: 'Security Profile 1: Unsecured Transport with Basic Authentication',
-    description:
-      'Charging Station authentication is done through a username and password. Install CA certificate in the charging station using this connection',
-  },
-  2: {
-    label: 'Security Profile 2: TLS with Basic Authentication',
-    description:
-      'The CSMS authenticates itself using a TLS server certificate. The Charging Stations authenticate themselves using HTTP Basic Authentication. Sign charging station certificate using this connection',
-  },
-  3: {
-    label: 'Security Profile 3: TLS with Client Side Certificates',
-    description: 'Both the Charging Station and CSMS authenticate themselves using certificates.',
-  },
-};
+// Security profile identifiers. Labels and descriptions are translated via
+// the `ChargingStations.connectionModal.securityProfiles.*` i18n keys.
+export const SecurityProfiles: number[] = [0, 1, 2, 3];
 
 interface ConnectionModalProps {
   open: boolean;
@@ -255,8 +237,7 @@ export const ConnectionModal = ({ open, onClose, isFirstLogin = false }: Connect
           </div>
         ) : hasConnections ? (
           <div className="space-y-6">
-            {Object.keys(SecurityProfiles).map((key) => {
-              const profile = Number(key);
+            {SecurityProfiles.map((profile) => {
               const servers = groupedServers[profile];
               if (!servers?.length) return null;
 

--- a/apps/operator-ui/src/lib/client/components/modals/shared/connector-selector/connector.selector.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/connector-selector/connector.selector.tsx
@@ -9,7 +9,7 @@ import { Combobox } from '@lib/client/components/combobox';
 import { GET_CONNECTOR_LIST_FOR_STATION_EVSE } from '@lib/queries/connectors';
 import { CONNECTOR_LIST_FOR_STATION_QUERY } from '@lib/queries/connectors';
 import { ResourceType } from '@lib/utils/access.types';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import { Field, FieldDescription, FieldLabel } from '@lib/client/components/ui/field';
 import {
   formLabelStyle,
@@ -35,6 +35,7 @@ export const ConnectorSelector = ({
   isOptional = false,
   requiresEvseId = false,
 }: ConnectorSelectorProps) => {
+  const translate = useTranslate();
   // Use different query based on whether we're filtering by EVSE (2.0.1) or not (1.6)
   const gqlQuery =
     evseId !== undefined ? GET_CONNECTOR_LIST_FOR_STATION_EVSE : CONNECTOR_LIST_FOR_STATION_QUERY;
@@ -80,16 +81,22 @@ export const ConnectorSelector = ({
   return (
     <Field>
       <FieldLabel className={formLabelWrapperStyle}>
-        <span className={formLabelStyle}>Connector</span>
+        <span className={formLabelStyle}>
+          {translate('ChargingStations.connectorSelector.label')}
+        </span>
         {!isOptional && formRequiredAsterisk}
       </FieldLabel>
       {requiresEvseId && !evseId && (
-        <span className="text-sm text-muted-foreground">Select an EVSE</span>
+        <span className="text-sm text-muted-foreground">
+          {translate('ChargingStations.connectorSelector.selectEvse')}
+        </span>
       )}
       {query.isLoading && ((requiresEvseId && evseId) || !requiresEvseId) && (
         <div className="flex items-center gap-2 py-4">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm text-muted-foreground">Loading Connectors...</span>
+          <span className="text-sm text-muted-foreground">
+            {translate('ChargingStations.connectorSelector.loading')}
+          </span>
         </div>
       )}
       {!query.isLoading && ((requiresEvseId && evseId) || !requiresEvseId) && (
@@ -98,14 +105,14 @@ export const ConnectorSelector = ({
           onSelect={onSelect}
           value={value}
           onSearch={onSearch}
-          placeholder={'Search Connectors'}
+          placeholder={translate('ChargingStations.connectorSelector.searchPlaceholder')}
           isLoading={query.isLoading}
         />
       )}
       <FieldDescription>
         {evseId !== undefined
-          ? `Connectors for selected EVSE`
-          : 'Connector IDs are serial integers starting at 1'}
+          ? translate('ChargingStations.connectorSelector.descriptionForEvse')
+          : translate('ChargingStations.connectorSelector.description')}
       </FieldDescription>
     </Field>
   );

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.selector.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.selector.tsx
@@ -8,7 +8,7 @@ import { EvseProps } from '@citrineos/base';
 import { Combobox } from '@lib/client/components/combobox';
 import { GET_EVSE_LIST_FOR_STATION } from '@lib/queries/evses';
 import { ResourceType } from '@lib/utils/access.types';
-import { useSelect } from '@refinedev/core';
+import { useSelect, useTranslate } from '@refinedev/core';
 import {
   formLabelStyle,
   formLabelWrapperStyle,
@@ -41,6 +41,7 @@ export const EvseSelector = ({
   value,
   isOptional = false,
 }: EvseSelectorProps) => {
+  const translate = useTranslate();
   const { options, onSearch, query } = useSelect<EvseDto>({
     resource: ResourceType.EVSES,
     optionLabel: 'evseTypeId',
@@ -79,13 +80,15 @@ export const EvseSelector = ({
   return (
     <Field>
       <FieldLabel className={formLabelWrapperStyle}>
-        <span className={formLabelStyle}>EVSE</span>
+        <span className={formLabelStyle}>{translate('ChargingStations.evseSelector.label')}</span>
         {!isOptional && formRequiredAsterisk}
       </FieldLabel>
       {query.isLoading && (
         <div className="flex items-center gap-2 py-4">
           <Loader2 className="h-4 w-4 animate-spin" />
-          <span className="text-sm text-muted-foreground">Loading EVSEs...</span>
+          <span className="text-sm text-muted-foreground">
+            {translate('ChargingStations.evseSelector.loading')}
+          </span>
         </div>
       )}
       {!query.isLoading && (
@@ -95,11 +98,11 @@ export const EvseSelector = ({
           value={value}
           onSelect={onSelect}
           onSearch={onSearch}
-          placeholder="Search EVSE"
+          placeholder={translate('ChargingStations.evseSelector.searchPlaceholder')}
           isLoading={query.isLoading}
         />
       )}
-      <FieldDescription>EVSE IDs are serial integers starting at 1</FieldDescription>
+      <FieldDescription>{translate('ChargingStations.evseSelector.description')}</FieldDescription>
     </Field>
   );
 };

--- a/apps/operator-ui/src/lib/client/components/multi-select/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/multi-select/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '@lib/client/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@lib/client/components/ui/popover';
 import { cn } from '@lib/utils/cn';
+import { useTranslate } from '@refinedev/core';
 import { Check, ChevronsUpDown, Search, X } from 'lucide-react';
 import React, { type JSX } from 'react';
 import { buttonIconSize } from '@lib/client/styles/icon';
@@ -33,6 +34,7 @@ export function MultiSelect<T extends string>({
   placeholder,
   searchPlaceholder,
 }: MultiSelectProps<T>): JSX.Element {
+  const translate = useTranslate();
   // Handle null, undefined and single value
   const selectedArray = Array.isArray(selectedValues)
     ? selectedValues
@@ -46,8 +48,8 @@ export function MultiSelect<T extends string>({
         <div className="relative flex gap-2 items-center h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm">
           <span>
             {selectedArray.length > 0
-              ? `${selectedArray.length} selected`
-              : placeholder || 'Select options...'}
+              ? `${selectedArray.length} ${translate('Common.selected')}`
+              : placeholder || translate('Common.selectOptions')}
           </span>
           <div className="absolute right-2 top-1/2 flex -translate-y-1/2 gap-0.5">
             {selectedArray.length > 0 && (
@@ -62,9 +64,9 @@ export function MultiSelect<T extends string>({
       </PopoverTrigger>
       <PopoverContent className="w-(--radix-popover-trigger-width) p-0">
         <Command>
-          <CommandInput placeholder={searchPlaceholder ?? 'Search Options'} />
+          <CommandInput placeholder={searchPlaceholder ?? translate('Common.searchOptions')} />
           <CommandList>
-            <CommandEmpty>Nothing found.</CommandEmpty>
+            <CommandEmpty>{translate('Common.nothingFound')}</CommandEmpty>
             <CommandGroup>
               {options.map((context) => (
                 <CommandItem

--- a/apps/operator-ui/src/lib/client/components/opening-hours/opening.hours.display.tsx
+++ b/apps/operator-ui/src/lib/client/components/opening-hours/opening.hours.display.tsx
@@ -10,29 +10,31 @@ import type { LocationHours } from '@citrineos/base';
 import { Clock, Calendar } from 'lucide-react';
 import { format, parseISO } from 'date-fns';
 import { NOT_APPLICABLE } from '@lib/utils/consts';
+import { useTranslate } from '@refinedev/core';
 
 interface OpeningHoursDisplayProps {
   openingHours?: LocationHours | null;
 }
 
-const WEEKDAY_NAMES = [
+const WEEKDAY_KEYS = [
   '', // 0 index unused
-  'Monday',
-  'Tuesday',
-  'Wednesday',
-  'Thursday',
-  'Friday',
-  'Saturday',
-  'Sunday',
+  'openingHours.weekdays.monday',
+  'openingHours.weekdays.tuesday',
+  'openingHours.weekdays.wednesday',
+  'openingHours.weekdays.thursday',
+  'openingHours.weekdays.friday',
+  'openingHours.weekdays.saturday',
+  'openingHours.weekdays.sunday',
 ];
 
 export const OpeningHoursDisplay: React.FC<OpeningHoursDisplayProps> = ({ openingHours }) => {
+  const translate = useTranslate();
   if (!openingHours) {
     return (
       <Card>
         <CardHeader className="flex flex-row items-center gap-2 py-3">
           <Clock className="h-4 w-4" />
-          <span className="font-medium">Opening Hours</span>
+          <span className="font-medium">{translate('openingHours.title')}</span>
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground">{NOT_APPLICABLE}</p>
@@ -68,29 +70,29 @@ export const OpeningHoursDisplay: React.FC<OpeningHoursDisplayProps> = ({ openin
     <Card>
       <CardHeader className="flex flex-row items-center gap-2 py-3">
         <Clock className="h-4 w-4" />
-        <span className="font-medium">Opening Hours</span>
+        <span className="font-medium">{translate('openingHours.title')}</span>
       </CardHeader>
       <CardContent className="space-y-4">
         {/* 24/7 Status */}
         {twentyfourSeven ? (
           <div className="space-y-2">
             <Badge variant="success" className="text-sm px-3 py-1">
-              24/7 Operation
+              {translate('openingHours.twentyFourSeven')}
             </Badge>
             <p className="text-sm text-muted-foreground">
-              This location is open 24 hours a day, 7 days a week
+              {translate('openingHours.twentyFourSevenDescription')}
             </p>
           </div>
         ) : (
           <div className="space-y-4">
             {/* Regular Hours */}
             <div>
-              <h4 className="font-medium mb-3">Regular Hours</h4>
+              <h4 className="font-medium mb-3">{translate('openingHours.regularHours')}</h4>
               {sortedRegularHours.length > 0 ? (
                 <div className="space-y-2">
                   {sortedRegularHours.map((hours, index) => (
                     <div key={index} className="flex justify-between items-center py-1">
-                      <span className="font-medium">{WEEKDAY_NAMES[hours.weekday]}</span>
+                      <span className="font-medium">{translate(WEEKDAY_KEYS[hours.weekday])}</span>
                       <span className="text-muted-foreground">
                         {formatTime(hours.periodBegin)} - {formatTime(hours.periodEnd)}
                       </span>
@@ -98,7 +100,7 @@ export const OpeningHoursDisplay: React.FC<OpeningHoursDisplayProps> = ({ openin
                   ))}
                 </div>
               ) : (
-                <p className="text-muted-foreground">No regular hours specified</p>
+                <p className="text-muted-foreground">{translate('openingHours.noRegularHours')}</p>
               )}
             </div>
           </div>
@@ -111,12 +113,12 @@ export const OpeningHoursDisplay: React.FC<OpeningHoursDisplayProps> = ({ openin
             <div>
               <div className="flex items-center gap-2 mb-3">
                 <Calendar className="h-4 w-4" />
-                <h4 className="font-medium">Exceptional Openings</h4>
+                <h4 className="font-medium">{translate('openingHours.exceptionalOpenings')}</h4>
               </div>
               <div className="space-y-2">
                 {exceptionalOpenings?.map((period, index) => (
                   <div key={index} className="flex items-center gap-2">
-                    <Badge variant="default">Special Opening</Badge>
+                    <Badge variant="default">{translate('openingHours.specialOpening')}</Badge>
                     <span className="text-sm">
                       {formatDateRange(period.periodBegin, period.periodEnd)}
                     </span>
@@ -134,12 +136,12 @@ export const OpeningHoursDisplay: React.FC<OpeningHoursDisplayProps> = ({ openin
             <div>
               <div className="flex items-center gap-2 mb-3">
                 <Calendar className="h-4 w-4" />
-                <h4 className="font-medium">Exceptional Closings</h4>
+                <h4 className="font-medium">{translate('openingHours.exceptionalClosings')}</h4>
               </div>
               <div className="space-y-2">
                 {exceptionalClosings?.map((period, index) => (
                   <div key={index} className="flex items-center gap-2">
-                    <Badge variant="destructive">Closed</Badge>
+                    <Badge variant="destructive">{translate('openingHours.closed')}</Badge>
                     <span className="text-sm">
                       {formatDateRange(period.periodBegin, period.periodEnd)}
                     </span>

--- a/apps/operator-ui/src/lib/client/components/opening-hours/opening.hours.form.tsx
+++ b/apps/operator-ui/src/lib/client/components/opening-hours/opening.hours.form.tsx
@@ -30,6 +30,7 @@ import { format } from 'date-fns';
 import type { DateRange } from 'react-day-picker';
 import { cn } from '@lib/utils/cn';
 import { heading3Style } from '@lib/client/styles/page';
+import { useTranslate } from '@refinedev/core';
 
 interface OpeningHoursFormProps {
   value?: LocationHours;
@@ -37,16 +38,17 @@ interface OpeningHoursFormProps {
 }
 
 const WEEKDAYS = [
-  { value: 1, label: 'Monday' },
-  { value: 2, label: 'Tuesday' },
-  { value: 3, label: 'Wednesday' },
-  { value: 4, label: 'Thursday' },
-  { value: 5, label: 'Friday' },
-  { value: 6, label: 'Saturday' },
-  { value: 7, label: 'Sunday' },
+  { value: 1, labelKey: 'openingHours.weekdays.monday' },
+  { value: 2, labelKey: 'openingHours.weekdays.tuesday' },
+  { value: 3, labelKey: 'openingHours.weekdays.wednesday' },
+  { value: 4, labelKey: 'openingHours.weekdays.thursday' },
+  { value: 5, labelKey: 'openingHours.weekdays.friday' },
+  { value: 6, labelKey: 'openingHours.weekdays.saturday' },
+  { value: 7, labelKey: 'openingHours.weekdays.sunday' },
 ];
 
 export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onChange }) => {
+  const translate = useTranslate();
   const defaultValue: LocationHours = { twentyfourSeven: false };
   const [localValue, setLocalValue] = useState<LocationHours>(value || defaultValue);
 
@@ -160,23 +162,23 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>Opening Hours</h3>
+        <h3 className={heading3Style}>{translate('openingHours.title')}</h3>
       </CardHeader>
       <CardContent className="space-y-6">
         {/* 24/7 Toggle */}
         <div className="flex items-center gap-3">
           <Switch checked={localValue.twentyfourSeven} onCheckedChange={toggle24Seven} />
-          <Label className="font-medium">24/7 Operation</Label>
+          <Label className="font-medium">{translate('openingHours.twentyFourSeven')}</Label>
         </div>
 
         {/* Regular Hours */}
         {!localValue.twentyfourSeven && (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h4 className="font-medium">Regular Hours</h4>
+              <h4 className="font-medium">{translate('openingHours.regularHours')}</h4>
               <Button type="button" variant="outline" size="sm" onClick={addRegularHours}>
                 <Plus className="h-4 w-4 mr-1" />
-                Add Hours
+                {translate('openingHours.form.addHours')}
               </Button>
             </div>
 
@@ -188,12 +190,12 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                     onValueChange={(val) => updateRegularHours(index, 'weekday', parseInt(val, 10))}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder="Select day" />
+                      <SelectValue placeholder={translate('openingHours.form.selectDay')} />
                     </SelectTrigger>
                     <SelectContent>
                       {WEEKDAYS.map((day) => (
                         <SelectItem key={day.value} value={String(day.value)}>
-                          {day.label}
+                          {translate(day.labelKey)}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -216,8 +218,8 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                   </div>
 
                   <ConfirmDialog
-                    title="Remove time slot?"
-                    description="Are you sure you want to remove this time slot?"
+                    title={translate('openingHours.form.removeTimeSlot')}
+                    description={translate('openingHours.form.removeTimeSlotConfirm')}
                     onConfirm={() => removeRegularHours(index)}
                   >
                     <Button type="button" variant="ghost" size="icon">
@@ -236,9 +238,9 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <h4 className="font-medium">Exceptional Openings</h4>
+              <h4 className="font-medium">{translate('openingHours.exceptionalOpenings')}</h4>
               <p className="text-sm text-muted-foreground">
-                Special dates when the location is open
+                {translate('openingHours.form.exceptionalOpeningsDescription')}
               </p>
             </div>
             <Button
@@ -248,7 +250,7 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
               onClick={() => addExceptionalPeriod('exceptionalOpenings')}
             >
               <Plus className="h-4 w-4 mr-1" />
-              Add Opening
+              {translate('openingHours.form.addOpening')}
             </Button>
           </div>
 
@@ -272,7 +274,7 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                           {format(new Date(period.periodEnd), 'LLL dd, y')}
                         </>
                       ) : (
-                        'Pick a date range'
+                        translate('Common.pickDateRange')
                       )}
                     </Button>
                   </PopoverTrigger>
@@ -292,8 +294,8 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                 </Popover>
 
                 <ConfirmDialog
-                  title="Remove exceptional opening?"
-                  description="Are you sure you want to remove this exceptional opening?"
+                  title={translate('openingHours.form.removeOpening')}
+                  description={translate('openingHours.form.removeOpeningConfirm')}
                   onConfirm={() => removeExceptionalPeriod('exceptionalOpenings', index)}
                 >
                   <Button type="button" variant="ghost" size="icon">
@@ -311,9 +313,9 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
         <div className="space-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <h4 className="font-medium">Exceptional Closings</h4>
+              <h4 className="font-medium">{translate('openingHours.exceptionalClosings')}</h4>
               <p className="text-sm text-muted-foreground">
-                Special dates when the location is closed
+                {translate('openingHours.form.exceptionalClosingsDescription')}
               </p>
             </div>
             <Button
@@ -323,7 +325,7 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
               onClick={() => addExceptionalPeriod('exceptionalClosings')}
             >
               <Plus className="h-4 w-4 mr-1" />
-              Add Closing
+              {translate('openingHours.form.addClosing')}
             </Button>
           </div>
 
@@ -347,7 +349,7 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                           {format(new Date(period.periodEnd), 'LLL dd, y')}
                         </>
                       ) : (
-                        'Pick a date range'
+                        translate('Common.pickDateRange')
                       )}
                     </Button>
                   </PopoverTrigger>
@@ -367,8 +369,8 @@ export const OpeningHoursForm: React.FC<OpeningHoursFormProps> = ({ value, onCha
                 </Popover>
 
                 <ConfirmDialog
-                  title="Remove exceptional closing?"
-                  description="Are you sure you want to remove this exceptional closing?"
+                  title={translate('openingHours.form.removeClosing')}
+                  description={translate('openingHours.form.removeClosingConfirm')}
                   onConfirm={() => removeExceptionalPeriod('exceptionalClosings', index)}
                 >
                   <Button type="button" variant="ghost" size="icon">

--- a/apps/operator-ui/src/lib/client/components/protocol-tag/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/protocol-tag/index.tsx
@@ -5,8 +5,10 @@
 import { OCPPVersion } from '@citrineos/base';
 import { Badge } from '@lib/client/components/ui/badge';
 import { cn } from '@lib/utils/cn';
+import { useTranslate } from '@refinedev/core';
 
 const ProtocolTag = ({ protocol }: { protocol: string | null | undefined }) => {
+  const translate = useTranslate();
   let colorClass: string;
   let protocolName: string;
 
@@ -25,7 +27,7 @@ const ProtocolTag = ({ protocol }: { protocol: string | null | undefined }) => {
       break;
     default:
       colorClass = 'bg-gray-100 text-gray-800 hover:bg-gray-100 border-gray-200';
-      protocolName = 'Unknown';
+      protocolName = translate('Common.unknown');
       break;
   }
 

--- a/apps/operator-ui/src/lib/client/components/range-picker/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/range-picker/index.tsx
@@ -10,6 +10,7 @@ import { format } from 'date-fns';
 import { CalendarIcon } from 'lucide-react';
 import type { FC } from 'react';
 import { type DateRange } from 'react-day-picker';
+import { useTranslate } from '@refinedev/core';
 
 export type RangePickerProps = {
   dateRange: DateRange | undefined;
@@ -17,6 +18,7 @@ export type RangePickerProps = {
 };
 
 export const RangePicker: FC<RangePickerProps> = ({ dateRange, setDateRange }) => {
+  const translate = useTranslate();
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -31,7 +33,7 @@ export const RangePicker: FC<RangePickerProps> = ({ dateRange, setDateRange }) =
               format(dateRange.from, 'LLL dd, y')
             )
           ) : (
-            'Pick a date range'
+            translate('Common.pickDateRange')
           )}
         </Button>
       </PopoverTrigger>

--- a/apps/operator-ui/src/lib/client/components/table/actions/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/table/actions/index.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@lib/client/components/ui/dropdown-menu';
+import { useTranslate } from '@refinedev/core';
 import { Ellipsis } from 'lucide-react';
 import Link from 'next/link';
 import type { FC, PropsWithChildren, ReactNode } from 'react';
@@ -55,12 +56,13 @@ export const RowAction: FC<RowActionProps> = (props) => {
 RowAction.displayName = 'RowAction';
 
 export function RowActions({ children }: RowActionsProps) {
+  const translate = useTranslate();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" size="icon">
           <Ellipsis className="h-4 w-4" />
-          <span className="sr-only">Open menu</span>
+          <span className="sr-only">{translate('Common.openMenu')}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">

--- a/apps/operator-ui/src/lib/client/components/table/fields/pagination.tsx
+++ b/apps/operator-ui/src/lib/client/components/table/fields/pagination.tsx
@@ -79,8 +79,10 @@ export const Pagination = <TData extends BaseRecord = BaseRecord>({
     <div className="flex flex-col sm:flex-row gap-y-4 sm-gap-y-0 items-center justify-between">
       {showSelectedText && (
         <div className="flex-1 text-sm text-muted-foreground">
-          {table.getFilteredSelectedRowModel().rows.length} of{' '}
-          {table.getFilteredRowModel().rows.length} row(s) selected.
+          {translate('Common.rowsSelected', {
+            selected: table.getFilteredSelectedRowModel().rows.length,
+            total: table.getFilteredRowModel().rows.length,
+          })}
         </div>
       )}
       <div className="flex relative flex-col-reverse gap-y-4 sm:gap-y-0 sm:flex-row items-center space-x-6 lg:space-x-8">
@@ -103,7 +105,10 @@ export const Pagination = <TData extends BaseRecord = BaseRecord>({
           </Select>
         </div>
         <div className="flex w-fit items-center justify-center text-sm font-medium">
-          Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          {translate('Common.pageOf', {
+            page: table.getState().pagination.pageIndex + 1,
+            total: table.getPageCount(),
+          })}
         </div>
         <div className="flex items-center space-x-2">
           <Button

--- a/apps/operator-ui/src/lib/client/components/table/toolbar/filter-popover.tsx
+++ b/apps/operator-ui/src/lib/client/components/table/toolbar/filter-popover.tsx
@@ -12,13 +12,16 @@ import type { ColumnConfiguration } from '@lib/utils/column.configuration';
 import type { FilterItem } from '@lib/client/components/table/fields/table-query-state';
 import { buttonIconSize } from '@lib/client/styles/icon';
 import { cn } from '@lib/utils/cn';
+import { useTranslate } from '@refinedev/core';
+
+type TranslateFn = ReturnType<typeof useTranslate>;
 
 const DATE_PRESETS = [
-  { label: 'Today', days: 0 },
-  { label: 'Last 7 days', days: 7 },
-  { label: 'Last 30 days', days: 30 },
-  { label: 'Last 3 months', days: 90 },
-  { label: 'This year', days: 365 },
+  { labelKey: 'filterPresets.today', days: 0 },
+  { labelKey: 'filterPresets.last7Days', days: 7 },
+  { labelKey: 'filterPresets.last30Days', days: 30 },
+  { labelKey: 'filterPresets.last3Months', days: 90 },
+  { labelKey: 'filterPresets.thisYear', days: 365 },
 ];
 
 function getPresetDate(days: number): string {
@@ -32,6 +35,7 @@ function getPresetDate(days: number): string {
 export function getFilterLabel(
   filter: FilterItem,
   columns: ColumnConfiguration[],
+  translate: TranslateFn,
 ): { field: string; value: string } {
   const col = columns.find((c) => (c.filterConfig?.field ?? c.key) === filter.field);
   const fieldLabel = col?.filterConfig?.label ?? col?.header ?? filter.field;
@@ -40,23 +44,23 @@ export function getFilterLabel(
   const val = filter.value;
   switch (filter.op) {
     case 'eq':
-      if (val === 'true') return { field: fieldLabel, value: 'Yes' };
-      if (val === 'false') return { field: fieldLabel, value: 'No' };
+      if (val === 'true') return { field: fieldLabel, value: translate('Common.yes') };
+      if (val === 'false') return { field: fieldLabel, value: translate('Common.no') };
       return { field: fieldLabel, value: String(val) };
     case 'lte':
       return {
         field: fieldLabel,
-        value: `at most ${val}${unit ? ' ' + unit : ''}`,
+        value: translate('Common.atMost', { value: `${val}${unit ? ' ' + unit : ''}` }),
       };
     case 'gte': {
       try {
         const d = new Date(String(val));
         return {
           field: fieldLabel,
-          value: `after ${d.toLocaleDateString()}`,
+          value: translate('Common.after', { value: d.toLocaleDateString() }),
         };
       } catch {
-        return { field: fieldLabel, value: `after ${val}` };
+        return { field: fieldLabel, value: translate('Common.after', { value: String(val) }) };
       }
     }
     case 'in':
@@ -102,12 +106,13 @@ function ValueInput({
   yesNoValue,
   onYesNoChange,
 }: ValueInputProps) {
+  const translate = useTranslate();
   const cfg = col.filterConfig!;
 
   if (cfg.type === 'text') {
     return (
       <Input
-        placeholder={`Search ${cfg.label ?? col.header}…`}
+        placeholder={translate('Common.searchField', { field: cfg.label ?? col.header })}
         value={textValue}
         onChange={(e) => onTextChange(e.target.value)}
         className="h-8 text-sm"
@@ -124,7 +129,7 @@ function ValueInput({
           {sliderValue}
           {cfg.unit && (
             <span className="ml-1 text-sm font-normal text-muted-foreground">
-              {cfg.unit} or less
+              {translate('filters.valueOrLess', { unit: cfg.unit })}
             </span>
           )}
         </p>
@@ -157,7 +162,7 @@ function ValueInput({
       <div className="flex flex-wrap gap-1.5">
         {DATE_PRESETS.map((preset, i) => (
           <button
-            key={preset.label}
+            key={preset.labelKey}
             onClick={() => onDatePresetChange(i)}
             className={cn(
               'rounded-full border px-3 py-1 text-xs transition-colors',
@@ -166,7 +171,7 @@ function ValueInput({
                 : 'border-border text-muted-foreground hover:border-foreground hover:text-foreground',
             )}
           >
-            {preset.label}
+            {translate(preset.labelKey)}
           </button>
         ))}
       </div>
@@ -206,7 +211,7 @@ function ValueInput({
               : 'border-border text-muted-foreground hover:bg-muted',
           )}
         >
-          Yes
+          {translate('Common.yes')}
         </button>
         <button
           onClick={() => onYesNoChange('false')}
@@ -217,7 +222,7 @@ function ValueInput({
               : 'border-border text-muted-foreground hover:bg-muted',
           )}
         >
-          No
+          {translate('Common.no')}
         </button>
       </div>
     );
@@ -245,6 +250,7 @@ export function FilterPopover({
   onRemove,
   onClear,
 }: FilterPopoverProps) {
+  const translate = useTranslate();
   const [open, setOpen] = useState(false);
   const [selectedField, setSelectedField] = useState<ColumnConfiguration | null>(
     filterableColumns[0] ?? null,
@@ -303,16 +309,25 @@ export function FilterPopover({
     if (!selectedField?.filterConfig) return '';
     const cfg = selectedField.filterConfig;
     const label = cfg.label ?? selectedField.header;
-    if (cfg.type === 'text') return textValue ? `"${label}" includes "${textValue}"` : '';
+    if (cfg.type === 'text')
+      return textValue ? translate('filters.previewText', { label, value: textValue }) : '';
     if (cfg.type === 'number')
-      return `"${label}" is at most ${sliderValue}${cfg.unit ? ' ' + cfg.unit : ''}`;
+      return translate('filters.previewNumber', {
+        label,
+        value: `${sliderValue}${cfg.unit ? ' ' + cfg.unit : ''}`,
+      });
     if (cfg.type === 'date')
-      return `"${label}" within ${DATE_PRESETS[selectedDatePreset].label.toLowerCase()}`;
+      return translate('filters.previewDate', {
+        label,
+        preset: translate(DATE_PRESETS[selectedDatePreset].labelKey).toLowerCase(),
+      });
     if (cfg.type === 'enum')
-      return selectedEnumValues.length ? `"${label}" is ${selectedEnumValues.join(', ')}` : '';
+      return selectedEnumValues.length
+        ? translate('filters.previewEnum', { label, value: selectedEnumValues.join(', ') })
+        : '';
     if (cfg.type === 'yesno') {
-      if (yesNoValue === 'true') return `"${label}" is Yes`;
-      if (yesNoValue === 'false') return `"${label}" is No`;
+      if (yesNoValue === 'true') return translate('filters.previewYes', { label });
+      if (yesNoValue === 'false') return translate('filters.previewNo', { label });
     }
     return '';
   };
@@ -324,7 +339,7 @@ export function FilterPopover({
       <PopoverTrigger asChild>
         <Button variant="secondary" className="gap-2">
           <ListFilter className={buttonIconSize} />
-          Filters
+          {translate('Common.filters')}
           {activeFilters.length > 0 && (
             <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary text-[10px] font-medium text-primary-foreground">
               {activeFilters.length}
@@ -337,11 +352,11 @@ export function FilterPopover({
         {activeFilters.length > 0 && (
           <div className="border-b p-3">
             <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Active filters
+              {translate('Common.activeFilters')}
             </p>
             <div className="flex flex-col gap-1">
               {activeFilters.map((f, i) => {
-                const { field: fl, value: vl } = getFilterLabel(f, filterableColumns);
+                const { field: fl, value: vl } = getFilterLabel(f, filterableColumns, translate);
                 return (
                   <div
                     key={i}
@@ -367,7 +382,7 @@ export function FilterPopover({
         {/* Add filter form */}
         <div className="p-3">
           <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Add a filter
+            {translate('Common.addFilter')}
           </p>
 
           {/* Field picker */}
@@ -422,13 +437,13 @@ export function FilterPopover({
               className="text-xs text-muted-foreground hover:text-foreground"
               onClick={onClear}
             >
-              Clear all
+              {translate('Common.clearAll')}
             </button>
           ) : (
             <div />
           )}
           <Button size="sm" onClick={handleAdd} disabled={!canAdd}>
-            Add filter
+            {translate('Common.addFilterButton')}
           </Button>
         </div>
       </PopoverContent>

--- a/apps/operator-ui/src/lib/client/components/ui/calendar.tsx
+++ b/apps/operator-ui/src/lib/client/components/ui/calendar.tsx
@@ -5,6 +5,7 @@ import { cn } from '@lib/utils/cn';
 import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, Clock2Icon, X } from 'lucide-react';
 import * as React from 'react';
 import { DayButton, DayPicker, getDefaultClassNames } from 'react-day-picker';
+import { useTranslation } from '@refinedev/core';
 import { Card, CardContent, CardFooter } from '@lib/client/components/ui/card';
 import { Field, FieldGroup, FieldLabel } from '@lib/client/components/ui/field';
 import {
@@ -193,6 +194,7 @@ function CalendarDayButton({
 
 // With time-syncing from https://daypicker.dev/guides/timepicker
 function CalendarWithTime({ date, onSelectDateAction }: CalendarWithTimeProps) {
+  const { translate } = useTranslation();
   const [timeValue, setTimeValue] = useState<string>('00:00:00');
 
   // Keep the time input in sync when the selected date changes elsewhere.
@@ -245,7 +247,7 @@ function CalendarWithTime({ date, onSelectDateAction }: CalendarWithTimeProps) {
       <Separator className="h-1 " />
       <FieldGroup>
         <Field>
-          <FieldLabel htmlFor="time">Time</FieldLabel>
+          <FieldLabel htmlFor="time">{translate('Common.time')}</FieldLabel>
           <InputGroup>
             <InputGroupInput
               id="time"

--- a/apps/operator-ui/src/lib/client/hooks/useColumnPreferences.tsx
+++ b/apps/operator-ui/src/lib/client/hooks/useColumnPreferences.tsx
@@ -116,7 +116,7 @@ export const useColumnPreferences = (allColumns: ColumnConfiguration[], resource
       </PopoverTrigger>
       <PopoverContent className="p-0">
         <Command>
-          <CommandInput placeholder="Search Columns" />
+          <CommandInput placeholder={translate('Common.searchColumns')} />
           <CommandList>
             <CommandEmpty></CommandEmpty>
             <CommandGroup>

--- a/apps/operator-ui/src/lib/client/hooks/useTableFilters.tsx
+++ b/apps/operator-ui/src/lib/client/hooks/useTableFilters.tsx
@@ -4,7 +4,7 @@
 'use client';
 
 import React from 'react';
-import type { CrudFilter } from '@refinedev/core';
+import { type CrudFilter, useTranslate } from '@refinedev/core';
 import { parseAsJson, useQueryState } from 'nuqs';
 import {
   type FilterItem,
@@ -25,6 +25,7 @@ import { X } from 'lucide-react';
  * - `activeFilters`   – raw FilterItem[] (for inspection / testing)
  */
 export const useTableFilters = (allColumns: ColumnConfiguration[], resource: ResourceType) => {
+  const translate = useTranslate();
   const [tableQueryState, setTableQueryState] = useQueryState(
     resource,
     parseAsJson(TableQueryStateSchema.parse),
@@ -92,7 +93,7 @@ export const useTableFilters = (allColumns: ColumnConfiguration[], resource: Res
     activeFilters.length > 0 ? (
       <div className="flex flex-wrap items-center gap-2 pb-2 pt-1">
         {activeFilters.map((f, i) => {
-          const { field, value } = getFilterLabel(f, filterableColumns);
+          const { field, value } = getFilterLabel(f, filterableColumns, translate);
           return (
             <span
               key={i}
@@ -103,7 +104,7 @@ export const useTableFilters = (allColumns: ColumnConfiguration[], resource: Res
               <button
                 className="rounded-full p-0.5 hover:bg-destructive/10 hover:text-destructive"
                 onClick={() => removeFilter(i)}
-                aria-label={`Remove filter: ${field}`}
+                aria-label={translate('Common.removeFilter', { field })}
               >
                 <X className="h-3 w-3" />
               </button>
@@ -114,7 +115,7 @@ export const useTableFilters = (allColumns: ColumnConfiguration[], resource: Res
           className="text-xs text-muted-foreground hover:text-foreground"
           onClick={clearFilters}
         >
-          Clear all
+          {translate('Common.clearAll')}
         </button>
       </div>
     ) : null;

--- a/apps/operator-ui/src/lib/client/pages/authorizations/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/authorizations/columns.tsx
@@ -16,22 +16,45 @@ import { EMPTY_VALUE } from '@lib/utils/consts';
 import { badgeListStyle } from '@lib/client/styles/page';
 import { TimestampDisplay } from '@lib/client/components/timestamp-display';
 
-export const authorizationsColumns: ColumnConfiguration[] = [
+type TranslateFn = (key: string, options?: any) => string;
+
+// English fallbacks used when the columns are built without a translator
+// (e.g. shared usage from areas that have not been wired to useTranslate yet).
+const englishFallbacks: Record<string, string> = {
+  'Authorizations.columns.authorizationId': 'Authorization ID',
+  'Authorizations.columns.type': 'Type',
+  'Authorizations.columns.status': 'Status',
+  'Authorizations.columns.concurrentTransactions': 'Concurrent Transactions',
+  'Authorizations.columns.allowedTypes': 'Allowed Types',
+  'Authorizations.columns.disallowedPrefixes': 'Disallowed Prefixes',
+  'Authorizations.columns.createdAt': 'Created At',
+  'Authorizations.columns.updatedAt': 'Updated At',
+  'Authorizations.noId': 'No ID',
+  'Authorizations.allowed': 'Allowed',
+  'Authorizations.notAllowed': 'Not Allowed',
+};
+
+const identityTranslate: TranslateFn = (key, options) =>
+  options?.fallback ?? englishFallbacks[key] ?? key;
+
+export const getAuthorizationsColumns = (
+  translate: TranslateFn = identityTranslate,
+): ColumnConfiguration[] => [
   {
     key: AuthorizationProps.idToken,
-    header: 'Authorization ID',
+    header: translate('Authorizations.columns.authorizationId'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) => (
       <TableCellLink
         path={`/${MenuSection.AUTHORIZATIONS}/${row.original.id}`}
-        value={row.original.idToken?.trim() ?? 'No ID'}
+        value={row.original.idToken?.trim() ?? translate('Authorizations.noId')}
       />
     ),
   },
   {
     key: AuthorizationProps.idTokenType,
-    header: 'Type',
+    header: translate('Authorizations.columns.type'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) => (
@@ -40,7 +63,7 @@ export const authorizationsColumns: ColumnConfiguration[] = [
   },
   {
     key: AuthorizationProps.status,
-    header: 'Status',
+    header: translate('Authorizations.columns.status'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) => (
@@ -49,20 +72,22 @@ export const authorizationsColumns: ColumnConfiguration[] = [
   },
   {
     key: AuthorizationProps.concurrentTransaction,
-    header: 'Concurrent Transactions',
+    header: translate('Authorizations.columns.concurrentTransactions'),
     visible: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) => {
       const concurrentTransaction = row.original.concurrentTransaction;
       return (
         <Badge variant={concurrentTransaction ? 'success' : 'destructive'}>
-          {concurrentTransaction ? 'Allowed' : 'Not Allowed'}
+          {concurrentTransaction
+            ? translate('Authorizations.allowed')
+            : translate('Authorizations.notAllowed')}
         </Badge>
       );
     },
   },
   {
     key: AuthorizationProps.allowedConnectorTypes,
-    header: 'Allowed Types',
+    header: translate('Authorizations.columns.allowedTypes'),
     visible: false,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) =>
       !isEmpty(row.original.allowedConnectorTypes) ? (
@@ -79,7 +104,7 @@ export const authorizationsColumns: ColumnConfiguration[] = [
   },
   {
     key: AuthorizationProps.disallowedEvseIdPrefixes,
-    header: 'Disallowed Prefixes',
+    header: translate('Authorizations.columns.disallowedPrefixes'),
     visible: false,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) =>
       !isEmpty(row.original.disallowedEvseIdPrefixes) ? (
@@ -96,7 +121,7 @@ export const authorizationsColumns: ColumnConfiguration[] = [
   },
   {
     key: AuthorizationProps.createdAt,
-    header: 'Created At',
+    header: translate('Authorizations.columns.createdAt'),
     visible: false,
     sortable: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) =>
@@ -108,7 +133,7 @@ export const authorizationsColumns: ColumnConfiguration[] = [
   },
   {
     key: AuthorizationProps.updatedAt,
-    header: 'Updated At',
+    header: translate('Authorizations.columns.updatedAt'),
     visible: false,
     sortable: true,
     cellRender: ({ row }: CellContext<AuthorizationDto, unknown>) =>

--- a/apps/operator-ui/src/lib/client/pages/authorizations/detail/authorization.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/authorizations/detail/authorization.detail.card.tsx
@@ -92,15 +92,21 @@ export const AuthorizationDetailCard: React.FC<AuthorizationDetailCardProps> = (
       </CardHeader>
       <CardContent>
         <div className={cardGridStyle}>
-          <KeyValueDisplay keyLabel="ID Token" value={authorization.idToken} />
           <KeyValueDisplay
-            keyLabel="Type"
+            keyLabel={translate('Authorizations.fields.idToken')}
+            value={authorization.idToken}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('Authorizations.columns.type')}
             value={authorization.idTokenType}
             valueRender={(type) => (type ? <Badge>{type}</Badge> : NOT_APPLICABLE)}
           />
-          <KeyValueDisplay keyLabel="Status" value={authorization.status} />
           <KeyValueDisplay
-            keyLabel="Partner"
+            keyLabel={translate('Authorizations.fields.status')}
+            value={authorization.status}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('Authorizations.detail.partner')}
             value={''}
             valueRender={() =>
               !authorization.tenantPartner?.partnerProfileOCPI?.roles?.[0]?.businessDetails
@@ -121,7 +127,7 @@ export const AuthorizationDetailCard: React.FC<AuthorizationDetailCardProps> = (
             }
           />
           <KeyValueDisplay
-            keyLabel="Allowed Types"
+            keyLabel={translate('Authorizations.columns.allowedTypes')}
             value={authorization.allowedConnectorTypes}
             valueRender={(allowedTypes: string[]) =>
               allowedTypes?.length > 0 ? (
@@ -136,7 +142,7 @@ export const AuthorizationDetailCard: React.FC<AuthorizationDetailCardProps> = (
             }
           />
           <KeyValueDisplay
-            keyLabel="Disallowed Prefixes"
+            keyLabel={translate('Authorizations.columns.disallowedPrefixes')}
             value={authorization.disallowedEvseIdPrefixes}
             valueRender={(disallowedPrefixes: string[]) =>
               disallowedPrefixes?.length > 0 ? (
@@ -151,28 +157,35 @@ export const AuthorizationDetailCard: React.FC<AuthorizationDetailCardProps> = (
             }
           />
           <KeyValueDisplay
-            keyLabel="Concurrent Transactions"
+            keyLabel={translate('Authorizations.columns.concurrentTransactions')}
             value={authorization.concurrentTransaction}
             valueRender={(concurrentTransaction) => (
               <Badge variant={concurrentTransaction ? 'success' : 'destructive'}>
-                {concurrentTransaction ? 'Allowed' : 'Not Allowed'}
+                {concurrentTransaction
+                  ? translate('Authorizations.allowed')
+                  : translate('Authorizations.notAllowed')}
               </Badge>
             )}
           />
-          <KeyValueDisplay keyLabel="Real-Time Authentication" value={authorization.realTimeAuth} />
           <KeyValueDisplay
-            keyLabel="Real-Time Authentication URL"
+            keyLabel={translate('Authorizations.fields.realTimeAuth')}
+            value={authorization.realTimeAuth}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('Authorizations.fields.realTimeAuthUrl')}
             value={authorization.realTimeAuthUrl}
           />
           <KeyValueDisplay
-            keyLabel="Real-Time Authentication Timeout"
+            keyLabel={translate('Authorizations.fields.realTimeAuthTimeout')}
             value={(authorization as any).realTimeAuthTimeout}
             valueRender={(timeout) =>
-              timeout !== undefined && timeout !== null ? `${timeout} seconds` : NOT_APPLICABLE
+              timeout !== undefined && timeout !== null
+                ? translate('Authorizations.detail.realTimeAuthTimeoutSeconds', { timeout })
+                : NOT_APPLICABLE
             }
           />
           <KeyValueDisplay
-            keyLabel="Additional Info"
+            keyLabel={translate('Authorizations.fields.additionalInfo')}
             value={authorization.additionalInfo}
             valueRender={(additionalInfo) =>
               additionalInfo?.length > 0 ? (

--- a/apps/operator-ui/src/lib/client/pages/authorizations/detail/authorization.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/authorizations/detail/authorization.detail.tabs.card.tsx
@@ -15,21 +15,25 @@ import { getPlainToInstanceOptions } from '@lib/utils/tables';
 import { TransactionClass } from '@lib/cls/transaction.dto';
 import type { AuthorizationDto } from '@citrineos/base';
 import {
+  getTransactionsColumns,
   transactionAuthorizationIdTokenField,
-  transactionsColumns,
 } from '@lib/client/pages/transactions/columns';
 import { cardTabsStyle } from '@lib/client/styles/card';
 import { useColumnPreferences } from '@lib/client/hooks/useColumnPreferences';
+import { useTranslate } from '@refinedev/core';
 
 export const AuthorizationDetailTabsCard = ({
   authorization,
 }: {
   authorization: AuthorizationDto;
 }) => {
+  const translate = useTranslate();
   const authIdToken = authorization?.idToken;
 
   const { renderedVisibleColumns } = useColumnPreferences(
-    transactionsColumns.filter((tc) => tc.key !== transactionAuthorizationIdTokenField),
+    getTransactionsColumns(translate).filter(
+      (tc) => tc.key !== transactionAuthorizationIdTokenField,
+    ),
     ResourceType.TRANSACTIONS,
   );
 
@@ -38,7 +42,7 @@ export const AuthorizationDetailTabsCard = ({
       <CardContent>
         <Tabs defaultValue="transactions">
           <TabsList>
-            <TabsTrigger value="transactions">Transactions</TabsTrigger>
+            <TabsTrigger value="transactions">{translate('Transactions.Transactions')}</TabsTrigger>
           </TabsList>
           <TabsContent value="transactions" className={cardTabsStyle}>
             <CanAccess

--- a/apps/operator-ui/src/lib/client/pages/authorizations/list/authorizations.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/authorizations/list/authorizations.list.tsx
@@ -7,7 +7,7 @@ import { MenuSection } from '@lib/client/components/main-menu/main.menu';
 import { Table } from '@lib/client/components/table';
 import { Button } from '@lib/client/components/ui/button';
 import {
-  authorizationsColumns,
+  getAuthorizationsColumns,
   getAuthorizationFilters,
 } from '@lib/client/pages/authorizations/columns';
 import { AuthorizationClass } from '@lib/cls/authorization.dto';
@@ -37,7 +37,7 @@ export const AuthorizationsList = () => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    authorizationsColumns,
+    getAuthorizationsColumns(translate),
     ResourceType.AUTHORIZATIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/authorizations/upsert/authorization.upsert.tsx
@@ -219,7 +219,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
             <div className={cardGridStyle}>
               <FormField
                 control={form.control}
-                label="ID Token"
+                label={translate('Authorizations.fields.idToken')}
                 name={AuthorizationProps.idToken}
                 required
               >
@@ -228,33 +228,33 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <ComboboxFormField
                 control={form.control}
-                label="ID Token Type"
+                label={translate('Authorizations.fields.idTokenType')}
                 name={AuthorizationProps.idTokenType}
                 options={idTokenTypes.map((type) => ({
                   label: type,
                   value: type,
                 }))}
-                placeholder="Select Type"
-                searchPlaceholder="Search Types"
+                placeholder={translate('Authorizations.placeholders.selectType')}
+                searchPlaceholder={translate('Authorizations.placeholders.searchTypes')}
                 required
               />
 
               <ComboboxFormField
                 control={form.control}
-                label="Status"
+                label={translate('Authorizations.fields.status')}
                 name={AuthorizationProps.status}
                 options={authorizationStatuses.map((status) => ({
                   label: status,
                   value: status,
                 }))}
-                placeholder="Select Status"
-                searchPlaceholder="Search Statuses"
+                placeholder={translate('Authorizations.placeholders.selectStatus')}
+                searchPlaceholder={translate('Authorizations.placeholders.searchStatuses')}
                 required
               />
 
               <FormField
                 control={form.control}
-                label="Cache Expiry DateTime"
+                label={translate('Authorizations.fields.cacheExpiryDateTime')}
                 name={AuthorizationProps.cacheExpiryDateTime}
               >
                 <Input type="datetime-local" />
@@ -262,7 +262,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Charging Priority"
+                label={translate('Authorizations.fields.chargingPriority')}
                 name={AuthorizationProps.chargingPriority}
               >
                 <Input type="number" min="0" />
@@ -270,7 +270,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Language 1"
+                label={translate('Authorizations.fields.language1')}
                 name={AuthorizationProps.language1}
               >
                 <Input />
@@ -278,7 +278,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Language 2"
+                label={translate('Authorizations.fields.language2')}
                 name={AuthorizationProps.language2}
               >
                 <Input />
@@ -286,7 +286,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Personal Message"
+                label={translate('Authorizations.fields.personalMessage')}
                 name={AuthorizationProps.personalMessage}
               >
                 <Input />
@@ -294,7 +294,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Group Authorization ID"
+                label={translate('Authorizations.fields.groupAuthorizationId')}
                 name={AuthorizationProps.groupAuthorizationId}
               >
                 <Input type="number" min="1" />
@@ -302,35 +302,39 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Allowed Connector Types (comma-separated)"
+                label={translate('Authorizations.fields.allowedConnectorTypes')}
                 name="allowedConnectorTypes"
               >
-                <Input placeholder="e.g., Type2, CCS" />
+                <Input
+                  placeholder={translate('Authorizations.placeholders.allowedConnectorTypes')}
+                />
               </FormField>
 
               <FormField
                 control={form.control}
-                label="Disallowed EVSE ID Prefixes (comma-separated)"
+                label={translate('Authorizations.fields.disallowedEvseIdPrefixes')}
                 name="disallowedEvseIdPrefixes"
               >
-                <Input placeholder="e.g., EVSE1, EVSE2" />
+                <Input
+                  placeholder={translate('Authorizations.placeholders.disallowedEvseIdPrefixes')}
+                />
               </FormField>
 
               <ComboboxFormField
                 control={form.control}
-                label="Real-Time Authentication"
+                label={translate('Authorizations.fields.realTimeAuth')}
                 name={AuthorizationProps.realTimeAuth}
                 options={authorizationWhitelistOptions.map((options) => ({
                   label: options,
                   value: options,
                 }))}
-                placeholder="Select Option"
-                searchPlaceholder="Search Option"
+                placeholder={translate('Authorizations.placeholders.selectOption')}
+                searchPlaceholder={translate('Authorizations.placeholders.searchOption')}
               />
 
               <FormField
                 control={form.control}
-                label="Real-Time Authentication URL"
+                label={translate('Authorizations.fields.realTimeAuthUrl')}
                 name={AuthorizationProps.realTimeAuthUrl}
               >
                 <Input type="url" />
@@ -338,7 +342,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Real-Time Authentication Timeout (seconds)"
+                label={translate('Authorizations.fields.realTimeAuthTimeout')}
                 name="realTimeAuthTimeout"
               >
                 <Input type="number" min="0" />
@@ -346,7 +350,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
 
               <CheckboxFormField
                 control={form.control}
-                label="Allow Concurrent Transaction"
+                label={translate('Authorizations.fields.concurrentTransaction')}
                 name={AuthorizationProps.concurrentTransaction}
               />
 
@@ -354,7 +358,7 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
                 <div className="flex items-start">
                   <AddArrayItemButton
                     onAppendAction={() => appendAdditionalInfo({ additionalIdToken: '', type: '' })}
-                    itemLabel="Additional Info"
+                    itemLabel={translate('Authorizations.fields.additionalInfo')}
                   />
                 </div>
                 <div className="flex flex-col gap-6 w-full">
@@ -362,17 +366,23 @@ export const AuthorizationUpsert = ({ params }: AuthorizationUpsertProps) => {
                     <div key={field.id} className={nestedFormRowFlex}>
                       <FormField
                         control={form.control}
-                        label={`Additional Id Token #${index + 1}`}
+                        label={translate('Authorizations.fields.additionalIdToken', {
+                          index: index + 1,
+                        })}
                         name={`additionalInfo.${index}.additionalIdToken`}
                       >
-                        <Input placeholder="Additional Info" />
+                        <Input
+                          placeholder={translate('Authorizations.placeholders.additionalInfo')}
+                        />
                       </FormField>
                       <FormField
                         control={form.control}
-                        label={`Type #${index + 1}`}
+                        label={translate('Authorizations.fields.typeNumbered', {
+                          index: index + 1,
+                        })}
                         name={`additionalInfo.${index}.type`}
                       >
-                        <Input placeholder="Type" />
+                        <Input placeholder={translate('Authorizations.placeholders.type')} />
                       </FormField>
                       <RemoveArrayItemButton onRemoveAction={() => removeAdditionalInfo(index)} />
                     </div>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/columns.tsx
@@ -27,14 +27,22 @@ import { badgeListStyle } from '@lib/client/styles/page';
 import { Badge } from '@lib/client/components/ui/badge';
 import { TimestampDisplay } from '@lib/client/components/timestamp-display';
 
-export const getChargingStationsColumns = (includeLocation = true): ColumnConfiguration[] => {
+type TranslateFn = (key: string, options?: any) => string;
+
+export const getChargingStationsColumns = (
+  includeLocation = true,
+  translate?: TranslateFn,
+): ColumnConfiguration[] => {
+  // Falls back to the English string when no translate function is provided
+  // (e.g. when invoked from areas that have not yet wired up i18n).
+  const t = (key: string, fallback: string) => (translate ? translate(key) : fallback);
   return [
     {
       key: ChargingStationProps.id,
-      header: 'Name',
+      header: t('ChargingStations.columns.name', 'Name'),
       visible: true,
       sortable: true,
-      filterConfig: { type: 'text', label: 'Station ID' },
+      filterConfig: { type: 'text', label: t('ChargingStations.columns.stationId', 'Station ID') },
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
         <TableCellLink
           path={`/${MenuSection.CHARGING_STATIONS}/${row.original.id}`}
@@ -46,7 +54,7 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
       ? [
           {
             key: ChargingStationDetailsProps.location,
-            header: 'Location',
+            header: t('ChargingStations.columns.location', 'Location'),
             visible: true,
             cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
               <TableCellLink
@@ -59,26 +67,26 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
       : []),
     {
       key: ChargingStationDetailsProps.statusNotifications,
-      header: 'Status',
+      header: t('Common.status', 'Status'),
       visible: true,
       filterConfig: {
         type: 'yesno',
         field: 'isOnline',
-        label: 'Online status',
+        label: t('ChargingStations.columns.onlineStatus', 'Online status'),
       },
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
         <span className={row.original.isOnline ? 'text-success' : 'text-destructive'}>
-          {row.original.isOnline ? 'Online' : 'Offline'}
+          {row.original.isOnline ? t('Common.online', 'Online') : t('Common.offline', 'Offline')}
         </span>
       ),
     },
     {
       key: ChargingStationDetailsProps.protocol,
-      header: 'Protocol',
+      header: t('ChargingStations.columns.protocol', 'Protocol'),
       visible: true,
       filterConfig: {
         type: 'enum',
-        label: 'Protocol',
+        label: t('ChargingStations.columns.protocol', 'Protocol'),
         enumOptions: [
           { label: 'OCPP 1.6', value: 'ocpp1.6' },
           { label: 'OCPP 2.0.1', value: 'ocpp2.0.1' },
@@ -91,12 +99,12 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: 'vendorModel',
-      header: 'Vendor / Model',
+      header: t('ChargingStations.columns.vendorModel', 'Vendor / Model'),
       visible: false,
       filterConfig: {
         type: 'text',
         field: 'chargePointVendor',
-        label: 'Vendor',
+        label: t('ChargingStations.columns.vendor', 'Vendor'),
       },
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
         <span>{`${row.original.chargePointVendor ?? EMPTY_VALUE} / ${row.original.chargePointModel ?? EMPTY_VALUE}`}</span>
@@ -104,13 +112,16 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: ChargingStationDetailsProps.floorLevel,
-      header: 'Floor Level',
+      header: t('ChargingStations.columns.floorLevel', 'Floor Level'),
       visible: false,
-      filterConfig: { type: 'text', label: 'Floor Level' },
+      filterConfig: {
+        type: 'text',
+        label: t('ChargingStations.columns.floorLevel', 'Floor Level'),
+      },
     },
     {
       key: ChargingStationDetailsProps.parkingRestrictions,
-      header: 'Parking Restrictions',
+      header: t('ChargingStations.columns.parkingRestrictions', 'Parking Restrictions'),
       visible: false,
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
         <div className={badgeListStyle}>
@@ -128,7 +139,7 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: ChargingStationDetailsProps.capabilities,
-      header: 'Capabilities',
+      header: t('ChargingStations.columns.capabilities', 'Capabilities'),
       visible: false,
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => (
         <div className={badgeListStyle}>
@@ -146,16 +157,19 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: ChargingStationDetailsProps.firmwareVersion,
-      header: 'Firmware Version',
+      header: t('ChargingStations.columns.firmwareVersion', 'Firmware Version'),
       visible: false,
-      filterConfig: { type: 'text', label: 'Firmware Version' },
+      filterConfig: {
+        type: 'text',
+        label: t('ChargingStations.columns.firmwareVersion', 'Firmware Version'),
+      },
     },
     {
       key: ChargingStationDetailsProps.createdAt,
-      header: 'Created At',
+      header: t('ChargingStations.columns.createdAt', 'Created At'),
       visible: false,
       sortable: true,
-      filterConfig: { type: 'date', label: 'Created At' },
+      filterConfig: { type: 'date', label: t('ChargingStations.columns.createdAt', 'Created At') },
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) =>
         row.original.createdAt ? (
           <TimestampDisplay isoTimestamp={row.original.createdAt} />
@@ -165,10 +179,10 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: ChargingStationDetailsProps.updatedAt,
-      header: 'Updated At',
+      header: t('ChargingStations.columns.updatedAt', 'Updated At'),
       visible: false,
       sortable: true,
-      filterConfig: { type: 'date', label: 'Updated At' },
+      filterConfig: { type: 'date', label: t('ChargingStations.columns.updatedAt', 'Updated At') },
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) =>
         row.original.updatedAt ? (
           <TimestampDisplay isoTimestamp={row.original.updatedAt} />
@@ -178,7 +192,7 @@ export const getChargingStationsColumns = (includeLocation = true): ColumnConfig
     },
     {
       key: ACTIONS_COLUMN,
-      header: 'Actions',
+      header: t('Common.actions', 'Actions'),
       visible: true,
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => {
         const hasActiveTransactions = !isEmpty(row.original.transactions);

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.aggregated.data.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.aggregated.data.tsx
@@ -12,7 +12,7 @@ import { GET_METER_VALUES_FOR_STATION } from '@lib/queries/meter.values';
 import { GET_TRANSACTION_LIST_FOR_STATION } from '@lib/queries/transactions';
 import { ResourceType } from '@lib/utils/access.types';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
-import { useList } from '@refinedev/core';
+import { useList, useTranslate } from '@refinedev/core';
 import { endOfDay, isAfter, isBefore, isSameDay, parseISO, startOfDay, subDays } from 'date-fns';
 import type { FC } from 'react';
 import { useMemo, useState } from 'react';
@@ -39,6 +39,7 @@ const filterByDate = (series: MeterValueDto[], range: DateRange | undefined) => 
 };
 
 export const AggregatedMeterValuesData: FC<{ id: number }> = ({ id }) => {
+  const translate = useTranslate();
   const {
     query: { data: txData, isLoading: txLoading },
   } = useList<TransactionDto>({
@@ -88,16 +89,20 @@ export const AggregatedMeterValuesData: FC<{ id: number }> = ({ id }) => {
     <div className={pageFlex}>
       <div className="grid grid-cols-3 gap-4 w-full">
         <div className="flex flex-col gap-2">
-          <label className="text-sm font-semibold">Time Range:</label>
+          <label className="text-sm font-semibold">
+            {translate('ChargingStations.aggregatedData.timeRange')}
+          </label>
           <RangePicker dateRange={dateRange} setDateRange={setDateRange} />
         </div>
         <div className="col-span-2 flex flex-col gap-2">
-          <label className="text-sm font-semibold">Contexts:</label>
+          <label className="text-sm font-semibold">
+            {translate('ChargingStations.aggregatedData.contexts')}
+          </label>
           <MultiSelect<OCPP2_0_1.ReadingContextEnumType>
             options={Object.values(OCPP2_0_1.ReadingContextEnumType)}
             selectedValues={validContexts}
             setSelectedValues={setValidContexts}
-            placeholder="Select reading contexts"
+            placeholder={translate('ChargingStations.aggregatedData.selectReadingContexts')}
           />
         </div>
       </div>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.configuration.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.configuration.tsx
@@ -63,20 +63,40 @@ interface ChargingStationConfigurationProps {
 }
 
 const CONFIG_1_6_COLUMNS = [
-  { key: 'key', header: 'Key', accessor: 'key' },
-  { key: 'value', header: 'Value', accessor: 'value' },
+  { key: 'key', headerKey: 'ChargingStations.configuration.key', accessor: 'key' },
+  {
+    key: 'value',
+    headerKey: 'ChargingStations.configuration.value',
+    accessor: 'value',
+  },
 ];
 
 const CONFIG_2_0_1_COLUMNS = [
-  { key: 'type', header: 'Type', accessor: 'type' },
-  { key: 'value', header: 'Value', accessor: 'value' },
+  {
+    key: 'type',
+    headerKey: 'ChargingStations.configuration.type',
+    accessor: 'type',
+  },
+  {
+    key: 'value',
+    headerKey: 'ChargingStations.configuration.value',
+    accessor: 'value',
+  },
   {
     key: 'component',
-    header: 'Component Name:Instance',
+    headerKey: 'ChargingStations.configuration.componentNameInstance',
     accessor: 'component',
   },
-  { key: 'variable', header: 'Variable Name:Instance', accessor: 'variable' },
-  { key: 'evse', header: 'EVSE ID:Connector ID', accessor: 'evse' },
+  {
+    key: 'variable',
+    headerKey: 'ChargingStations.configuration.variableNameInstance',
+    accessor: 'variable',
+  },
+  {
+    key: 'evse',
+    headerKey: 'ChargingStations.configuration.evseConnectorId',
+    accessor: 'evse',
+  },
 ];
 
 export const ChargingStationConfiguration: React.FC<ChargingStationConfigurationProps> = ({
@@ -222,10 +242,10 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
     }
 
     if (attributesError) {
-      toast.error('Failed to load variable attributes');
+      toast.error(translate('ChargingStations.configuration.loadAttributesError'));
     }
     if (configurationsError) {
-      toast.error('Failed to load change configurations');
+      toast.error(translate('ChargingStations.configuration.loadConfigurationsError'));
     }
   }, [
     version,
@@ -233,6 +253,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
     changeConfigurationsResult,
     attributesError,
     configurationsError,
+    translate,
   ]);
 
   const filteredDataSource = useMemo(() => {
@@ -250,23 +271,29 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
   const handleDownloadConfigurations = () => {
     if (version === '1.6') {
       if (!changeConfigurationsForDownload?.data) {
-        toast.error('No data available for download');
+        toast.error(translate('ChargingStations.configuration.noDataForDownload'));
         return;
       }
       downloadCSV(
         `configurations_${station?.ocppConnectionName}_${version}_${new Date().toISOString()}`,
-        ['Station Id', ...CONFIG_1_6_COLUMNS.map((col) => col.header)],
+        [
+          translate('ChargingStations.configuration.stationId'),
+          ...CONFIG_1_6_COLUMNS.map((col) => translate(col.headerKey)),
+        ],
         changeConfigurationsForDownload.data,
         (item) => [item.ocppConnectionName, item.key, item.value ?? ''],
       );
     } else {
       if (!variableAttributesForDownload?.data) {
-        toast.error('No data available for download');
+        toast.error(translate('ChargingStations.configuration.noDataForDownload'));
         return;
       }
       downloadCSV(
         `configurations_${station?.ocppConnectionName}_${version}_${new Date().toISOString()}`,
-        ['Station Id', ...CONFIG_2_0_1_COLUMNS.map((col) => col.header)],
+        [
+          translate('ChargingStations.configuration.stationId'),
+          ...CONFIG_2_0_1_COLUMNS.map((col) => translate(col.headerKey)),
+        ],
         variableAttributesForDownload.data,
         (item) => [
           String(id),
@@ -347,7 +374,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
             </Select>
           </div>
           <div className="flex items-center justify-center text-sm font-medium">
-            Page {currentPage} of {totalPages}
+            {translate('Common.pageOf', { page: currentPage, total: totalPages })}
           </div>
           <div className="flex items-center space-x-2">
             <Button
@@ -404,11 +431,13 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
               <tr>
                 {columns.map((col) => (
                   <th key={col.key} className="px-4 py-2 text-left text-sm font-medium">
-                    {col.header}
+                    {translate(col.headerKey)}
                   </th>
                 ))}
                 {version === '1.6' && (
-                  <th className="px-4 py-2 text-left text-sm font-medium">Action</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium">
+                    {translate('ChargingStations.configuration.action')}
+                  </th>
                 )}
               </tr>
             </thead>
@@ -419,7 +448,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
                     colSpan={columns.length + (version === '1.6' ? 1 : 0)}
                     className="px-4 py-8 text-center text-muted-foreground"
                   >
-                    Loading...
+                    {translate('Common.loadingEllipsis')}
                   </td>
                 </tr>
               ) : filteredDataSource.length === 0 ? (
@@ -428,7 +457,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
                     colSpan={columns.length + (version === '1.6' ? 1 : 0)}
                     className="px-4 py-8 text-center text-muted-foreground"
                   >
-                    No data
+                    {translate('ChargingStations.configuration.noData')}
                   </td>
                 </tr>
               ) : (
@@ -448,7 +477,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
                           disabled={!isConnected}
                         >
                           <Edit className="mr-2 h-4 w-4" />
-                          Edit
+                          {translate('Common.edit')}
                         </Button>
                       </td>
                     )}
@@ -466,7 +495,9 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
     <div className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="space-y-2">
-          <label className="text-sm font-medium">Select OCPP Version</label>
+          <label className="text-sm font-medium">
+            {translate('ChargingStations.configuration.selectOcppVersion')}
+          </label>
           <div className="flex gap-2">
             <Select value={version} onValueChange={(v: '1.6' | '2.0.1') => setVersion(v)}>
               <SelectTrigger className="flex-1">
@@ -482,14 +513,14 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
               onClick={handleDownloadConfigurations}
               disabled={isDownloadChangeConfigurationsLoading && isAttributesDownloadLoading}
             >
-              Download CSV
+              {translate('ChargingStations.configuration.downloadCsv')}
             </Button>
           </div>
         </div>
         <div className="space-y-2">
-          <label className="text-sm font-medium">Search</label>
+          <label className="text-sm font-medium">{translate('Common.search')}</label>
           <Input
-            placeholder="Search..."
+            placeholder={translate('ChargingStations.configuration.searchPlaceholder')}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -500,7 +531,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
         <div className="flex justify-end">
           <Button onClick={handleAddConfig} disabled={!isConnected}>
             <Plus className="mr-2 h-4 w-4" />
-            Add Configuration
+            {translate('ChargingStations.configuration.addConfiguration')}
           </Button>
         </div>
       )}
@@ -513,7 +544,9 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {changeConfigMode === 'add' ? 'Add Configuration' : 'Edit Configuration'}
+              {changeConfigMode === 'add'
+                ? translate('ChargingStations.configuration.addConfiguration')
+                : translate('ChargingStations.configuration.editConfiguration')}
             </DialogTitle>
           </DialogHeader>
           <ChangeConfigurationModal

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
@@ -48,8 +48,6 @@ import { Skeleton } from '@lib/client/components/ui/skeleton';
 import { NoDataFoundCard } from '@lib/client/components/no-data-found-card';
 import { isEmpty } from '@lib/utils/assertion';
 
-const UNKNOWN_TEXT = 'Unknown';
-
 export interface ChargingStationDetailCardContentProps {
   id: number;
   transaction?: TransactionClass;
@@ -176,6 +174,8 @@ export const ChargingStationDetailCard = ({
     latestTimestamp = formatDate(latestLog.timestamp);
   }
 
+  const unknownText = translate('Common.unknown');
+
   return (
     <Card>
       <CardHeader>
@@ -192,7 +192,7 @@ export const ChargingStationDetailCard = ({
           />
           <h2 className={heading2Style}>{station.ocppConnectionName}</h2>
           <span className={station.isOnline ? 'text-success' : 'text-destructive'}>
-            {station.isOnline ? 'Online' : 'Offline'}
+            {station.isOnline ? translate('Common.online') : translate('Common.offline')}
           </span>
           <CanAccess
             resource={ResourceType.CHARGING_STATIONS}
@@ -248,12 +248,12 @@ export const ChargingStationDetailCard = ({
           <div className="flex-1">
             <div className={cardGridStyle}>
               <KeyValueDisplay
-                keyLabel="Protocol"
+                keyLabel={translate('ChargingStations.columns.protocol')}
                 value={station[ChargingStationProps.protocol]}
                 valueRender={(protocol: any) => <ProtocolTag protocol={protocol} />}
               />
               <KeyValueDisplay
-                keyLabel="Location"
+                keyLabel={translate('ChargingStations.columns.location')}
                 value={station?.location?.name}
                 valueRender={(locationName: any) =>
                   locationName ? (
@@ -270,7 +270,7 @@ export const ChargingStationDetailCard = ({
                 }
               />
               <KeyValueDisplay
-                keyLabel="Latitude"
+                keyLabel={translate('ChargingStations.upsert.latitude')}
                 value={
                   station.coordinates
                     ? station.coordinates.coordinates[1].toFixed(4)
@@ -281,7 +281,7 @@ export const ChargingStationDetailCard = ({
               />
 
               <KeyValueDisplay
-                keyLabel="Longitude"
+                keyLabel={translate('ChargingStations.upsert.longitude')}
                 value={
                   station.coordinates
                     ? station.coordinates.coordinates[0].toFixed(4)
@@ -292,7 +292,7 @@ export const ChargingStationDetailCard = ({
               />
 
               <KeyValueDisplay
-                keyLabel="Status"
+                keyLabel={translate('Common.status')}
                 value={''}
                 valueRender={() =>
                   (station.evses?.length ?? 0) > 0 ? (
@@ -303,20 +303,23 @@ export const ChargingStationDetailCard = ({
                 }
               />
 
-              <KeyValueDisplay keyLabel="Last OCPP Message" value={latestTimestamp} />
-
               <KeyValueDisplay
-                keyLabel="Vendor / Model"
-                value={`${station.chargePointVendor ?? UNKNOWN_TEXT} / ${station.chargePointModel ?? UNKNOWN_TEXT}`}
+                keyLabel={translate('ChargingStations.detailCard.lastOcppMessage')}
+                value={latestTimestamp}
               />
 
               <KeyValueDisplay
-                keyLabel="Floor Level"
+                keyLabel={translate('ChargingStations.columns.vendorModel')}
+                value={`${station.chargePointVendor ?? unknownText} / ${station.chargePointModel ?? unknownText}`}
+              />
+
+              <KeyValueDisplay
+                keyLabel={translate('ChargingStations.columns.floorLevel')}
                 value={station.floorLevel || NOT_APPLICABLE}
               />
 
               <KeyValueDisplay
-                keyLabel="Parking Restrictions"
+                keyLabel={translate('ChargingStations.columns.parkingRestrictions')}
                 value={station.parkingRestrictions}
                 valueRender={(parkingRestrictions) => (
                   <div className={badgeListStyle}>
@@ -334,7 +337,7 @@ export const ChargingStationDetailCard = ({
               />
 
               <KeyValueDisplay
-                keyLabel="Capabilities"
+                keyLabel={translate('ChargingStations.columns.capabilities')}
                 value={station.capabilities}
                 valueRender={(capabilities) => (
                   <div className={badgeListStyle}>
@@ -351,7 +354,10 @@ export const ChargingStationDetailCard = ({
                 )}
               />
 
-              <KeyValueDisplay keyLabel="Firmware Version" value={station.firmwareVersion} />
+              <KeyValueDisplay
+                keyLabel={translate('ChargingStations.columns.firmwareVersion')}
+                value={station.firmwareVersion}
+              />
 
               <KeyValueDisplay
                 keyLabel={
@@ -374,11 +380,15 @@ export const ChargingStationDetailCard = ({
                     )}
                   </div>
                 }
-                value={station.use16StatusNotification0 ? 'Enabled' : 'Disabled'}
+                value={
+                  station.use16StatusNotification0
+                    ? translate('Common.enabled')
+                    : translate('Common.disabled')
+                }
               />
 
               <KeyValueDisplay
-                keyLabel="Connector Types"
+                keyLabel={translate('ChargingStations.detailCard.connectorTypes')}
                 value={
                   isEmpty(station.connectors)
                     ? NOT_APPLICABLE
@@ -389,7 +399,10 @@ export const ChargingStationDetailCard = ({
                 }
               />
 
-              <KeyValueDisplay keyLabel="Total EVSEs" value={station.evses?.length ?? 0} />
+              <KeyValueDisplay
+                keyLabel={translate('ChargingStations.detailCard.totalEvses')}
+                value={station.evses?.length ?? 0}
+              />
             </div>
           </div>
 

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.tabs.card.tsx
@@ -19,8 +19,8 @@ import { AggregatedMeterValuesData } from '@lib/client/pages/charging-stations/d
 import React from 'react';
 import ChargingStationConfiguration from '@lib/client/pages/charging-stations/detail/charging.station.configuration';
 import {
+  getTransactionsColumns,
   transactionChargingStationLocationNameField,
-  transactionsColumns,
   transactionStationIdField,
 } from '@lib/client/pages/transactions/columns';
 import { cardTabsStyle } from '@lib/client/styles/card';
@@ -39,7 +39,7 @@ export const ChargingStationDetailTabsCard = ({ id }: { id: number }) => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns } = useColumnPreferences(
-    transactionsColumns.filter(
+    getTransactionsColumns(translate).filter(
       (tc) =>
         tc.key !== transactionStationIdField &&
         tc.key !== transactionChargingStationLocationNameField,
@@ -59,18 +59,20 @@ export const ChargingStationDetailTabsCard = ({ id }: { id: number }) => {
           onValueChange={(selectedTab: string) => setTab(selectedTab)}
         >
           <TabsList>
-            <TabsTrigger value={ChargingStationDetailTabType.evses}>EVSEs</TabsTrigger>
+            <TabsTrigger value={ChargingStationDetailTabType.evses}>
+              {translate('ChargingStations.tabs.evses')}
+            </TabsTrigger>
             <TabsTrigger value={ChargingStationDetailTabType.ocppMessages}>
-              OCPP Messages
+              {translate('ChargingStations.tabs.ocppMessages')}
             </TabsTrigger>
             <TabsTrigger value={ChargingStationDetailTabType.configuration}>
-              Configuration
+              {translate('ChargingStations.tabs.configuration')}
             </TabsTrigger>
             <TabsTrigger value={ChargingStationDetailTabType.transactions}>
               {translate('Transactions.Transactions')}
             </TabsTrigger>
             <TabsTrigger value={ChargingStationDetailTabType.aggregated}>
-              Aggregated Meter Values Data
+              {translate('ChargingStations.tabs.aggregatedMeterValuesData')}
             </TabsTrigger>
           </TabsList>
 
@@ -84,7 +86,7 @@ export const ChargingStationDetailTabsCard = ({ id }: { id: number }) => {
               }}
               fallback={
                 <p className="text-muted-foreground">
-                  You don&#39;t have permission to view EVSEs.
+                  {translate('ChargingStations.tabs.noEvsesPermission')}
                 </p>
               }
             >
@@ -102,7 +104,7 @@ export const ChargingStationDetailTabsCard = ({ id }: { id: number }) => {
               }}
               fallback={
                 <p className="text-muted-foreground">
-                  You don&#39;t have permission to view OCPP logs.
+                  {translate('ChargingStations.tabs.noOcppLogsPermission')}
                 </p>
               }
             >
@@ -120,7 +122,7 @@ export const ChargingStationDetailTabsCard = ({ id }: { id: number }) => {
               }}
               fallback={
                 <p className="text-muted-foreground">
-                  You don&#39;t have permission to view station configurations.
+                  {translate('ChargingStations.tabs.noConfigurationsPermission')}
                 </p>
               }
             >

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/collapsible.ocpp.message.viewer.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/collapsible.ocpp.message.viewer.tsx
@@ -20,11 +20,13 @@ import {
 import { ScrollArea } from '@ferdiunal/refine-shadcn/ui';
 import { copy } from '@lib/utils/copy';
 import { formatDate } from '@lib/client/components/timestamp-display';
+import { useTranslate } from '@refinedev/core';
 
 export const CollapsibleOCPPMessageViewer: React.FC<{
   ocppMessageDto: OCPPMessageDto;
   unparsed?: boolean;
 }> = ({ ocppMessageDto, unparsed }) => {
+  const translate = useTranslate();
   const [open, setOpen] = useState(false);
   const threshold = 7;
 
@@ -90,7 +92,7 @@ export const CollapsibleOCPPMessageViewer: React.FC<{
           size="xs"
           onClick={async (e) => {
             e.stopPropagation();
-            await copy(JSON.stringify(ocppMessage, null, 2), false);
+            await copy(JSON.stringify(ocppMessage, null, 2), false, translate);
           }}
           className={`absolute top-1 ${isExpandable ? 'right-8' : 'right-1'} p-1`}
         >
@@ -116,7 +118,7 @@ export const CollapsibleOCPPMessageViewer: React.FC<{
                   size="xs"
                   onClick={async (e) => {
                     e.stopPropagation();
-                    await copy(correlationId);
+                    await copy(correlationId, true, translate);
                   }}
                 >
                   <Copy className={buttonIconSize} />
@@ -156,7 +158,7 @@ export const CollapsibleOCPPMessageViewer: React.FC<{
             size="xs"
             onClick={async (e) => {
               e.stopPropagation();
-              await copy(JSON.stringify(ocppMessage, null, 2), false);
+              await copy(JSON.stringify(ocppMessage, null, 2), false, translate);
             }}
             className="absolute top-4 right-6 p-1"
           >

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/connectors/connectors.table.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/connectors/connectors.table.tsx
@@ -7,6 +7,7 @@ import type { ConnectorDto } from '@citrineos/base';
 import { MenuSection } from '@lib/client/components/main-menu/main.menu';
 import { Button } from '@lib/client/components/ui/button';
 import { clickableLinkStyle } from '@lib/client/styles/page';
+import { useTranslate } from '@refinedev/core';
 import Link from 'next/link';
 import React from 'react';
 
@@ -17,6 +18,7 @@ interface ConnectorsTableProps {
 }
 
 export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({ connectors, onEdit }) => {
+  const translate = useTranslate();
   const formatPower = (value: number | undefined) =>
     value ? (value > 10000 ? `${(value / 1000).toFixed(1)} kW` : `${value} W`) : '-';
 
@@ -25,20 +27,30 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({ connectors, on
       <table className="w-full border-collapse text-sm">
         <thead className="bg-muted">
           <tr>
-            <th className="px-4 py-2 text-left font-medium">Connector ID</th>
-            <th className="px-4 py-2 text-left font-medium">EVSE Type Connector ID</th>
-            <th className="px-4 py-2 text-left font-medium">Type</th>
-            <th className="px-4 py-2 text-left font-medium">Status</th>
-            <th className="px-4 py-2 text-left font-medium">Max Power</th>
-            <th className="px-4 py-2 text-left font-medium">Tariff</th>
-            <th className="px-4 py-2 text-left font-medium">Actions</th>
+            <th className="px-4 py-2 text-left font-medium">
+              {translate('ChargingStations.connectors.connectorId')}
+            </th>
+            <th className="px-4 py-2 text-left font-medium">
+              {translate('ChargingStations.connectors.evseTypeConnectorId')}
+            </th>
+            <th className="px-4 py-2 text-left font-medium">
+              {translate('ChargingStations.connectors.type')}
+            </th>
+            <th className="px-4 py-2 text-left font-medium">{translate('Common.status')}</th>
+            <th className="px-4 py-2 text-left font-medium">
+              {translate('ChargingStations.connectors.maxPower')}
+            </th>
+            <th className="px-4 py-2 text-left font-medium">
+              {translate('ChargingStations.connectors.tariff')}
+            </th>
+            <th className="px-4 py-2 text-left font-medium">{translate('Common.actions')}</th>
           </tr>
         </thead>
         <tbody>
           {connectors.length === 0 ? (
             <tr>
               <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
-                No connectors
+                {translate('ChargingStations.connectors.noConnectors')}
               </td>
             </tr>
           ) : (
@@ -67,7 +79,7 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({ connectors, on
                   </td>
                   <td className="px-4 py-2">
                     <Button variant="outline" size="sm" onClick={() => onEdit(connector)}>
-                      Edit
+                      {translate('Common.edit')}
                     </Button>
                   </td>
                 </tr>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/connectors/connectors.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/connectors/connectors.upsert.tsx
@@ -40,7 +40,7 @@ import { Controller } from 'react-hook-form';
 import { ScrollArea } from '@ferdiunal/refine-shadcn/ui';
 import { evsesFormUpsertGrid } from '@lib/client/pages/charging-stations/detail/evses/evses.list';
 import { Combobox } from '@lib/client/components/combobox';
-import { useList } from '@refinedev/core';
+import { useList, useTranslate } from '@refinedev/core';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 interface ConnectorUpsertProps {
@@ -60,6 +60,7 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
   connector,
   evseId,
 }) => {
+  const translate = useTranslate();
   const selectedChargingStation = useSelector(getSelectedChargingStation());
 
   const tenantId = useTenantId();
@@ -154,8 +155,8 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.connectorId}
-            label="Connector ID"
-            description="The serial integers starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station."
+            label={translate('ChargingStations.connectors.connectorId')}
+            description={translate('ChargingStations.connectors.connectorIdDescription')}
           >
             <Input />
           </FormField>
@@ -163,8 +164,8 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.evseTypeConnectorId}
-            label="EVSE Type Connector ID"
-            description="The serial integers starting at 1 used in OCPP 2.0.1 to refer to the connector, unique per EVSE."
+            label={translate('ChargingStations.connectors.evseTypeConnectorId')}
+            description={translate('ChargingStations.connectors.evseTypeConnectorIdDescription')}
           >
             <Input />
           </FormField>
@@ -175,7 +176,9 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
             render={({ field, fieldState }) => (
               <Field data-invalid={fieldState.invalid}>
                 <FieldLabel htmlFor={field.name} className={formLabelWrapperStyle}>
-                  <span className={formLabelStyle}>Type</span>
+                  <span className={formLabelStyle}>
+                    {translate('ChargingStations.connectors.type')}
+                  </span>
                   {formRequiredAsterisk}
                 </FieldLabel>
                 <Combobox<string>
@@ -185,8 +188,8 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
                   }))}
                   value={field.value ?? undefined}
                   onSelect={(value) => form.setValue(ConnectorProps.type, value)}
-                  placeholder="Select Type"
-                  searchPlaceholder="Search Types"
+                  placeholder={translate('ChargingStations.connectors.selectType')}
+                  searchPlaceholder={translate('ChargingStations.connectors.searchTypes')}
                 />
                 {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
               </Field>
@@ -199,12 +202,16 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
             render={({ field, fieldState }) => (
               <Field data-invalid={fieldState.invalid}>
                 <FieldLabel htmlFor={field.name} className={formLabelWrapperStyle}>
-                  <span className={formLabelStyle}>Format</span>
+                  <span className={formLabelStyle}>
+                    {translate('ChargingStations.connectors.format')}
+                  </span>
                   {formRequiredAsterisk}
                 </FieldLabel>
                 <Select value={field.value} onValueChange={field.onChange}>
                   <SelectTrigger>
-                    <SelectValue placeholder="Select Format" />
+                    <SelectValue
+                      placeholder={translate('ChargingStations.connectors.selectFormat')}
+                    />
                   </SelectTrigger>
                   <SelectContent>
                     {formats.map((f) => (
@@ -225,7 +232,9 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
             render={({ field, fieldState }) => (
               <Field data-invalid={fieldState.invalid}>
                 <FieldLabel htmlFor={field.name} className={formLabelWrapperStyle}>
-                  <span className={formLabelStyle}>Power Type</span>
+                  <span className={formLabelStyle}>
+                    {translate('ChargingStations.connectors.powerType')}
+                  </span>
                   {formRequiredAsterisk}
                 </FieldLabel>
                 <Combobox<string>
@@ -235,8 +244,8 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
                   }))}
                   value={field.value ?? undefined}
                   onSelect={(value) => form.setValue(ConnectorProps.powerType, value)}
-                  placeholder="Select Power Type"
-                  searchPlaceholder="Search Power Types"
+                  placeholder={translate('ChargingStations.connectors.selectPowerType')}
+                  searchPlaceholder={translate('ChargingStations.connectors.searchPowerTypes')}
                 />
                 {fieldState.invalid && <FieldError errors={[fieldState.error]} />}
               </Field>
@@ -246,7 +255,7 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.maximumAmperage}
-            label="Maximum Amperage"
+            label={translate('ChargingStations.connectors.maximumAmperage')}
           >
             <Input type="number" />
           </FormField>
@@ -254,7 +263,7 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.maximumVoltage}
-            label="Maximum Voltage"
+            label={translate('ChargingStations.connectors.maximumVoltage')}
           >
             <Input type="number" />
           </FormField>
@@ -262,7 +271,7 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.maximumPowerWatts}
-            label="Maximum Power Watts"
+            label={translate('ChargingStations.connectors.maximumPowerWatts')}
           >
             <Input type="number" />
           </FormField>
@@ -270,7 +279,7 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <FormField
             control={form.control}
             name={ConnectorProps.termsAndConditionsUrl}
-            label="Terms and Conditions URL"
+            label={translate('ChargingStations.connectors.termsAndConditionsUrl')}
           >
             <Input />
           </FormField>
@@ -278,10 +287,10 @@ export const ConnectorsUpsert: React.FC<ConnectorUpsertProps> = ({
           <ComboboxFormField<number, any>
             control={form.control}
             name="tariffId"
-            label="Tariff"
+            label={translate('ChargingStations.connectors.tariff')}
             options={tariffOptions}
-            placeholder="Select Tariff"
-            searchPlaceholder="Search Tariffs"
+            placeholder={translate('ChargingStations.connectors.selectTariff')}
+            searchPlaceholder={translate('ChargingStations.connectors.searchTariffs')}
             isLoading={tariffQuery.isLoading}
           />
         </div>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
@@ -16,7 +16,7 @@ import { CHARGING_STATIONS_GET_QUERY } from '@lib/queries/charging.stations';
 import { ResourceType } from '@lib/utils/access.types';
 import { setSelectedChargingStation } from '@lib/utils/store/selected.charging.station.slice';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
-import { useOne } from '@refinedev/core';
+import { useOne, useTranslate } from '@refinedev/core';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
@@ -27,6 +27,7 @@ interface EVSESListProps {
 export const evsesFormUpsertGrid = 'grid grid-cols-2 xs:grid-cols-1 gap-6';
 
 export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
+  const translate = useTranslate();
   const dispatch = useDispatch();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [modalType, setModalType] = useState<'evse' | 'connector' | null>(null);
@@ -148,13 +149,17 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
 
   const modalTitle = useMemo(() => {
     if (modalType === 'evse') {
-      return selectedItem ? 'Edit Evse' : 'Add New Evse';
+      return selectedItem
+        ? translate('ChargingStations.evses.editEvse')
+        : translate('ChargingStations.evses.addNewEvse');
     }
     if (modalType === 'connector') {
-      return selectedItem ? 'Edit Connector' : 'Add New Connector';
+      return selectedItem
+        ? translate('ChargingStations.connectors.editConnector')
+        : translate('ChargingStations.connectors.addNewConnector');
     }
     return '';
-  }, [modalType, selectedItem]);
+  }, [modalType, selectedItem, translate]);
 
   const handleConnectorEdit = (connector: ConnectorDto, evseId: number | undefined) => {
     if (evseId === undefined) return;
@@ -166,30 +171,38 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
     openModal('connector', null, evseId);
   };
 
-  if (isLoading) return <p>Loading...</p>;
-  if (!station) return <p>No Data Found</p>;
+  if (isLoading) return <p>{translate('Common.loadingEllipsis')}</p>;
+  if (!station) return <p>{translate('Common.noDataFound')}</p>;
 
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <Button onClick={() => openModal('evse')}>Add New EVSE</Button>
+        <Button onClick={() => openModal('evse')}>
+          {translate('ChargingStations.evses.addNewEvse')}
+        </Button>
       </div>
 
       <div className="border rounded-lg overflow-hidden">
         <table className="w-full border-collapse">
           <thead className="bg-muted">
             <tr>
-              <th className="px-4 py-2 text-left font-medium">EVSE Type ID</th>
-              <th className="px-4 py-2 text-left font-medium">EVSE ID</th>
-              <th className="px-4 py-2 text-left font-medium">Physical Reference</th>
-              <th className="px-4 py-2 text-left font-medium">Actions</th>
+              <th className="px-4 py-2 text-left font-medium">
+                {translate('ChargingStations.evses.evseTypeId')}
+              </th>
+              <th className="px-4 py-2 text-left font-medium">
+                {translate('ChargingStations.evses.evseId')}
+              </th>
+              <th className="px-4 py-2 text-left font-medium">
+                {translate('ChargingStations.evses.physicalReference')}
+              </th>
+              <th className="px-4 py-2 text-left font-medium">{translate('Common.actions')}</th>
             </tr>
           </thead>
           <tbody>
             {!station.evses || station.evses.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-4 py-8 text-center text-muted-foreground">
-                  No EVSEs
+                  {translate('ChargingStations.evses.noEvses')}
                 </td>
               </tr>
             ) : (
@@ -212,7 +225,7 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
                             onClick={() => handleExpandToggle(evse)}
                             className="flex items-center gap-1"
                           >
-                            <span>View Connectors</span>
+                            <span>{translate('ChargingStations.evses.viewConnectors')}</span>
                             <ChevronDown
                               className={`h-4 w-4 transition-transform ${
                                 isExpanded ? 'rotate-180' : ''
@@ -224,14 +237,14 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
                             size="sm"
                             onClick={() => openModal('evse', evse)}
                           >
-                            Edit
+                            {translate('Common.edit')}
                           </Button>
                           <Button
                             variant="outline"
                             size="sm"
                             onClick={() => openModal('connector', null, evseId)}
                           >
-                            Add Connector
+                            {translate('ChargingStations.connectors.addConnector')}
                           </Button>
                         </div>
                       </td>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.upsert.tsx
@@ -16,6 +16,7 @@ import { getSerializedValues } from '@lib/utils/middleware';
 import { useForm } from '@refinedev/react-hook-form';
 import { evsesFormUpsertGrid } from '@lib/client/pages/charging-stations/detail/evses/evses.list';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
+import { useTranslate } from '@refinedev/core';
 
 interface EvseUpsertProps {
   onSubmit: () => void;
@@ -30,6 +31,7 @@ export const EvseUpsert: React.FC<EvseUpsertProps> = ({
   ocppConnectionName,
   evse,
 }) => {
+  const translate = useTranslate();
   const tenantId = useTenantId();
 
   const form = useForm({
@@ -86,8 +88,8 @@ export const EvseUpsert: React.FC<EvseUpsertProps> = ({
         <FormField
           control={form.control}
           name={EvseProps.evseTypeId}
-          label="EVSE Type ID"
-          description="The serial integers used in OCPP 2.0.1 to refer to the EVSE, unique per Charging Station."
+          label={translate('ChargingStations.evses.evseTypeId')}
+          description={translate('ChargingStations.evses.evseTypeIdDescription')}
           required
         >
           <Input type="number" />
@@ -96,8 +98,8 @@ export const EvseUpsert: React.FC<EvseUpsertProps> = ({
         <FormField
           control={form.control}
           name={EvseProps.evseId}
-          label="EVSE ID"
-          description="The eMI3 compliant EVSE ID, which must be globally unique."
+          label={translate('ChargingStations.evses.evseId')}
+          description={translate('ChargingStations.evses.evseIdDescription')}
           required
         >
           <Input />
@@ -106,8 +108,8 @@ export const EvseUpsert: React.FC<EvseUpsertProps> = ({
         <FormField
           control={form.control}
           name={EvseProps.physicalReference}
-          label="Physical Reference"
-          description="Any identifier printed on the EVSE used to identify it when physically at the location, e.g. a number or a letter."
+          label={translate('ChargingStations.evses.physicalReference')}
+          description={translate('ChargingStations.evses.physicalReferenceDescription')}
         >
           <Input />
         </FormField>
@@ -115,8 +117,8 @@ export const EvseUpsert: React.FC<EvseUpsertProps> = ({
         <CheckboxFormField
           control={form.control}
           name={EvseProps.removed}
-          label="Removed"
-          description="Marked as REMOVED"
+          label={translate('ChargingStations.evses.removed')}
+          description={translate('ChargingStations.evses.removedDescription')}
         />
       </div>
     </Form>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/ocpp.messages.export.dialog.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/ocpp.messages.export.dialog.tsx
@@ -83,25 +83,40 @@ export const OCPPMessagesExportDialog = ({
     );
 
     if (correlationIdFilter) {
-      messageItems.push(createFilterListItem('Correlation ID', correlationIdFilter.value));
+      messageItems.push(
+        createFilterListItem(
+          translate('ChargingStations.exportDialog.correlationId'),
+          correlationIdFilter.value,
+        ),
+      );
     }
     if (actionsFilter && actionsFilter.value.length > 0) {
-      messageItems.push(createFilterListItem('Actions', actionsFilter.value.join(', ')));
+      messageItems.push(
+        createFilterListItem(
+          translate('ChargingStations.exportDialog.actions'),
+          actionsFilter.value.join(', '),
+        ),
+      );
     }
     if (originFilter) {
-      messageItems.push(createFilterListItem('Origin', originFilter.value));
+      messageItems.push(
+        createFilterListItem(translate('ChargingStations.exportDialog.origin'), originFilter.value),
+      );
     }
     if (startDateFilter) {
       messageItems.push(
         createFilterListItem(
-          'Start Date',
+          translate('ChargingStations.exportDialog.startDate'),
           formatDate(startDateFilter.value, dateTimePickerDateFormat),
         ),
       );
     }
     if (endDateFilter) {
       messageItems.push(
-        createFilterListItem('End Date', formatDate(endDateFilter.value, dateTimePickerDateFormat)),
+        createFilterListItem(
+          translate('ChargingStations.exportDialog.endDate'),
+          formatDate(endDateFilter.value, dateTimePickerDateFormat),
+        ),
       );
     }
 
@@ -119,7 +134,7 @@ export const OCPPMessagesExportDialog = ({
         onOpenChangeAction(false);
       })
       .catch((err) => {
-        toast.error(`Could export to CSV due to error: ${JSON.stringify(err)}`);
+        toast.error(translate('ChargingStations.exportToCsvError', { error: JSON.stringify(err) }));
       });
   };
 

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/ocpp.messages.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/ocpp.messages.tsx
@@ -56,14 +56,6 @@ const actionOptions = [
 
 const allOption = 'all';
 
-const originOptions = [
-  { label: 'All Origins', value: allOption },
-  ...Object.values(MessageOrigin).map((o) => ({
-    label: o.toUpperCase(),
-    value: o,
-  })),
-];
-
 export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
   stationId,
   initialStartDate = null,
@@ -82,6 +74,17 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
   const translate = useTranslate();
   const liveMode = liveLogEnabled ? 'auto' : 'off';
   const invalidate = useInvalidate();
+
+  const originOptions = useMemo(
+    () => [
+      { label: translate('ChargingStations.ocppMessages.allOrigins'), value: allOption },
+      ...Object.values(MessageOrigin).map((o) => ({
+        label: o.toUpperCase(),
+        value: o,
+      })),
+    ],
+    [translate],
+  );
 
   const [tableQueryState, _] = useQueryState(
     ResourceType.OCPP_MESSAGES,
@@ -261,19 +264,19 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
         <div className="grid grid-cols-5 gap-2 w-full">
           <DebounceSearch
             onSearch={setSearchCid}
-            placeholder="Search Correlation ID"
+            placeholder={translate('ChargingStations.ocppMessages.searchCorrelationId')}
             className="relative w-full"
           />
           <MultiSelect
             options={actionOptions}
             selectedValues={selectedActions}
             setSelectedValues={setSelectedActions}
-            placeholder="Select Actions"
-            searchPlaceholder="Search Actions"
+            placeholder={translate('ChargingStations.ocppMessages.selectActions')}
+            searchPlaceholder={translate('ChargingStations.ocppMessages.searchActions')}
           />
           <Select value={selectedOrigin ?? ''} onValueChange={setSelectedOrigin}>
             <SelectTrigger className="w-full">
-              <SelectValue placeholder="Filter Origins" />
+              <SelectValue placeholder={translate('ChargingStations.ocppMessages.filterOrigins')} />
             </SelectTrigger>
             <SelectContent>
               {originOptions.map((opt) => (
@@ -286,12 +289,12 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
           <DateTimePicker
             date={startDate ?? undefined}
             onSelectDateAction={(date) => setStartDate(date ?? null)}
-            placeholder="Pick Start Date"
+            placeholder={translate('ChargingStations.ocppMessages.pickStartDate')}
           />
           <DateTimePicker
             date={endDate ?? undefined}
             onSelectDateAction={(date) => setEndDate(date ?? null)}
-            placeholder="Pick End Date"
+            placeholder={translate('ChargingStations.ocppMessages.pickEndDate')}
           />
         </div>
 
@@ -323,7 +326,7 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
               id="correlationId"
               key="correlationId"
               accessorKey="correlationId"
-              header="Correlation ID"
+              header={translate('ChargingStations.ocppMessages.correlationId')}
               cell={({ row }: CellContext<OCPPMessageDto, unknown>) => {
                 return (
                   <TooltipProvider>
@@ -344,7 +347,9 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
                             <Link className={buttonIconSize} />
                           </Button>
                         </TooltipTrigger>
-                        <TooltipContent>Find related message</TooltipContent>
+                        <TooltipContent>
+                          {translate('ChargingStations.ocppMessages.findRelatedMessage')}
+                        </TooltipContent>
                       </Tooltip>
                       {row.original.correlationId && (
                         <Tooltip>
@@ -354,13 +359,15 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
                               size="xs"
                               onClick={async (e) => {
                                 e.stopPropagation();
-                                await copy(row.original.correlationId);
+                                await copy(row.original.correlationId, true, translate);
                               }}
                             >
                               <Copy className={buttonIconSize} />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Copy Correlation ID</TooltipContent>
+                          <TooltipContent>
+                            {translate('ChargingStations.ocppMessages.copyCorrelationId')}
+                          </TooltipContent>
                         </Tooltip>
                       )}
                     </div>
@@ -372,11 +379,13 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
               id="action"
               key="action"
               accessorKey="action"
-              header="Action - Origin"
+              header={translate('ChargingStations.ocppMessages.actionOrigin')}
               cell={({ row }: CellContext<OCPPMessageDto, unknown>) => {
                 return (
                   <span>
-                    {row.original.action ?? 'Unknown Action'} - {row.original.origin}
+                    {row.original.action ??
+                      translate('ChargingStations.ocppMessages.unknownAction')}{' '}
+                    - {row.original.origin}
                   </span>
                 );
               }}
@@ -385,7 +394,7 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
               id="timestamp"
               key="timestamp"
               accessorKey="timestamp"
-              header="Timestamp"
+              header={translate('ChargingStations.ocppMessages.timestamp')}
               enableSorting
               cell={({ row }: CellContext<OCPPMessageDto, unknown>) => {
                 return (
@@ -400,7 +409,7 @@ export const OCPPMessages: React.FC<OCPPMessagesProps> = ({
               id="message"
               key="message"
               accessorKey="message"
-              header="Content"
+              header={translate('ChargingStations.ocppMessages.content')}
               cell={({ row }: CellContext<OCPPMessageDto, unknown>) => {
                 return (
                   <CollapsibleOCPPMessageViewer

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/list/charging.stations.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/list/charging.stations.list.tsx
@@ -39,12 +39,12 @@ export const ChargingStationsList = () => {
   const [searchFilters, setSearchFilters] = useState<any>(EMPTY_FILTER);
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    getChargingStationsColumns(),
+    getChargingStationsColumns(true, translate),
     ResourceType.CHARGING_STATIONS,
   );
 
   const { filterButton, filterChips, activeCrudFilters } = useTableFilters(
-    getChargingStationsColumns(),
+    getChargingStationsColumns(true, translate),
     ResourceType.CHARGING_STATIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/upsert/charging.stations.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/upsert/charging.stations.upsert.tsx
@@ -284,7 +284,7 @@ export const ChargingStationUpsert = ({
             <div className={cardGridStyle}>
               <FormField
                 control={form.control}
-                label="Name"
+                label={translate('ChargingStations.columns.name')}
                 name={ChargingStationProps.ocppConnectionName}
                 required
               >
@@ -293,17 +293,17 @@ export const ChargingStationUpsert = ({
               <ComboboxFormField<number, ChargingStationCreateDto>
                 control={form.control}
                 name={ChargingStationProps.locationId}
-                label="Location"
+                label={translate('ChargingStations.columns.location')}
                 options={locationOptions}
                 onSearch={onSearch}
-                placeholder="Select Location"
+                placeholder={translate('ChargingStations.upsert.selectLocation')}
                 isLoading={locationQuery.isLoading}
                 required
                 disabled={!!locationId}
               />
               <FormField
                 control={form.control}
-                label="Floor Level"
+                label={translate('ChargingStations.columns.floorLevel')}
                 name={ChargingStationProps.floorLevel}
               >
                 <Input />
@@ -315,19 +315,19 @@ export const ChargingStationUpsert = ({
               >
                 control={form.control}
                 name={ChargingStationProps.parkingRestrictions}
-                label="Parking Restrictions"
+                label={translate('ChargingStations.columns.parkingRestrictions')}
                 options={parkingRestrictions}
-                placeholder="Select Parking Restrictions"
-                searchPlaceholder="Search Parking Restrictions"
+                placeholder={translate('ChargingStations.upsert.selectParkingRestrictions')}
+                searchPlaceholder={translate('ChargingStations.upsert.searchParkingRestrictions')}
               />
 
               <MultiSelectFormField<ChargingStationCapabilityEnumType, ChargingStationCreateDto>
                 control={form.control}
                 name={ChargingStationProps.capabilities}
-                label="Capabilities"
+                label={translate('ChargingStations.columns.capabilities')}
                 options={capabilities}
-                placeholder="Select Capabilities"
-                searchPlaceholder="Search Capabilities"
+                placeholder={translate('ChargingStations.upsert.selectCapabilities')}
+                searchPlaceholder={translate('ChargingStations.upsert.searchCapabilities')}
               />
 
               <CheckboxFormField
@@ -357,13 +357,17 @@ export const ChargingStationUpsert = ({
                       }
                     }}
                   />
-                  <Label htmlFor="useLocationCoordinates">Use Location Coordinates</Label>
+                  <Label htmlFor="useLocationCoordinates">
+                    {translate('ChargingStations.upsert.useLocationCoordinates')}
+                  </Label>
                 </div>
               </Field>
 
               <Field>
                 <FieldLabel>
-                  <span className={formLabelStyle}>Latitude</span>
+                  <span className={formLabelStyle}>
+                    {translate('ChargingStations.upsert.latitude')}
+                  </span>
                 </FieldLabel>
                 <Input
                   type="number"
@@ -373,13 +377,15 @@ export const ChargingStationUpsert = ({
                     setLatitude(e.target.value ? parseFloat(e.target.value) : undefined)
                   }
                   disabled={useLocationCoordinates}
-                  placeholder="Enter latitude"
+                  placeholder={translate('ChargingStations.upsert.enterLatitude')}
                 />
               </Field>
 
               <Field>
                 <FieldLabel>
-                  <span className={formLabelStyle}>Longitude</span>
+                  <span className={formLabelStyle}>
+                    {translate('ChargingStations.upsert.longitude')}
+                  </span>
                 </FieldLabel>
                 <Input
                   type="number"
@@ -389,14 +395,16 @@ export const ChargingStationUpsert = ({
                     setLongitude(e.target.value ? parseFloat(e.target.value) : undefined)
                   }
                   disabled={useLocationCoordinates}
-                  placeholder="Enter longitude"
+                  placeholder={translate('ChargingStations.upsert.enterLongitude')}
                 />
               </Field>
 
               {allowImageUpload && (
                 <Field>
                   <FieldLabel>
-                    <span className={formLabelStyle}>Image</span>
+                    <span className={formLabelStyle}>
+                      {translate('ChargingStations.upsert.image')}
+                    </span>
                   </FieldLabel>
                   <Input
                     type="file"

--- a/apps/operator-ui/src/lib/client/pages/locations/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/columns.tsx
@@ -17,33 +17,36 @@ import { badgeListStyle } from '@lib/client/styles/page';
 import { isEmpty } from '@lib/utils/assertion';
 import { Badge } from '@lib/client/components/ui/badge';
 import { TimestampDisplay } from '@lib/client/components/timestamp-display';
+type TranslateFn = (key: string, options?: any) => string;
 
-export const locationsColumns: ColumnConfiguration[] = [
+export const getLocationsColumns = (translate: TranslateFn): ColumnConfiguration[] => [
   {
     key: LocationProps.name,
-    header: 'Name',
+    header: translate('Locations.columns.name'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <TableCellLink
         path={`/${MenuSection.LOCATIONS}/${row.original.id}`}
-        value={row.original.name ?? 'Unnamed Location'}
+        value={row.original.name ?? translate('Locations.unnamedLocation')}
       />
     ),
   },
   {
     key: LocationProps.address,
-    header: 'Address',
+    header: translate('Locations.columns.address'),
     visible: true,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <span>
-        {row.original.address ? getFullAddress(row.original as Partial<LocationDto>) : 'No address'}
+        {row.original.address
+          ? getFullAddress(row.original as Partial<LocationDto>)
+          : translate('Locations.noAddress')}
       </span>
     ),
   },
   {
     key: 'latitude',
-    header: 'Latitude',
+    header: translate('Locations.columns.latitude'),
     visible: false,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <span>
@@ -55,7 +58,7 @@ export const locationsColumns: ColumnConfiguration[] = [
   },
   {
     key: 'longitude',
-    header: 'Longitude',
+    header: translate('Locations.columns.longitude'),
     visible: false,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <span>
@@ -67,18 +70,18 @@ export const locationsColumns: ColumnConfiguration[] = [
   },
   {
     key: LocationProps.timeZone,
-    header: 'Time Zone',
+    header: translate('Locations.columns.timeZone'),
     visible: false,
     sortable: true,
   },
   {
     key: LocationProps.parkingType,
-    header: 'Parking Type',
+    header: translate('Locations.columns.parkingType'),
     visible: false,
   },
   {
     key: LocationProps.facilities,
-    header: 'Facilities',
+    header: translate('Locations.columns.facilities'),
     visible: false,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <div className={badgeListStyle}>
@@ -96,7 +99,7 @@ export const locationsColumns: ColumnConfiguration[] = [
   },
   {
     key: 'totalStations',
-    header: 'Total Stations',
+    header: translate('Locations.columns.totalStations'),
     visible: true,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) => (
       <span>{row.original.chargingPool?.length ?? 0}</span>
@@ -104,7 +107,7 @@ export const locationsColumns: ColumnConfiguration[] = [
   },
   {
     key: LocationProps.createdAt,
-    header: 'Created At',
+    header: translate('Locations.columns.createdAt'),
     visible: false,
     sortable: true,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) =>
@@ -116,7 +119,7 @@ export const locationsColumns: ColumnConfiguration[] = [
   },
   {
     key: LocationProps.updatedAt,
-    header: 'Updated At',
+    header: translate('Locations.columns.updatedAt'),
     visible: false,
     sortable: true,
     cellRender: ({ row }: CellContext<LocationDto, unknown>) =>
@@ -138,7 +141,7 @@ export const locationsColumns: ColumnConfiguration[] = [
           row.toggleExpanded();
         }}
       >
-        <span className="text-sm">View Stations</span>
+        <span className="text-sm">{translate('Locations.viewStations')}</span>
         <ChevronDownIcon
           className={`transition-transform duration-200 ${row.getIsExpanded() ? 'rotate-180' : ''}`}
         />

--- a/apps/operator-ui/src/lib/client/pages/locations/detail/location.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/detail/location.detail.card.tsx
@@ -66,11 +66,13 @@ export const LocationDetailCard = ({ location, imageUrl }: LocationDetailCardPro
           <div className="flex-1">
             <div className={cardGridStyle}>
               <KeyValueDisplay
-                keyLabel="Address"
-                value={location.address ? getFullAddress(location) : 'No Address'}
+                keyLabel={translate('Locations.columns.address')}
+                value={
+                  location.address ? getFullAddress(location) : translate('Locations.noAddress')
+                }
               />
               <KeyValueDisplay
-                keyLabel="Latitude"
+                keyLabel={translate('Locations.columns.latitude')}
                 value={
                   location?.coordinates
                     ? location.coordinates.coordinates[1].toFixed(4)
@@ -78,17 +80,23 @@ export const LocationDetailCard = ({ location, imageUrl }: LocationDetailCardPro
                 }
               />
               <KeyValueDisplay
-                keyLabel="Longitude"
+                keyLabel={translate('Locations.columns.longitude')}
                 value={
                   location?.coordinates
                     ? location.coordinates.coordinates[0].toFixed(4)
                     : NOT_APPLICABLE
                 }
               />
-              <KeyValueDisplay keyLabel="Time Zone" value={location.timeZone} />
-              <KeyValueDisplay keyLabel="Parking Type" value={location.parkingType} />
               <KeyValueDisplay
-                keyLabel="Facilities"
+                keyLabel={translate('Locations.columns.timeZone')}
+                value={location.timeZone}
+              />
+              <KeyValueDisplay
+                keyLabel={translate('Locations.columns.parkingType')}
+                value={location.parkingType}
+              />
+              <KeyValueDisplay
+                keyLabel={translate('Locations.columns.facilities')}
                 value={
                   location.facilities ? (
                     <div className={badgeListStyle}>
@@ -104,7 +112,7 @@ export const LocationDetailCard = ({ location, imageUrl }: LocationDetailCardPro
                 }
               />
               <KeyValueDisplay
-                keyLabel="Total Chargers"
+                keyLabel={translate('Locations.detail.totalChargers')}
                 value={location.chargingPool?.length ?? 0}
               />
             </div>
@@ -114,7 +122,7 @@ export const LocationDetailCard = ({ location, imageUrl }: LocationDetailCardPro
             <div className="flex-shrink-0 w-64 md:w-48 sm:w-32 h-64 md:h-48 sm:h-32 flex items-center justify-center bg-gray-100 rounded-md">
               <Image
                 src={imageUrl}
-                alt={`${location.name} image`}
+                alt={translate('Locations.detail.imageAlt', { name: location.name })}
                 className="w-full h-full object-contain rounded-md bg-gray-100"
                 onError={(e) => {
                   (e.currentTarget as HTMLImageElement).style.display = 'none';

--- a/apps/operator-ui/src/lib/client/pages/locations/detail/locations.detail.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/detail/locations.detail.tsx
@@ -88,8 +88,12 @@ export const LocationsDetail = ({ params }: LocationDetailProps) => {
           <CardContent>
             <Tabs defaultValue="charging-stations">
               <TabsList>
-                <TabsTrigger value="charging-stations">Charging Stations</TabsTrigger>
-                <TabsTrigger value="opening-hours">Opening Hours</TabsTrigger>
+                <TabsTrigger value="charging-stations">
+                  {translate('Locations.chargingStations')}
+                </TabsTrigger>
+                <TabsTrigger value="opening-hours">
+                  {translate('Locations.openingHours')}
+                </TabsTrigger>
               </TabsList>
               <TabsContent value="charging-stations">
                 <LocationsChargingStationsTable location={location} showHeader />

--- a/apps/operator-ui/src/lib/client/pages/locations/list/locations.charging.stations.table.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/list/locations.charging.stations.table.tsx
@@ -34,7 +34,7 @@ export const LocationsChargingStationsTable = ({
   const stationsToDisplay = location.chargingPool ?? [];
 
   const { renderedVisibleColumns } = useColumnPreferences(
-    getChargingStationsColumns(false),
+    getChargingStationsColumns(false, translate),
     ResourceType.CHARGING_STATIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/locations/list/locations.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/list/locations.list.tsx
@@ -8,7 +8,7 @@ import { DebounceSearch } from '@lib/client/components/debounce-search';
 import { MenuSection } from '@lib/client/components/main-menu/main.menu';
 import { Table } from '@lib/client/components/table';
 import { Button } from '@lib/client/components/ui/button';
-import { getLocationFilters, locationsColumns } from '@lib/client/pages/locations/columns';
+import { getLocationFilters, getLocationsColumns } from '@lib/client/pages/locations/columns';
 import { LocationsChargingStationsTable } from '@lib/client/pages/locations/list/locations.charging.stations.table';
 import { LocationClass } from '@lib/cls/location.dto';
 import { LOCATIONS_LIST_QUERY } from '@lib/queries/locations';
@@ -37,7 +37,7 @@ export const LocationsList = () => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    locationsColumns,
+    getLocationsColumns(translate),
     ResourceType.LOCATIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/locations/map/location-marker/index.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/map/location-marker/index.tsx
@@ -5,7 +5,7 @@
 import type { LocationDto } from '@citrineos/base';
 import { Button } from '@lib/client/components/ui/button';
 import { ResourceType } from '@lib/utils/access.types';
-import { useNavigation } from '@refinedev/core';
+import { useNavigation, useTranslate } from '@refinedev/core';
 import React from 'react';
 
 interface LocationMarkerProps {
@@ -14,6 +14,7 @@ interface LocationMarkerProps {
 
 export const LocationMarker: React.FC<LocationMarkerProps> = ({ location }) => {
   const { show } = useNavigation();
+  const translate = useTranslate();
 
   const handleShowClick = () => {
     show(ResourceType.LOCATIONS, location.id!);
@@ -27,7 +28,7 @@ export const LocationMarker: React.FC<LocationMarkerProps> = ({ location }) => {
         {location.city}, {location.state} {location.postalCode}, {location.country}
       </p>
       <Button onClick={handleShowClick} className="mt-2">
-        View Details
+        {translate('Locations.map.viewDetails')}
       </Button>
     </div>
   );

--- a/apps/operator-ui/src/lib/client/pages/locations/map/stations.map.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/map/stations.map.tsx
@@ -17,7 +17,7 @@ import { LocationClass } from '@lib/cls/location.dto';
 import { CHARGING_STATIONS_LIST_QUERY } from '@lib/queries/charging.stations';
 import { LOCATIONS_LIST_QUERY } from '@lib/queries/locations';
 import { ResourceType } from '@lib/utils/access.types';
-import { useList } from '@refinedev/core';
+import { useList, useTranslate } from '@refinedev/core';
 import { plainToInstance } from 'class-transformer';
 import React, { useState } from 'react';
 
@@ -33,6 +33,7 @@ export const CombinedMap: React.FC<CombinedMapProps> = ({
   const [activeTab, setActiveTab] = useState<'all' | 'locations' | 'stations'>('all');
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [selectedType, setSelectedType] = useState<'location' | 'station' | 'mixed' | null>(null);
+  const translate = useTranslate();
 
   const {
     query: { data: locationsData },
@@ -83,16 +84,16 @@ export const CombinedMap: React.FC<CombinedMapProps> = ({
   return (
     <div className="combined-map-container">
       <div className="map-controls flex justify-between items-center">
-        <h2 className="text-2xl font-semibold">Network Overview</h2>
+        <h2 className="text-2xl font-semibold">{translate('Locations.map.networkOverview')}</h2>
         <div className="flex items-center gap-4">
           <Tabs
             value={activeTab}
             onValueChange={(value) => setActiveTab(value as 'all' | 'locations' | 'stations')}
           >
             <TabsList>
-              <TabsTrigger value="all">All</TabsTrigger>
-              <TabsTrigger value="locations">Locations</TabsTrigger>
-              <TabsTrigger value="stations">Stations</TabsTrigger>
+              <TabsTrigger value="all">{translate('Locations.map.all')}</TabsTrigger>
+              <TabsTrigger value="locations">{translate('Locations.map.locations')}</TabsTrigger>
+              <TabsTrigger value="stations">{translate('Locations.map.stations')}</TabsTrigger>
             </TabsList>
           </Tabs>
           {selectedId && selectedType && (
@@ -107,11 +108,11 @@ export const CombinedMap: React.FC<CombinedMapProps> = ({
                           : `/charging-stations/${selectedId}`;
                     }}
                   >
-                    View Details
+                    {translate('Locations.map.viewDetails')}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>View {selectedType} details</p>
+                  <p>{translate('Locations.map.viewTypeDetails', { type: selectedType })}</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
@@ -135,21 +136,21 @@ export const CombinedMap: React.FC<CombinedMapProps> = ({
             className="legend-color w-4 h-4 rounded"
             style={{ backgroundColor: 'var(--primary-color-1)' }}
           ></div>
-          <span>Online</span>
+          <span>{translate('Locations.map.online')}</span>
         </div>
         <div className="legend-item flex items-center gap-2">
           <div
             className="legend-color w-4 h-4 rounded"
             style={{ backgroundColor: 'var(--grayscale-color-2)' }}
           ></div>
-          <span>Partial</span>
+          <span>{translate('Locations.map.partial')}</span>
         </div>
         <div className="legend-item flex items-center gap-2">
           <div
             className="legend-color w-4 h-4 rounded"
             style={{ backgroundColor: 'var(--secondary-color-2)' }}
           ></div>
-          <span>Offline</span>
+          <span>{translate('Locations.map.offline')}</span>
         </div>
       </div>
     </div>

--- a/apps/operator-ui/src/lib/client/pages/locations/upsert/locations.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/upsert/locations.upsert.tsx
@@ -68,36 +68,37 @@ type LocationsUpsertProps = {
   allowImageUpload?: boolean;
 };
 
-const LocationCreateSchema = LocationSchema.pick({
-  [LocationProps.name]: true,
-  [LocationProps.address]: true,
-  [LocationProps.city]: true,
-  [LocationProps.postalCode]: true,
-  [LocationProps.state]: true,
-  [LocationProps.country]: true,
-  [LocationProps.timeZone]: true,
-  [LocationProps.coordinates]: true,
-  [LocationProps.parkingType]: true,
-  [LocationProps.facilities]: true,
-  [LocationProps.chargingPool]: true,
-  [LocationProps.openingHours]: true,
-}).extend({
-  [LocationProps.chargingPool]: z
-    .array(
-      ChargingStationSchema.pick({
-        [ChargingStationProps.id]: true,
-      }),
-    )
-    .nullable()
-    .optional(),
-  [LocationProps.address]: z.string().min(1, 'Street address is required'),
-  [LocationProps.city]: z.string().optional().default(''),
-  [LocationProps.state]: z.string().nullable().optional().default(''),
-  [LocationProps.postalCode]: z.string().optional().default(''),
-  [LocationProps.country]: z.string().optional().default(''),
-});
+const buildLocationCreateSchema = (addressRequiredMessage: string) =>
+  LocationSchema.pick({
+    [LocationProps.name]: true,
+    [LocationProps.address]: true,
+    [LocationProps.city]: true,
+    [LocationProps.postalCode]: true,
+    [LocationProps.state]: true,
+    [LocationProps.country]: true,
+    [LocationProps.timeZone]: true,
+    [LocationProps.coordinates]: true,
+    [LocationProps.parkingType]: true,
+    [LocationProps.facilities]: true,
+    [LocationProps.chargingPool]: true,
+    [LocationProps.openingHours]: true,
+  }).extend({
+    [LocationProps.chargingPool]: z
+      .array(
+        ChargingStationSchema.pick({
+          [ChargingStationProps.id]: true,
+        }),
+      )
+      .nullable()
+      .optional(),
+    [LocationProps.address]: z.string().min(1, addressRequiredMessage),
+    [LocationProps.city]: z.string().optional().default(''),
+    [LocationProps.state]: z.string().nullable().optional().default(''),
+    [LocationProps.postalCode]: z.string().optional().default(''),
+    [LocationProps.country]: z.string().optional().default(''),
+  });
 
-type LocationCreateDto = z.infer<typeof LocationCreateSchema>;
+type LocationCreateDto = z.infer<ReturnType<typeof buildLocationCreateSchema>>;
 
 const defaultLocation = {
   [LocationProps.name]: '',
@@ -157,7 +158,9 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
       },
     },
     defaultValues: defaultLocation,
-    resolver: zodResolver(LocationCreateSchema),
+    resolver: zodResolver(
+      buildLocationCreateSchema(translate('Locations.form.streetAddressRequired')),
+    ),
     warnWhenUnsavedChanges: true,
   });
 
@@ -235,9 +238,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
     }
 
     Promise.all(updateOperations).catch((err: any) =>
-      toast.error(
-        `Failed to update charging stations on location due to error ${JSON.stringify(err)}`,
-      ),
+      toast.error(translate('Locations.form.uploadFailedToast', { error: JSON.stringify(err) })),
     );
   };
 
@@ -376,7 +377,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   <div className="col-span-2">
                     <FormField
                       control={form.control}
-                      label="Name"
+                      label={translate('Locations.form.name')}
                       name={LocationProps.name}
                       required
                     >
@@ -388,7 +389,9 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   <div className="col-span-2">
                     <Field>
                       <FieldLabel className={formLabelWrapperStyle}>
-                        <span className={formLabelStyle}>Street Address</span>
+                        <span className={formLabelStyle}>
+                          {translate('Locations.form.streetAddress')}
+                        </span>
                         {formRequiredAsterisk}
                       </FieldLabel>
                       <AddressAutocomplete
@@ -409,7 +412,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                             });
                           }
                         }}
-                        placeholder="Start typing to search, or enter manually below"
+                        placeholder={translate('Locations.form.addressAutocompletePlaceholder')}
                       />
                       {form.formState.errors[LocationProps.address] && (
                         <p className="text-sm text-destructive mt-1">
@@ -420,40 +423,46 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   </div>
 
                   {/* City */}
-                  <FormField control={form.control} label="City" name={LocationProps.city}>
-                    <Input placeholder="e.g. Berlin" />
+                  <FormField
+                    control={form.control}
+                    label={translate('Locations.form.city')}
+                    name={LocationProps.city}
+                  >
+                    <Input placeholder={translate('Locations.form.cityPlaceholder')} />
                   </FormField>
 
                   {/* State / Province / Region — free text, works globally */}
                   <FormField
                     control={form.control}
-                    label="State / Province / Region"
+                    label={translate('Locations.form.stateProvinceRegion')}
                     name={LocationProps.state}
                   >
-                    <Input placeholder="e.g. California, Ontario, Bayern" />
+                    <Input
+                      placeholder={translate('Locations.form.stateProvinceRegionPlaceholder')}
+                    />
                   </FormField>
 
                   {/* Postal Code */}
                   <FormField
                     control={form.control}
-                    label="Postal Code"
+                    label={translate('Locations.form.postalCode')}
                     name={LocationProps.postalCode}
                   >
-                    <Input placeholder="e.g. 94105, SW1A 1AA, 10115" />
+                    <Input placeholder={translate('Locations.form.postalCodePlaceholder')} />
                   </FormField>
 
                   {/* Country */}
                   <ComboboxFormField
                     control={form.control}
                     name={LocationProps.country}
-                    label="Country"
+                    label={translate('Locations.form.country')}
                     value={chosenCountryName}
                     options={countryList.map((country) => ({
                       label: country.name,
                       value: country.name,
                     }))}
-                    placeholder="Select country"
-                    searchPlaceholder="Search countries..."
+                    placeholder={translate('Locations.form.selectCountry')}
+                    searchPlaceholder={translate('Locations.form.searchCountries')}
                     onSelect={(countryName: string) => {
                       const selected = countryList.find((c) => c.name === countryName);
                       if (selected) {
@@ -465,7 +474,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   {/* Lat / Lng */}
                   <Field>
                     <FieldLabel htmlFor="latitude" className={formLabelWrapperStyle}>
-                      <span className={formLabelStyle}>Latitude</span>
+                      <span className={formLabelStyle}>{translate('Locations.form.latitude')}</span>
                       {formRequiredAsterisk}
                     </FieldLabel>
                     <Input
@@ -481,12 +490,14 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                           });
                       }}
                       type="number"
-                      placeholder="Auto-filled from address"
+                      placeholder={translate('Locations.form.autoFilledFromAddress')}
                     />
                   </Field>
                   <Field>
                     <FieldLabel htmlFor="longitude" className={formLabelWrapperStyle}>
-                      <span className={formLabelStyle}>Longitude</span>
+                      <span className={formLabelStyle}>
+                        {translate('Locations.form.longitude')}
+                      </span>
                       {formRequiredAsterisk}
                     </FieldLabel>
                     <Input
@@ -502,14 +513,14 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                           });
                       }}
                       type="number"
-                      placeholder="Auto-filled from address"
+                      placeholder={translate('Locations.form.autoFilledFromAddress')}
                     />
                   </Field>
 
                   {/* Time Zone */}
                   <FormField
                     control={form.control}
-                    label="Time Zone"
+                    label={translate('Locations.form.timeZone')}
                     name={LocationProps.timeZone}
                     required
                   >
@@ -520,24 +531,24 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   <ComboboxFormField
                     control={form.control}
                     name={LocationProps.parkingType}
-                    label="Parking Type"
+                    label={translate('Locations.form.parkingType')}
                     options={parkingTypes.map((pt: LocationParkingEnumType) => ({
                       label: pt,
                       value: pt,
                     }))}
-                    placeholder="Select Parking Type"
-                    searchPlaceholder="Search Parking Types"
+                    placeholder={translate('Locations.form.selectParkingType')}
+                    searchPlaceholder={translate('Locations.form.searchParkingTypes')}
                   />
 
                   {/* Facilities */}
                   <div className="col-span-2">
                     <MultiSelectFormField
                       control={form.control}
-                      label="Facilities"
+                      label={translate('Locations.form.facilities')}
                       name={LocationProps.facilities}
                       options={facilities}
-                      placeholder="Select Facilities"
-                      searchPlaceholder="Search Facilities"
+                      placeholder={translate('Locations.form.selectFacilities')}
+                      searchPlaceholder={translate('Locations.form.searchFacilities')}
                     />
                   </div>
 
@@ -545,7 +556,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                   {allowImageUpload && (
                     <Field>
                       <FieldLabel>
-                        <span className={formLabelStyle}>Image</span>
+                        <span className={formLabelStyle}>{translate('Locations.form.image')}</span>
                       </FieldLabel>
                       <Input
                         type="file"
@@ -565,7 +576,7 @@ export const LocationsUpsert = ({ params, allowImageUpload = false }: LocationsU
                         onClick={() => document.getElementById('uploadInput')?.click()}
                       >
                         <UploadIcon className={buttonIconSize} />
-                        Upload
+                        {translate('Locations.form.upload')}
                       </Button>
                       {uploadedFileName && (
                         <span className="text-sm text-gray-700">{uploadedFileName}</span>

--- a/apps/operator-ui/src/lib/client/pages/locations/upsert/selected.charging.stations.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/upsert/selected.charging.stations.tsx
@@ -100,14 +100,18 @@ export const SelectedChargingStations = ({ form, params }: SelectedChargingStati
                 append(JSON.parse(stringifiedStation));
               }}
               onSearch={onSearch}
-              placeholder="Search Charging Station"
-              emptyMessage={query.isLoading ? 'Loading...' : 'No Charging Stations found'}
+              placeholder={translate('Locations.stations.searchChargingStation')}
+              emptyMessage={
+                query.isLoading
+                  ? translate('Common.loadingEllipsis')
+                  : translate('Locations.stations.noChargingStationsFound')
+              }
               isLoading={query.isLoading}
               skipValue
             />
             {chargingStations.length === 0 ? (
               <div className="text-center text-muted-foreground py-8">
-                No Charging Stations selected
+                {translate('Locations.stations.noChargingStationsSelected')}
               </div>
             ) : (
               <div className="border rounded-md flex flex-col gap-4">
@@ -116,23 +120,33 @@ export const SelectedChargingStations = ({ form, params }: SelectedChargingStati
                     key={station.fieldArrayId}
                     className="flex items-center justify-between gap-4 p-4 w-full border-b last:border-b-0"
                   >
-                    <KeyValueDisplay keyLabel="Station ID" value={station.ocppConnectionName} />
                     <KeyValueDisplay
-                      keyLabel="Status"
+                      keyLabel={translate('Locations.stations.stationId')}
+                      value={station.ocppConnectionName}
+                    />
+                    <KeyValueDisplay
+                      keyLabel={translate('Common.status')}
                       value={station.isOnline}
                       valueRender={(isOnline: any) => (
                         <span className={isOnline ? 'text-success' : 'text-destructive'}>
-                          {isOnline ? 'Online' : 'Offline'}
+                          {isOnline ? translate('Common.online') : translate('Common.offline')}
                         </span>
                       )}
                     />
                     <KeyValueDisplay
-                      keyLabel="Configuration"
-                      value={station.firmwareVersion ?? 'Needs configuration'}
+                      keyLabel={translate('Locations.stations.configuration')}
+                      value={
+                        station.firmwareVersion ??
+                        translate('Locations.stations.needsConfiguration')
+                      }
                     />
                     <KeyValueDisplay
-                      keyLabel="Model / Vendor"
-                      value={`${station.chargePointModel ?? 'Needs model'} / ${station.chargePointVendor ?? 'Needs Vendor'}`}
+                      keyLabel={translate('Locations.stations.modelVendor')}
+                      value={`${
+                        station.chargePointModel ?? translate('Locations.stations.needsModel')
+                      } / ${
+                        station.chargePointVendor ?? translate('Locations.stations.needsVendor')
+                      }`}
                     />
                     <RemoveArrayItemButton onRemoveAction={() => remove(index)} />
                   </div>

--- a/apps/operator-ui/src/lib/client/pages/overview/active-transactions/active.transactions.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/active-transactions/active.transactions.card.tsx
@@ -103,19 +103,19 @@ export const ActiveTransactionsCard = () => {
         <CardHeader>
           <div className="flex justify-between">
             <h2 className={heading2Style}>
-              {translate('overview.activeTransactions')} ({total})
+              {translate('Overview.activeTransactions')} ({total})
             </h2>
             <div
               className={overviewClickableStyle}
               onClick={() => push(`/${MenuSection.TRANSACTIONS}`)}
             >
-              {translate('overview.viewAllTransactions')} <ChevronRightIcon />
+              {translate('Overview.viewAllTransactions')} <ChevronRightIcon />
             </div>
           </div>
         </CardHeader>
         <CardContent>
           {isError ? (
-            <p>{translate('overview.errorLoadingData')}</p>
+            <p>{translate('Overview.errorLoadingData')}</p>
           ) : (
             <div className="flex flex-col gap-4">
               <div className="max-w-md">
@@ -141,14 +141,28 @@ export const ActiveTransactionsCard = () => {
                         <span className="link">{transaction.transactionId}</span>
                       </div>
 
-                      <div>Station: {transaction.ocppConnectionName}</div>
-                      <div>Total kWh: {transaction.totalKwh?.toFixed(2)}</div>
-                      <div>Total Time: {transaction.timeSpentCharging}</div>
-                      <div>Status: {transaction.chargingState}</div>
+                      <div>
+                        {translate('Overview.stationLabel', {
+                          value: transaction.ocppConnectionName,
+                        })}
+                      </div>
+                      <div>
+                        {translate('Overview.totalKwh', {
+                          value: transaction.totalKwh?.toFixed(2),
+                        })}
+                      </div>
+                      <div>
+                        {translate('Overview.totalTime', { value: transaction.timeSpentCharging })}
+                      </div>
+                      <div>
+                        {translate('Overview.transactionStatus', {
+                          value: transaction.chargingState,
+                        })}
+                      </div>
                     </div>
                   ))
                 ) : (
-                  <span>{translate('overview.noActiveTransactions')}</span>
+                  <span>{translate('Overview.noActiveTransactions')}</span>
                 )}
               </div>
             </div>

--- a/apps/operator-ui/src/lib/client/pages/overview/charger-activity/charger.activity.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/charger-activity/charger.activity.card.tsx
@@ -233,11 +233,11 @@ export const ChargerActivityCard: React.FC = () => {
     >
       <Card>
         <CardHeader>
-          <h2 className={heading2Style}>{translate('overview.chargerActivity')}</h2>
+          <h2 className={heading2Style}>{translate('Overview.chargerActivity')}</h2>
         </CardHeader>
         <CardContent>
           {error ? (
-            <p>{translate('overview.errorLoadingData')}</p>
+            <p>{translate('Overview.errorLoadingData')}</p>
           ) : (
             <div className="flex gap-2">
               {[

--- a/apps/operator-ui/src/lib/client/pages/overview/charger-activity/charger.activity.stations.sheet.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/charger-activity/charger.activity.stations.sheet.tsx
@@ -27,7 +27,7 @@ export const ChargerActivityStationsSheet = ({
       <SheetContent>
         <SheetHeader>
           <SheetTitle>
-            {status} {translate('overview.chargers')}
+            {status} {translate('Overview.chargers')}
           </SheetTitle>
         </SheetHeader>
         <ScrollArea className="overflow-hidden">
@@ -43,7 +43,7 @@ export const ChargerActivityStationsSheet = ({
                 />
               ))
             ) : (
-              <span>{translate('overview.noChargersStatus', { status })}</span>
+              <span>{translate('Overview.noChargersStatus', { status })}</span>
             )}
           </div>
         </ScrollArea>

--- a/apps/operator-ui/src/lib/client/pages/overview/charger.row.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/charger.row.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 import React from 'react';
 import { Separator } from '@radix-ui/react-menu';
 import type { ChargerStatusEnum } from '@lib/utils/enums';
+import { useTranslate } from '@refinedev/core';
 
 export interface ChargerRowProps {
   chargingStation: ChargingStationDetailsDto;
@@ -28,6 +29,7 @@ export const ChargerRow: React.FC<ChargerRowProps> = ({
   showSeparator,
 }) => {
   const { push } = useRouter();
+  const translate = useTranslate();
   const label = evse
     ? `${chargingStation.ocppConnectionName}:EVSE ${evse.id}`
     : chargingStation.ocppConnectionName;
@@ -41,7 +43,7 @@ export const ChargerRow: React.FC<ChargerRowProps> = ({
         >
           <div className="flex items-center gap-2">
             <span className="font-bold text-lg">
-              Station <span>{label}</span>
+              {translate('Overview.station')} <span>{label}</span>
             </span>
             <Circle color={circleColor} status={lastStatus} />
           </div>
@@ -50,7 +52,7 @@ export const ChargerRow: React.FC<ChargerRowProps> = ({
           className="flex items-center gap-2 cursor-pointer hover:text-primary"
           onClick={() => push(`/${MenuSection.LOCATIONS}/${chargingStation.location?.id}`)}
         >
-          Location:
+          {translate('Overview.location')}
           <span>{chargingStation.location?.name}</span>
         </div>
       </div>

--- a/apps/operator-ui/src/lib/client/pages/overview/faulted-chargers/faulted.chargers.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/faulted-chargers/faulted.chargers.card.tsx
@@ -11,12 +11,13 @@ import { ChargingStationClass } from '@lib/cls/charging.station.dto';
 import { FAULTED_CHARGING_STATIONS_LIST_QUERY } from '@lib/queries/charging.stations';
 import { ResourceType } from '@lib/utils/access.types';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
-import { useList } from '@refinedev/core';
+import { useList, useTranslate } from '@refinedev/core';
 import { ChevronRightIcon } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 export const FaultedChargersCard = () => {
   const { push } = useRouter();
+  const translate = useTranslate();
 
   const {
     query: { data, isLoading, isError },
@@ -39,22 +40,22 @@ export const FaultedChargersCard = () => {
   const chargingStations: ChargingStationDto[] = data?.data ?? [];
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <div>{translate('Common.loadingEllipsis')}</div>;
   }
 
   if (isError) {
-    return <div>Something went wrong!</div>;
+    return <div>{translate('Overview.somethingWentWrong')}</div>;
   }
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex justify-between">
-        <h4 className="text-lg font-semibold">Faulted Chargers</h4>
+        <h4 className="text-lg font-semibold">{translate('Overview.faultedChargers')}</h4>
         <div
           className="link flex items-center cursor-pointer"
           onClick={() => push(`/${MenuSection.CHARGING_STATIONS}`)}
         >
-          View all <ChevronRightIcon />
+          {translate('Overview.viewAll')} <ChevronRightIcon />
         </div>
       </div>
       <div className="flex flex-col gap-4">

--- a/apps/operator-ui/src/lib/client/pages/overview/locations/locations.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/locations/locations.card.tsx
@@ -23,7 +23,7 @@ export const LocationsCard = () => {
         <div className="flex items-center justify-between">
           <h2 className={heading2Style}>{translate('Locations.Locations')}</h2>
           <div className={overviewClickableStyle} onClick={() => push(`/${MenuSection.LOCATIONS}`)}>
-            {translate('overview.viewAllLocations')} <ChevronRightIcon />
+            {translate('Overview.viewAllLocations')} <ChevronRightIcon />
           </div>
         </div>
       </CardHeader>

--- a/apps/operator-ui/src/lib/client/pages/overview/online-status/online.status.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/online-status/online.status.card.tsx
@@ -48,32 +48,32 @@ export const OnlineStatusCard = () => {
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <h2 className={heading2Style}>{translate('overview.chargerOnlineStatus')}</h2>
+            <h2 className={heading2Style}>{translate('Overview.chargerOnlineStatus')}</h2>
             <div
               onClick={() => push(`/${MenuSection.CHARGING_STATIONS}`)}
               className={overviewClickableStyle}
             >
-              {translate('overview.viewAllChargers')} <ChevronRightIcon />
+              {translate('Overview.viewAllChargers')} <ChevronRightIcon />
             </div>
           </div>
         </CardHeader>
         <CardContent>
           {error ? (
-            <p>{translate('overview.errorLoadingData')}</p>
+            <p>{translate('Overview.errorLoadingData')}</p>
           ) : (
             <div className="flex items-center gap-12">
               <div className={statusFlex}>
                 <span className={statusLabelStyle}>{onlineCount}</span>
                 <div className={statusIndicatorFlex}>
                   <Circle status={ChargerStatusEnum.ONLINE} />
-                  Online
+                  {translate('Common.online')}
                 </div>
               </div>
               <div className={statusFlex}>
                 <span className={statusLabelStyle}>{offlineCount}</span>
                 <div className={statusIndicatorFlex}>
                   <Circle status={ChargerStatusEnum.OFFLINE} />
-                  Offline
+                  {translate('Common.offline')}
                 </div>
               </div>
             </div>

--- a/apps/operator-ui/src/lib/client/pages/overview/plugin-success-rate/plugin.success.rate.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/overview/plugin-success-rate/plugin.success.rate.card.tsx
@@ -38,11 +38,11 @@ export const PluginSuccessRateCard = () => {
     >
       <Card>
         <CardHeader>
-          <h2 className={heading2Style}>{translate('overview.plugInSuccessRate')}</h2>
+          <h2 className={heading2Style}>{translate('Overview.plugInSuccessRate')}</h2>
         </CardHeader>
         <CardContent>
           {error ? (
-            <p>{translate('overview.errorLoadingData')}</p>
+            <p>{translate('Overview.errorLoadingData')}</p>
           ) : (
             <div className="flex flex-col gap-4">
               <div className="w-full h-6 bg-gray-200 rounded-full overflow-hidden">

--- a/apps/operator-ui/src/lib/client/pages/partners/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/columns.tsx
@@ -10,28 +10,33 @@ import { TenantPartnerClass } from '@lib/cls/tenant.partner.cls';
 import { TableCellLink } from '@lib/client/components/table-cell-link';
 import type { CellContext } from '@tanstack/react-table';
 
-export const partnersColumns = [
+type TranslateFn = (key: string, options?: any) => string;
+
+const identityTranslate: TranslateFn = (key, options) => options?.fallback ?? key;
+
+export const getPartnersColumns = (translate: TranslateFn = identityTranslate) => [
   {
     key: TenantPartnerProps.partnerProfileOCPI,
-    header: 'Name',
+    header: translate('TenantPartners.columns.name'),
     visible: true,
     cellRender: ({ row }: CellContext<TenantPartnerClass, unknown>) => (
       <TableCellLink
         path={`/${MenuSection.PARTNERS}/${row.original.id}`}
         value={
-          row.original.partnerProfileOCPI?.roles[0]?.businessDetails?.name ?? 'Unnamed Business'
+          row.original.partnerProfileOCPI?.roles[0]?.businessDetails?.name ??
+          translate('TenantPartners.unnamedBusiness')
         }
       />
     ),
   },
   {
     key: TenantPartnerProps.countryCode,
-    header: 'Country Code',
+    header: translate('TenantPartners.columns.countryCode'),
     visible: true,
   },
   {
     key: TenantPartnerProps.partyId,
-    header: 'Party ID',
+    header: translate('TenantPartners.columns.partyId'),
     visible: true,
   },
 ];

--- a/apps/operator-ui/src/lib/client/pages/partners/detail/partner.authorizations.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/detail/partner.authorizations.tsx
@@ -10,15 +10,17 @@ import { AUTHORIZATIONS_LIST_QUERY } from '@lib/queries/authorizations';
 import { ResourceType } from '@lib/utils/access.types';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
 import { useColumnPreferences } from '@lib/client/hooks/useColumnPreferences';
-import { authorizationsColumns } from '@lib/client/pages/authorizations/columns';
+import { getAuthorizationsColumns } from '@lib/client/pages/authorizations/columns';
+import { useTranslate } from '@refinedev/core';
 
 interface PartnerAuthorizationsProps {
   partnerId: number;
 }
 
 export const PartnerAuthorizations: React.FC<PartnerAuthorizationsProps> = ({ partnerId }) => {
+  const translate = useTranslate();
   const { renderedVisibleColumns } = useColumnPreferences(
-    authorizationsColumns,
+    getAuthorizationsColumns(translate),
     ResourceType.AUTHORIZATIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/partners/detail/partner.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/detail/partner.detail.card.tsx
@@ -45,7 +45,7 @@ export const PartnerDetailCard = ({ tenantPartner }: { tenantPartner: TenantPart
             <Image
               width={40}
               src={businessDetails.logo.url}
-              alt={`${businessDetails.name} logo`}
+              alt={translate('TenantPartners.detail.logoAlt', { name: businessDetails.name })}
               className="rounded"
             />
           )}
@@ -61,10 +61,16 @@ export const PartnerDetailCard = ({ tenantPartner }: { tenantPartner: TenantPart
       </CardHeader>
       <CardContent>
         <div className={cardGridStyle}>
-          <KeyValueDisplay keyLabel="Country Code" value={tenantPartner?.countryCode} />
-          <KeyValueDisplay keyLabel="Party ID" value={tenantPartner?.partyId} />
           <KeyValueDisplay
-            keyLabel="Website"
+            keyLabel={translate('TenantPartners.detail.countryCode')}
+            value={tenantPartner?.countryCode}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('TenantPartners.detail.partyId')}
+            value={tenantPartner?.partyId}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('TenantPartners.detail.website')}
             value={''}
             valueRender={() =>
               businessDetails?.website ? (
@@ -82,7 +88,7 @@ export const PartnerDetailCard = ({ tenantPartner }: { tenantPartner: TenantPart
             }
           />
           <KeyValueDisplay
-            keyLabel="Roles"
+            keyLabel={translate('TenantPartners.detail.roles')}
             value={''}
             valueRender={() =>
               tenantPartner?.partnerProfileOCPI?.roles?.map((role: any) => (
@@ -91,11 +97,11 @@ export const PartnerDetailCard = ({ tenantPartner }: { tenantPartner: TenantPart
             }
           />
           <KeyValueDisplay
-            keyLabel="OCPI Version"
+            keyLabel={translate('TenantPartners.detail.ocpiVersion')}
             value={tenantPartner?.partnerProfileOCPI?.version?.version}
           />
           <KeyValueDisplay
-            keyLabel="Versions URL"
+            keyLabel={translate('TenantPartners.detail.versionsUrl')}
             value={''}
             valueRender={() =>
               tenantPartner?.partnerProfileOCPI?.version?.versionDetailsUrl ? (

--- a/apps/operator-ui/src/lib/client/pages/partners/detail/partner.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/detail/partner.detail.tabs.card.tsx
@@ -19,7 +19,9 @@ export const PartnerDetailTabsCard = ({ tenantPartner }: { tenantPartner: Tenant
       <CardContent>
         <Tabs defaultValue="endpoints">
           <TabsList>
-            <TabsTrigger value="endpoints">Endpoints</TabsTrigger>
+            <TabsTrigger value="endpoints">
+              {translate('TenantPartners.tabs.endpoints')}
+            </TabsTrigger>
             <TabsTrigger value="authorizations">
               {translate('Authorizations.Authorizations')}
             </TabsTrigger>
@@ -33,7 +35,9 @@ export const PartnerDetailTabsCard = ({ tenantPartner }: { tenantPartner: Tenant
                 partnerProfileOCPI={tenantPartner?.partnerProfileOCPI}
               />
             ) : (
-              <div className="p-8 text-center text-muted-foreground">Loading partner data...</div>
+              <div className="p-8 text-center text-muted-foreground">
+                {translate('TenantPartners.loadingPartnerData')}
+              </div>
             )}
           </TabsContent>
 

--- a/apps/operator-ui/src/lib/client/pages/partners/detail/partner.endpoints.table.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/detail/partner.endpoints.table.tsx
@@ -81,11 +81,11 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
     let isValid = true;
 
     if (!formData.identifier.trim()) {
-      newErrors.identifier = 'Please input identifier';
+      newErrors.identifier = translate('TenantPartners.endpoints.errorIdentifierRequired');
       isValid = false;
     }
     if (!formData.url.trim()) {
-      newErrors.url = 'Please input URL';
+      newErrors.url = translate('TenantPartners.endpoints.errorUrlRequired');
       isValid = false;
     }
 
@@ -158,7 +158,7 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
           disabled={!isValidPartnerId}
         >
           <Plus className={buttonIconSize} />
-          {translate('buttons.add')} Endpoint
+          {translate('buttons.add')} {translate('TenantPartners.endpoints.endpoint')}
         </Button>
       </div>
 
@@ -167,13 +167,13 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
           <thead>
             <tr className="border-b bg-muted/50">
               <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground">
-                Identifier
+                {translate('TenantPartners.endpoints.identifier')}
               </th>
               <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground">
-                URL
+                {translate('TenantPartners.endpoints.url')}
               </th>
               <th className="h-12 px-4 text-left align-middle font-medium text-muted-foreground">
-                Actions
+                {translate('table.actions')}
               </th>
             </tr>
           </thead>
@@ -181,7 +181,7 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
             {data.length === 0 ? (
               <tr>
                 <td colSpan={3} className="h-24 text-center text-muted-foreground">
-                  No endpoints found
+                  {translate('TenantPartners.endpoints.noEndpointsFound')}
                 </td>
               </tr>
             ) : (
@@ -229,26 +229,31 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
         <DialogContent>
           <DialogHeader>
             <DialogTitle>
-              {translate(`actions.${editingKey ? 'edit' : 'create'}`)} Endpoint
+              {translate(`actions.${editingKey ? 'edit' : 'create'}`)}{' '}
+              {translate('TenantPartners.endpoints.endpoint')}
             </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Identifier</label>
+              <label className="text-sm font-medium">
+                {translate('TenantPartners.endpoints.identifier')}
+              </label>
               <Input
                 value={formData.identifier}
                 onChange={(e) => setFormData({ ...formData, identifier: e.target.value })}
                 disabled={!!editingKey}
-                placeholder="Enter identifier"
+                placeholder={translate('TenantPartners.endpoints.placeholderIdentifier')}
               />
               {errors.identifier && <p className="text-sm text-destructive">{errors.identifier}</p>}
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium">URL</label>
+              <label className="text-sm font-medium">
+                {translate('TenantPartners.endpoints.url')}
+              </label>
               <Input
                 value={formData.url}
                 onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-                placeholder="Enter URL"
+                placeholder={translate('TenantPartners.endpoints.placeholderUrl')}
               />
               {errors.url && <p className="text-sm text-destructive">{errors.url}</p>}
             </div>
@@ -267,9 +272,11 @@ export const PartnerEndpointsTable: React.FC<PartnerEndpointsTableProps> = ({
       <AlertDialog open={!!deleteTarget} onOpenChange={() => setDeleteTarget(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{translate('actions.delete')} Endpoint</AlertDialogTitle>
+            <AlertDialogTitle>
+              {translate('actions.delete')} {translate('TenantPartners.endpoints.endpoint')}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to delete this endpoint? This action cannot be undone.
+              {translate('TenantPartners.endpoints.deleteConfirm')}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/operator-ui/src/lib/client/pages/partners/list/partners.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/list/partners.list.tsx
@@ -6,7 +6,7 @@
 import { MenuSection } from '@lib/client/components/main-menu/main.menu';
 import { Table } from '@lib/client/components/table';
 import { Button } from '@lib/client/components/ui/button';
-import { partnersColumns } from '@lib/client/pages/partners/columns';
+import { getPartnersColumns } from '@lib/client/pages/partners/columns';
 import { TenantPartnerClass } from '@lib/cls/tenant.partner.cls';
 import { PARTNERS_LIST_QUERY } from '@lib/queries/tenant.partners';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
@@ -30,7 +30,7 @@ export const PartnersList = () => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    partnersColumns,
+    getPartnersColumns(translate),
     ResourceType.PARTNERS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/partners/upsert/partners.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/partners/upsert/partners.upsert.tsx
@@ -17,7 +17,7 @@ import {
 } from '@lib/queries/tenant.partners';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
 import { getSerializedValues } from '@lib/utils/middleware';
-import { CanAccess, type GetOneResponse } from '@refinedev/core';
+import { CanAccess, type GetOneResponse, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { ChevronLeft } from 'lucide-react';
 import { useFieldArray } from 'react-hook-form';
@@ -36,30 +36,33 @@ type PartnersUpsertProps = {
   params: { id?: string };
 };
 
-const TenantPartnerCreateSchema = TenantPartnerSchema.pick({
-  [TenantPartnerProps.countryCode]: true,
-  [TenantPartnerProps.partyId]: true,
-  [TenantPartnerProps.partnerProfileOCPI]: true,
-}).extend({
-  countryCode: z
-    .string()
-    .min(2, {
-      message: 'Country Code must be exactly 2 characters.',
-    })
-    .max(2, {
-      message: 'Country Code must be exactly 2 characters.',
-    }),
-  partyId: z
-    .string()
-    .min(3, {
-      message: 'Party ID must be exactly 3 characters.',
-    })
-    .max(3, {
-      message: 'Party ID must be exactly 3 characters.',
-    }),
-});
+type TranslateFn = (key: string, options?: any) => string;
 
-export type TenantPartnerCreateDto = z.infer<typeof TenantPartnerCreateSchema>;
+const createTenantPartnerSchema = (translate: TranslateFn) =>
+  TenantPartnerSchema.pick({
+    [TenantPartnerProps.countryCode]: true,
+    [TenantPartnerProps.partyId]: true,
+    [TenantPartnerProps.partnerProfileOCPI]: true,
+  }).extend({
+    countryCode: z
+      .string()
+      .min(2, {
+        message: translate('TenantPartners.validation.countryCodeLength'),
+      })
+      .max(2, {
+        message: translate('TenantPartners.validation.countryCodeLength'),
+      }),
+    partyId: z
+      .string()
+      .min(3, {
+        message: translate('TenantPartners.validation.partyIdLength'),
+      })
+      .max(3, {
+        message: translate('TenantPartners.validation.partyIdLength'),
+      }),
+  });
+
+export type TenantPartnerCreateDto = z.infer<ReturnType<typeof createTenantPartnerSchema>>;
 
 const defaultValues = {
   [TenantPartnerProps.countryCode]: '',
@@ -84,6 +87,7 @@ const ocpiVersions = ['2.2.1'];
 export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
   const { id } = params;
   const { back, replace } = useRouter();
+  const translate = useTranslate();
 
   const tenantId = useTenantId();
 
@@ -99,13 +103,17 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
       action: id ? 'edit' : 'create',
       successNotification: () => {
         return {
-          message: `Partner ${id ? 'updated' : 'created'} successfully`,
+          message: id
+            ? translate('TenantPartners.notifications.updateSuccess')
+            : translate('TenantPartners.notifications.createSuccess'),
           type: 'success',
         };
       },
       errorNotification: (error) => {
         return {
-          message: `Error ${id ? 'updating' : 'creating'} partner: ${error?.message}`,
+          message: id
+            ? translate('TenantPartners.notifications.updateError', { message: error?.message })
+            : translate('TenantPartners.notifications.createError', { message: error?.message }),
           type: 'error',
         };
       },
@@ -115,7 +123,7 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
       },
     },
     defaultValues: { ...defaultValues },
-    resolver: zodResolver(TenantPartnerCreateSchema),
+    resolver: zodResolver(createTenantPartnerSchema(translate)),
     warnWhenUnsavedChanges: true,
   });
 
@@ -159,7 +167,10 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
         <CardHeader>
           <div className={cardHeaderFlex}>
             <ChevronLeft onClick={() => back()} className="cursor-pointer" />
-            <h2 className={heading2Style}>{id ? 'Edit' : 'Create'} Partner</h2>
+            <h2 className={heading2Style}>
+              {translate(`actions.${id ? 'edit' : 'create'}`)}{' '}
+              {translate('TenantPartners.tenantPartner')}
+            </h2>
           </div>
         </CardHeader>
         <CardContent>
@@ -168,7 +179,7 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
               <div className={cardGridStyle}>
                 <FormField
                   control={form.control}
-                  label="Country Code"
+                  label={translate('TenantPartners.fields.countryCode')}
                   name={TenantPartnerProps.countryCode}
                   required
                 >
@@ -176,7 +187,7 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
                 </FormField>
                 <FormField
                   control={form.control}
-                  label="Party ID"
+                  label={translate('TenantPartners.fields.partyId')}
                   name={TenantPartnerProps.partyId}
                   required
                 >
@@ -185,29 +196,29 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
 
                 <FormField
                   control={form.control}
-                  label="Versions URL"
+                  label={translate('TenantPartners.fields.versionsUrl')}
                   name="partnerProfileOCPI.credentials.versionsUrl"
                 >
                   <Input />
                 </FormField>
                 <FormField
                   control={form.control}
-                  label="Client Token"
+                  label={translate('TenantPartners.fields.clientToken')}
                   name="partnerProfileOCPI.credentials.token"
                 >
                   <Input />
                 </FormField>
                 <SelectFormField
                   control={form.control}
-                  label="OCPI Version"
+                  label={translate('TenantPartners.fields.ocpiVersion')}
                   name="partnerProfileOCPI.version.version"
                   options={ocpiVersions}
-                  placeholder="Select Version"
+                  placeholder={translate('TenantPartners.placeholders.selectVersion')}
                 />
 
                 <FormField
                   control={form.control}
-                  label="Version Details URL"
+                  label={translate('TenantPartners.fields.versionDetailsUrl')}
                   name="partnerProfileOCPI.version.versionDetailsUrl"
                 >
                   <Input />
@@ -215,7 +226,7 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
 
                 <FormField
                   control={form.control}
-                  label="(Server Credentials) Versions URL"
+                  label={translate('TenantPartners.fields.serverCredentialsVersionsUrl')}
                   name="partnerProfileOCPI.serverCredentials.versionsUrl"
                 >
                   <Input />
@@ -223,14 +234,14 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
 
                 <FormField
                   control={form.control}
-                  label="(Server Credentials) Token"
+                  label={translate('TenantPartners.fields.serverCredentialsToken')}
                   name="partnerProfileOCPI.serverCredentials.token"
                 >
                   <Input />
                 </FormField>
               </div>
               <div className="flex flex-col gap-4 items-start">
-                <h3 className={heading3Style}>Roles</h3>
+                <h3 className={heading3Style}>{translate('TenantPartners.fields.roles')}</h3>
                 <AddArrayItemButton
                   onAppendAction={() =>
                     append({
@@ -238,33 +249,35 @@ export const PartnersUpsert = ({ params }: PartnersUpsertProps) => {
                       businessDetails: { name: '', website: '' },
                     })
                   }
-                  itemLabel="Role"
+                  itemLabel={translate('TenantPartners.fields.role')}
                 />
                 <div className="flex flex-col gap-6 w-full">
                   {fields.map((field, index) => (
                     <div className={nestedFormRowFlex} key={field.id}>
                       <SelectFormField
                         control={form.control}
-                        label="Role"
+                        label={translate('TenantPartners.fields.role')}
                         name={`partnerProfileOCPI.roles.${index}.role`}
                         options={roleOptions}
-                        placeholder="Select Role"
+                        placeholder={translate('TenantPartners.placeholders.selectRole')}
                       />
 
                       <FormField
                         control={form.control}
-                        label="Business Name"
+                        label={translate('TenantPartners.fields.businessName')}
                         name={`partnerProfileOCPI.roles.${index}.businessDetails.name`}
                       >
-                        <Input placeholder="Business Name" />
+                        <Input
+                          placeholder={translate('TenantPartners.placeholders.businessName')}
+                        />
                       </FormField>
 
                       <FormField
                         control={form.control}
-                        label="Website"
+                        label={translate('TenantPartners.fields.website')}
                         name={`partnerProfileOCPI.roles.${index}.businessDetails.website`}
                       >
-                        <Input placeholder="Website" />
+                        <Input placeholder={translate('TenantPartners.placeholders.website')} />
                       </FormField>
 
                       <RemoveArrayItemButton onRemoveAction={() => remove(index)} />

--- a/apps/operator-ui/src/lib/client/pages/tariffs/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/tariffs/columns.tsx
@@ -13,10 +13,16 @@ import type { CellContext } from '@tanstack/react-table';
 import type { ColumnConfiguration } from '@lib/utils/column.configuration';
 import { EMPTY_VALUE } from '@lib/utils/consts';
 
-export const tariffsColumns: ColumnConfiguration[] = [
+type TranslateFn = (key: string, options?: any) => string;
+
+const identityTranslate: TranslateFn = (key, options) => options?.fallback ?? key;
+
+export const getTariffsColumns = (
+  translate: TranslateFn = identityTranslate,
+): ColumnConfiguration[] => [
   {
     key: TariffProps.id,
-    header: 'ID',
+    header: translate('Tariffs.columns.id'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<TariffClass, unknown>) => (
@@ -25,7 +31,7 @@ export const tariffsColumns: ColumnConfiguration[] = [
   },
   {
     key: TariffProps.currency,
-    header: 'Currency',
+    header: translate('Tariffs.columns.currency'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<TariffClass, unknown>) => (
@@ -34,7 +40,7 @@ export const tariffsColumns: ColumnConfiguration[] = [
   },
   {
     key: TariffProps.pricePerKwh,
-    header: 'Price / kWh',
+    header: translate('Tariffs.columns.pricePerKwh'),
     visible: true,
     sortable: true,
     cellRender: ({ row }: CellContext<TariffClass, unknown>) => (
@@ -43,7 +49,7 @@ export const tariffsColumns: ColumnConfiguration[] = [
   },
   {
     key: TariffProps.pricePerMin,
-    header: 'Price / min',
+    header: translate('Tariffs.columns.pricePerMin'),
     visible: true,
     cellRender: ({ row }: CellContext<TariffClass, unknown>) => (
       <span>
@@ -53,7 +59,7 @@ export const tariffsColumns: ColumnConfiguration[] = [
   },
   {
     key: TariffProps.pricePerSession,
-    header: 'Price / session',
+    header: translate('Tariffs.columns.pricePerSession'),
     visible: true,
     cellRender: ({ row }: CellContext<TariffClass, unknown>) => (
       <span>

--- a/apps/operator-ui/src/lib/client/pages/tariffs/detail/tariff.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/tariffs/detail/tariff.detail.card.tsx
@@ -85,23 +85,26 @@ export const TariffDetailCard = ({ tariff }: TariffDetailCardProps) => {
       </CardHeader>
       <CardContent>
         <div className={cardGridStyle}>
-          <KeyValueDisplay keyLabel="Currency" value={tariff.currency} />
           <KeyValueDisplay
-            keyLabel="Price / kWh"
+            keyLabel={translate('Tariffs.detail.currency')}
+            value={tariff.currency}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('Tariffs.detail.pricePerKwh')}
             value={tariff.pricePerKwh?.toFixed(2) ?? NOT_APPLICABLE}
           />
           <KeyValueDisplay
-            keyLabel="Price / min"
+            keyLabel={translate('Tariffs.detail.pricePerMin')}
             value={tariff.pricePerMin != null ? tariff.pricePerMin.toFixed(2) : NOT_APPLICABLE}
           />
           <KeyValueDisplay
-            keyLabel="Price / session"
+            keyLabel={translate('Tariffs.detail.pricePerSession')}
             value={
               tariff.pricePerSession != null ? tariff.pricePerSession.toFixed(2) : NOT_APPLICABLE
             }
           />
           <KeyValueDisplay
-            keyLabel="Authorization Amount"
+            keyLabel={translate('Tariffs.detail.authorizationAmount')}
             value={
               tariff.authorizationAmount != null
                 ? tariff.authorizationAmount.toFixed(2)
@@ -109,11 +112,11 @@ export const TariffDetailCard = ({ tariff }: TariffDetailCardProps) => {
             }
           />
           <KeyValueDisplay
-            keyLabel="Payment Fee"
+            keyLabel={translate('Tariffs.detail.paymentFee')}
             value={tariff.paymentFee != null ? tariff.paymentFee.toFixed(2) : NOT_APPLICABLE}
           />
           <KeyValueDisplay
-            keyLabel="Tax Rate (%)"
+            keyLabel={translate('Tariffs.detail.taxRate')}
             value={tariff.taxRate != null ? tariff.taxRate.toFixed(4) : NOT_APPLICABLE}
           />
         </div>

--- a/apps/operator-ui/src/lib/client/pages/tariffs/detail/tariff.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/tariffs/detail/tariff.detail.tabs.card.tsx
@@ -20,7 +20,7 @@ import {
   GET_CHARGING_STATIONS_FOR_TARIFF,
   GET_TRANSACTIONS_FOR_TARIFF,
 } from '@lib/queries/tariffs';
-import { transactionsColumns } from '@lib/client/pages/transactions/columns';
+import { getTransactionsColumns } from '@lib/client/pages/transactions/columns';
 import { getChargingStationsColumns } from '@lib/client/pages/charging-stations/columns';
 import { useColumnPreferences } from '../../../hooks/useColumnPreferences';
 
@@ -28,12 +28,12 @@ export const TariffDetailTabsCard = ({ tariff }: { tariff: TariffDto }) => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns: renderedChargingStationColumns } = useColumnPreferences(
-    getChargingStationsColumns(false),
+    getChargingStationsColumns(false, translate),
     ResourceType.CHARGING_STATIONS,
   );
 
   const { renderedVisibleColumns: renderedTransactionColumns } = useColumnPreferences(
-    transactionsColumns,
+    getTransactionsColumns(translate),
     ResourceType.TRANSACTIONS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/tariffs/list/tariffs.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/tariffs/list/tariffs.list.tsx
@@ -4,7 +4,7 @@
 'use client';
 
 import { Table } from '@lib/client/components/table';
-import { getTariffsFilters, tariffsColumns } from '@lib/client/pages/tariffs/columns';
+import { getTariffsColumns, getTariffsFilters } from '@lib/client/pages/tariffs/columns';
 import { TariffClass } from '@lib/cls/tariff.dto';
 import { TARIFF_LIST_QUERY } from '@lib/queries/tariffs';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
@@ -33,7 +33,7 @@ export const TariffsList = () => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    tariffsColumns,
+    getTariffsColumns(translate),
     ResourceType.TARIFFS,
   );
 

--- a/apps/operator-ui/src/lib/client/pages/tariffs/upsert/tariff.upsert.tsx
+++ b/apps/operator-ui/src/lib/client/pages/tariffs/upsert/tariff.upsert.tsx
@@ -149,16 +149,16 @@ export const TariffUpsert = ({ params }: TariffUpsertProps) => {
             <div className={cardGridStyle}>
               <FormField
                 control={form.control}
-                label="Currency (3-letter code)"
+                label={translate('Tariffs.fields.currency')}
                 name={TariffProps.currency}
                 required
               >
-                <Input placeholder="e.g. USD" maxLength={3} />
+                <Input placeholder={translate('Tariffs.placeholders.currency')} maxLength={3} />
               </FormField>
 
               <FormField
                 control={form.control}
-                label="Price per kWh"
+                label={translate('Tariffs.fields.pricePerKwh')}
                 name={TariffProps.pricePerKwh}
                 required
               >
@@ -167,7 +167,7 @@ export const TariffUpsert = ({ params }: TariffUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Price per min"
+                label={translate('Tariffs.fields.pricePerMin')}
                 name={TariffProps.pricePerMin}
               >
                 <Input type="number" min="0" step="0.01" />
@@ -175,7 +175,7 @@ export const TariffUpsert = ({ params }: TariffUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Price per session"
+                label={translate('Tariffs.fields.pricePerSession')}
                 name={TariffProps.pricePerSession}
               >
                 <Input type="number" min="0" step="0.01" />
@@ -183,26 +183,34 @@ export const TariffUpsert = ({ params }: TariffUpsertProps) => {
 
               <FormField
                 control={form.control}
-                label="Authorization Amount"
+                label={translate('Tariffs.fields.authorizationAmount')}
                 name={TariffProps.authorizationAmount}
               >
                 <Input type="number" min="0" step="0.01" />
               </FormField>
 
-              <FormField control={form.control} label="Payment Fee" name={TariffProps.paymentFee}>
+              <FormField
+                control={form.control}
+                label={translate('Tariffs.fields.paymentFee')}
+                name={TariffProps.paymentFee}
+              >
                 <Input type="number" min="0" step="0.01" />
               </FormField>
 
-              <FormField control={form.control} label="Tax Rate (%)" name={TariffProps.taxRate}>
+              <FormField
+                control={form.control}
+                label={translate('Tariffs.fields.taxRate')}
+                name={TariffProps.taxRate}
+              >
                 <Input type="number" min="0" step="0.0001" />
               </FormField>
 
               <FormField
                 control={form.control}
-                label="Tariff Alt Text (JSON)"
+                label={translate('Tariffs.fields.tariffAltText')}
                 name={TariffProps.tariffAltText}
               >
-                <Textarea placeholder='{ "en": "Standard tariff", "de": "Standardtarif" }' />
+                <Textarea placeholder={translate('Tariffs.placeholders.tariffAltText')} />
               </FormField>
             </div>
           </Form>

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/current.over.time.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/current.over.time.tsx
@@ -8,11 +8,10 @@ import { OCPP2_0_1 } from '@citrineos/base';
 import {
   chartMargin,
   chartSize,
-  elapsedTimeAxisLabel,
   formatTimeLabel,
   generateTimeTicks,
+  getXAxisLabelConfig,
   getYAxisLabelConfig,
-  xAxisLabelConfig,
 } from '@lib/client/pages/transactions/chart/util';
 import { getTimestampToMeasurandArray } from '@lib/cls/meter.value.dto';
 import { useMemo } from 'react';
@@ -25,24 +24,26 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@lib/client/components/ui/chart';
+import { useTranslate } from '@refinedev/core';
 
 export interface CurrentOverTimeProps {
   meterValues: MeterValueDto[];
   validContexts: OCPP2_0_1.ReadingContextEnumType[];
 }
 
-const currentAxisLabel = 'Current (A)';
-
-const chartConfig = {
-  elapsedTime: {
-    label: elapsedTimeAxisLabel,
-  },
-  a: {
-    label: currentAxisLabel,
-  },
-} satisfies ChartConfig;
-
 export const CurrentOverTime = ({ meterValues, validContexts }: CurrentOverTimeProps) => {
+  const translate = useTranslate();
+  const currentAxisLabel = translate('Transactions.charts.currentLabel');
+
+  const chartConfig = {
+    elapsedTime: {
+      label: translate('Transactions.charts.timeElapsed'),
+    },
+    a: {
+      label: currentAxisLabel,
+    },
+  } satisfies ChartConfig;
+
   const buffer = 1;
 
   const { chartData, minValue, maxValue } = useMemo(() => {
@@ -66,11 +67,11 @@ export const CurrentOverTime = ({ meterValues, validContexts }: CurrentOverTimeP
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>Current Over Time</h3>
+        <h3 className={heading3Style}>{translate('Transactions.charts.currentTitle')}</h3>
       </CardHeader>
       <CardContent>
         {!chartData || chartData.length === 0 ? (
-          <div>No Current data available</div>
+          <div>{translate('Transactions.charts.noCurrentData')}</div>
         ) : (
           <ChartContainer config={chartConfig} className={chartSize}>
             <LineChart data={chartData} margin={chartMargin}>
@@ -80,7 +81,7 @@ export const CurrentOverTime = ({ meterValues, validContexts }: CurrentOverTimeP
                 type="number"
                 ticks={generateTimeTicks(chartData)}
                 tickFormatter={formatTimeLabel}
-                label={xAxisLabelConfig}
+                label={getXAxisLabelConfig(translate('Transactions.charts.timeElapsed'))}
               />
               <YAxis
                 domain={[minValue - buffer, maxValue + buffer]}

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/energy.over.time.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/energy.over.time.tsx
@@ -8,11 +8,10 @@ import { OCPP2_0_1 } from '@citrineos/base';
 import {
   chartMargin,
   chartSize,
-  elapsedTimeAxisLabel,
   formatTimeLabel,
   generateTimeTicks,
+  getXAxisLabelConfig,
   getYAxisLabelConfig,
-  xAxisLabelConfig,
 } from '@lib/client/pages/transactions/chart/util';
 import { getTimestampToMeasurandArray } from '@lib/cls/meter.value.dto';
 import { useMemo } from 'react';
@@ -25,24 +24,26 @@ import {
   ChartTooltipContent,
 } from '@lib/client/components/ui/chart';
 import { heading3Style } from '@lib/client/styles/page';
+import { useTranslate } from '@refinedev/core';
 
 interface EnergyOverTimeProps {
   meterValues: MeterValueDto[];
   validContexts: OCPP2_0_1.ReadingContextEnumType[];
 }
 
-const energyAxisLabel = 'Energy (kWh)';
-
-const chartConfig = {
-  elapsedTime: {
-    label: elapsedTimeAxisLabel,
-  },
-  kWh: {
-    label: energyAxisLabel,
-  },
-} satisfies ChartConfig;
-
 export const EnergyOverTime = ({ meterValues, validContexts }: EnergyOverTimeProps) => {
+  const translate = useTranslate();
+  const energyAxisLabel = translate('Transactions.charts.energyLabel');
+
+  const chartConfig = {
+    elapsedTime: {
+      label: translate('Transactions.charts.timeElapsed'),
+    },
+    kWh: {
+      label: energyAxisLabel,
+    },
+  } satisfies ChartConfig;
+
   const buffer = 1;
 
   const { chartData, minValue, maxValue } = useMemo(() => {
@@ -66,11 +67,11 @@ export const EnergyOverTime = ({ meterValues, validContexts }: EnergyOverTimePro
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>Energy Over Time</h3>
+        <h3 className={heading3Style}>{translate('Transactions.charts.energyTitle')}</h3>
       </CardHeader>
       <CardContent>
         {!chartData || chartData.length === 0 ? (
-          <div>No Energy data available</div>
+          <div>{translate('Transactions.charts.noEnergyData')}</div>
         ) : (
           <ChartContainer config={chartConfig} className={chartSize}>
             <LineChart data={chartData} margin={chartMargin}>
@@ -80,7 +81,7 @@ export const EnergyOverTime = ({ meterValues, validContexts }: EnergyOverTimePro
                 type="number"
                 ticks={generateTimeTicks(chartData)}
                 tickFormatter={formatTimeLabel}
-                label={xAxisLabelConfig}
+                label={getXAxisLabelConfig(translate('Transactions.charts.timeElapsed'))}
               />
               <YAxis
                 domain={[minValue - buffer, maxValue + buffer]}

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/power.over.time.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/power.over.time.tsx
@@ -8,11 +8,10 @@ import { OCPP2_0_1 } from '@citrineos/base';
 import {
   chartMargin,
   chartSize,
-  elapsedTimeAxisLabel,
   formatTimeLabel,
   generateTimeTicks,
+  getXAxisLabelConfig,
   getYAxisLabelConfig,
-  xAxisLabelConfig,
 } from '@lib/client/pages/transactions/chart/util';
 import { getTimestampToMeasurandArray } from '@lib/cls/meter.value.dto';
 import { useMemo } from 'react';
@@ -25,24 +24,26 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@lib/client/components/ui/chart';
+import { useTranslate } from '@refinedev/core';
 
 export interface PowerOverTimeProps {
   meterValues: MeterValueDto[];
   validContexts: OCPP2_0_1.ReadingContextEnumType[];
 }
 
-const powerAxisLabel = 'Power (kW)';
-
-const chartConfig = {
-  elapsedTime: {
-    label: elapsedTimeAxisLabel,
-  },
-  kw: {
-    label: powerAxisLabel,
-  },
-} satisfies ChartConfig;
-
 export const PowerOverTime = ({ meterValues, validContexts }: PowerOverTimeProps) => {
+  const translate = useTranslate();
+  const powerAxisLabel = translate('Transactions.charts.powerLabel');
+
+  const chartConfig = {
+    elapsedTime: {
+      label: translate('Transactions.charts.timeElapsed'),
+    },
+    kw: {
+      label: powerAxisLabel,
+    },
+  } satisfies ChartConfig;
+
   const buffer = 1;
 
   const { chartData, minValue, maxValue } = useMemo(() => {
@@ -66,11 +67,11 @@ export const PowerOverTime = ({ meterValues, validContexts }: PowerOverTimeProps
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>Power Over Time</h3>
+        <h3 className={heading3Style}>{translate('Transactions.charts.powerTitle')}</h3>
       </CardHeader>
       <CardContent>
         {!chartData || chartData.length === 0 ? (
-          <div>No Power data available</div>
+          <div>{translate('Transactions.charts.noPowerData')}</div>
         ) : (
           <ChartContainer config={chartConfig} className={chartSize}>
             <LineChart data={chartData} margin={chartMargin}>
@@ -80,7 +81,7 @@ export const PowerOverTime = ({ meterValues, validContexts }: PowerOverTimeProps
                 type="number"
                 ticks={generateTimeTicks(chartData)}
                 tickFormatter={formatTimeLabel}
-                label={xAxisLabelConfig}
+                label={getXAxisLabelConfig(translate('Transactions.charts.timeElapsed'))}
               />
               <YAxis
                 domain={[minValue - buffer, maxValue + buffer]}

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/state.of.charge.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/state.of.charge.tsx
@@ -8,11 +8,10 @@ import { OCPP2_0_1 } from '@citrineos/base';
 import {
   chartMargin,
   chartSize,
-  elapsedTimeAxisLabel,
   formatTimeLabel,
   generateTimeTicks,
+  getXAxisLabelConfig,
   getYAxisLabelConfig,
-  xAxisLabelConfig,
 } from '@lib/client/pages/transactions/chart/util';
 import { getTimestampToMeasurandArray } from '@lib/cls/meter.value.dto';
 import { useMemo } from 'react';
@@ -25,24 +24,26 @@ import {
 } from '@lib/client/components/ui/chart';
 import { Card, CardContent, CardHeader } from '@lib/client/components/ui/card';
 import { heading3Style } from '@lib/client/styles/page';
+import { useTranslate } from '@refinedev/core';
 
 interface StateOfChargeProps {
   meterValues: MeterValueDto[];
   validContexts: OCPP2_0_1.ReadingContextEnumType[];
 }
 
-const socAxisLabel = 'State of Charge (%)';
-
-const chartConfig = {
-  elapsedTime: {
-    label: elapsedTimeAxisLabel,
-  },
-  stateOfCharge: {
-    label: socAxisLabel,
-  },
-} satisfies ChartConfig;
-
 export const StateOfCharge = ({ meterValues, validContexts }: StateOfChargeProps) => {
+  const translate = useTranslate();
+  const socAxisLabel = translate('Transactions.charts.stateOfChargeLabel');
+
+  const chartConfig = {
+    elapsedTime: {
+      label: translate('Transactions.charts.timeElapsed'),
+    },
+    stateOfCharge: {
+      label: socAxisLabel,
+    },
+  } satisfies ChartConfig;
+
   const chartData = useMemo(() => {
     const rawData = getTimestampToMeasurandArray(
       meterValues,
@@ -62,11 +63,11 @@ export const StateOfCharge = ({ meterValues, validContexts }: StateOfChargeProps
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>State of Charge Over Time</h3>
+        <h3 className={heading3Style}>{translate('Transactions.charts.stateOfChargeTitle')}</h3>
       </CardHeader>
       <CardContent>
         {!chartData || chartData.length === 0 ? (
-          <div>No State of Charge data available</div>
+          <div>{translate('Transactions.charts.noStateOfChargeData')}</div>
         ) : (
           <ChartContainer config={chartConfig} className={chartSize}>
             <LineChart data={chartData} margin={chartMargin}>
@@ -76,7 +77,7 @@ export const StateOfCharge = ({ meterValues, validContexts }: StateOfChargeProps
                 type="number"
                 ticks={generateTimeTicks(chartData)}
                 tickFormatter={formatTimeLabel}
-                label={xAxisLabelConfig}
+                label={getXAxisLabelConfig(translate('Transactions.charts.timeElapsed'))}
               />
               <YAxis
                 domain={[0, 100]}

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/util.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/util.tsx
@@ -53,13 +53,12 @@ export const formatTimeLabel = (seconds: number) => {
 
 export const chartSize = 'min-w-[50px] min-h-[100px]';
 export const chartMargin = { bottom: 25 };
-export const elapsedTimeAxisLabel = 'Time Elapsed';
 
-export const xAxisLabelConfig: ImplicitLabelType = {
-  value: elapsedTimeAxisLabel,
+export const getXAxisLabelConfig = (label: string): ImplicitLabelType => ({
+  value: label,
   position: 'insideBottom',
   offset: -20,
-};
+});
 export const getYAxisLabelConfig = (label: string): ImplicitLabelType => ({
   value: label,
   angle: -90,

--- a/apps/operator-ui/src/lib/client/pages/transactions/chart/voltage.over.time.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/chart/voltage.over.time.tsx
@@ -8,11 +8,10 @@ import { OCPP2_0_1 } from '@citrineos/base';
 import {
   chartMargin,
   chartSize,
-  elapsedTimeAxisLabel,
   formatTimeLabel,
   generateTimeTicks,
+  getXAxisLabelConfig,
   getYAxisLabelConfig,
-  xAxisLabelConfig,
 } from '@lib/client/pages/transactions/chart/util';
 import { getTimestampToMeasurandArray } from '@lib/cls/meter.value.dto';
 import { useMemo } from 'react';
@@ -25,24 +24,26 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@lib/client/components/ui/chart';
+import { useTranslate } from '@refinedev/core';
 
 export interface VoltageOverTimeProps {
   meterValues: MeterValueDto[];
   validContexts: OCPP2_0_1.ReadingContextEnumType[];
 }
 
-const voltageAxisLabel = 'Voltage (V)';
-
-const chartConfig = {
-  elapsedTime: {
-    label: elapsedTimeAxisLabel,
-  },
-  v: {
-    label: voltageAxisLabel,
-  },
-} satisfies ChartConfig;
-
 export const VoltageOverTime = ({ meterValues, validContexts }: VoltageOverTimeProps) => {
+  const translate = useTranslate();
+  const voltageAxisLabel = translate('Transactions.charts.voltageLabel');
+
+  const chartConfig = {
+    elapsedTime: {
+      label: translate('Transactions.charts.timeElapsed'),
+    },
+    v: {
+      label: voltageAxisLabel,
+    },
+  } satisfies ChartConfig;
+
   const buffer = 1;
 
   const { chartData, minValue, maxValue } = useMemo(() => {
@@ -66,11 +67,11 @@ export const VoltageOverTime = ({ meterValues, validContexts }: VoltageOverTimeP
   return (
     <Card>
       <CardHeader>
-        <h3 className={heading3Style}>Voltage Over Time</h3>
+        <h3 className={heading3Style}>{translate('Transactions.charts.voltageTitle')}</h3>
       </CardHeader>
       <CardContent>
         {!chartData || chartData.length === 0 ? (
-          <div>No Voltage data available</div>
+          <div>{translate('Transactions.charts.noVoltageData')}</div>
         ) : (
           <ChartContainer config={chartConfig} className={chartSize}>
             <LineChart data={chartData} margin={chartMargin}>
@@ -80,7 +81,7 @@ export const VoltageOverTime = ({ meterValues, validContexts }: VoltageOverTimeP
                 type="number"
                 ticks={generateTimeTicks(chartData)}
                 tickFormatter={formatTimeLabel}
-                label={xAxisLabelConfig}
+                label={getXAxisLabelConfig(translate('Transactions.charts.timeElapsed'))}
               />
               <YAxis
                 domain={[minValue - buffer, maxValue + buffer]}

--- a/apps/operator-ui/src/lib/client/pages/transactions/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/columns.tsx
@@ -27,145 +27,158 @@ export const transactionStationIdField = 'ocppConnectionName';
 export const transactionChargingStationLocationNameField = 'ChargingStation.Location.name';
 export const transactionAuthorizationIdTokenField = 'authorization.idToken';
 
-export const transactionsColumns: ColumnConfiguration[] = [
-  {
-    key: TransactionProps.transactionId,
-    header: 'Transaction ID',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) => (
-      <TableCellLink
-        path={`/${MenuSection.TRANSACTIONS}/${row.original.id}`}
-        value={row.original.transactionId}
-      />
-    ),
-  },
-  {
-    key: TransactionProps.isActive,
-    header: 'Active',
-    visible: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
-      row.original.isActive ? (
-        <CircleCheck className={`${buttonIconSize} text-success`} />
-      ) : (
-        <CircleX className={`${buttonIconSize} text-destructive`} />
-      ),
-  },
-  {
-    key: transactionStationIdField,
-    header: 'Station ID',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) => (
-      <TableCellLink
-        path={`/${MenuSection.CHARGING_STATIONS}/${row.original.chargingStation?.id}`}
-        value={row.original.chargingStation?.ocppConnectionName ?? EMPTY_VALUE}
-      />
-    ),
-  },
-  {
-    key: transactionChargingStationLocationNameField,
-    header: 'Location',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<BaseRecord, unknown>) => (
-      <TableCellLink
-        path={`/${MenuSection.LOCATIONS}/${row.original.chargingStation?.location?.id}`}
-        value={row.original.chargingStation?.location?.name ?? EMPTY_VALUE}
-      />
-    ),
-  },
-  {
-    key: transactionAuthorizationIdTokenField,
-    header: 'ID Token',
-    visible: true,
-    cellRender: ({ row }: CellContext<BaseRecord, unknown>) => {
-      const idToken = row.original.authorization?.idToken;
-      return idToken ? (
+type TranslateFn = (key: string, options?: any) => string;
+
+/**
+ * Builds the transactions table columns with translated headers.
+ *
+ * @param translate - the `useTranslate()` function. When omitted, headers fall
+ *   back to their default English text so the columns can be referenced outside
+ *   of a React render (e.g. shared filtering helpers in other resource pages).
+ */
+export const getTransactionsColumns = (translate?: TranslateFn): ColumnConfiguration[] => {
+  const t = (key: string, fallback: string) => (translate ? translate(key, fallback) : fallback);
+
+  return [
+    {
+      key: TransactionProps.transactionId,
+      header: t('Transactions.columns.transactionId', 'Transaction ID'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) => (
         <TableCellLink
-          path={`/${MenuSection.AUTHORIZATIONS}/${row.original.authorization?.id}`}
-          value={idToken}
+          path={`/${MenuSection.TRANSACTIONS}/${row.original.id}`}
+          value={row.original.transactionId}
         />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
-      );
+      ),
     },
-  },
-  {
-    key: TransactionProps.totalKwh,
-    header: 'Total kWh',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
-      row.original.totalKwh ? (
-        <span>{row.original.totalKwh.toFixed(2)} kWh</span>
-      ) : (
-        <span>{EMPTY_VALUE}</span>
-      ),
-  },
-  {
-    key: 'status',
-    header: 'Status',
-    visible: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
-      row.original.chargingState ? (
-        <GenericTag
-          enumValue={row.original.chargingState as OCPP2_0_1.ChargingStateEnumType}
-          enumType={OCPP2_0_1.ChargingStateEnumType}
+    {
+      key: TransactionProps.isActive,
+      header: t('Transactions.columns.active', 'Active'),
+      visible: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
+        row.original.isActive ? (
+          <CircleCheck className={`${buttonIconSize} text-success`} />
+        ) : (
+          <CircleX className={`${buttonIconSize} text-destructive`} />
+        ),
+    },
+    {
+      key: transactionStationIdField,
+      header: t('Transactions.columns.stationId', 'Station ID'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) => (
+        <TableCellLink
+          path={`/${MenuSection.CHARGING_STATIONS}/${row.original.chargingStation?.id}`}
+          value={row.original.chargingStation?.ocppConnectionName ?? EMPTY_VALUE}
         />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
       ),
-  },
-  {
-    key: TransactionProps.startTime,
-    header: 'Start Time',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
-      row.original.startTime ? (
-        <TimestampDisplay isoTimestamp={row.original.startTime} />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
+    },
+    {
+      key: transactionChargingStationLocationNameField,
+      header: t('Transactions.columns.location', 'Location'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<BaseRecord, unknown>) => (
+        <TableCellLink
+          path={`/${MenuSection.LOCATIONS}/${row.original.chargingStation?.location?.id}`}
+          value={row.original.chargingStation?.location?.name ?? EMPTY_VALUE}
+        />
       ),
-  },
-  {
-    key: TransactionProps.endTime,
-    header: 'End Time',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
-      row.original.endTime ? (
-        <TimestampDisplay isoTimestamp={row.original.endTime} />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
-      ),
-  },
-  {
-    key: TransactionProps.createdAt,
-    header: 'Created At',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionDto, unknown>) =>
-      row.original.createdAt ? (
-        <TimestampDisplay isoTimestamp={row.original.createdAt} />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
-      ),
-  },
-  {
-    key: TransactionProps.updatedAt,
-    header: 'Updated At',
-    visible: true,
-    sortable: true,
-    cellRender: ({ row }: CellContext<TransactionDto, unknown>) =>
-      row.original.updatedAt ? (
-        <TimestampDisplay isoTimestamp={row.original.updatedAt} />
-      ) : (
-        <span>{EMPTY_VALUE}</span>
-      ),
-  },
-];
+    },
+    {
+      key: transactionAuthorizationIdTokenField,
+      header: t('Transactions.columns.idToken', 'ID Token'),
+      visible: true,
+      cellRender: ({ row }: CellContext<BaseRecord, unknown>) => {
+        const idToken = row.original.authorization?.idToken;
+        return idToken ? (
+          <TableCellLink
+            path={`/${MenuSection.AUTHORIZATIONS}/${row.original.authorization?.id}`}
+            value={idToken}
+          />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        );
+      },
+    },
+    {
+      key: TransactionProps.totalKwh,
+      header: t('Transactions.columns.totalKwh', 'Total kWh'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
+        row.original.totalKwh ? (
+          <span>{row.original.totalKwh.toFixed(2)} kWh</span>
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+    {
+      key: 'status',
+      header: t('Transactions.columns.status', 'Status'),
+      visible: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
+        row.original.chargingState ? (
+          <GenericTag
+            enumValue={row.original.chargingState as OCPP2_0_1.ChargingStateEnumType}
+            enumType={OCPP2_0_1.ChargingStateEnumType}
+          />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+    {
+      key: TransactionProps.startTime,
+      header: t('Transactions.columns.startTime', 'Start Time'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
+        row.original.startTime ? (
+          <TimestampDisplay isoTimestamp={row.original.startTime} />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+    {
+      key: TransactionProps.endTime,
+      header: t('Transactions.columns.endTime', 'End Time'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionClass, unknown>) =>
+        row.original.endTime ? (
+          <TimestampDisplay isoTimestamp={row.original.endTime} />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+    {
+      key: TransactionProps.createdAt,
+      header: t('Transactions.columns.createdAt', 'Created At'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionDto, unknown>) =>
+        row.original.createdAt ? (
+          <TimestampDisplay isoTimestamp={row.original.createdAt} />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+    {
+      key: TransactionProps.updatedAt,
+      header: t('Transactions.columns.updatedAt', 'Updated At'),
+      visible: true,
+      sortable: true,
+      cellRender: ({ row }: CellContext<TransactionDto, unknown>) =>
+        row.original.updatedAt ? (
+          <TimestampDisplay isoTimestamp={row.original.updatedAt} />
+        ) : (
+          <span>{EMPTY_VALUE}</span>
+        ),
+    },
+  ];
+};
 
 export const getTransactionsFilters = (value: string): CrudFilters => {
   return [

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/columns.tsx
@@ -8,20 +8,22 @@ import { Table } from '@lib/client/components/table';
 import { TimestampDisplay } from '@lib/client/components/timestamp-display';
 import { ChevronDownIcon } from 'lucide-react';
 
-export const getMeterValueColumns = () => {
+type TranslateFn = (key: string, options?: any) => string;
+
+export const getMeterValueColumns = (translate: TranslateFn) => {
   return [
     <Table.Column
       id={MeterValueProps.id}
       key={MeterValueProps.id}
       accessorKey={MeterValueProps.id}
-      header="ID"
+      header={translate('Transactions.meterValues.id')}
       enableSorting
     />,
     <Table.Column
       id={MeterValueProps.timestamp}
       key={MeterValueProps.timestamp}
       accessorKey={MeterValueProps.timestamp}
-      header="Timestamp"
+      header={translate('Transactions.meterValues.timestamp')}
       cell={({ row }) => <TimestampDisplay isoTimestamp={row.original.timestamp} />}
     />,
     <Table.Column
@@ -36,7 +38,7 @@ export const getMeterValueColumns = () => {
             row.toggleExpanded();
           }}
         >
-          <span className="text-sm">Sample Values</span>
+          <span className="text-sm">{translate('Transactions.meterValues.sampleValues')}</span>
           <ChevronDownIcon
             className={`transition-transform duration-200 ${
               row.getIsExpanded() ? 'rotate-180' : ''

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/meter.values.list.tsx
@@ -15,6 +15,7 @@ import {
 } from '@lib/queries/meter.values';
 import { ResourceType } from '@lib/utils/access.types';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
+import { useTranslate } from '@refinedev/core';
 import type { ExpandedState } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 
@@ -26,7 +27,8 @@ export const MeterValuesList = ({
   meterValueTimestamps,
 }: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
-  const columns = useMemo(() => getMeterValueColumns(), []);
+  const translate = useTranslate();
+  const columns = useMemo(() => getMeterValueColumns(translate), [translate]);
 
   return (
     <Table

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/sampled.values.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/meter-values/sampled.values.list.tsx
@@ -6,6 +6,7 @@
 import { OCPP2_0_1, type SampledValue } from '@citrineos/base';
 import GenericTag from '@lib/client/components/tag';
 import { Separator } from '@lib/client/components/ui/separator';
+import { useTranslate } from '@refinedev/core';
 import React from 'react';
 
 interface SampledValueProps {
@@ -13,6 +14,8 @@ interface SampledValueProps {
 }
 
 export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) => {
+  const translate = useTranslate();
+
   const DescriptionRow = ({ label, children }: { label: string; children: React.ReactNode }) => (
     <div className="grid grid-cols-3 gap-4 py-3 border-b last:border-b-0">
       <div className="font-medium text-sm text-muted-foreground">{label}</div>
@@ -22,7 +25,7 @@ export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) 
 
   return (
     <div className="border rounded-lg overflow-hidden">
-      <DescriptionRow label="Value">
+      <DescriptionRow label={translate('Transactions.meterValues.value')}>
         {sampledValue.value !== null && sampledValue.value !== undefined ? (
           sampledValue.value
         ) : (
@@ -30,7 +33,7 @@ export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) 
         )}
       </DescriptionRow>
 
-      <DescriptionRow label="Context">
+      <DescriptionRow label={translate('Transactions.meterValues.context')}>
         {sampledValue.context ? (
           <GenericTag
             enumValue={sampledValue.context as OCPP2_0_1.ReadingContextEnumType}
@@ -41,7 +44,7 @@ export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) 
         )}
       </DescriptionRow>
 
-      <DescriptionRow label="Measurand">
+      <DescriptionRow label={translate('Transactions.meterValues.measurand')}>
         {sampledValue.measurand ? (
           <GenericTag
             enumValue={sampledValue.measurand as OCPP2_0_1.MeasurandEnumType}
@@ -52,7 +55,7 @@ export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) 
         )}
       </DescriptionRow>
 
-      <DescriptionRow label="Phase">
+      <DescriptionRow label={translate('Transactions.meterValues.phase')}>
         {sampledValue.phase ? (
           <GenericTag
             enumValue={sampledValue.phase as OCPP2_0_1.PhaseEnumType}
@@ -63,7 +66,7 @@ export const SampledValueView: React.FC<SampledValueProps> = ({ sampledValue }) 
         )}
       </DescriptionRow>
 
-      <DescriptionRow label="Location">
+      <DescriptionRow label={translate('Transactions.meterValues.location')}>
         {sampledValue.location ? (
           <GenericTag
             enumValue={sampledValue.location as OCPP2_0_1.LocationEnumType}
@@ -82,13 +85,17 @@ interface SampledValuesListProps {
 }
 
 export const SampledValuesListView: React.FC<SampledValuesListProps> = ({ sampledValues }) => {
+  const translate = useTranslate();
+
   return (
     <div className="space-y-6">
       {sampledValues.map((sampledValue, index) => (
         <div key={index}>
           <div className="flex items-center gap-4 mb-4">
             <Separator className="flex-1" />
-            <h4 className="text-sm font-medium text-muted-foreground">Sampled Value {index + 1}</h4>
+            <h4 className="text-sm font-medium text-muted-foreground">
+              {translate('Transactions.meterValues.sampledValue', { index: index + 1 })}
+            </h4>
             <Separator className="flex-1" />
           </div>
           <SampledValueView sampledValue={sampledValue} />

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/columns.tsx
@@ -8,19 +8,21 @@ import { Table } from '@lib/client/components/table';
 import { TimestampDisplay } from '@lib/client/components/timestamp-display';
 import React from 'react';
 
-export const getTransactionEventColumns = () => {
+type TranslateFn = (key: string, options?: any) => string;
+
+export const getTransactionEventColumns = (translate: TranslateFn) => {
   return [
     <Table.Column
       id={TransactionEventProps.eventType}
       key={TransactionEventProps.eventType}
       accessorKey={TransactionEventProps.eventType}
-      header="Event Type"
+      header={translate('Transactions.events.eventType')}
     />,
     <Table.Column
       id={TransactionEventProps.timestamp}
       key={TransactionEventProps.timestamp}
       accessorKey={TransactionEventProps.timestamp}
-      header="Timestamp"
+      header={translate('Transactions.events.timestamp')}
       enableSorting
       cell={({ row }) => <TimestampDisplay isoTimestamp={row.original.timestamp} />}
     />,
@@ -28,14 +30,14 @@ export const getTransactionEventColumns = () => {
       id={TransactionEventProps.seqNo}
       key={TransactionEventProps.seqNo}
       accessorKey={TransactionEventProps.seqNo}
-      header="Seq. #"
+      header={translate('Transactions.events.seqNo')}
       enableSorting
     />,
     <Table.Column
       id={TransactionEventProps.triggerReason}
       key={TransactionEventProps.triggerReason}
       accessorKey={TransactionEventProps.triggerReason}
-      header="Trigger Reason"
+      header={translate('Transactions.events.triggerReason')}
     />,
   ];
 };

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction-events/transaction.events.list.tsx
@@ -17,7 +17,7 @@ import {
 } from '@lib/queries/transaction.events';
 import { ResourceType } from '@lib/utils/access.types';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
-import { useList } from '@refinedev/core';
+import { useList, useTranslate } from '@refinedev/core';
 import { ChevronDownIcon } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
 import type { ExpandedState } from '@tanstack/react-table';
@@ -29,6 +29,7 @@ export const TransactionEventsList = ({
   ocppConnectionName,
 }: any) => {
   const [expanded, setExpanded] = useState<ExpandedState>({});
+  const translate = useTranslate();
 
   const tenantId = useTenantId();
 
@@ -107,7 +108,7 @@ export const TransactionEventsList = ({
   }, [eventsData?.data, messagesData?.data, transactionDatabaseId, tenantId]);
 
   const columns = [
-    ...getTransactionEventColumns(),
+    ...getTransactionEventColumns(translate),
     <Table.Column
       id="meterValues"
       key="meterValues"
@@ -123,7 +124,7 @@ export const TransactionEventsList = ({
               row.toggleExpanded();
             }}
           >
-            <span className="text-sm">View Meter Values</span>
+            <span className="text-sm">{translate('Transactions.events.viewMeterValues')}</span>
             <ChevronDownIcon
               className={`transition-transform duration-200 ${
                 row.getIsExpanded() ? 'rotate-180' : ''

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.card.tsx
@@ -65,7 +65,7 @@ export const TransactionDetailCard = ({ transaction }: TransactionDetailCardProp
             {translate('Transactions.transaction')} {transaction.transactionId}
           </h2>
           <Badge variant={transaction.isActive ? 'success' : 'destructive'}>
-            {transaction.isActive ? 'Active' : 'Inactive'}
+            {transaction.isActive ? translate('Common.active') : translate('Common.inactive')}
           </Badge>
           <CanAccess
             resource={ResourceType.TRANSACTIONS}
@@ -103,7 +103,7 @@ export const TransactionDetailCard = ({ transaction }: TransactionDetailCardProp
             }
           />
           <KeyValueDisplay
-            keyLabel="Station ID"
+            keyLabel={translate('Transactions.detail.stationId')}
             value={''}
             valueRender={() => (
               <Link
@@ -116,7 +116,7 @@ export const TransactionDetailCard = ({ transaction }: TransactionDetailCardProp
             )}
           />
           <KeyValueDisplay
-            keyLabel="Location"
+            keyLabel={translate('Transactions.detail.location')}
             value={''}
             valueRender={() => (
               <Link
@@ -129,22 +129,25 @@ export const TransactionDetailCard = ({ transaction }: TransactionDetailCardProp
             )}
           />
           <KeyValueDisplay
-            keyLabel="Total kWh"
+            keyLabel={translate('Transactions.detail.totalKwh')}
             value={`${transaction.totalKwh ? transaction.totalKwh.toFixed(2) : 0} kWh`}
           />
-          <KeyValueDisplay keyLabel="Charging State" value={transaction.chargingState} />
           <KeyValueDisplay
-            keyLabel="Start Time"
+            keyLabel={translate('Transactions.detail.chargingState')}
+            value={transaction.chargingState}
+          />
+          <KeyValueDisplay
+            keyLabel={translate('Transactions.detail.startTime')}
             value={transaction.startTime}
             valueRender={(startTime) => <TimestampDisplay isoTimestamp={startTime ?? ''} />}
           />
           <KeyValueDisplay
-            keyLabel="End Time"
+            keyLabel={translate('Transactions.detail.endTime')}
             value={transaction.endTime}
             valueRender={(endTime) => <TimestampDisplay isoTimestamp={endTime ?? ''} />}
           />
           <KeyValueDisplay
-            keyLabel="Tariff"
+            keyLabel={translate('Transactions.detail.tariff')}
             value={''}
             valueRender={() =>
               transaction.connector?.tariff ? (

--- a/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.tabs.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/detail/transaction.detail.tabs.card.tsx
@@ -28,7 +28,7 @@ import { MeterValueClass } from '@lib/cls/meter.value.dto';
 import { useState } from 'react';
 import { AuthorizationClass } from '@lib/cls/authorization.dto';
 import { useColumnPreferences } from '@lib/client/hooks/useColumnPreferences';
-import { authorizationsColumns } from '@lib/client/pages/authorizations/columns';
+import { getAuthorizationsColumns } from '@lib/client/pages/authorizations/columns';
 import { useQueryState } from 'nuqs';
 import { DETAIL_TAB_STATE } from '@lib/utils/consts';
 
@@ -69,7 +69,7 @@ export const TransactionDetailTabsCard = ({ transaction }: { transaction: Transa
   const authorization = transaction?.authorization;
 
   const { renderedVisibleColumns } = useColumnPreferences(
-    authorizationsColumns,
+    getAuthorizationsColumns(translate),
     ResourceType.AUTHORIZATIONS,
   );
 
@@ -88,9 +88,15 @@ export const TransactionDetailTabsCard = ({ transaction }: { transaction: Transa
             <TabsTrigger value={TransactionDetailTabType.authorizations}>
               {translate('Authorizations.Authorizations')}
             </TabsTrigger>
-            <TabsTrigger value={TransactionDetailTabType.meterValues}>Meter Value Data</TabsTrigger>
-            <TabsTrigger value={TransactionDetailTabType.events}>Events</TabsTrigger>
-            <TabsTrigger value={TransactionDetailTabType.ocppMessages}>OCPP Messages</TabsTrigger>
+            <TabsTrigger value={TransactionDetailTabType.meterValues}>
+              {translate('Transactions.tabs.meterValueData')}
+            </TabsTrigger>
+            <TabsTrigger value={TransactionDetailTabType.events}>
+              {translate('Transactions.tabs.events')}
+            </TabsTrigger>
+            <TabsTrigger value={TransactionDetailTabType.ocppMessages}>
+              {translate('Transactions.tabs.ocppMessages')}
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value={TransactionDetailTabType.authorizations} className={cardTabsStyle}>
@@ -140,13 +146,15 @@ export const TransactionDetailTabsCard = ({ transaction }: { transaction: Transa
             >
               <div className={pageFlex}>
                 <div className="flex flex-col gap-2">
-                  <label className="text-sm font-semibold">Contexts:</label>
+                  <label className="text-sm font-semibold">
+                    {translate('Transactions.tabs.contexts')}
+                  </label>
                   <MultiSelect<OCPP2_0_1.ReadingContextEnumType>
                     options={Object.values(OCPP2_0_1.ReadingContextEnumType)}
                     selectedValues={validContexts}
                     setSelectedValues={setValidContexts}
-                    placeholder="Select reading contexts"
-                    searchPlaceholder="Search reading contexts"
+                    placeholder={translate('Transactions.tabs.selectReadingContexts')}
+                    searchPlaceholder={translate('Transactions.tabs.searchReadingContexts')}
                   />
                 </div>
 

--- a/apps/operator-ui/src/lib/client/pages/transactions/list/transactions.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/transactions/list/transactions.list.tsx
@@ -5,8 +5,8 @@
 
 import { Table } from '@lib/client/components/table';
 import {
+  getTransactionsColumns,
   getTransactionsFilters,
-  transactionsColumns,
 } from '@lib/client/pages/transactions/columns';
 import { TransactionClass } from '@lib/cls/transaction.dto';
 import { TRANSACTION_LIST_QUERY } from '@lib/queries/transactions';
@@ -30,7 +30,7 @@ export const TransactionsList = () => {
   const translate = useTranslate();
 
   const { renderedVisibleColumns, columnSelector } = useColumnPreferences(
-    transactionsColumns,
+    getTransactionsColumns(translate),
     ResourceType.TRANSACTIONS,
   );
 

--- a/apps/operator-ui/src/lib/i18n/request.ts
+++ b/apps/operator-ui/src/lib/i18n/request.ts
@@ -15,6 +15,7 @@ const messageFilenames = [
   'tariffs',
   'transactions',
   'tenantPartners',
+  'overview',
 ];
 
 export default getRequestConfig(async () => {

--- a/apps/operator-ui/src/lib/providers/auth-provider/generic-auth-provider/index.tsx
+++ b/apps/operator-ui/src/lib/providers/auth-provider/generic-auth-provider/index.tsx
@@ -17,7 +17,7 @@ import { Label } from '@lib/client/components/ui/label';
 import { type AuthenticationContextProvider, type User } from '@lib/utils/access.types';
 import config from '@lib/utils/config';
 import { HasuraHeader, HasuraRole } from '@lib/utils/hasura.types';
-import { useLogin, type AuthProvider } from '@refinedev/core';
+import { useLogin, useTranslate, type AuthProvider } from '@refinedev/core';
 import React, { useState } from 'react';
 import { signIn } from 'next-auth/react';
 
@@ -50,6 +50,7 @@ const LoginPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const { mutate: login, isPending: isLoading } = useLogin();
+  const translate = useTranslate();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,8 +59,8 @@ const LoginPage: React.FC = () => {
     login(
       { email, password },
       {
-        onError: (error) => {
-          setError(error?.message || 'Invalid email or password');
+        onError: () => {
+          setError(translate('pages.login.invalidCredentials'));
         },
       },
     );
@@ -69,9 +70,11 @@ const LoginPage: React.FC = () => {
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12 sm:px-6 lg:px-8">
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <CardTitle className="text-2xl font-bold text-center">Sign in to your account</CardTitle>
+          <CardTitle className="text-2xl font-bold text-center">
+            {translate('pages.login.title')}
+          </CardTitle>
           <CardDescription className="text-center">
-            Enter your credentials to access the dashboard
+            {translate('pages.login.description')}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -83,11 +86,11 @@ const LoginPage: React.FC = () => {
             )}
 
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="email">{translate('pages.login.fields.email')}</Label>
               <Input
                 id="email"
                 type="email"
-                placeholder="admin@example.com"
+                placeholder={translate('pages.login.placeholders.email')}
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
@@ -97,11 +100,11 @@ const LoginPage: React.FC = () => {
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="password">{translate('pages.login.fields.password')}</Label>
               <Input
                 id="password"
                 type="password"
-                placeholder="Enter your password"
+                placeholder={translate('pages.login.placeholders.password')}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
                 required
@@ -111,7 +114,7 @@ const LoginPage: React.FC = () => {
             </div>
 
             <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? 'Signing in...' : 'Sign in'}
+              {isLoading ? translate('pages.login.signingIn') : translate('pages.login.signin')}
             </Button>
           </form>
         </CardContent>

--- a/apps/operator-ui/src/lib/providers/auth-provider/keycloak-auth-provider/index.tsx
+++ b/apps/operator-ui/src/lib/providers/auth-provider/keycloak-auth-provider/index.tsx
@@ -6,7 +6,7 @@
 import { type AuthenticationContextProvider, type User } from '@/lib/utils/access.types';
 import config from '@/lib/utils/config';
 import { getSession, signIn, signOut } from 'next-auth/react';
-import type { AuthProvider } from '@refinedev/core';
+import { type AuthProvider, useTranslate } from '@refinedev/core';
 import { HasuraHeader, HasuraRole } from '@lib/utils/hasura.types';
 import React, { useEffect } from 'react';
 import { parseJwt, getTokenClaim } from '@lib/utils/jwt';
@@ -37,6 +37,7 @@ const HASURA_CLAIM = config.hasuraClaim!;
  * Automatically redirects to Keycloak login
  */
 const KeycloakLoginPage: React.FC = () => {
+  const translate = useTranslate();
   useEffect(() => {
     signIn('keycloak', { callbackUrl: '/overview' });
   }, []);
@@ -44,8 +45,8 @@ const KeycloakLoginPage: React.FC = () => {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="text-center">
-        <h2 className="text-xl font-semibold mb-2">Redirecting to Keycloak...</h2>
-        <p className="text-gray-600">Redirecting to Keycloak login...</p>
+        <h2 className="text-xl font-semibold mb-2">{translate('pages.redirectingToKeycloak')}</h2>
+        <p className="text-gray-600">{translate('pages.redirectingToKeycloakLogin')}</p>
       </div>
     </div>
   );

--- a/apps/operator-ui/src/lib/providers/index.tsx
+++ b/apps/operator-ui/src/lib/providers/index.tsx
@@ -9,7 +9,7 @@ import { createAccessProvider } from '@lib/providers/access-control-provider';
 import { authProvider } from '@lib/providers/auth-provider';
 import dataProvider from '@lib/providers/data-provider';
 import liveProvider from '@lib/providers/live-provider';
-import { notificationProvider } from '@lib/providers/notification-provider';
+import { createNotificationProvider } from '@lib/providers/notification-provider';
 import ReduxProvider from '@lib/providers/redux-provider';
 import { setUserLocale } from '@lib/server/hooks/getUserLocale';
 import { resources } from '@lib/utils/resources';
@@ -61,6 +61,11 @@ export function Providers({
     getLocale: useLocale,
     changeLocale: setUserLocale,
   };
+
+  const notificationProvider = useMemo(
+    () => createNotificationProvider((key, options) => t(key, options)),
+    [t],
+  );
 
   if (!mounted) return null;
 

--- a/apps/operator-ui/src/lib/providers/notification-provider/index.tsx
+++ b/apps/operator-ui/src/lib/providers/notification-provider/index.tsx
@@ -7,10 +7,17 @@ import { HasuraClaimType } from '@lib/utils/hasura.types';
 import type { NotificationProvider } from '@refinedev/core';
 import { toast } from 'sonner';
 
+/**
+ * Subset of refine's TranslateFunction. Optional so the provider keeps working
+ * (with English fallbacks) when created without an i18n translate function.
+ */
+type TranslateFn = (key: string, options?: any, defaultMessage?: string) => string;
+
 const getNotificationMessageDescriptionAndType = (
   message: string,
   type: 'success' | 'error' | 'progress',
   description: string | undefined,
+  translate?: TranslateFn,
 ): {
   message: string;
   type: 'success' | 'error' | 'progress';
@@ -23,8 +30,12 @@ const getNotificationMessageDescriptionAndType = (
 
     if (missingRequiredTenantId) {
       return {
-        message: 'Not allowed',
-        description: `Missing required Parameter: ${HasuraClaimType.X_HASURA_TENANT_ID}`,
+        message: translate ? translate('notificationProvider.notAllowed') : 'Not allowed',
+        description: translate
+          ? translate('notificationProvider.missingRequiredParameter', {
+              parameter: HasuraClaimType.X_HASURA_TENANT_ID,
+            })
+          : `Missing required Parameter: ${HasuraClaimType.X_HASURA_TENANT_ID}`,
         type: 'error',
       };
     }
@@ -42,8 +53,12 @@ const getNotificationMessageDescriptionAndType = (
 
     if (isPermissionError) {
       return {
-        message: 'You do not have permission to access this resource.',
-        description: 'Please contact your administrator if you believe this is a mistake.',
+        message: translate
+          ? translate('notificationProvider.noPermission')
+          : 'You do not have permission to access this resource.',
+        description: translate
+          ? translate('notificationProvider.contactAdministrator')
+          : 'Please contact your administrator if you believe this is a mistake.',
         type: 'error',
       };
     }
@@ -56,13 +71,13 @@ const getNotificationMessageDescriptionAndType = (
   };
 };
 
-export const notificationProvider: NotificationProvider = {
+export const createNotificationProvider = (translate?: TranslateFn): NotificationProvider => ({
   open: ({ key, message, type, description, undoableTimeout, cancelMutation }) => {
     const {
       message: mappedMessage,
       type: mappedType,
       description: mappedDescription,
-    } = getNotificationMessageDescriptionAndType(message, type, description);
+    } = getNotificationMessageDescriptionAndType(message, type, description, translate);
 
     switch (mappedType) {
       case 'success':
@@ -110,4 +125,10 @@ export const notificationProvider: NotificationProvider = {
   close: (id) => {
     toast.dismiss(id);
   },
-};
+});
+
+/**
+ * Default notification provider without i18n translation. Prefer
+ * {@link createNotificationProvider} with a translate function when available.
+ */
+export const notificationProvider: NotificationProvider = createNotificationProvider();

--- a/apps/operator-ui/src/lib/utils/consts.tsx
+++ b/apps/operator-ui/src/lib/utils/consts.tsx
@@ -8,6 +8,11 @@ import { ResourceType } from '@lib/utils/access.types';
 export const I18N_COOKIE_NAME = 'NEXT_LOCALE';
 export const DEFAULT_LOCALE = 'en';
 
+export const LOCALES = [
+  { value: 'en', label: 'English' },
+  { value: 'pt-BR', label: 'Português (Brasil)' },
+];
+
 export const NEW_IDENTIFIER = 'new';
 
 export const EMPTY_FILTER: CrudFilter[] = [

--- a/apps/operator-ui/src/lib/utils/copy.ts
+++ b/apps/operator-ui/src/lib/utils/copy.ts
@@ -3,10 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 import { toast } from 'sonner';
 
-export const copy = async (value: string | null | undefined, displayValue = true) => {
+/**
+ * Subset of refine's TranslateFunction. Optional so this utility keeps working
+ * (with an English fallback) when called outside of a React component/hook.
+ */
+type TranslateFn = (key: string, options?: any, defaultMessage?: string) => string;
+
+export const copy = async (
+  value: string | null | undefined,
+  displayValue = true,
+  translate?: TranslateFn,
+) => {
   if (!value) return;
 
   await navigator.clipboard.writeText(value);
 
-  toast.message(`Copied${displayValue ? ` ${value}` : ''} to clipboard.`);
+  let message: string;
+  if (translate) {
+    message = displayValue
+      ? translate('Common.copiedValueToClipboard', { value })
+      : translate('Common.copiedToClipboard');
+  } else {
+    message = `Copied${displayValue ? ` ${value}` : ''} to clipboard.`;
+  }
+
+  toast.message(message);
 };

--- a/apps/operator-ui/src/lib/utils/messages.utils.tsx
+++ b/apps/operator-ui/src/lib/utils/messages.utils.tsx
@@ -10,15 +10,24 @@ import store from '@lib/utils/store/store';
 import { Expose } from 'class-transformer';
 import { toast } from 'sonner';
 
-export const showSuccess = (payload?: string | object) => {
+/**
+ * Subset of refine's TranslateFunction. Optional so these utilities keep working
+ * (with English fallbacks) when called outside of a React component/hook.
+ */
+type TranslateFn = (key: string, options?: any, defaultMessage?: string) => string;
+
+export const showSuccess = (payload?: string | object, translate?: TranslateFn) => {
   const payloadString = payload ? JSON.stringify(payload) : '.';
-  toast.success('Success', {
-    description: `The request was successful ${payloadString}`,
+  const description = translate
+    ? translate('messages.requestSuccessful', { payload: payloadString })
+    : `The request was successful ${payloadString}`;
+  toast.success(translate ? translate('Common.success') : 'Success', {
+    description,
   });
 };
 
-export const showError = (msg: string) => {
-  toast.error('Request Failed', {
+export const showError = (msg: string, translate?: TranslateFn) => {
+  toast.error(translate ? translate('messages.requestFailed') : 'Request Failed', {
     description: msg,
   });
 };
@@ -30,6 +39,7 @@ export interface TriggerMessageAndHandleResponseProps<T> {
   method?: HttpMethod;
   setLoading?: (loading: boolean) => void;
   responseSuccessCheck?: (response: T) => boolean;
+  translate?: TranslateFn;
 }
 
 type MessageConfirmationOrArray = MessageConfirmation | MessageConfirmation[];
@@ -41,6 +51,7 @@ export const triggerMessageAndHandleResponse = async <T extends MessageConfirmat
   method = HttpMethod.Post,
   setLoading,
   responseSuccessCheck,
+  translate,
 }: TriggerMessageAndHandleResponseProps<T>) => {
   try {
     setLoading?.(true);
@@ -60,12 +71,12 @@ export const triggerMessageAndHandleResponse = async <T extends MessageConfirmat
 
     if (!response.data && response.status === 200) {
       store.dispatch(closeModal());
-      showSuccess();
+      showSuccess(undefined, translate);
       return;
     }
     if (responseSuccessCheck && responseSuccessCheck(response.data)) {
       store.dispatch(closeModal());
-      showSuccess();
+      showSuccess(undefined, translate);
     } else if (ocppResponseSuccessCheck(response.data)) {
       store.dispatch(closeModal());
       const payload = Array.isArray(response.data)
@@ -74,16 +85,23 @@ export const triggerMessageAndHandleResponse = async <T extends MessageConfirmat
           : undefined
         : response.data.payload;
 
-      showSuccess(payload);
+      showSuccess(payload, translate);
     } else {
-      let msg = 'The request did not receive a successful response.';
+      let msg = translate
+        ? translate('messages.noSuccessfulResponse')
+        : 'The request did not receive a successful response.';
       if (response instanceof MessageConfirmation || Array.isArray(response)) {
         msg += ` ${generateErrorMessageFromResponses(response)}`;
       }
-      showError(msg);
+      showError(msg, translate);
     }
   } catch (error: any) {
-    showError('The request failed with message: ' + error.message);
+    showError(
+      translate
+        ? translate('messages.requestFailedWithMessage', { message: error.message })
+        : 'The request failed with message: ' + error.message,
+      translate,
+    );
   } finally {
     setLoading?.(false);
   }

--- a/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { test, expect } from '../../fixtures';
+import { OverviewPage } from '../../pages/overview.page';
+
+test.use({ storageState: 'playwright/.auth/admin.json' });
+
+test.setTimeout(90_000);
+
+test.describe('overview › locale', () => {
+  test('E2E-018: language switcher changes UI language and persists across reload', async ({
+    page,
+  }) => {
+    const overview = new OverviewPage(page);
+    await overview.goto();
+
+    // Default locale is English: the Locations card heading is rendered in English.
+    await expect(page.getByRole('heading', { name: /^locations$/i })).toBeVisible();
+
+    // Switch to Brazilian Portuguese via the sidebar language switcher.
+    await page.getByRole('button', { name: /^language$/i }).click();
+    await page.getByRole('menuitemradio', { name: /portugu[êe]s \(brasil\)/i }).click();
+
+    // The UI re-renders with pt-BR messages.
+    const ptHeading = page.getByRole('heading', { name: /^locais$/i });
+    await expect(ptHeading).toBeVisible({ timeout: 30_000 });
+
+    // The selection is stored in the NEXT_LOCALE cookie and survives a reload.
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+    await expect(ptHeading).toBeVisible({ timeout: 60_000 });
+
+    // Switch back to English from the localized UI (the switcher label is now "Idioma").
+    await page.getByRole('button', { name: /^idioma$/i }).click();
+    await page.getByRole('menuitemradio', { name: /^english$/i }).click();
+    await expect(page.getByRole('heading', { name: /^locations$/i })).toBeVisible({
+      timeout: 30_000,
+    });
+    // No reset needed: each test loads a fresh context from admin.json
+    // storageState, so the locale cookie cannot leak into another test.
+  });
+});


### PR DESCRIPTION
## Summary

The Operator UI already ships i18n infrastructure (next-intl wired into Refine's `i18nProvider`, per-namespace JSON files under `public/locales/en/`, `NEXT_LOCALE` cookie helpers), but it was only used on the login page — the rest of the UI had hardcoded English strings. This PR extends i18n to the entire UI and adds Brazilian Portuguese as the first additional locale.

## What's included

- **String externalization across the whole UI** — pages (overview, charging stations, transactions, locations, authorizations, tariffs, partners), shared components (tables, filters, pagination, forms, opening hours), all OCPP 1.6/2.0.1 command modals, toasts/notifications, zod validation messages, and permission fallbacks. ~880 keys per locale.
- **pt-BR locale** for all namespaces, with key parity to `en` enforced (verified programmatically).
- **Language switcher** in the sidebar next to the theme toggle, following the same visual pattern. Selection persists via the existing `NEXT_LOCALE` cookie. English remains the default locale and the runtime fallback for any missing key, so partial locales are safe.
- **Column factories** — static column definitions (`transactionsColumns`, etc.) became `getXColumns(translate)` factories so cross-resource embedded tables (e.g. transactions inside a charging station detail) localize correctly.
- **Docs** — new "Internationalization (i18n)" section in the operator-ui README, including a step-by-step for adding a new language.
- **Tests** — new Playwright spec (E2E-018) covering switch to pt-BR, persistence across reload, and switch back to English.
- **REUSE** — new locale JSONs registered in `.reuse/ignore-files.txt`, matching how the existing `en` files are handled; all new source files carry SPDX headers.

## Conventions followed

- Keys keep the existing convention: one PascalCase root per namespace file (`ChargingStations`, `Transactions`, …), camelCase sub-keys, ICU parameters (`{id}`).
- Components use Refine's `useTranslate()` (the dominant pattern in the codebase) against the merged message tree.
- `en` values are byte-for-byte the previous hardcoded strings — no copy changes, so existing e2e specs keep passing.

## Validation

- `pnpm --filter @citrineos/operator-ui build` ✅
- `eslint` ✅ (0 errors; the 2 pre-existing `useEffect` warnings on `next` are untouched)
- Full Playwright suite: **89 passed, 1 flaky (E2E-017 theme toggle, passes on retry, pre-existing), 15 skipped** ✅
- Locale parity and key-resolution checked programmatically (all 730+ `translate()` references resolve; en/pt-BR key sets identical)

## Notes for reviewers

- The diff is large but mechanical; the behavioral surface is the new locale-switcher component and the column factories.
- Happy to split this into smaller PRs (foundation + per-resource) if you prefer.
- pt-BR translations were reviewed for EV-charging domain terminology (e.g. "Remote Start" → "Partida Remota"); native review is welcome.