### PR TITLE
Avoid modify ended transaction

### DIFF
--- a/packages/core/src/modules/Transactions/src/module/module.ts
+++ b/packages/core/src/modules/Transactions/src/module/module.ts
@@ -118,6 +118,9 @@ export class TransactionsModule extends AbstractModule {
    * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
    * It is used to propagate system-wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
    *
+   * @param {OCPPValidator}[ocppValidator] - An optional parameter that represents an instance of {@link OCPPValidator} used to validate and sanitize incoming OCPP request and response payloads against
+   * the schema. If no `ocppValidator` is provided, a default {@link OCPPValidator} instance is created and used.
+   *
    * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository} which represents a repository for accessing and manipulating transaction event data.
    * If no `transactionEventRepository` is provided, a default {@link sequelize:transactionEventRepository} instance
    * is created and used.
@@ -164,6 +167,10 @@ export class TransactionsModule extends AbstractModule {
    *
    * @param {IAuthorizer} [realTimeAuthorizer] - An optional parameter of type {@link IAuthorizer} which represents
    * a real-time authorizer that can be used to authorize real-time requests.
+   *
+   * @param {IChargingProfileRepository} [chargingProfileRepository] - An optional parameter of type {@link IChargingProfileRepository}
+   * which represents a repository for accessing and manipulating charging profile Message data.
+   * If no `chargingProfileRepository` is provided, a default {@link sequelize:chargingProfileRepository} instance is created and used.
    */
   constructor(
     config: BootstrapConfig & SystemConfig,
@@ -297,7 +304,7 @@ export class TransactionsModule extends AbstractModule {
     let response: OCPP2_response_types.TransactionEventResponse | undefined = undefined;
     let transaction: Transaction | undefined = undefined;
     if (transactionEvent.idToken) {
-      if (message.protocol === OCPPVersion.OCPP2_1) {
+      if (isOcpp21) {
         response = await this._transactionService.authorizeOcpp21IdToken(
           tenantId,
           transactionEvent,
@@ -311,6 +318,22 @@ export class TransactionsModule extends AbstractModule {
         );
       }
     }
+    if (transactionEvent.eventType !== TransactionEventEnum.Started) {
+      const existingTransaction =
+        await this._transactionEventRepository.readTransactionByStationIdAndTransactionId(
+          tenantId,
+          ocppConnectionName,
+          transactionId,
+        );
+      if (existingTransaction && !existingTransaction.isActive) {
+        this._logger.warn(
+          `Received ${transactionEvent.eventType} for already-ended transaction ${transactionId} on ${ocppConnectionName}. Ignoring.`,
+        );
+        await this.sendCallResultWithMessage(message, response ?? {});
+        return;
+      }
+    }
+
     try {
       transaction =
         await this._transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(

--- a/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
@@ -117,6 +117,7 @@ describe('F07 - Remote start with fixed cost, energy, SoC or time', () => {
     transactionEventRepository = {
       createOrUpdateTransactionByTransactionEventAndStationId: vi.fn(),
       updateTransactionByStationIdAndTransactionId: vi.fn(),
+      readTransactionByStationIdAndTransactionId: vi.fn().mockResolvedValue(null),
     };
 
     mockCache = {

--- a/packages/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
@@ -113,6 +113,7 @@ describe('TransactionsModule - E16 Transaction Limits', () => {
   beforeEach(() => {
     transactionEventRepository = {
       createOrUpdateTransactionByTransactionEventAndStationId: vi.fn(),
+      readTransactionByStationIdAndTransactionId: vi.fn().mockResolvedValue(null),
     };
 
     const config = makeConfig();

--- a/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
@@ -122,6 +122,7 @@ describe('TransactionsModule - _handleTransactionEvent and _handleOcpp16StartTra
         totalKwh: null,
       }),
       createTransactionByStartTransaction: vi.fn().mockResolvedValue({ transactionId: '100' }),
+      readTransactionByStationIdAndTransactionId: vi.fn().mockResolvedValue(null),
     };
 
     locationRepository = {

--- a/packages/core/src/modules/Transactions/test/module/TransactionsModule.endedTransaction.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionsModule.endedTransaction.test.ts
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ILogObj } from 'tslog';
+import { Logger } from 'tslog';
+import type {
+  BootstrapConfig,
+  CrudRepository,
+  IAuthorizer,
+  ICache,
+  IFileStorage,
+  IMessage,
+  IMessageHandler,
+  IMessageSender,
+  OcppRequest,
+  SystemConfig,
+} from '@citrineos/base';
+import {
+  AuthorizationStatusEnum,
+  DEFAULT_TENANT_ID,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/base';
+import type {
+  IAuthorizationRepository,
+  IDeviceModelRepository,
+  ILocationRepository,
+  IOCPPMessageRepository,
+  IReservationRepository,
+  ITariffRepository,
+  ITransactionEventRepository,
+} from '@dal/interfaces/repositories.js';
+import { TransactionsModule } from '../../src/module/module.js';
+
+vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
+  SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
+    validateMeterValues: vi.fn().mockResolvedValue(true),
+  })),
+}));
+
+vi.mock('@util/authorizer/RealTimeAuthorizer.js', () => ({
+  RealTimeAuthorizer: vi.fn().mockImplementation(() => ({
+    authorize: vi.fn().mockResolvedValue('Accepted'),
+  })),
+}));
+
+function makeConfig(): BootstrapConfig & SystemConfig {
+  return {
+    env: 'test',
+    logLevel: 6,
+    maxCallLengthSeconds: 30,
+    maxCachingSeconds: 30,
+    centralSystem: { host: '0.0.0.0', port: 8080 },
+    modules: {
+      transactions: {
+        requests: [],
+        responses: [],
+        sendCostUpdatedOnMeterValue: false,
+      },
+    },
+    util: {
+      cache: { memory: true },
+      messageBroker: { amqp: { url: 'amqp://localhost', exchange: 'x' } },
+      authProvider: { localByPass: true },
+      swagger: { path: '/docs', logoPath: '', exposeData: false, exposeMessage: false },
+      networkConnection: { websocketServers: [] },
+      certificateAuthority: {
+        v2gCA: {
+          name: 'hubject',
+          hubject: { baseUrl: '', tokenUrl: '', clientId: '', clientSecret: '' },
+        },
+        chargingStationCA: {
+          name: 'acme',
+          acme: { env: 'staging', accountKeyFilePath: '', email: '' },
+        },
+      },
+    },
+  } as unknown as BootstrapConfig & SystemConfig;
+}
+
+function makeMessage<T extends OcppRequest>(payload: T, action: string): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Transactions,
+    action,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<T>;
+}
+
+describe('TransactionsModule - ended transaction guard', () => {
+  let module: TransactionsModule;
+  let transactionEventRepository: Partial<ITransactionEventRepository>;
+  let sendCallResultSpy: ReturnType<typeof vi.spyOn>;
+  let createOrUpdateSpy: ReturnType<typeof vi.fn>;
+
+  function setupModule(readTransactionResult: { isActive: boolean } | null) {
+    createOrUpdateSpy = vi.fn().mockResolvedValue({
+      id: 1,
+      transactionId: 'txn-001',
+      isActive: true,
+      totalKwh: null,
+    });
+
+    transactionEventRepository = {
+      createOrUpdateTransactionByTransactionEventAndStationId: createOrUpdateSpy,
+      readTransactionByStationIdAndTransactionId: vi.fn().mockResolvedValue(readTransactionResult),
+    };
+
+    const config = makeConfig();
+    const logger = new Logger<ILogObj>({ name: 'test', minLevel: 6 });
+
+    const mockHandler = {
+      subscribe: vi.fn().mockResolvedValue(true),
+      shutdown: vi.fn(),
+      set module(_: any) {},
+    } as unknown as IMessageHandler;
+
+    const mockSender = {
+      sendResponse: vi.fn().mockResolvedValue({ success: true }),
+      sendRequest: vi.fn().mockResolvedValue({ success: true }),
+      shutdown: vi.fn(),
+    } as unknown as IMessageSender;
+
+    const mockCache = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn().mockResolvedValue(true),
+    } as unknown as ICache;
+
+    module = new TransactionsModule(
+      config,
+      mockCache,
+      {} as IFileStorage,
+      mockSender,
+      mockHandler,
+      logger,
+      /* ocppValidator */ undefined,
+      transactionEventRepository as ITransactionEventRepository,
+      /* authorizeRepository */ {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as IAuthorizationRepository,
+      /* deviceModelRepository */ {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as IDeviceModelRepository,
+      /* componentRepository */ {
+        readAllByQuery: vi.fn().mockResolvedValue([]),
+      } as unknown as CrudRepository<any>,
+      /* locationRepository */ {} as ILocationRepository,
+      /* tariffRepository */ {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as ITariffRepository,
+      /* reservationRepository */ {
+        updateAllByQuery: vi.fn().mockResolvedValue([]),
+      } as unknown as IReservationRepository,
+      /* ocppMessageRepository */ {
+        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
+      } as unknown as IOCPPMessageRepository,
+      /* realTimeAuthorizer */ {
+        authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
+      } as unknown as IAuthorizer,
+      /* authorizers */ undefined,
+      /* chargingProfileRepository */ {
+        readAllByQuery: vi.fn().mockResolvedValue([]),
+      } as unknown as any,
+    );
+
+    sendCallResultSpy = vi
+      .spyOn(module, 'sendCallResultWithMessage')
+      .mockResolvedValue({ success: true });
+    vi.spyOn(module, 'sendCallErrorWithMessage').mockResolvedValue({ success: true });
+  }
+
+  describe('when transaction has already ended (isActive=false)', () => {
+    beforeEach(() => {
+      setupModule({ isActive: false });
+    });
+
+    it('should send an empty TransactionEventResponse and not update transaction for eventType=Updated', async () => {
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Updated,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.MeterValuePeriodic,
+        seqNo: 5,
+        transactionInfo: { transactionId: 'txn-001' },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(sendCallResultSpy).toHaveBeenCalledOnce();
+      expect(sendCallResultSpy).toHaveBeenCalledWith(expect.anything(), {});
+      expect(createOrUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should send an empty TransactionEventResponse and not update transaction for eventType=Ended', async () => {
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Ended,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.EVDisconnected,
+        seqNo: 5,
+        transactionInfo: { transactionId: 'txn-001' },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(sendCallResultSpy).toHaveBeenCalledOnce();
+      expect(sendCallResultSpy).toHaveBeenCalledWith(expect.anything(), {});
+      expect(createOrUpdateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should forward the authorization response when idToken is present', async () => {
+      const authResponse = { idTokenInfo: { status: AuthorizationStatusEnum.Accepted } };
+      vi.spyOn((module as any)._transactionService, 'authorizeOcpp201IdToken').mockResolvedValue(
+        authResponse,
+      );
+
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Updated,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.MeterValuePeriodic,
+        seqNo: 5,
+        transactionInfo: { transactionId: 'txn-001' },
+        idToken: { idToken: 'RFID-001', type: OCPP2_0_1.IdTokenEnumType.ISO14443 },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(sendCallResultSpy).toHaveBeenCalledOnce();
+      expect(sendCallResultSpy).toHaveBeenCalledWith(expect.anything(), authResponse);
+      expect(createOrUpdateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when transaction is still active (isActive=true)', () => {
+    beforeEach(() => {
+      setupModule({ isActive: true });
+    });
+
+    it('should proceed normally and call createOrUpdate for eventType=Updated', async () => {
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Updated,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.MeterValuePeriodic,
+        seqNo: 2,
+        transactionInfo: { transactionId: 'txn-001' },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(createOrUpdateSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when transaction is not found', () => {
+    beforeEach(() => {
+      setupModule(null);
+    });
+
+    it('should proceed normally and call createOrUpdate for eventType=Updated', async () => {
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Updated,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.MeterValuePeriodic,
+        seqNo: 2,
+        transactionInfo: { transactionId: 'txn-unknown' },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(createOrUpdateSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when eventType=Started', () => {
+    beforeEach(() => {
+      setupModule({ isActive: false });
+    });
+
+    it('should skip the ended-transaction check entirely and proceed normally', async () => {
+      const payload: OCPP2_0_1.TransactionEventRequest = {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+        seqNo: 0,
+        transactionInfo: { transactionId: 'txn-new' },
+      };
+
+      await (module as any)._handleTransactionEvent(
+        makeMessage(payload, OCPP_CallAction.TransactionEvent),
+      );
+
+      expect(
+        transactionEventRepository.readTransactionByStationIdAndTransactionId,
+      ).not.toHaveBeenCalled();
+      expect(createOrUpdateSpy).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
### Changes
This is a fix for https://github.com/citrineos/citrineos/issues/204

### Tests
1. prepares a ended transaction <img width="769" height="55" alt="Screenshot 2026-06-05 at 4 59 16 PM" src="https://github.com/user-attachments/assets/db06035d-7426-45dc-8d00-fae2a2893f5d" />
2. sends a transactionEvent (type=updated) and still send the reponse <img width="893" height="85" alt="Screenshot 2026-06-05 at 5 05 31 PM" src="https://github.com/user-attachments/assets/ea0cabfd-f5b8-4815-b114-7adae87e68da" />
3. but transaction is not updated <img width="1110" height="45" alt="Screenshot 2026-06-05 at 5 05 16 PM" src="https://github.com/user-attachments/assets/c93b6429-949d-46f6-a8df-a0795057db13" />