### PR TITLE
Introducing Awilix to CitrineOS.

### DIFF
--- a/apps/Server/DEPENDENCY_INJECTION.md
+++ b/apps/Server/DEPENDENCY_INJECTION.md
@@ -1,0 +1,201 @@
+# Dependency Injection (Awilix)
+
+How DI is orchestrated in the server. Read this alongside `apps/Server/src/container.ts` and `apps/Server/src/citrineOSServer.ts`
+
+## The model
+
+One Awilix container, built once at a single composition root: `buildContainer()` in `container.ts`. The server `citrineOSServer.ts` builds it in its constructor and then resolves everything from it.
+
+The container runs in PROXY mode: a class declares its dependencies as a destructured constructor object, and Awilix supplies them by matching parameter name → registered token name.
+
+```ts
+// because it's registered under the token `transactionEventRepository`,
+// naming the constructor param the same thing is all the wiring needed:
+constructor({ transactionEventRepository, logger }: { ... }) { ... }
+```
+
+So when wiring a new dependency: register it under a token and name the constructor param the same. Nothing is wired by hand.
+
+A handful of registrations use `asFunction` instead of `asClass` — where construction composes other objects (the RabbitMQ `sender`/`handler`), needs a runtime choice (`apiAuthProvider`), needs a narrowed input (`bootNotificationService` gets `config.modules.configuration`, not the full `config`), or must defer a lookup (`costUpdatedNotifier`). Everything else uses a destructured constructor + `asClass`.
+
+## Bootstrap flow
+
+```
+constructor   build the prebuilt primitives the container needs (logger, cache,
+              ocppValidator, server, fileStorage), then buildContainer(config, {…})
+
+initialize()  resolve & wire from the container, in order:
+              registerHttpPlugins → sequelize → message broker
+              → initSystem (modules) → db → health → shutdown handlers
+```
+
+Those few primitives are built before the container because the container depends on them; they're passed in and registered as values.
+
+## Lifetimes
+
+| Lifetime | Meaning | Used for |
+|---|---|---|
+| `value` | a prebuilt instance/constant | config, the Sequelize instance, the Fastify server, cache |
+| `singleton` | one app-wide instance | repositories, shared services, the network stack, broker connection/channel |
+| `scoped` | one per module | each module + its `sender`/`handler` + its internal services + its APIs |
+
+The rule: a dependency must live at least as long as its consumer (`singleton` ≥ `scoped`). Break it and Awilix throws at startup. 
+- Modules are scoped, so `sender`/`handler` are scoped too (a scoped module is allowed to depend on them).
+- The router is a singleton, so it gets its *own* singleton `routerSender`/`routerHandler` — a singleton can't depend on the scoped pair.
+
+Per-module scopes: each module is resolved in its own child scope (`initModuleInScope`) together with its sender/handler, internal services, and APIs.
+
+## Where things are registered
+
+`buildContainer()` calls one registrar per layer. To find a registration, open `container.ts` and go to:
+
+| Registrar | What it registers |
+|---|---|
+| `registerPrimitives` | config + derived scalars, the Sequelize instance, prebuilt infra (all values) |
+| `registerMessaging` | RabbitMQ connection/channel managers, `sender`/`handler`, `routerSender`/`routerHandler` |
+| `registerRepositories` | every repository (singletons) |
+| `registerServices` | shared services + `apiAuthProvider` |
+| `registerModuleServices` | calls each module package's own `register<Module>Services` (see next section) |
+| `registerNetwork` | filters, authenticator, router, network connection, `adminApi` |
+| `registerModules` / `registerModuleApis` | the 8 modules and their APIs (scoped) |
+
+## Module-internal services live in the module packages
+
+Services that belong to a single module (e.g. `TransactionService`, `BootNotificationService`) are not registered in `container.ts`. 
+Each module package owns a `src/register.ts` exporting `register<Module>Services(container)`, and `registerModuleServices` just calls all six.
+
+Why it's done this way: the service classes stay private to their package (only the registrar is exported). 
+To add or change a module's internal service, edit that package's `register.ts`.
+
+## Patterns worth knowing
+
+- Breaking a dependency cycle. `CostNotifier` has to call back into its module to send a message. Instead of holding the module (a cycle), it injects a `costUpdatedNotifier` function token whose factory reads the module lazily, only when invoked — so there's no cycle at construction time. 
+- One API instance serves multiple OCPP versions; the version is threaded through as a parameter (`AbstractModuleApi.supportedVersions`)
+
+## Intentionally NOT in the container
+
+Deliberate — don't "fix" these:
+
+| Thing | Why |
+|---|---|
+| `TlsCredentialManager` | per-config private internal helper inside `WebsocketNetworkConnection` |
+| `RbacRulesLoader` | private internal helper inside `OIDCAuthProvider` |
+| `HealthCheckService` | depends on `networkConnection`; resolving it through the container would start the websocket servers in modules-only mode, so it's built in the bootstrap |
+
+## Tests
+
+`packages/core/src/test/testContainer.ts` gives tests the same container settings as production
+- `createTestContainer()` → a container with a mock logger pre-registered.
+- `getTestInstance(container, Class, mocks)` → registers your mocks + the class, then resolves it. `mocks` is typed against the constructor, so a wrong or missing dependency name is a compile error.
+
+## Adding things
+
+All of these follow the same model from the top of this doc: register under a token, then name the constructor param to match.
+See start of document regarding singleton vs scoped vs value. We do not use transient in this application as there isn't an applicable case worth doing. 
+
+### …a dependency on an existing class
+
+Add the parameter to the class's destructured constructor. A token of that name is registered and visible where the class resolves.
+- `singleton` and `value` tokens are visible everywhere;
+- a `scoped` token (e.g. another module-internal service) is only visible inside that module's scope — so it must be registered in that module's `register.ts`.
+
+**Example** — adding `tariffRepository` to a class's constructor:
+
+```ts
+constructor({ transactionEventRepository, tariffRepository, logger }: { /* … */ }) {
+  this._tariffRepository = tariffRepository;
+}
+```
+
+### …a repository
+
+Add one line to `registerRepositories`: `xRepository: asClass(SequelizeXRepository).singleton()`.
+Any class can now inject it by naming an `xRepository` constructor param.
+
+**Example** — `SequelizeAsyncJobStatusRepository` takes the standard `{ config, logger, sequelizeInstance }` and forwards them to the base:
+
+```ts
+export class SequelizeAsyncJobStatusRepository extends SequelizeRepository<AsyncJobStatus> {
+  constructor({ config, logger, sequelizeInstance }: {
+    config: BootstrapConfig; logger?: Logger<ILogObj>; sequelizeInstance?: Sequelize;
+  }) {
+    super({ config, namespace: AsyncJobStatus.MODEL_NAME, logger, sequelizeInstance });
+  }
+}
+```
+
+One line in `registerRepositories` then exposes it as the `asyncJobStatusRepository` token:
+
+```ts
+asyncJobStatusRepository: asClass(SequelizeAsyncJobStatusRepository).singleton(),
+```
+
+### …a shared (app-wide) service
+
+A service used across modules or by the network stack.
+
+1. Give it a destructured constructor whose param names are existing tokens; export it from `@citrineos/core`.
+2. Register it in `registerServices` as `asClass(X).singleton()` — or `asFunction(({ … }) => new X(…))` if construction needs a runtime choice or a narrowed input.
+
+**Example** — `realTimeAuthorizer` is a plain singleton, while `apiAuthProvider` uses `asFunction` because it picks an implementation at runtime. Both live in `registerServices`:
+
+```ts
+realTimeAuthorizer: asClass(RealTimeAuthorizer).singleton(),
+
+apiAuthProvider: asFunction(({ config, logger }): IApiAuthProvider => {
+  if (config.util.authProvider.oidc) return new OIDCAuthProvider(config.util.authProvider.oidc, logger);
+  if (config.util.authProvider.localByPass) return new LocalBypassAuthProvider(logger);
+  throw new Error('No valid API authentication provider configured');
+}).singleton(),
+```
+
+### …a module-internal service
+
+A service used by exactly one module.
+
+1. Add it to that module package's `src/register.ts` — `asClass(X).scoped()` (or `asFunction(...)` only if construction needs a narrowed input). Export only the registrar.
+2. Add a param to the module's constructor named after the new token.
+
+It resolves in the module's scope, alongside the module's other scoped services.
+
+**Example** — Monitoring registers its two services in its own `register.ts`:
+
+```ts
+export function registerMonitoringServices(container: AwilixContainer): void {
+  container.register({
+    monitoringService: asClass(MonitoringService).scoped(),
+    monitoringDeviceModelService: asClass(DeviceModelService).scoped(),
+  });
+}
+```
+
+`MonitoringModule` then names them in its constructor to receive that module's instances:
+
+```ts
+constructor({ monitoringService, monitoringDeviceModelService }: { /* … */ }) {
+  this._monitoringService = monitoringService;
+}
+```
+
+### …a new module
+
+1. If it has internal services: add `register<Module>Services` in the package and export it.
+2. Register the module + its APIs in `container.ts` (`registerModules`, `registerModuleApis`).
+3. Add one row to `MODULE_INITS` in `citrineOSServer.ts`: `{ moduleToken, routeApis, configKey }`.
+
+**Example** — the Tenant module (no internal services, so no `register.ts`). Its module and API are registered in `container.ts`:
+
+```ts
+tenantModule: asClass(TenantModule).scoped(),
+tenantDataApi: asClass(TenantDataApi).scoped(),
+```
+
+and one row in `citrineOSServer.ts` drives its startup:
+
+```ts
+[EventGroup.Tenant]: {
+  moduleToken: 'tenantModule',
+  routeApis: ['tenantDataApi'],
+  configKey: 'tenant',
+},
+```

--- a/apps/Server/DEPENDENCY_INJECTION.md
+++ b/apps/Server/DEPENDENCY_INJECTION.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Dependency Injection (Awilix)
 
 How DI is orchestrated in the server. Read this alongside `apps/Server/src/container.ts` and `apps/Server/src/citrineOSServer.ts`

--- a/apps/Server/README.md
+++ b/apps/Server/README.md
@@ -18,6 +18,9 @@ It is one workspace member of the `citrineos-core` pnpm monorepo. For repository
 `pnpm install`, building, the full-stack Docker Compose files, and the operator UI), see the
 [root README](../../README.md).
 
+How the server wires its dependencies — the Awilix container, module/service registration, and the
+bootstrap sequence — is documented in [`DEPENDENCY_INJECTION.md`](./DEPENDENCY_INJECTION.md).
+
 ## Table of Contents
 
 - [Running the Server](#running-the-server)
@@ -205,13 +208,12 @@ field-level validation that the official schemas lack.
 
 It is possible to add custom JSON schemas to validate the data fields of DataTransfer messages, which are supported by
 all OCPP versions.
-In the `apps/Server/src/index.ts` code, there is a function `ajvInstance()` that creates the AJV instance. Here, you
-could register DataTransfer schemas:
+The OCPP message validator is created in `apps/Server/src/citrineOSServer.ts`. Register a DataTransfer schema by
+compiling it onto that validator's AJV and passing it in:
 
-```
-import { MyDataTransferRequestSchema } from './path'
-...
-ajvInstance.compile(MyDataTransferRequestSchema);
+```ts
+const ocppAjv = OCPPValidator.createValidatorAjvInstance();
+ocppAjv.compile(MyDataTransferRequestSchema);
 ```
 
 Note: The schema's `$id` field must follow this format:

--- a/apps/Server/package.json
+++ b/apps/Server/package.json
@@ -50,10 +50,11 @@
     "@citrineos/base": "workspace:*",
     "@citrineos/core": "workspace:*",
     "@fastify/cors": "10.1.0",
+    "awilix": "^13.0.3",
     "cross-env": "7.0.3",
     "fastify": "^5.8.5",
-    "tslog": "^4.9.2",
     "sqlite3": "5.1.7",
+    "tslog": "^4.9.2",
     "ws": "8.20.1"
   },
   "optionalDependencies": {

--- a/apps/Server/src/citrineOSServer.ts
+++ b/apps/Server/src/citrineOSServer.ts
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { AwilixContainer } from 'awilix';
+import { buildContainer } from './container.js';
 import type {
   AbstractModule,
   BootstrapConfig,
   IApiAuthProvider,
-  IAuthorizer,
   ICache,
   IFileStorage,
-  IMessageHandler,
   IMessageRouter,
   IModule,
   IModuleApi,
@@ -22,62 +22,20 @@ import {
   eventGroupFromString,
   type IAuthenticator,
   OCPPValidator,
-  OCPPVersion,
 } from '@citrineos/base';
-import type { ISmartCharging } from '@citrineos/core';
 import {
   AdminApi,
   apiAuthPluginFp,
-  Authenticator,
-  BasicAuthenticationFilter,
   BrokerAwareMessageSender,
-  CertificateAuthorityService,
-  CertificatesDataApi,
-  CertificatesModule,
-  CertificatesOcpp2Api,
-  ConfigurationDataApi,
-  ConfigurationModule,
-  ConfigurationOcpp16Api,
-  ConfigurationOcpp2Api,
-  ConnectedStationFilter,
   DefaultDrizzleInstance,
-  EVDriverDataApi,
-  EVDriverModule,
-  EVDriverOcpp16Api,
-  EVDriverOcpp2Api,
-  IdGenerator,
   initSwagger,
-  InternalSmartCharging,
-  LocalBypassAuthProvider,
+  type IServerNetworkProfileRepository,
   MemoryCache,
-  MessageRouterImpl,
-  MonitoringDataApi,
-  MonitoringModule,
-  MonitoringOcpp2Api,
-  NetworkProfileFilter,
-  OIDCAuthProvider,
   RabbitMQChannelManager,
   RabbitMQConnectionManager,
-  RabbitMqReceiver,
-  RabbitMqSender,
-  RealTimeAuthorizer,
   RedisCache,
-  ReportingModule,
-  ReportingOcpp16Api,
-  ReportingOcpp2Api,
-  RepositoryStore,
   sequelize,
   Sequelize,
-  SmartChargingModule,
-  SmartChargingOcpp16Api,
-  SmartChargingOcpp2Api,
-  TenantDataApi,
-  TenantModule,
-  TransactionsDataApi,
-  TransactionsModule,
-  TransactionsOcpp2Api,
-  UnknownStationFilter,
-  WebhookDispatcher,
   WebsocketNetworkConnection,
 } from '@citrineos/core';
 import cors from '@fastify/cors';
@@ -92,6 +50,13 @@ import type {
 import type { RedisClientOptions } from 'redis';
 import { type ILogObj, Logger } from 'tslog';
 import { type HealthCheckResult, HealthCheckService } from './health/HealthCheckService.js';
+
+/** The container tokens needed to initialize a module and its APIs in a scope. */
+interface ModuleInitSpec {
+  moduleToken: string;
+  routeApis: string[];
+  configKey: keyof (BootstrapConfig & SystemConfig)['modules'];
+}
 
 export class CitrineOSServer {
   /**
@@ -113,29 +78,60 @@ export class CitrineOSServer {
   protected _authenticator?: IAuthenticator;
   protected _router?: IMessageRouter;
   protected _networkConnection?: WebsocketNetworkConnection;
-  protected _repositoryStore!: RepositoryStore;
-  protected _idGenerator!: IdGenerator;
-  protected _certificateAuthorityService!: CertificateAuthorityService;
-  protected _smartChargingService!: ISmartCharging;
-  protected _realTimeAuthorizer!: IAuthorizer;
 
   protected readonly appName: string;
   protected _isShuttingDown = false;
+  protected _container!: AwilixContainer;
   protected _connectionManager?: RabbitMQConnectionManager;
   protected _channelManager?: RabbitMQChannelManager;
   protected _healthCheckService?: HealthCheckService;
 
-  /**
-   * Constructor for the class.
-   *
-   * @param {EventGroup} appName - app type
-   * @param {BootstrapConfig} bootstrapConfig
-   * @param {SystemConfig} systemConfig - config
-   * @param {FastifyInstance} server - optional Fastify server instance
-   * @param {Ajv} ajv - optional Ajv JSON schema validator instance
-   * @param {ICache} cache - cache
-   * @param {IFileStorage} _fileStorage - file storage
-   */
+  // Single source of truth mapping each module's EventGroup to the container
+  // tokens + config flag needed to initialize it. initAllModules() and
+  // initModule() both read from this instead of repeating the mapping.
+  private static readonly MODULE_SPECS: Partial<Record<EventGroup, ModuleInitSpec>> = {
+    [EventGroup.Certificates]: {
+      moduleToken: 'certificatesModule',
+      routeApis: ['certificatesOcpp2Api', 'certificatesDataApi'],
+      configKey: 'certificates',
+    },
+    [EventGroup.Configuration]: {
+      moduleToken: 'configurationModule',
+      routeApis: ['configurationOcpp2Api', 'configurationOcpp16Api', 'configurationDataApi'],
+      configKey: 'configuration',
+    },
+    [EventGroup.EVDriver]: {
+      moduleToken: 'evDriverModule',
+      routeApis: ['evDriverOcpp2Api', 'evDriverOcpp16Api', 'evDriverDataApi'],
+      configKey: 'evdriver',
+    },
+    [EventGroup.Monitoring]: {
+      moduleToken: 'monitoringModule',
+      routeApis: ['monitoringOcpp2Api', 'monitoringDataApi'],
+      configKey: 'monitoring',
+    },
+    [EventGroup.Reporting]: {
+      moduleToken: 'reportingModule',
+      routeApis: ['reportingOcpp2Api', 'reportingOcpp16Api'],
+      configKey: 'reporting',
+    },
+    [EventGroup.SmartCharging]: {
+      moduleToken: 'smartChargingModule',
+      routeApis: ['smartChargingOcpp2Api', 'smartChargingOcpp16Api'],
+      configKey: 'smartcharging',
+    },
+    [EventGroup.Transactions]: {
+      moduleToken: 'transactionsModule',
+      routeApis: ['transactionsOcpp2Api', 'transactionsDataApi'],
+      configKey: 'transactions',
+    },
+    [EventGroup.Tenant]: {
+      moduleToken: 'tenantModule',
+      routeApis: ['tenantDataApi'],
+      configKey: 'tenant',
+    },
+  };
+
   // todo rename event group to type
   constructor(
     appName: string,
@@ -144,26 +140,24 @@ export class CitrineOSServer {
     server?: FastifyInstance,
     ajv?: Ajv.Ajv,
     cache?: ICache,
-    _fileStorage?: IFileStorage,
   ) {
     // TODO: Create and export config schemas for each util module, such as amqp, redis, etc, to avoid passing them possibly invalid configuration
     if (!systemConfig.util.messageBroker.amqp) {
       throw new Error('This server implementation requires amqp configuration for rabbitMQ.');
     }
 
+    // Create the prebuilt primitives the container depends on, then build it.
     this.appName = appName;
     this._config = { ...bootstrapConfig, ...systemConfig };
     this._server = server || fastify().withTypeProvider<JsonSchemaToTsProvider>();
 
     // enable cors
-    (this._server as any).register(cors, {
+    this._server.register(cors, {
       origin: true, // This can be customized to specify allowed origins
       methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'], // Specify allowed HTTP methods
     });
 
     console.log('Bootstrap configuration loaded');
-    // Add health check
-    this.initHealthCheck();
 
     // Create Ajv JSON schema validator instance
     this._ajv = OCPPValidator.createServerAjvInstance(ajv);
@@ -179,49 +173,52 @@ export class CitrineOSServer {
     // Set cache implementation
     this._cache = this.initCache(cache);
 
-    // Initialize Swagger if enabled
-    this.initSwagger()
-      .then()
-      .catch((error) => this._logger.error('Could not initialize swagger', { error }));
-
-    // Register API authentication
-    this.registerApiAuth();
-
     // Initialize File Access Implementation
     this._fileStorage = ConfigStoreFactory.getInstance();
 
-    // Register AJV for schema validation
-    this.registerAjv();
-
-    // Initialize repository store
-    this.initRepositoryStore();
-    this.initIdGenerator();
-    this.initCertificateAuthorityService();
-    this.initSmartChargingService();
-    this.initRealTimeAuthorizer();
+    // Build the DI container from the prebuilt primitives. Everything else is
+    // resolved from / wired through it in initialize().
+    this._container = buildContainer(this._config, {
+      logger: this._logger,
+      cache: this._cache,
+      ocppValidator: this._ocppValidator,
+      server: this._server,
+    });
   }
 
-  async initialize(): Promise<void> {
-    await this.initMessageBrokerConnection();
-    // Initialize module & API
-    // Always initialize API after SwaggerUI
-    await this.initSystem();
-    // Initialize database
-    await this.initDb();
-
-    this.initHealthCheckService();
-
-    // Set up shutdown handlers
-    for (const event of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
-      process.on(event, () => {
-        this._logger.info(`Received ${event}`);
-        this.shutdown().catch((err) => {
-          console.error('Shutdown error:', err);
+  async run(): Promise<void> {
+    try {
+      await this.initialize();
+      await this._syncWebsocketConfig();
+      await this._server
+        .listen({
+          host: this.host,
+          port: this.port,
+        })
+        .then((address) => {
+          this._logger?.info(`Server listening at ${address}`);
+        })
+        .catch((error) => {
+          this._logger?.error(error);
           process.exit(1);
         });
-      });
+      // TODO Push config to microservices
+    } catch (error) {
+      throw error;
     }
   }
+
+  // Wire everything that depends on the container, as an ordered sequence.
+  async initialize(): Promise<void> {
+    await this.registerHttpPlugins();
+    this.initSequelizeInstance();
+    await this.initMessageBrokerConnection();
+    await this.initSystem();
+    await this.initDb();
+    this.initHealthCheckService();
+    this.registerShutdownHandlers();
+  }
+
   async shutdown() {
     if (this._isShuttingDown) return;
     this._isShuttingDown = true;
@@ -249,72 +246,83 @@ export class CitrineOSServer {
     await this._channelManager?.closeAll();
     await this._connectionManager?.close();
 
-    this._logger.info('Closing PostgresSQL connections...');
+    this._logger.info('Closing PostgreSQL connections...');
     await this._sequelizeInstance.connectionManager.close();
 
     this._logger.info('Shutdown complete');
     process.exitCode = 0;
   }
 
-  async run(): Promise<void> {
-    try {
-      await this.initialize();
-      await this._syncWebsocketConfig();
-      await this._server
-        .listen({
-          host: this.host,
-          port: this.port,
-        })
-        .then((address) => {
-          this._logger?.info(`Server listening at ${address}`);
-        })
-        .catch((error) => {
-          this._logger?.error(error);
-          process.exit(1);
-        });
-      // TODO Push config to microservices
-    } catch (error) {
-      await Promise.reject(error);
+  protected initLogger() {
+    const isCloud = process.env.DEPLOYMENT_TARGET === 'cloud';
+
+    const loggerSettings = {
+      name: 'CitrineOS Logger',
+      minLevel: this._config.logLevel,
+      hideLogPositionForProduction: this._config.env === 'production',
+      type: isCloud ? ('json' as const) : ('pretty' as const),
+    };
+
+    return new Logger<ILogObj>(loggerSettings);
+  }
+
+  protected initCache(cache?: ICache): ICache {
+    if (cache) return cache;
+    if (this._config.util.cache.redis) {
+      const redisClientOptions: RedisClientOptions =
+        'url' in this._config.util.cache.redis
+          ? { url: this._config.util.cache.redis.url }
+          : {
+            socket: {
+              host: this._config.util.cache.redis.host,
+              port: this._config.util.cache.redis.port,
+            },
+          };
+      return new RedisCache(redisClientOptions, this._logger);
+    }
+    return new MemoryCache();
+  }
+
+  /**
+   * Registers the HTTP plugins/routes that depend on the container or must be in
+   * place before module APIs register their routes
+   */
+  protected async registerHttpPlugins(): Promise<void> {
+    this.registerAjv();
+    await this.initSwagger();
+    this.registerApiAuth();
+    this.initHealthCheck();
+  }
+
+  protected registerAjv() {
+    // todo type schema instead of any
+    const fastifySchemaCompiler: FastifySchemaCompiler<any> = (
+      routeSchema: FastifyRouteSchemaDef<any>,
+    ) => this._ajv?.compile(routeSchema.schema) as FastifyValidationResult;
+    this._server.setValidatorCompiler(fastifySchemaCompiler);
+  }
+
+  protected async initSwagger() {
+    if (this._config.util.swagger) {
+      await initSwagger(this._config, this._server);
     }
   }
 
-  protected async _syncWebsocketConfig() {
-    for (const websocketServerConfig of this._config.util.networkConnection.websocketServers) {
-      await this._repositoryStore.serverNetworkProfileRepository.upsertServerNetworkProfile(
-        websocketServerConfig,
-        this._config.maxCallLengthSeconds,
-      );
-    }
-  }
-
-  async initMessageBrokerConnection(): Promise<any> {
-    const url = this._config.util.messageBroker.amqp?.url;
-    if (!url) {
-      throw new Error('RabbitMQ URL is not configured');
-    }
-    this._connectionManager = new RabbitMQConnectionManager(this._config.maxReconnectDelay, url);
-    this._channelManager = new RabbitMQChannelManager(this._connectionManager);
-    await this._connectionManager.connect();
-  }
-
-  protected _createSender(): BrokerAwareMessageSender {
-    const exchange = this._config.util.messageBroker.amqp?.exchange;
-    if (!exchange) {
-      throw new Error('RabbitMQ exchange is not configured');
-    }
-    if (!this._connectionManager || !this._channelManager) {
-      throw new Error('RabbitMQ connection or channel manager is not initialized');
-    }
-    return new BrokerAwareMessageSender(
-      new RabbitMqSender(exchange, this._connectionManager, this._channelManager, this._logger),
-      this._connectionManager,
-      this._config.maxCallLengthSeconds,
-      this._logger,
-    );
-  }
-
-  protected _createHandler(): IMessageHandler {
-    return new RabbitMqReceiver(this._config, this._channelManager!, this._logger);
+  protected registerApiAuth() {
+    const authProvider = this._container.resolve<IApiAuthProvider>('apiAuthProvider');
+    this._server.register(apiAuthPluginFp, {
+      provider: authProvider,
+      options: {
+        excludedRoutes: [
+          '/health',
+          '/health/live',
+          '/health/ready',
+          '/docs', // API documentation
+        ],
+        debug: this._config.logLevel <= 2, // Enable debug logs in dev mode
+      },
+      logger: this._logger,
+    });
   }
 
   protected initHealthCheck() {
@@ -347,432 +355,14 @@ export class CitrineOSServer {
     this._server.get('/health/ready', readiness);
   }
 
-  protected initHealthCheckService() {
-    this._healthCheckService = new HealthCheckService(
-      this._networkConnection,
-      this._connectionManager,
-      this._cache,
-      this._sequelizeInstance,
-      this._config.notReadyThresholdSeconds,
-      this._logger,
-    );
+  protected initSequelizeInstance() {
+    this._sequelizeInstance = this._container.resolve('sequelizeInstance');
   }
 
-  protected initLogger() {
-    const isCloud = process.env.DEPLOYMENT_TARGET === 'cloud';
-
-    const loggerSettings = {
-      name: 'CitrineOS Logger',
-      minLevel: this._config.logLevel,
-      hideLogPositionForProduction: this._config.env === 'production',
-      type: isCloud ? ('json' as const) : ('pretty' as const),
-    };
-
-    return new Logger<ILogObj>(loggerSettings);
-  }
-
-  protected async initDb() {
-    await sequelize.DefaultSequelizeInstance.initializeSequelize();
-    if (process.env.CITRINEOS_USE_DRIZZLE_SECURITY_EVENT === 'true') {
-      await DefaultDrizzleInstance.initialize();
-    }
-  }
-
-  protected initCache(cache?: ICache): ICache {
-    if (cache) return cache;
-    if (this._config.util.cache.redis) {
-      const redisClientOptions: RedisClientOptions =
-        'url' in this._config.util.cache.redis
-          ? { url: this._config.util.cache.redis.url }
-          : {
-              socket: {
-                host: this._config.util.cache.redis.host,
-                port: this._config.util.cache.redis.port,
-              },
-            };
-      return new RedisCache(redisClientOptions, this._logger);
-    }
-    return new MemoryCache();
-  }
-
-  protected async initSwagger() {
-    if (this._config.util.swagger) {
-      await initSwagger(this._config, this._server);
-    }
-  }
-
-  protected registerAjv() {
-    // todo type schema instead of any
-    const fastifySchemaCompiler: FastifySchemaCompiler<any> = (
-      routeSchema: FastifyRouteSchemaDef<any>,
-    ) => this._ajv?.compile(routeSchema.schema) as FastifyValidationResult;
-    this._server.setValidatorCompiler(fastifySchemaCompiler);
-  }
-
-  protected registerApiAuth() {
-    const authProvider = this.initApiAuthProvider();
-    this._server.register(apiAuthPluginFp, {
-      provider: authProvider,
-      options: {
-        excludedRoutes: [
-          '/health',
-          '/health/live',
-          '/health/ready',
-          '/docs', // API documentation
-        ],
-        debug: this._config.logLevel <= 2, // Enable debug logs in dev mode
-      },
-      logger: this._logger,
-    });
-  }
-
-  protected initNetworkConnection() {
-    this._authenticator = new Authenticator(
-      new UnknownStationFilter(
-        new sequelize.SequelizeLocationRepository(this._config, this._logger),
-        this._logger,
-      ),
-      new ConnectedStationFilter(this._cache, this._logger),
-      new NetworkProfileFilter(
-        new sequelize.SequelizeDeviceModelRepository(this._config, this._logger),
-        this._logger,
-      ),
-      new BasicAuthenticationFilter(
-        new sequelize.SequelizeDeviceModelRepository(this._config, this._logger),
-        this._logger,
-      ),
-      this._logger,
-    );
-
-    const webhookDispatcher = new WebhookDispatcher(
-      this._repositoryStore.ocppMessageRepository,
-      this._repositoryStore.subscriptionRepository,
-      this._cache,
-      this._logger,
-      this._config,
-    );
-
-    const routerSender = this._createSender();
-
-    this._router = new MessageRouterImpl(
-      this._config,
-      this._cache,
-      routerSender,
-      this._createHandler(),
-      webhookDispatcher,
-      async (_identifier: string, _message: string) => {},
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.locationRepository,
-    );
-
-    this._networkConnection = new WebsocketNetworkConnection(
-      this._config,
-      this._cache,
-      this._authenticator,
-      this._router,
-      this._fileStorage,
-      this._logger,
-      this._repositoryStore.locationRepository.doesChargingStationExistByStationId.bind(
-        this._repositoryStore.locationRepository,
-      ),
-      async (tenantId: number) => {
-        const tenant = await this._repositoryStore.tenantRepository.readByKey(tenantId, tenantId);
-        return tenant?.maxChargingStations ?? null;
-      },
-      this._connectionManager,
-    );
-
-    routerSender.onCallTimeout = (ocppConnectionName, tenantId) =>
-      this._networkConnection!.disconnect(tenantId, ocppConnectionName).then(() => undefined);
-
-    this._router.networkHook = this._networkConnection.bindNetworkHook();
-
-    this.apis.push(
-      new AdminApi(
-        this._router,
-        this._networkConnection,
-        this._server,
-        this._config,
-        this._logger,
-        this._repositoryStore.subscriptionRepository,
-        this._repositoryStore.serverNetworkProfileRepository,
-      ),
-    );
-  }
-
-  protected async initHandlersAndAddModule(module: AbstractModule) {
-    await module.initHandlers();
-    this.modules.push(module);
-  }
-
-  protected async initAllModules() {
-    if (this._config.modules.certificates) {
-      await this.initCertificatesModule();
-    }
-
-    if (this._config.modules.configuration) {
-      await this.initConfigurationModule();
-    }
-
-    if (this._config.modules.evdriver) {
-      await this.initEVDriverModule();
-    }
-
-    if (this._config.modules.monitoring) {
-      await this.initMonitoringModule();
-    }
-
-    if (this._config.modules.reporting) {
-      await this.initReportingModule();
-    }
-
-    if (this._config.modules.smartcharging) {
-      await this.initSmartChargingModule();
-    }
-
-    if (this._config.modules.transactions) {
-      await this.initTransactionsModule();
-    }
-
-    if (this._config.modules.tenant) {
-      await this.initTenantModule();
-    }
-  }
-
-  protected initApiAuthProvider(): IApiAuthProvider {
-    this._logger.info('Initializing API authentication provider,', this._config.util.authProvider);
-    if (this._config.util.authProvider.oidc) {
-      return new OIDCAuthProvider(this._config.util.authProvider.oidc, this._logger);
-    } else if (this._config.util.authProvider.localByPass) {
-      return new LocalBypassAuthProvider(this._logger);
-    } else {
-      throw new Error('No valid API authentication provider configured');
-    }
-  }
-
-  protected async initCertificatesModule() {
-    const module = new CertificatesModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._fileStorage,
-      this._networkConnection!,
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.certificateRepository,
-      this._repositoryStore.installedCertificateRepository,
-      this._repositoryStore.installCertificateAttemptRepository,
-      this._repositoryStore.deleteCertificateAttemptRepository,
-      this._repositoryStore.ocppMessageRepository,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new CertificatesOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new CertificatesOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new CertificatesDataApi(
-        module,
-        this._server,
-        this._fileStorage,
-        this._config.util.networkConnection.websocketServers,
-        this._logger,
-      ),
-    );
-  }
-
-  protected async initConfigurationModule() {
-    const module = new ConfigurationModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.bootRepository,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.messageInfoRepository,
-      this._repositoryStore.locationRepository,
-      this._repositoryStore.changeConfigurationRepository,
-      this._repositoryStore.ocppMessageRepository,
-      this._idGenerator,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new ConfigurationOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new ConfigurationOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new ConfigurationOcpp16Api(module, this._server, this._logger),
-      new ConfigurationDataApi(module, this._server, this._logger),
-    );
-  }
-
-  protected async initEVDriverModule() {
-    const module = new EVDriverModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.authorizationRepository,
-      this._repositoryStore.localAuthListRepository,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.tariffRepository,
-      this._repositoryStore.transactionEventRepository,
-      this._repositoryStore.chargingProfileRepository,
-      this._repositoryStore.reservationRepository,
-      this._repositoryStore.ocppMessageRepository,
-      this._repositoryStore.locationRepository,
-      this._certificateAuthorityService,
-      this._realTimeAuthorizer,
-      [],
-      this._idGenerator,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new EVDriverOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new EVDriverOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new EVDriverOcpp16Api(module, this._server, this._logger),
-      new EVDriverDataApi(module, this._server, this._logger),
-    );
-  }
-
-  protected async initMonitoringModule() {
-    const module = new MonitoringModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.variableMonitoringRepository,
-      this._repositoryStore.ocppMessageRepository,
-      this._idGenerator,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new MonitoringOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new MonitoringOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new MonitoringDataApi(module, this._server, this._logger),
-    );
-  }
-
-  protected async initReportingModule() {
-    const module = new ReportingModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.securityEventRepository,
-      this._repositoryStore.variableMonitoringRepository,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new ReportingOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new ReportingOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new ReportingOcpp16Api(module, this._server, this._logger),
-    );
-  }
-
-  protected async initSmartChargingModule() {
-    const module = new SmartChargingModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.transactionEventRepository,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.chargingProfileRepository,
-      this._smartChargingService,
-      this._idGenerator,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new SmartChargingOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new SmartChargingOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new SmartChargingOcpp16Api(module, this._server, this._logger),
-    );
-  }
-
-  protected async initTransactionsModule() {
-    const module = new TransactionsModule(
-      this._config,
-      this._cache,
-      this._fileStorage,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.transactionEventRepository,
-      this._repositoryStore.authorizationRepository,
-      this._repositoryStore.deviceModelRepository,
-      this._repositoryStore.componentRepository,
-      this._repositoryStore.locationRepository,
-      this._repositoryStore.tariffRepository,
-      this._repositoryStore.reservationRepository,
-      this._repositoryStore.ocppMessageRepository,
-      this._realTimeAuthorizer,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(
-      new TransactionsOcpp2Api(module, this._server, OCPPVersion.OCPP2_0_1, this._logger),
-      new TransactionsOcpp2Api(module, this._server, OCPPVersion.OCPP2_1, this._logger),
-      new TransactionsDataApi(module, this._server, this._logger),
-    );
-  }
-
-  protected async initTenantModule() {
-    const module = new TenantModule(
-      this._config,
-      this._cache,
-      this._createSender(),
-      this._createHandler(),
-      this._logger,
-      this._ocppValidator,
-      this._repositoryStore.tenantRepository,
-    );
-    await this.initHandlersAndAddModule(module);
-    this.apis.push(new TenantDataApi(module, this._server, this._logger));
-    this._logger.info('Tenant module initialized');
-  }
-
-  protected async initModule(eventGroup = this.eventGroup) {
-    this._logger.info(`Initializing module: ${this.appName}`);
-    switch (eventGroup) {
-      case EventGroup.Certificates:
-        await this.initCertificatesModule();
-        break;
-      case EventGroup.Configuration:
-        await this.initConfigurationModule();
-        break;
-      case EventGroup.EVDriver:
-        await this.initEVDriverModule();
-        break;
-      case EventGroup.Monitoring:
-        await this.initMonitoringModule();
-        break;
-      case EventGroup.Reporting:
-        await this.initReportingModule();
-        break;
-      case EventGroup.SmartCharging:
-        await this.initSmartChargingModule();
-        break;
-      case EventGroup.Transactions:
-        await this.initTransactionsModule();
-        break;
-      case EventGroup.Tenant:
-        await this.initTenantModule();
-        break;
-      default:
-        throw new Error('Unhandled module type: ' + this.appName);
-    }
+  protected async initMessageBrokerConnection(): Promise<void> {
+    this._connectionManager = this._container.resolve('connectionManager');
+    this._channelManager = this._container.resolve('channelManager');
+    await this._connectionManager.connect();
   }
 
   protected async initSystem() {
@@ -787,10 +377,8 @@ export class CitrineOSServer {
       await this.initAllModules();
     } else if (this.eventGroup === EventGroup.Router) {
       this._logger.info('Initializing in ROUTER mode: WebSocket server, no modules');
-      // OCPP Router only: WebSocket server, no modules
       this.initNetworkConnection();
     } else if (this.eventGroup === EventGroup.Modules) {
-      // All modules, no WebSocket server
       this._logger.info('Initializing in MODULES mode: all modules without NetworkConnection');
       await this.initAllModules();
     } else {
@@ -798,44 +386,95 @@ export class CitrineOSServer {
     }
   }
 
-  protected initRepositoryStore() {
-    this._sequelizeInstance = sequelize.DefaultSequelizeInstance.getInstance(
-      this._config,
-      this._logger,
-    );
-    this._repositoryStore = new RepositoryStore(
-      this._config,
-      this._logger,
-      this._sequelizeInstance,
-    );
+  protected initNetworkConnection() {
+    this._authenticator = this._container.resolve('authenticator');
+    this._router = this._container.resolve('router');
+    this._networkConnection = this._container.resolve('networkConnection');
+
+    const routerSender = this._container.resolve<BrokerAwareMessageSender>('routerSender');
+    routerSender.onCallTimeout = (ocppConnectionName, tenantId) =>
+      this._networkConnection!.disconnect(tenantId, ocppConnectionName).then(() => undefined);
+
+    this.apis.push(this._container.resolve<AdminApi>('adminApi'));
   }
 
-  protected initIdGenerator() {
-    this._idGenerator = new IdGenerator(this._repositoryStore.chargingStationSequenceRepository);
+  protected async initAllModules() {
+    for (const spec of Object.values(CitrineOSServer.MODULE_SPECS)) {
+      if (spec && this._config.modules[spec.configKey]) {
+        await this.initModuleInScope(spec.moduleToken, spec.routeApis);
+      }
+    }
   }
 
-  protected initCertificateAuthorityService() {
-    this._certificateAuthorityService = new CertificateAuthorityService(
-      this._config,
+  protected async initModule(eventGroup = this.eventGroup) {
+    this._logger.info(`Initializing module: ${this.appName}`);
+    const spec = eventGroup ? CitrineOSServer.MODULE_SPECS[eventGroup] : undefined;
+    if (!spec) {
+      throw new Error('Unhandled module type: ' + this.appName);
+    }
+    await this.initModuleInScope(spec.moduleToken, spec.routeApis);
+  }
+
+  /**
+   * Builds a module and its APIs together in their own isolated scope, so each
+   * API is wired to the exact module instance created here (and the module gets
+   * its own message sender/handler). App-wide singletons — repositories,
+   * services, the network stack — are created once and reused by every module
+   */
+  private async initModuleInScope(moduleToken: string, routeApis: string[]): Promise<void> {
+    const scope = this._container.createScope();
+    const module = scope.resolve<AbstractModule>(moduleToken);
+    await this.initHandlersAndAddModule(module);
+    for (const routeApi of routeApis) {
+      this.apis.push(scope.resolve<IModuleApi>(routeApi));
+    }
+  }
+
+  protected async initHandlersAndAddModule(module: AbstractModule) {
+    await module.initHandlers();
+    this.modules.push(module);
+  }
+
+  protected async initDb() {
+    await sequelize.DefaultSequelizeInstance.initializeSequelize();
+    if (process.env.CITRINEOS_USE_DRIZZLE_SECURITY_EVENT === 'true') {
+      await DefaultDrizzleInstance.initialize();
+    }
+  }
+
+  // Not containerized: depends on networkConnection, which only exists in network
+  // modes — resolving it from the container would start the websocket servers even
+  // in modules-only mode.
+  protected initHealthCheckService() {
+    this._healthCheckService = new HealthCheckService(
+      this._networkConnection,
+      this._connectionManager,
       this._cache,
+      this._sequelizeInstance,
+      this._config.notReadyThresholdSeconds,
       this._logger,
-      undefined,
-      undefined,
-      this._fileStorage,
     );
   }
 
-  protected initSmartChargingService() {
-    this._smartChargingService = new InternalSmartCharging(
-      this._repositoryStore.chargingProfileRepository,
-    );
+  protected registerShutdownHandlers(): void {
+    for (const event of ['SIGINT', 'SIGTERM', 'SIGQUIT']) {
+      process.on(event, () => {
+        this._logger.info(`Received ${event}`);
+        this.shutdown().catch((err) => {
+          console.error('Shutdown error:', err);
+          process.exit(1);
+        });
+      });
+    }
   }
 
-  protected initRealTimeAuthorizer() {
-    this._realTimeAuthorizer = new RealTimeAuthorizer(
-      this._repositoryStore.locationRepository,
-      this._config,
-      this._logger,
-    );
+  protected async _syncWebsocketConfig() {
+    const serverNetworkProfileRepository = this._container.resolve<IServerNetworkProfileRepository>('serverNetworkProfileRepository');
+    for (const websocketServerConfig of this._config.util.networkConnection.websocketServers) {
+      await serverNetworkProfileRepository.upsertServerNetworkProfile(
+        websocketServerConfig,
+        this._config.maxCallLengthSeconds,
+      );
+    }
   }
 }

--- a/apps/Server/src/citrineOSServer.ts
+++ b/apps/Server/src/citrineOSServer.ts
@@ -204,6 +204,7 @@ export class CitrineOSServer {
         });
       // TODO Push config to microservices
     } catch (error) {
+      this._logger?.error('Fatal error during startup', error);
       throw error;
     }
   }
@@ -273,11 +274,11 @@ export class CitrineOSServer {
         'url' in this._config.util.cache.redis
           ? { url: this._config.util.cache.redis.url }
           : {
-            socket: {
-              host: this._config.util.cache.redis.host,
-              port: this._config.util.cache.redis.port,
-            },
-          };
+              socket: {
+                host: this._config.util.cache.redis.host,
+                port: this._config.util.cache.redis.port,
+              },
+            };
       return new RedisCache(redisClientOptions, this._logger);
     }
     return new MemoryCache();
@@ -469,7 +470,9 @@ export class CitrineOSServer {
   }
 
   protected async _syncWebsocketConfig() {
-    const serverNetworkProfileRepository = this._container.resolve<IServerNetworkProfileRepository>('serverNetworkProfileRepository');
+    const serverNetworkProfileRepository = this._container.resolve<IServerNetworkProfileRepository>(
+      'serverNetworkProfileRepository',
+    );
     for (const websocketServerConfig of this._config.util.networkConnection.websocketServers) {
       await serverNetworkProfileRepository.upsertServerNetworkProfile(
         websocketServerConfig,

--- a/apps/Server/src/container.ts
+++ b/apps/Server/src/container.ts
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, asFunction, asValue, createContainer, InjectionMode } from 'awilix';
+import type { AwilixContainer } from 'awilix';
+import type { FastifyInstance } from 'fastify';
+
+// -- Config & Base --
+import type { BootstrapConfig, ICache, SystemConfig } from '@citrineos/base';
+import { ConfigStoreFactory, OCPPValidator } from '@citrineos/base';
+
+// -- Infrastructure --
+import { Logger, type ILogObj } from 'tslog';
+
+// -- DB --
+import { DefaultSequelizeInstance } from '@citrineos/core';
+
+// -- RabbitMQ --
+import {
+  RabbitMQConnectionManager,
+  RabbitMQChannelManager,
+  RabbitMqSender,
+  RabbitMqReceiver,
+  BrokerAwareMessageSender,
+} from '@citrineos/core';
+
+// -- Repositories --
+import {
+  Component,
+  DrizzleSecurityEventRepository,
+  SequelizeRepository,
+  SequelizeAsyncJobStatusRepository,
+  SequelizeAuthorizationRepository,
+  SequelizeBootRepository,
+  SequelizeCertificateRepository,
+  SequelizeChangeConfigurationRepository,
+  SequelizeChargingProfileRepository,
+  SequelizeChargingStationSecurityInfoRepository,
+  SequelizeChargingStationSequenceRepository,
+  SequelizeDeleteCertificateAttemptRepository,
+  SequelizeDeviceModelRepository,
+  SequelizeInstallCertificateAttemptRepository,
+  SequelizeInstalledCertificateRepository,
+  SequelizeLocalAuthListRepository,
+  SequelizeLocationRepository,
+  SequelizeMessageInfoRepository,
+  SequelizeOCPPMessageRepository,
+  SequelizeReservationRepository,
+  SequelizeSecurityEventRepository,
+  SequelizeServerNetworkProfileRepository,
+  SequelizeSubscriptionRepository,
+  SequelizeTariffRepository,
+  SequelizeTenantRepository,
+  SequelizeTransactionEventRepository,
+  SequelizeVariableMonitoringRepository,
+} from '@citrineos/core';
+
+// -- Services --
+import {
+  CertificateAuthorityService,
+  InternalSmartCharging,
+  RealTimeAuthorizer,
+  IdGenerator,
+} from '@citrineos/core';
+
+// -- API authentication --
+import { LocalBypassAuthProvider, OIDCAuthProvider } from '@citrineos/core';
+import type { IApiAuthProvider } from '@citrineos/base';
+
+// -- Network Connection --
+import {
+  Authenticator,
+  UnknownStationFilter,
+  ConnectedStationFilter,
+  NetworkProfileFilter,
+  BasicAuthenticationFilter,
+  MessageRouterImpl,
+  WebsocketNetworkConnection,
+  WebhookDispatcher,
+  AdminApi,
+} from '@citrineos/core';
+
+// -- Modules --
+import {
+  CertificatesModule,
+  ConfigurationModule,
+  EVDriverModule,
+  MonitoringModule,
+  ReportingModule,
+  SmartChargingModule,
+  TransactionsModule,
+  TenantModule,
+} from '@citrineos/core';
+
+// -- Module-internal services (registered by each module package's own registrar) --
+import {
+  registerCertificatesServices,
+  registerConfigurationServices,
+  registerEVDriverServices,
+  registerMonitoringServices,
+  registerReportingServices,
+  registerTransactionsServices,
+} from '@citrineos/core';
+
+// -- Module APIs --
+import {
+  CertificatesOcpp2Api,
+  CertificatesDataApi,
+  ConfigurationOcpp2Api,
+  ConfigurationOcpp16Api,
+  ConfigurationDataApi,
+  EVDriverOcpp2Api,
+  EVDriverOcpp16Api,
+  EVDriverDataApi,
+  MonitoringOcpp2Api,
+  MonitoringDataApi,
+  ReportingOcpp2Api,
+  ReportingOcpp16Api,
+  SmartChargingOcpp2Api,
+  SmartChargingOcpp16Api,
+  TransactionsOcpp2Api,
+  TransactionsDataApi,
+  TenantDataApi,
+} from '@citrineos/core';
+
+type Prebuilt = {
+  logger: Logger<ILogObj>;
+  cache: ICache;
+  ocppValidator: OCPPValidator;
+  server: FastifyInstance;
+};
+
+/**
+ * Builds the application's Awilix container.
+ *
+ * Registration is split into per-layer registrar functions
+ *
+ * - System Config → registerPrimitives
+ * - DB           → registerPrimitives (sequelizeInstance)
+ * - RabbitMQ     → registerMessaging
+ * - Repositories → registerRepositories
+ * - Services     → registerServices (incl. apiAuthProvider) + registerModuleServices
+ *                  (each module package's own register<Module>Services) + registerNetwork (adminApi)
+ * - Modules      → registerModules + registerModuleApis
+ *
+ * Lifetime model:
+ * - asValue: shared constants / prebuilt instances.
+ * - singleton: one app-wide instance (repos, services, network stack, the router
+ *   and its dedicated routerSender/routerHandler, the broker connection/channel).
+ * - scoped: one-per-child-scope. Each module is resolved in its own scope (see
+ *   CitrineOSServer.initModuleInScope) together with its sender/handler and APIs,
+ *   so they share one instance per module without a singleton→transient leak.
+ */
+export function buildContainer(config: BootstrapConfig & SystemConfig, prebuilt: Prebuilt) {
+  const container = createContainer({
+    injectionMode: InjectionMode.PROXY,
+    strict: true,
+  });
+
+  registerPrimitives(container, config, prebuilt);
+  registerMessaging(container);
+  registerRepositories(container);
+  registerServices(container);
+  registerModuleServices(container);
+  registerNetwork(container);
+  registerModules(container);
+  registerModuleApis(container);
+
+  return container;
+}
+
+// ============================================================
+// Module-internal services in scope. Each module package owns the wiring of its
+// own services via a register<Module>Services(container) function; 
+// The service classes stay private to their packages. 
+// Resolved per-module-scope alongside the module itself.
+// ============================================================
+function registerModuleServices(container: AwilixContainer): void {
+  registerCertificatesServices(container);
+  registerConfigurationServices(container);
+  registerEVDriverServices(container);
+  registerMonitoringServices(container);
+  registerReportingServices(container);
+  registerTransactionsServices(container);
+}
+
+// ============================================================
+// Config, primitives & prebuilt infrastructure
+// Already-constructed scalars/instances passed straight through as values
+// ============================================================
+function registerPrimitives(
+  container: AwilixContainer,
+  config: BootstrapConfig & SystemConfig,
+  prebuilt: Prebuilt,
+): void {
+  const { logger, cache, ocppValidator, server } = prebuilt;
+
+  container.register({
+    config: asValue(config),
+    fileStorage: asValue(ConfigStoreFactory.getInstance()),
+    exchange: asValue(config.util.messageBroker.amqp!.exchange),
+    amqpUrl: asValue(config.util.messageBroker.amqp!.url),
+    maxCallLengthSeconds: asValue(config.maxCallLengthSeconds),
+    maxReconnectDelay: asValue(config.maxReconnectDelay),
+    // Consumed by CertificatesDataApi for certificate-chain generation.
+    websocketServersConfig: asValue(config.util.networkConnection.websocketServers),
+    logger: asValue(logger),
+    ocppValidator: asValue(ocppValidator),
+    cache: asValue(cache),
+    sequelizeInstance: asValue(DefaultSequelizeInstance.getInstance(config, logger)),
+    // The Fastify server is shared as a value — module APIs resolve it to register routes.
+    server: asValue(server),
+  });
+}
+
+// ============================================================
+// RabbitMQ messaging
+// sender + handler: each per-module child scope gets its own pair
+// routerSender + routerHandler: dedicated singleton pair for the singleton MessageRouterImpl. 
+// sender/routerSender are a BrokerAwareMessageSender wrapping a RabbitMqSender.
+// ============================================================
+function registerMessaging(container: AwilixContainer): void {
+  container.register({
+    connectionManager: asClass(RabbitMQConnectionManager).singleton(),
+    channelManager: asClass(RabbitMQChannelManager).singleton(),
+  });
+
+  // This is the message bus per module. Set to be scoped to each specific instance. 
+  container.register({
+    sender: asFunction(({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
+      new BrokerAwareMessageSender(
+        new RabbitMqSender(exchange, connectionManager, channelManager, logger),
+        connectionManager,
+        maxCallLengthSeconds,
+        logger,
+      )
+    ).scoped(),
+
+    handler: asFunction(({ config, channelManager, logger }) =>
+      new RabbitMqReceiver({ config, channelManager, logger })
+    ).scoped(),
+  });
+
+  // This is the routing messenger between the charging stations and the message bus
+  container.register({
+    routerSender: asFunction(({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
+      new BrokerAwareMessageSender(
+        new RabbitMqSender(exchange, connectionManager, channelManager, logger),
+        connectionManager,
+        maxCallLengthSeconds,
+        logger,
+      )
+    ).singleton(),
+    routerHandler: asFunction(({ config, channelManager, logger }) =>
+      new RabbitMqReceiver({ config, channelManager, logger })
+    ).singleton(),
+  });
+}
+
+// ============================================================
+// Repositories — all singletons, registered from @citrineos/core named exports.
+// Each class uses a proxy constructor
+// Drizzle security event overrides securityEventRepository.
+// ============================================================
+function registerRepositories(container: AwilixContainer): void {
+  container.register({
+    asyncJobStatusRepository: asClass(SequelizeAsyncJobStatusRepository).singleton(),
+    authorizationRepository: asClass(SequelizeAuthorizationRepository).singleton(),
+    bootRepository: asClass(SequelizeBootRepository).singleton(),
+    certificateRepository: asClass(SequelizeCertificateRepository).singleton(),
+    changeConfigurationRepository: asClass(SequelizeChangeConfigurationRepository).singleton(),
+    chargingProfileRepository: asClass(SequelizeChargingProfileRepository).singleton(),
+    chargingStationSecurityInfoRepository: asClass(SequelizeChargingStationSecurityInfoRepository).singleton(),
+    chargingStationSequenceRepository: asClass(SequelizeChargingStationSequenceRepository).singleton(),
+    deleteCertificateAttemptRepository: asClass(SequelizeDeleteCertificateAttemptRepository).singleton(),
+    deviceModelRepository: asClass(SequelizeDeviceModelRepository).singleton(),
+    installCertificateAttemptRepository: asClass(SequelizeInstallCertificateAttemptRepository).singleton(),
+    installedCertificateRepository: asClass(SequelizeInstalledCertificateRepository).singleton(),
+    localAuthListRepository: asClass(SequelizeLocalAuthListRepository).singleton(),
+    locationRepository: asClass(SequelizeLocationRepository).singleton(),
+    messageInfoRepository: asClass(SequelizeMessageInfoRepository).singleton(),
+    ocppMessageRepository: asClass(SequelizeOCPPMessageRepository).singleton(),
+    reservationRepository: asClass(SequelizeReservationRepository).singleton(),
+    securityEventRepository: asClass(SequelizeSecurityEventRepository).singleton(),
+    serverNetworkProfileRepository: asClass(SequelizeServerNetworkProfileRepository).singleton(),
+    subscriptionRepository: asClass(SequelizeSubscriptionRepository).singleton(),
+    tariffRepository: asClass(SequelizeTariffRepository).singleton(),
+    tenantRepository: asClass(SequelizeTenantRepository).singleton(),
+    transactionEventRepository: asClass(SequelizeTransactionEventRepository).singleton(),
+    variableMonitoringRepository: asClass(SequelizeVariableMonitoringRepository).singleton(),
+    componentRepository: asFunction(({ config, logger }) =>
+      new SequelizeRepository<Component>({ config, namespace: Component.MODEL_NAME, logger })
+    ).singleton(),
+  });
+
+  if (process.env.CITRINEOS_USE_DRIZZLE_SECURITY_EVENT === 'true') {
+    container.register({
+      securityEventRepository: asFunction(({ config, logger }) =>
+        new DrizzleSecurityEventRepository(config, logger)
+      ).singleton(),
+    });
+  }
+}
+
+// ============================================================
+// Services — all singletons; depend on repos and config.
+// authorizers: potential additional authorizers consumed by EVDriverModule and TransactionsModule.
+// apiAuthProvider: HTTP API auth — OIDC or local-bypass selected per config
+// ============================================================
+function registerServices(container: AwilixContainer): void {
+  container.register({
+    idGenerator: asClass(IdGenerator).singleton(),
+    certificateAuthorityService: asClass(CertificateAuthorityService).singleton(),
+    smartChargingService: asClass(InternalSmartCharging).singleton(),
+    realTimeAuthorizer: asClass(RealTimeAuthorizer).singleton(),
+    authorizers: asValue([]),
+    apiAuthProvider: asFunction(({ config, logger }): IApiAuthProvider => {
+      if (config.util.authProvider.oidc) {
+        return new OIDCAuthProvider(config.util.authProvider.oidc, logger);
+      }
+      if (config.util.authProvider.localByPass) {
+        return new LocalBypassAuthProvider(logger);
+      }
+      throw new Error('No valid API authentication provider configured');
+    }).singleton(),
+  });
+}
+
+// ============================================================
+// Network connection
+// ============================================================
+function registerNetwork(container: AwilixContainer): void {
+  container.register({
+    networkHook: asValue(async (_identifier: string, _message: string) => { }),
+
+    doesChargingStationExistByStationId: asFunction(({ locationRepository }) =>
+      (tenantId: number, ocppConnectionName: string): Promise<boolean> =>
+        locationRepository.doesChargingStationExistByStationId(tenantId, ocppConnectionName)
+    ).singleton(),
+    getMaxChargingStationsForTenant: asFunction(({ tenantRepository }) =>
+      async (tenantId: number): Promise<number | null> => {
+        const tenant = await tenantRepository.readByKey(tenantId, tenantId);
+        return tenant?.maxChargingStations ?? null;
+      }
+    ).singleton(),
+
+    unknownStationFilter: asClass(UnknownStationFilter).singleton(),
+    connectedStationFilter: asClass(ConnectedStationFilter).singleton(),
+    networkProfileFilter: asClass(NetworkProfileFilter).singleton(),
+    basicAuthenticationFilter: asClass(BasicAuthenticationFilter).singleton(),
+    authenticator: asClass(Authenticator).singleton(),
+    webhookDispatcher: asClass(WebhookDispatcher).singleton(),
+    router: asClass(MessageRouterImpl).singleton(),
+    networkConnection: asClass(WebsocketNetworkConnection).singleton(),
+    adminApi: asClass(AdminApi).singleton(),
+  });
+}
+
+// ============================================================
+// Modules — Resolved once per per-module child scope
+// ============================================================
+function registerModules(container: AwilixContainer): void {
+  container.register({
+    certificatesModule: asClass(CertificatesModule).scoped(),
+    configurationModule: asClass(ConfigurationModule).scoped(),
+    evDriverModule: asClass(EVDriverModule).scoped(),
+    monitoringModule: asClass(MonitoringModule).scoped(),
+    reportingModule: asClass(ReportingModule).scoped(),
+    smartChargingModule: asClass(SmartChargingModule).scoped(),
+    transactionsModule: asClass(TransactionsModule).scoped(),
+    tenantModule: asClass(TenantModule).scoped(),
+  });
+}
+
+// ============================================================
+// Module APIs — Resolved in the same per-module scope as their module
+// ============================================================
+function registerModuleApis(container: AwilixContainer): void {
+  container.register({
+    certificatesOcpp2Api: asClass(CertificatesOcpp2Api).scoped(),
+    certificatesDataApi: asClass(CertificatesDataApi).scoped(),
+    configurationOcpp2Api: asClass(ConfigurationOcpp2Api).scoped(),
+    configurationOcpp16Api: asClass(ConfigurationOcpp16Api).scoped(),
+    configurationDataApi: asClass(ConfigurationDataApi).scoped(),
+    evDriverOcpp2Api: asClass(EVDriverOcpp2Api).scoped(),
+    evDriverOcpp16Api: asClass(EVDriverOcpp16Api).scoped(),
+    evDriverDataApi: asClass(EVDriverDataApi).scoped(),
+    monitoringOcpp2Api: asClass(MonitoringOcpp2Api).scoped(),
+    monitoringDataApi: asClass(MonitoringDataApi).scoped(),
+    reportingOcpp2Api: asClass(ReportingOcpp2Api).scoped(),
+    reportingOcpp16Api: asClass(ReportingOcpp16Api).scoped(),
+    smartChargingOcpp2Api: asClass(SmartChargingOcpp2Api).scoped(),
+    smartChargingOcpp16Api: asClass(SmartChargingOcpp16Api).scoped(),
+    transactionsOcpp2Api: asClass(TransactionsOcpp2Api).scoped(),
+    transactionsDataApi: asClass(TransactionsDataApi).scoped(),
+    tenantDataApi: asClass(TenantDataApi).scoped(),
+  });
+}

--- a/apps/Server/src/container.ts
+++ b/apps/Server/src/container.ts
@@ -172,8 +172,8 @@ export function buildContainer(config: BootstrapConfig & SystemConfig, prebuilt:
 
 // ============================================================
 // Module-internal services in scope. Each module package owns the wiring of its
-// own services via a register<Module>Services(container) function; 
-// The service classes stay private to their packages. 
+// own services via a register<Module>Services(container) function;
+// The service classes stay private to their packages.
 // Resolved per-module-scope alongside the module itself.
 // ============================================================
 function registerModuleServices(container: AwilixContainer): void {
@@ -217,7 +217,7 @@ function registerPrimitives(
 // ============================================================
 // RabbitMQ messaging
 // sender + handler: each per-module child scope gets its own pair
-// routerSender + routerHandler: dedicated singleton pair for the singleton MessageRouterImpl. 
+// routerSender + routerHandler: dedicated singleton pair for the singleton MessageRouterImpl.
 // sender/routerSender are a BrokerAwareMessageSender wrapping a RabbitMqSender.
 // ============================================================
 function registerMessaging(container: AwilixContainer): void {
@@ -226,34 +226,38 @@ function registerMessaging(container: AwilixContainer): void {
     channelManager: asClass(RabbitMQChannelManager).singleton(),
   });
 
-  // This is the message bus per module. Set to be scoped to each specific instance. 
+  // This is the message bus per module. Set to be scoped to each specific instance.
   container.register({
-    sender: asFunction(({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
-      new BrokerAwareMessageSender(
-        new RabbitMqSender(exchange, connectionManager, channelManager, logger),
-        connectionManager,
-        maxCallLengthSeconds,
-        logger,
-      )
+    sender: asFunction(
+      ({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
+        new BrokerAwareMessageSender(
+          new RabbitMqSender(exchange, connectionManager, channelManager, logger),
+          connectionManager,
+          maxCallLengthSeconds,
+          logger,
+        ),
     ).scoped(),
 
-    handler: asFunction(({ config, channelManager, logger }) =>
-      new RabbitMqReceiver({ config, channelManager, logger })
+    handler: asFunction(
+      ({ config, channelManager, logger }) =>
+        new RabbitMqReceiver({ config, channelManager, logger }),
     ).scoped(),
   });
 
   // This is the routing messenger between the charging stations and the message bus
   container.register({
-    routerSender: asFunction(({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
-      new BrokerAwareMessageSender(
-        new RabbitMqSender(exchange, connectionManager, channelManager, logger),
-        connectionManager,
-        maxCallLengthSeconds,
-        logger,
-      )
+    routerSender: asFunction(
+      ({ exchange, connectionManager, channelManager, logger, maxCallLengthSeconds }) =>
+        new BrokerAwareMessageSender(
+          new RabbitMqSender(exchange, connectionManager, channelManager, logger),
+          connectionManager,
+          maxCallLengthSeconds,
+          logger,
+        ),
     ).singleton(),
-    routerHandler: asFunction(({ config, channelManager, logger }) =>
-      new RabbitMqReceiver({ config, channelManager, logger })
+    routerHandler: asFunction(
+      ({ config, channelManager, logger }) =>
+        new RabbitMqReceiver({ config, channelManager, logger }),
     ).singleton(),
   });
 }
@@ -271,11 +275,19 @@ function registerRepositories(container: AwilixContainer): void {
     certificateRepository: asClass(SequelizeCertificateRepository).singleton(),
     changeConfigurationRepository: asClass(SequelizeChangeConfigurationRepository).singleton(),
     chargingProfileRepository: asClass(SequelizeChargingProfileRepository).singleton(),
-    chargingStationSecurityInfoRepository: asClass(SequelizeChargingStationSecurityInfoRepository).singleton(),
-    chargingStationSequenceRepository: asClass(SequelizeChargingStationSequenceRepository).singleton(),
-    deleteCertificateAttemptRepository: asClass(SequelizeDeleteCertificateAttemptRepository).singleton(),
+    chargingStationSecurityInfoRepository: asClass(
+      SequelizeChargingStationSecurityInfoRepository,
+    ).singleton(),
+    chargingStationSequenceRepository: asClass(
+      SequelizeChargingStationSequenceRepository,
+    ).singleton(),
+    deleteCertificateAttemptRepository: asClass(
+      SequelizeDeleteCertificateAttemptRepository,
+    ).singleton(),
     deviceModelRepository: asClass(SequelizeDeviceModelRepository).singleton(),
-    installCertificateAttemptRepository: asClass(SequelizeInstallCertificateAttemptRepository).singleton(),
+    installCertificateAttemptRepository: asClass(
+      SequelizeInstallCertificateAttemptRepository,
+    ).singleton(),
     installedCertificateRepository: asClass(SequelizeInstalledCertificateRepository).singleton(),
     localAuthListRepository: asClass(SequelizeLocalAuthListRepository).singleton(),
     locationRepository: asClass(SequelizeLocationRepository).singleton(),
@@ -289,15 +301,16 @@ function registerRepositories(container: AwilixContainer): void {
     tenantRepository: asClass(SequelizeTenantRepository).singleton(),
     transactionEventRepository: asClass(SequelizeTransactionEventRepository).singleton(),
     variableMonitoringRepository: asClass(SequelizeVariableMonitoringRepository).singleton(),
-    componentRepository: asFunction(({ config, logger }) =>
-      new SequelizeRepository<Component>({ config, namespace: Component.MODEL_NAME, logger })
+    componentRepository: asFunction(
+      ({ config, logger }) =>
+        new SequelizeRepository<Component>({ config, namespace: Component.MODEL_NAME, logger }),
     ).singleton(),
   });
 
   if (process.env.CITRINEOS_USE_DRIZZLE_SECURITY_EVENT === 'true') {
     container.register({
-      securityEventRepository: asFunction(({ config, logger }) =>
-        new DrizzleSecurityEventRepository(config, logger)
+      securityEventRepository: asFunction(
+        ({ config, logger }) => new DrizzleSecurityEventRepository(config, logger),
       ).singleton(),
     });
   }
@@ -332,17 +345,19 @@ function registerServices(container: AwilixContainer): void {
 // ============================================================
 function registerNetwork(container: AwilixContainer): void {
   container.register({
-    networkHook: asValue(async (_identifier: string, _message: string) => { }),
+    networkHook: asValue(async (_identifier: string, _message: string) => {}),
 
-    doesChargingStationExistByStationId: asFunction(({ locationRepository }) =>
-      (tenantId: number, ocppConnectionName: string): Promise<boolean> =>
-        locationRepository.doesChargingStationExistByStationId(tenantId, ocppConnectionName)
+    doesChargingStationExistByStationId: asFunction(
+      ({ locationRepository }) =>
+        (tenantId: number, ocppConnectionName: string): Promise<boolean> =>
+          locationRepository.doesChargingStationExistByStationId(tenantId, ocppConnectionName),
     ).singleton(),
-    getMaxChargingStationsForTenant: asFunction(({ tenantRepository }) =>
-      async (tenantId: number): Promise<number | null> => {
-        const tenant = await tenantRepository.readByKey(tenantId, tenantId);
-        return tenant?.maxChargingStations ?? null;
-      }
+    getMaxChargingStationsForTenant: asFunction(
+      ({ tenantRepository }) =>
+        async (tenantId: number): Promise<number | null> => {
+          const tenant = await tenantRepository.readByKey(tenantId, tenantId);
+          return tenant?.maxChargingStations ?? null;
+        },
     ).singleton(),
 
     unknownStationFilter: asClass(UnknownStationFilter).singleton(),

--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -51,6 +51,7 @@ export type {
   IMessageSender,
 } from './src/interfaces/messages/index.js';
 export { AbstractModule } from './src/interfaces/modules/AbstractModule.js';
+export type { OcppModuleDependencies } from './src/interfaces/modules/AbstractModule.js';
 export { AsHandler } from './src/interfaces/modules/AsHandler.js';
 export type { IModule } from './src/interfaces/modules/Module.js';
 export { OCPPValidator } from './src/interfaces/modules/OCPPValidator.js';

--- a/packages/base/src/interfaces/api/AbstractModuleApi.ts
+++ b/packages/base/src/interfaces/api/AbstractModuleApi.ts
@@ -27,23 +27,31 @@ import { AuthorizationSecurity } from '@interfaces/api/AuthorizationSecurity.js'
 import { z } from 'zod';
 
 /**
+ * Canonical signature every OCPP message-endpoint handler is invoked with by
+ * {@link AbstractModuleApi._addMessageRoute}. 
+ */
+export type OcppMessageHandler = (
+  identifiers: string[],
+  // Fastify surfaces the parsed body as `unknown` at this boundary; each handler
+  // re-types it to its specific OCPP request type.
+  request: unknown,
+  callbackUrl: string | undefined,
+  tenantId: number,
+  version: OCPPVersion | null,
+  extraQueries?: Record<string, unknown>,
+) => Promise<IMessageConfirmation[]>;
+
+/**
  * Abstract module api class implementation.
  */
 export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi {
   protected readonly _server: FastifyInstance;
   protected readonly _module: T;
   protected readonly _logger: Logger<ILogObj>;
-  protected readonly _ocppVersion: OCPPVersion | null;
 
-  constructor(
-    module: T,
-    server: FastifyInstance,
-    ocppVersion: OCPPVersion | null,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor(module: T, server: FastifyInstance, logger?: Logger<ILogObj>) {
     this._module = module;
     this._server = server;
-    this._ocppVersion = ocppVersion;
 
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
@@ -52,25 +60,47 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
   }
 
   /**
+   * The OCPP versions this API serves. Each message endpoint is registered once
+   * per version, with the version threaded through schema selection, the route
+   * path, and the request handler — so one API instance can serve several
+   * versions (e.g. 2.0.1 and 2.1) from distinct `/ocpp/<version>/...` routes.
+   *
+   * Defaults to [null], version-agnostic. Data-only APIs, whose routes
+   * carry no version segment. 
+   * OCPP message APIs override this: 
+   * OCPP2 APIs return [OCPP2_0_1, OCPP2_1], OCPP 1.6 APIs return [OCPP1_6].
+   */
+  protected get supportedVersions(): (OCPPVersion | null)[] {
+    return [null];
+  }
+
+  /**
    * Initializes the API for the given module.
    *
    * @param {T} module - The module to initialize the API for.
    */
   protected _init(module: T): void {
-    (
-      Reflect.getMetadata(
-        METADATA_MESSAGE_ENDPOINTS,
-        this.constructor,
-      ) as Array<IMessageEndpointDefinition>
-    )?.forEach((expose) => {
-      this._addMessageRoute.call(
-        this,
-        expose.action,
-        expose.method,
-        typeof expose.bodySchema === 'function' ? expose.bodySchema(this) : expose.bodySchema,
-        expose.optionalQuerystrings,
-      );
-    });
+    const messageEndpointDefinitions = Reflect.getMetadata(
+      METADATA_MESSAGE_ENDPOINTS,
+      this.constructor,
+    ) as Array<IMessageEndpointDefinition>;
+
+    // Register each message endpoint once per supported version. The version is
+    // passed to the schema getter, the path builder, and the handler closure.
+    for (const version of this.supportedVersions) {
+      messageEndpointDefinitions?.forEach((expose) => {
+        this._addMessageRoute.call(
+          this,
+          expose.action,
+          expose.method,
+          typeof expose.bodySchema === 'function'
+            ? expose.bodySchema(this, version)
+            : expose.bodySchema,
+          expose.optionalQuerystrings,
+          version,
+        );
+      });
+    }
 
     const dataEndpointDefinitions = Reflect.getMetadata(
       METADATA_DATA_ENDPOINTS,
@@ -109,17 +139,21 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
    */
   protected _addMessageRoute(
     action: CallAction,
-    method: (...args: any[]) => any,
+    method: OcppMessageHandler,
     bodySchema: object,
     optionalQuerystrings?: Record<string, any>,
+    version: OCPPVersion | null = null,
   ): void {
     if (!bodySchema) {
       this._logger.debug(
-        `Skipping message route for ${action} — schema not available for ${this._ocppVersion}`,
+        `Skipping message route for ${action} — schema not available for ${version}`,
       );
       return;
     }
-    this._logger.debug(`Adding message route for ${action}`, this._toMessagePath(action));
+    this._logger.debug(
+      `Adding message route for ${action}`,
+      this._toMessagePath(action, version),
+    );
 
     /**
      * Executes the handler function for the given request.
@@ -143,6 +177,7 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
         request.body,
         callbackUrl,
         tenantId,
+        version,
         Object.keys(extraQueries).length > 0 ? extraQueries : undefined,
       );
     };
@@ -157,7 +192,7 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
 
     const _opts: any = {
       method: HttpMethod.Post,
-      url: this._toMessagePath(action),
+      url: this._toMessagePath(action, version),
       handler: _handler,
       schema: {
         body: bodySchema,
@@ -174,7 +209,7 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
 
     if (this._module.config.util.swagger?.exposeMessage) {
       this._server.register(async (fastifyInstance) => {
-        this.registerSchemaForOpts(fastifyInstance, _opts);
+        this.registerSchemaForOpts(fastifyInstance, _opts, version);
         fastifyInstance.route(_opts);
       });
     } else {
@@ -298,7 +333,11 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
     }
   }
 
-  private registerSchemaForOpts = (fastifyInstance: FastifyInstance, _opts: any) => {
+  private registerSchemaForOpts = (
+    fastifyInstance: FastifyInstance,
+    _opts: any,
+    version: OCPPVersion | null = null,
+  ) => {
     if (_opts.schema['querystring']) {
       _opts.schema['querystring'] = this.registerSchema(
         fastifyInstance,
@@ -309,7 +348,7 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
       _opts.schema['body'] = this.registerSchema(
         fastifyInstance,
         _opts.schema['body'],
-        this._ocppVersion ? `${this._ocppVersion}-` : '',
+        version ? `${version}-` : '',
       );
     }
     if (_opts.schema['params']) {
@@ -462,12 +501,10 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
    * @param {string} prefix - The module name.
    * @returns {string} - String representation of URL path.
    */
-  protected _toMessagePath(input: CallAction, prefix?: string): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null, prefix?: string): string {
     const endpointPrefix = prefix || '';
-    const endpointVersion = (this._ocppVersion ? this._ocppVersion : OCPPVersion.OCPP2_0_1).replace(
-      /^ocpp/,
-      '',
-    );
+    const effectiveVersion = version ?? OCPPVersion.OCPP2_0_1;
+    const endpointVersion = effectiveVersion.replace(/^ocpp/, '');
     return `/ocpp/${endpointVersion}${!endpointPrefix.startsWith('/') ? '/' : ''}${endpointPrefix}${!endpointPrefix.endsWith('/') ? '/' : ''}${input.charAt(0).toLowerCase() + input.slice(1)}`;
   }
 

--- a/packages/base/src/interfaces/api/AbstractModuleApi.ts
+++ b/packages/base/src/interfaces/api/AbstractModuleApi.ts
@@ -28,7 +28,7 @@ import { z } from 'zod';
 
 /**
  * Canonical signature every OCPP message-endpoint handler is invoked with by
- * {@link AbstractModuleApi._addMessageRoute}. 
+ * {@link AbstractModuleApi._addMessageRoute}.
  */
 export type OcppMessageHandler = (
   identifiers: string[],
@@ -66,8 +66,8 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
    * versions (e.g. 2.0.1 and 2.1) from distinct `/ocpp/<version>/...` routes.
    *
    * Defaults to [null], version-agnostic. Data-only APIs, whose routes
-   * carry no version segment. 
-   * OCPP message APIs override this: 
+   * carry no version segment.
+   * OCPP message APIs override this:
    * OCPP2 APIs return [OCPP2_0_1, OCPP2_1], OCPP 1.6 APIs return [OCPP1_6].
    */
   protected get supportedVersions(): (OCPPVersion | null)[] {
@@ -150,10 +150,7 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
       );
       return;
     }
-    this._logger.debug(
-      `Adding message route for ${action}`,
-      this._toMessagePath(action, version),
-    );
+    this._logger.debug(`Adding message route for ${action}`, this._toMessagePath(action, version));
 
     /**
      * Executes the handler function for the given request.
@@ -501,7 +498,11 @@ export abstract class AbstractModuleApi<T extends IModule> implements IModuleApi
    * @param {string} prefix - The module name.
    * @returns {string} - String representation of URL path.
    */
-  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null, prefix?: string): string {
+  protected _toMessagePath(
+    input: CallAction,
+    version?: OCPPVersion | null,
+    prefix?: string,
+  ): string {
     const endpointPrefix = prefix || '';
     const effectiveVersion = version ?? OCPPVersion.OCPP2_0_1;
     const endpointVersion = effectiveVersion.replace(/^ocpp/, '');

--- a/packages/base/src/interfaces/api/AsMessageEndpoint.ts
+++ b/packages/base/src/interfaces/api/AsMessageEndpoint.ts
@@ -4,7 +4,7 @@
 
 import type { IMessageEndpointDefinition } from '@interfaces/api/MessageEndpointDefinition.js';
 import { METADATA_MESSAGE_ENDPOINTS } from '@interfaces/api/metadata.js';
-import type { CallAction } from '@ocpp/rpc/message.js';
+import type { CallAction, OCPPVersion } from '@ocpp/rpc/message.js';
 
 /**
  * Decorator for use in module API class to expose methods as REST OCPP message endpoints.
@@ -16,7 +16,7 @@ import type { CallAction } from '@ocpp/rpc/message.js';
  */
 export const AsMessageEndpoint = function (
   action: CallAction,
-  bodySchema: object | ((instance: any) => object),
+  bodySchema: object | ((instance: any, version: OCPPVersion | null) => object),
   optionalQuerystrings?: Record<string, any>,
 ) {
   return (target: any, propertyKey: string, descriptor: PropertyDescriptor): void => {

--- a/packages/base/src/interfaces/api/MessageEndpointDefinition.ts
+++ b/packages/base/src/interfaces/api/MessageEndpointDefinition.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { CallAction } from '@ocpp/rpc/message.js';
+import type { CallAction, OCPPVersion } from '@ocpp/rpc/message.js';
 
 /**
  * Interface for usage in {@link AsMessageEndpoint} decorator.
@@ -11,6 +11,8 @@ export interface IMessageEndpointDefinition {
   action: CallAction;
   method: (...args: any[]) => any;
   methodName: string;
-  bodySchema: object | ((instance: any) => object);
+  // The schema getter receives the OCPP version the route is being registered for, 
+  // so a single API instance can resolve version-specific schemas.
+  bodySchema: object | ((instance: any, version: OCPPVersion | null) => object);
   optionalQuerystrings?: Record<string, any>;
 }

--- a/packages/base/src/interfaces/api/MessageEndpointDefinition.ts
+++ b/packages/base/src/interfaces/api/MessageEndpointDefinition.ts
@@ -11,7 +11,7 @@ export interface IMessageEndpointDefinition {
   action: CallAction;
   method: (...args: any[]) => any;
   methodName: string;
-  // The schema getter receives the OCPP version the route is being registered for, 
+  // The schema getter receives the OCPP version the route is being registered for,
   // so a single API instance can resolve version-specific schemas.
   bodySchema: object | ((instance: any, version: OCPPVersion | null) => object);
   optionalQuerystrings?: Record<string, any>;

--- a/packages/base/src/interfaces/modules/AbstractModule.ts
+++ b/packages/base/src/interfaces/modules/AbstractModule.ts
@@ -6,6 +6,7 @@ import 'reflect-metadata';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { v4 as uuidv4 } from 'uuid';
+import type { BootstrapConfig } from '@config/bootstrap.config.js';
 import type { SystemConfig } from '@config/types.js';
 import type { OcppRequest, OcppResponse } from '@ocpp/internal-types.js';
 import type { CallAction, OCPPVersionType } from '@ocpp/rpc/message.js';
@@ -26,6 +27,19 @@ import type { IModule } from '@interfaces/modules/Module.js';
 import type { IHandlerDefinition } from '@interfaces/modules/HandlerDefinition.js';
 import { AS_HANDLER_METADATA } from '@interfaces/modules/AsHandler.js';
 import { OCPPValidator } from './OCPPValidator.js';
+
+/**
+ * The dependencies every OCPP module receives through the container. Each concrete
+ * module extends this with its own repositories and internal services.
+ */
+export interface OcppModuleDependencies {
+  config: BootstrapConfig & SystemConfig;
+  cache: ICache;
+  sender: IMessageSender;
+  handler: IMessageHandler;
+  logger: Logger<ILogObj>;
+  ocppValidator: OCPPValidator;
+}
 
 export abstract class AbstractModule implements IModule {
   public static readonly CALLBACK_URL_CACHE_PREFIX: string = 'CALLBACK_URL_';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
     "ws": "^8.17.0"
   },
   "devDependencies": {
+    "awilix": "^13.0.3",
     "@eslint/js": "catalog:",
     "@faker-js/faker": "^8.0.0",
     "@types/amqplib": "0.10.4",

--- a/packages/core/src/dal/index.ts
+++ b/packages/core/src/dal/index.ts
@@ -80,8 +80,9 @@ export {
   SequelizeTenantRepository,
   SequelizeAsyncJobStatusRepository,
   SequelizeServerNetworkProfileRepository,
+  SequelizeLocalAuthListRepository,
   OCPP2_0_1_Mapper,
   OCPP1_6_Mapper,
 } from './layers/sequelize/index.js'; // TODO ensure all needed modules are properly exported
 export { RepositoryStore } from './layers/sequelize/repository/RepositoryStore.js';
-export { DefaultDrizzleInstance } from './layers/drizzle/index.js';
+export { DefaultDrizzleInstance, DrizzleSecurityEventRepository } from './layers/drizzle/index.js';

--- a/packages/core/src/dal/layers/sequelize/repository/AsyncJobStatus.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/AsyncJobStatus.ts
@@ -2,17 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { FindOptions } from 'sequelize';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { AsyncJobStatus } from '../model/AsyncJob/AsyncJobStatus.js';
 
 export class SequelizeAsyncJobStatusRepository extends SequelizeRepository<AsyncJobStatus> {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, AsyncJobStatus.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: AsyncJobStatus.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async createAsyncJobStatus(asyncJobStatus: AsyncJobStatus): Promise<AsyncJobStatus> {
@@ -57,3 +53,5 @@ export class SequelizeAsyncJobStatusRepository extends SequelizeRepository<Async
     return await this._deleteByKey(0, jobId);
   }
 }
+
+export default SequelizeAsyncJobStatusRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
@@ -2,21 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { type IAuthorizationRepository } from '../../../interfaces/repositories.js';
 import { type AuthorizationQuerystring } from '../../../interfaces/queries/Authorization.js';
 import { Authorization } from '../model/Authorization/Authorization.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeAuthorizationRepository
   extends SequelizeRepository<Authorization>
   implements IAuthorizationRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, Authorization.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Authorization.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async readAllByQuerystring(
@@ -52,3 +48,5 @@ export class SequelizeAuthorizationRepository
     };
   }
 }
+
+export default SequelizeAuthorizationRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Base.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Base.ts
@@ -16,17 +16,27 @@ import { type Model, type Sequelize } from 'sequelize-typescript';
 import { type ILogObj, Logger } from 'tslog';
 import { DefaultSequelizeInstance } from '../util.js';
 
+/**
+ * Dependencies every Sequelize repository takes. `logger` and `sequelizeInstance`
+ * are optional — the base falls back to a default logger and the shared instance.
+ */
+export interface SequelizeRepositoryDependencies {
+  config: BootstrapConfig;
+  logger?: Logger<ILogObj>;
+  sequelizeInstance?: Sequelize;
+}
+
 export class SequelizeRepository<T extends Model<any, any>> extends CrudRepository<T> {
   protected s: Sequelize;
   protected namespace: string;
   protected logger: Logger<ILogObj>;
 
-  constructor(
-    config: BootstrapConfig,
-    namespace: string,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-  ) {
+  constructor({
+    config,
+    namespace,
+    logger,
+    sequelizeInstance,
+  }: SequelizeRepositoryDependencies & { namespace: string }) {
     super();
     this.s = sequelizeInstance ?? DefaultSequelizeInstance.getInstance(config, logger);
     this.namespace = namespace;

--- a/packages/core/src/dal/layers/sequelize/repository/Boot.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Boot.ts
@@ -1,39 +1,24 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type {
-  BootConfig,
-  BootstrapConfig,
-  OCPP2_common_types,
-  RegistrationStatusEnumType,
-} from '@citrineos/base';
+import type { BootConfig, OCPP2_common_types, RegistrationStatusEnumType } from '@citrineos/base';
 import { CrudRepository } from '@citrineos/base';
 import type { IBootRepository } from '../../../interfaces/repositories.js';
 import { Boot } from '../model/Boot.js';
 import { VariableAttribute } from '../model/DeviceModel/VariableAttribute.js';
-import { SequelizeRepository } from './Base.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { Sequelize } from 'sequelize-typescript';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeBootRepository extends SequelizeRepository<Boot> implements IBootRepository {
   variableAttributes: CrudRepository<VariableAttribute>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    variableAttributes?: CrudRepository<VariableAttribute>,
-  ) {
-    super(config, Boot.MODEL_NAME, logger, sequelizeInstance);
-    this.variableAttributes = variableAttributes
-      ? variableAttributes
-      : new SequelizeRepository<VariableAttribute>(
-          config,
-          VariableAttribute.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Boot.MODEL_NAME, logger, sequelizeInstance });
+    this.variableAttributes = new SequelizeRepository<VariableAttribute>({
+      config,
+      namespace: VariableAttribute.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async createOrUpdateByKey(
@@ -137,3 +122,5 @@ export class SequelizeBootRepository extends SequelizeRepository<Boot> implement
     return managedSetVariables;
   }
 }
+
+export default SequelizeBootRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Certificate.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Certificate.ts
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { ICertificateRepository } from '../../../interfaces/repositories.js';
 import { Certificate } from '../model/Certificate/Certificate.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeCertificateRepository
   extends SequelizeRepository<Certificate>
   implements ICertificateRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, Certificate.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Certificate.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async createOrUpdateCertificate(
@@ -49,3 +45,5 @@ export class SequelizeCertificateRepository
     });
   }
 }
+
+export default SequelizeCertificateRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/ChangeConfiguration.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ChangeConfiguration.ts
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BootstrapConfig } from '@citrineos/base';
 import type { IChangeConfigurationRepository } from '../../../interfaces/repositories.js';
 import { ChangeConfiguration } from '../model/ChangeConfiguration.js';
-import { SequelizeRepository } from './Base.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { Sequelize } from 'sequelize-typescript';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeChangeConfigurationRepository
   extends SequelizeRepository<ChangeConfiguration>
   implements IChangeConfigurationRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, ChangeConfiguration.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: ChangeConfiguration.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async createOrUpdateChangeConfiguration(
@@ -49,3 +45,5 @@ export class SequelizeChangeConfigurationRepository
     return changeConfiguration;
   }
 }
+
+export default SequelizeChangeConfigurationRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/ChargingProfile.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ChargingProfile.ts
@@ -2,13 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-  BootstrapConfig,
-  ChargingLimitSourceEnumType,
-  ChargingProfilePurposeEnumType,
-} from '@citrineos/base';
+import type { ChargingLimitSourceEnumType, ChargingProfilePurposeEnumType } from '@citrineos/base';
 import { ChargingLimitSourceEnum, CrudRepository, OCPP2_0_1 } from '@citrineos/base';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { IChargingProfileRepository } from '../../../interfaces/repositories.js';
 import type {
   ChargingProfileInput,
@@ -22,9 +18,6 @@ import { SalesTariff } from '../model/ChargingProfile/SalesTariff.js';
 import { Evse } from '../model/Location/Evse.js';
 import { EvseType } from '../model/DeviceModel/EvseType.js';
 import { Transaction } from '../model/TransactionEvent/Transaction.js';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeChargingProfileRepository
   extends SequelizeRepository<ChargingProfile>
@@ -37,61 +30,44 @@ export class SequelizeChargingProfileRepository
   evse: CrudRepository<EvseType>;
   compositeSchedule: CrudRepository<CompositeSchedule>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    chargingNeeds?: CrudRepository<ChargingNeeds>,
-    chargingSchedule?: CrudRepository<ChargingSchedule>,
-    salesTariff?: CrudRepository<SalesTariff>,
-    transaction?: CrudRepository<Transaction>,
-    evse?: CrudRepository<EvseType>,
-    compositeSchedule?: CrudRepository<CompositeSchedule>,
-  ) {
-    super(config, ChargingProfile.MODEL_NAME, logger, sequelizeInstance);
-    this.chargingNeeds = chargingNeeds
-      ? chargingNeeds
-      : new SequelizeRepository<ChargingNeeds>(
-          config,
-          ChargingNeeds.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.chargingSchedule = chargingSchedule
-      ? chargingSchedule
-      : new SequelizeRepository<ChargingSchedule>(
-          config,
-          ChargingSchedule.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.evse = evse
-      ? evse
-      : new SequelizeRepository<EvseType>(config, EvseType.MODEL_NAME, logger, sequelizeInstance);
-    this.salesTariff = salesTariff
-      ? salesTariff
-      : new SequelizeRepository<SalesTariff>(
-          config,
-          SalesTariff.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.transaction = transaction
-      ? transaction
-      : new SequelizeRepository<Transaction>(
-          config,
-          Transaction.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.compositeSchedule = compositeSchedule
-      ? compositeSchedule
-      : new SequelizeRepository<CompositeSchedule>(
-          config,
-          CompositeSchedule.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: ChargingProfile.MODEL_NAME, logger, sequelizeInstance });
+    this.chargingNeeds = new SequelizeRepository<ChargingNeeds>({
+      config,
+      namespace: ChargingNeeds.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.chargingSchedule = new SequelizeRepository<ChargingSchedule>({
+      config,
+      namespace: ChargingSchedule.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.evse = new SequelizeRepository<EvseType>({
+      config,
+      namespace: EvseType.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.salesTariff = new SequelizeRepository<SalesTariff>({
+      config,
+      namespace: SalesTariff.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.transaction = new SequelizeRepository<Transaction>({
+      config,
+      namespace: Transaction.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.compositeSchedule = new SequelizeRepository<CompositeSchedule>({
+      config,
+      namespace: CompositeSchedule.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async createOrUpdateChargingProfile(
@@ -278,3 +254,5 @@ export class SequelizeChargingProfileRepository
     );
   }
 }
+
+export default SequelizeChargingProfileRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/ChargingStationSecurityInfo.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ChargingStationSecurityInfo.ts
@@ -1,20 +1,16 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { ChargingStationSecurityInfo } from '../model/ChargingStationSecurityInfo.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { Sequelize } from 'sequelize-typescript';
-import type { BootstrapConfig } from '@citrineos/base';
 import type { IChargingStationSecurityInfoRepository } from '../../../interfaces/repositories.js';
 
 export class SequelizeChargingStationSecurityInfoRepository
   extends SequelizeRepository<ChargingStationSecurityInfo>
   implements IChargingStationSecurityInfoRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, ChargingStationSecurityInfo.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: ChargingStationSecurityInfo.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async readChargingStationPublicKeyFileId(
@@ -43,3 +39,5 @@ export class SequelizeChargingStationSecurityInfoRepository
     });
   }
 }
+
+export default SequelizeChargingStationSecurityInfoRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/ChargingStationSequence.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ChargingStationSequence.ts
@@ -1,13 +1,10 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig, ChargingStationSequenceTypeEnumType } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
+import type { ChargingStationSequenceTypeEnumType } from '@citrineos/base';
 import type { IChargingStationSequenceRepository } from '../../../interfaces/repositories.js';
 import { ChargingStationSequence } from '../model/ChargingStationSequence/ChargingStationSequence.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeChargingStationSequenceRepository
   extends SequelizeRepository<ChargingStationSequence>
@@ -15,8 +12,8 @@ export class SequelizeChargingStationSequenceRepository
 {
   private static readonly SEQUENCE_START = 1;
 
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, ChargingStationSequence.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: ChargingStationSequence.MODEL_NAME, logger, sequelizeInstance });
   }
 
   /**
@@ -68,3 +65,5 @@ export class SequelizeChargingStationSequenceRepository
     });
   }
 }
+
+export default SequelizeChargingStationSequenceRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/DeleteCertificateAttempt.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/DeleteCertificateAttempt.ts
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { DeleteCertificateAttempt } from '../model/Certificate/DeleteCertificateAttempt.js';
 import type { IDeleteCertificateAttemptRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
 
 export class SequelizeDeleteCertificateAttemptRepository
   extends SequelizeRepository<DeleteCertificateAttempt>
   implements IDeleteCertificateAttemptRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, DeleteCertificateAttempt.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: DeleteCertificateAttempt.MODEL_NAME, logger, sequelizeInstance });
   }
 }
+
+export default SequelizeDeleteCertificateAttemptRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
@@ -1,12 +1,8 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig } from '@citrineos/base';
 import { CrudRepository, OCPP2_0_1 } from '@citrineos/base';
 import { Op } from 'sequelize';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { type VariableAttributeQuerystring } from '../../../interfaces/queries/VariableAttribute.js';
 import { type IDeviceModelRepository } from '../../../interfaces/repositories.js';
 import { Component } from '../model/DeviceModel/Component.js';
@@ -16,7 +12,7 @@ import { Variable } from '../model/DeviceModel/Variable.js';
 import { VariableAttribute } from '../model/DeviceModel/VariableAttribute.js';
 import { VariableCharacteristics } from '../model/DeviceModel/VariableCharacteristics.js';
 import { VariableStatus } from '../model/DeviceModel/VariableStatus.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 // TODO: Document this
 
@@ -31,51 +27,44 @@ export class SequelizeDeviceModelRepository
   componentVariable: CrudRepository<ComponentVariable>;
   variableStatus: CrudRepository<VariableStatus>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    variable?: CrudRepository<Variable>,
-    component?: CrudRepository<Component>,
-    evse?: CrudRepository<EvseType>,
-    componentVariable?: CrudRepository<ComponentVariable>,
-    variableCharacteristics?: CrudRepository<VariableCharacteristics>,
-    variableStatus?: CrudRepository<VariableStatus>,
-  ) {
-    super(config, VariableAttribute.MODEL_NAME, logger, sequelizeInstance);
-    this.variable = variable
-      ? variable
-      : new SequelizeRepository<Variable>(config, Variable.MODEL_NAME, logger, sequelizeInstance);
-    this.component = component
-      ? component
-      : new SequelizeRepository<Component>(config, Component.MODEL_NAME, logger, sequelizeInstance);
-    this.evse = evse
-      ? evse
-      : new SequelizeRepository<EvseType>(config, EvseType.MODEL_NAME, logger, sequelizeInstance);
-    this.componentVariable = componentVariable
-      ? componentVariable
-      : new SequelizeRepository<ComponentVariable>(
-          config,
-          ComponentVariable.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.variableCharacteristics = variableCharacteristics
-      ? variableCharacteristics
-      : new SequelizeRepository<VariableCharacteristics>(
-          config,
-          VariableCharacteristics.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.variableStatus = variableStatus
-      ? variableStatus
-      : new SequelizeRepository<VariableStatus>(
-          config,
-          VariableStatus.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: VariableAttribute.MODEL_NAME, logger, sequelizeInstance });
+    this.variable = new SequelizeRepository<Variable>({
+      config,
+      namespace: Variable.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.component = new SequelizeRepository<Component>({
+      config,
+      namespace: Component.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.evse = new SequelizeRepository<EvseType>({
+      config,
+      namespace: EvseType.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.componentVariable = new SequelizeRepository<ComponentVariable>({
+      config,
+      namespace: ComponentVariable.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.variableCharacteristics = new SequelizeRepository<VariableCharacteristics>({
+      config,
+      namespace: VariableCharacteristics.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.variableStatus = new SequelizeRepository<VariableStatus>({
+      config,
+      namespace: VariableStatus.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async createOrUpdateDeviceModelByStationId(
@@ -633,3 +622,5 @@ export class SequelizeDeviceModelRepository
     };
   }
 }
+
+export default SequelizeDeviceModelRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/InstallCertificateAttempt.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/InstallCertificateAttempt.ts
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { IInstallCertificateAttemptRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { InstallCertificateAttempt } from '../model/Certificate/InstallCertificateAttempt.js';
 
 export class SequelizeInstallCertificateAttemptRepository
   extends SequelizeRepository<InstallCertificateAttempt>
   implements IInstallCertificateAttemptRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, InstallCertificateAttempt.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: InstallCertificateAttempt.MODEL_NAME, logger, sequelizeInstance });
   }
 }
+
+export default SequelizeInstallCertificateAttemptRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/InstalledCertificate.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/InstalledCertificate.ts
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { IInstalledCertificateRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { InstalledCertificate } from '../model/Certificate/InstalledCertificate.js';
 
 export class SequelizeInstalledCertificateRepository
   extends SequelizeRepository<InstalledCertificate>
   implements IInstalledCertificateRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, InstalledCertificate.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: InstalledCertificate.MODEL_NAME, logger, sequelizeInstance });
   }
 }
+
+export default SequelizeInstalledCertificateRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
@@ -1,11 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig } from '@citrineos/base';
 import { CrudRepository, OCPP2_0_1 } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import type {
   IAuthorizationRepository,
   ILocalAuthListRepository,
@@ -18,7 +14,7 @@ import { LocalListVersionAuthorization } from '../model/Authorization/LocalListV
 import { SendLocalList } from '../model/Authorization/SendLocalList.js';
 import { SendLocalListAuthorization } from '../model/Authorization/SendLocalListAuthorization.js';
 import { SequelizeAuthorizationRepository } from './Authorization.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeLocalAuthListRepository
   extends SequelizeRepository<LocalListVersion>
@@ -28,34 +24,25 @@ export class SequelizeLocalAuthListRepository
   localListAuthorization: CrudRepository<LocalListAuthorization>;
   sendLocalList: CrudRepository<SendLocalList>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    authorization?: IAuthorizationRepository,
-    localListAuthorization?: CrudRepository<LocalListAuthorization>,
-    sendLocalList?: CrudRepository<SendLocalList>,
-  ) {
-    super(config, Authorization.MODEL_NAME, logger, sequelizeInstance);
-    this.authorization = authorization
-      ? authorization
-      : new SequelizeAuthorizationRepository(config, logger);
-    this.localListAuthorization = localListAuthorization
-      ? localListAuthorization
-      : new SequelizeRepository<LocalListAuthorization>(
-          config,
-          LocalListAuthorization.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.sendLocalList = sendLocalList
-      ? sendLocalList
-      : new SequelizeRepository<SendLocalList>(
-          config,
-          SendLocalList.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Authorization.MODEL_NAME, logger, sequelizeInstance });
+    this.authorization = new SequelizeAuthorizationRepository({
+      config,
+      logger,
+      sequelizeInstance,
+    });
+    this.localListAuthorization = new SequelizeRepository<LocalListAuthorization>({
+      config,
+      namespace: LocalListAuthorization.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.sendLocalList = new SequelizeRepository<SendLocalList>({
+      config,
+      namespace: SendLocalList.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async createSendLocalListFromRequestData(
@@ -324,3 +311,5 @@ export class SequelizeLocalAuthListRepository
     return localListVersion;
   }
 }
+
+export default SequelizeLocalAuthListRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -2,12 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BootstrapConfig, ChargingStationDto, OCPP2_0_1 } from '@citrineos/base';
+import type { ChargingStationDto, OCPP2_0_1 } from '@citrineos/base';
 import { CrudRepository, OCPPVersion } from '@citrineos/base';
 import { Op } from 'sequelize';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { type ILocationRepository } from '../../../interfaces/repositories.js';
 import { EvseType } from '../model/DeviceModel/EvseType.js';
 import { ChargingStation } from '../model/Location/ChargingStation.js';
@@ -16,7 +13,7 @@ import { Evse } from '../model/Location/Evse.js';
 import { LatestStatusNotification } from '../model/Location/LatestStatusNotification.js';
 import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeLocationRepository
   extends SequelizeRepository<Location>
@@ -27,43 +24,32 @@ export class SequelizeLocationRepository
   latestStatusNotification: CrudRepository<LatestStatusNotification>;
   connector: CrudRepository<Connector>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    chargingStation?: CrudRepository<ChargingStation>,
-    statusNotification?: CrudRepository<StatusNotification>,
-    latestStatusNotification?: CrudRepository<LatestStatusNotification>,
-    connector?: CrudRepository<Connector>,
-  ) {
-    super(config, Location.MODEL_NAME, logger, sequelizeInstance);
-    this.chargingStation = chargingStation
-      ? chargingStation
-      : new SequelizeRepository<ChargingStation>(
-          config,
-          ChargingStation.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.statusNotification = statusNotification
-      ? statusNotification
-      : new SequelizeRepository<StatusNotification>(
-          config,
-          StatusNotification.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.latestStatusNotification = latestStatusNotification
-      ? latestStatusNotification
-      : new SequelizeRepository<LatestStatusNotification>(
-          config,
-          LatestStatusNotification.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.connector = connector
-      ? connector
-      : new SequelizeRepository<Connector>(config, Connector.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Location.MODEL_NAME, logger, sequelizeInstance });
+    this.chargingStation = new SequelizeRepository<ChargingStation>({
+      config,
+      namespace: ChargingStation.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.statusNotification = new SequelizeRepository<StatusNotification>({
+      config,
+      namespace: StatusNotification.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.latestStatusNotification = new SequelizeRepository<LatestStatusNotification>({
+      config,
+      namespace: LatestStatusNotification.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.connector = new SequelizeRepository<Connector>({
+      config,
+      namespace: Connector.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async readLocationById(tenantId: number, id: number): Promise<Location | undefined> {
@@ -433,3 +419,5 @@ export class SequelizeLocationRepository
     );
   }
 }
+
+export default SequelizeLocationRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/MessageInfo.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/MessageInfo.ts
@@ -2,21 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { MessageInfo } from '../model/MessageInfo/MessageInfo.js';
 import type { IMessageInfoRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
 import { OCPP2_0_1 } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeMessageInfoRepository
   extends SequelizeRepository<MessageInfo>
   implements IMessageInfoRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, MessageInfo.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: MessageInfo.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async deactivateAllByStationId(tenantId: number, ocppConnectionName: string): Promise<void> {
@@ -76,3 +72,5 @@ export class SequelizeMessageInfoRepository
     });
   }
 }
+
+export default SequelizeMessageInfoRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/OCPPMessage.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/OCPPMessage.ts
@@ -2,20 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { MessageState, type BootstrapConfig, type OCPPMessageDto } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
+import { MessageState, type OCPPMessageDto } from '@citrineos/base';
 import type { IOCPPMessageRepository } from '../../../interfaces/repositories.js';
 import { OCPPMessage } from '../model/OCPPMessage.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeOCPPMessageRepository
   extends SequelizeRepository<OCPPMessage>
   implements IOCPPMessageRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, OCPPMessage.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: OCPPMessage.MODEL_NAME, logger, sequelizeInstance });
   }
 
   public async createOCPPMessage(tenantId: number, message: OCPPMessageDto): Promise<OCPPMessage> {
@@ -84,3 +81,5 @@ export class SequelizeOCPPMessageRepository
     });
   }
 }
+
+export default SequelizeOCPPMessageRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
@@ -83,111 +83,122 @@ export class RepositoryStore {
   tenantRepository: ITenantRepository;
   serverNetworkProfileRepository: IServerNetworkProfileRepository;
 
-  constructor(config: BootstrapConfig, logger: Logger<ILogObj>, sequelizeInstance: Sequelize) {
+  constructor({
+    config,
+    logger,
+    sequelizeInstance,
+  }: {
+    config: BootstrapConfig;
+    logger: Logger<ILogObj>;
+    sequelizeInstance: Sequelize;
+  }) {
     this.sequelizeInstance = sequelizeInstance;
-    this.authorizationRepository = new SequelizeAuthorizationRepository(
+    this.authorizationRepository = new SequelizeAuthorizationRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.bootRepository = new SequelizeBootRepository(config, logger, sequelizeInstance);
-    this.certificateRepository = new SequelizeCertificateRepository(
+    });
+    this.bootRepository = new SequelizeBootRepository({ config, logger, sequelizeInstance });
+    this.certificateRepository = new SequelizeCertificateRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.installedCertificateRepository = new SequelizeInstalledCertificateRepository(
+    });
+    this.installedCertificateRepository = new SequelizeInstalledCertificateRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.installCertificateAttemptRepository = new SequelizeInstallCertificateAttemptRepository(
+    });
+    this.installCertificateAttemptRepository = new SequelizeInstallCertificateAttemptRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.deleteCertificateAttemptRepository = new SequelizeDeleteCertificateAttemptRepository(
+    });
+    this.deleteCertificateAttemptRepository = new SequelizeDeleteCertificateAttemptRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.changeConfigurationRepository = new SequelizeChangeConfigurationRepository(
+    });
+    this.changeConfigurationRepository = new SequelizeChangeConfigurationRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.chargingProfileRepository = new SequelizeChargingProfileRepository(
+    });
+    this.chargingProfileRepository = new SequelizeChargingProfileRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.chargingStationSequenceRepository = new SequelizeChargingStationSequenceRepository(
+    });
+    this.chargingStationSequenceRepository = new SequelizeChargingStationSequenceRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.componentRepository = new SequelizeRepository<Component>(
+    });
+    this.componentRepository = new SequelizeRepository<Component>({
       config,
-      Component.MODEL_NAME,
+      namespace: Component.MODEL_NAME,
       logger,
-    );
-    this.deviceModelRepository = new SequelizeDeviceModelRepository(
-      config,
-      logger,
-      sequelizeInstance,
-    );
-    this.localAuthListRepository = new SequelizeLocalAuthListRepository(
+    });
+    this.deviceModelRepository = new SequelizeDeviceModelRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.locationRepository = new SequelizeLocationRepository(config, logger, sequelizeInstance);
-    this.messageInfoRepository = new SequelizeMessageInfoRepository(
+    });
+    this.localAuthListRepository = new SequelizeLocalAuthListRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.ocppMessageRepository = new SequelizeOCPPMessageRepository(
+    });
+    this.locationRepository = new SequelizeLocationRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.reservationRepository = new SequelizeReservationRepository(
+    });
+    this.messageInfoRepository = new SequelizeMessageInfoRepository({
       config,
       logger,
       sequelizeInstance,
-    );
+    });
+    this.ocppMessageRepository = new SequelizeOCPPMessageRepository({
+      config,
+      logger,
+      sequelizeInstance,
+    });
+    this.reservationRepository = new SequelizeReservationRepository({
+      config,
+      logger,
+      sequelizeInstance,
+    });
     if (process.env.CITRINEOS_USE_DRIZZLE_SECURITY_EVENT === 'true') {
       this.securityEventRepository = new DrizzleSecurityEventRepository(config, logger);
     } else {
-      this.securityEventRepository = new SequelizeSecurityEventRepository(
+      this.securityEventRepository = new SequelizeSecurityEventRepository({
         config,
         logger,
         sequelizeInstance,
-      );
+      });
     }
-    this.subscriptionRepository = new SequelizeSubscriptionRepository(
+    this.subscriptionRepository = new SequelizeSubscriptionRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.tariffRepository = new SequelizeTariffRepository(config, logger, sequelizeInstance);
-    this.transactionEventRepository = new SequelizeTransactionEventRepository(
-      config,
-      logger,
-      TransactionEvent.MODEL_NAME,
-      sequelizeInstance,
-    );
-    this.variableMonitoringRepository = new SequelizeVariableMonitoringRepository(
+    });
+    this.tariffRepository = new SequelizeTariffRepository({ config, logger, sequelizeInstance });
+    this.transactionEventRepository = new SequelizeTransactionEventRepository({
       config,
       logger,
       sequelizeInstance,
-    );
-    this.tenantRepository = new SequelizeTenantRepository(config, logger, sequelizeInstance);
-    this.serverNetworkProfileRepository = new SequelizeServerNetworkProfileRepository(
+    });
+    this.variableMonitoringRepository = new SequelizeVariableMonitoringRepository({
       config,
       logger,
       sequelizeInstance,
-    );
+    });
+    this.tenantRepository = new SequelizeTenantRepository({ config, logger, sequelizeInstance });
+    this.serverNetworkProfileRepository = new SequelizeServerNetworkProfileRepository({
+      config,
+      logger,
+      sequelizeInstance,
+    });
   }
 }

--- a/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
@@ -43,7 +43,6 @@ import { SequelizeTransactionEventRepository } from './TransactionEvent.js';
 import { SequelizeVariableMonitoringRepository } from './VariableMonitoring.js';
 import { Sequelize } from 'sequelize-typescript';
 import { Component } from '../model/DeviceModel/Component.js';
-import { TransactionEvent } from '../model/TransactionEvent/TransactionEvent.js';
 import { SequelizeRepository } from './Base.js';
 import { SequelizeReservationRepository } from './Reservation.js';
 import { SequelizeLocalAuthListRepository } from './LocalAuthList.js';

--- a/packages/core/src/dal/layers/sequelize/repository/Reservation.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Reservation.ts
@@ -1,11 +1,9 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig } from '@citrineos/base';
 import { CrudRepository, OCPP2_0_1 } from '@citrineos/base';
 import type { IReservationRepository } from '../../../interfaces/repositories.js';
-import { SequelizeRepository } from './Base.js';
-import { Sequelize } from 'sequelize-typescript';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { EvseType } from '../model/DeviceModel/EvseType.js';
@@ -18,17 +16,14 @@ export class SequelizeReservationRepository
   evse: CrudRepository<EvseType>;
   logger: Logger<ILogObj>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    evse?: CrudRepository<EvseType>,
-  ) {
-    super(config, Reservation.MODEL_NAME, logger, sequelizeInstance);
-    this.evse = evse
-      ? evse
-      : new SequelizeRepository<EvseType>(config, EvseType.MODEL_NAME, logger, sequelizeInstance);
-
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Reservation.MODEL_NAME, logger, sequelizeInstance });
+    this.evse = new SequelizeRepository<EvseType>({
+      config,
+      namespace: EvseType.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
     this.logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
       : new Logger<ILogObj>({ name: this.constructor.name });
@@ -96,3 +91,5 @@ export class SequelizeReservationRepository
     });
   }
 }
+
+export default SequelizeReservationRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/SecurityEvent.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/SecurityEvent.ts
@@ -1,22 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig } from '@citrineos/base';
 import { OCPP2_0_1 } from '@citrineos/base';
 import { SecurityEvent } from '../model/SecurityEvent.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { Op } from 'sequelize';
 import type { ISecurityEventRepository } from '../../../interfaces/repositories.js';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeSecurityEventRepository
   extends SequelizeRepository<SecurityEvent>
   implements ISecurityEventRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, SecurityEvent.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: SecurityEvent.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async createByStationId(
@@ -69,3 +65,5 @@ export class SequelizeSecurityEventRepository
     return { timestamp: { [Op.between]: [from, to] } };
   }
 }
+
+export default SequelizeSecurityEventRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/ServerNetworkProfile.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ServerNetworkProfile.ts
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import type { IServerNetworkProfileRepository } from '../../../interfaces/repositories.js';
 import { ServerNetworkProfile } from '../model/Location/ServerNetworkProfile.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
 export class SequelizeServerNetworkProfileRepository
   extends SequelizeRepository<ServerNetworkProfile>
   implements IServerNetworkProfileRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, ServerNetworkProfile.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: ServerNetworkProfile.MODEL_NAME, logger, sequelizeInstance });
   }
 
   /**
@@ -49,3 +45,5 @@ export class SequelizeServerNetworkProfileRepository
     return serverNetworkProfile;
   }
 }
+
+export default SequelizeServerNetworkProfileRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Subscription.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Subscription.ts
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Sequelize } from 'sequelize-typescript';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { Subscription } from '../model/Subscription/Subscription.js';
 import type { ISubscriptionRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeSubscriptionRepository
   extends SequelizeRepository<Subscription>
   implements ISubscriptionRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, Subscription.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Subscription.MODEL_NAME, logger, sequelizeInstance });
   }
 
   /**
@@ -41,3 +37,5 @@ export class SequelizeSubscriptionRepository
     return super.deleteByKey(tenantId, key);
   }
 }
+
+export default SequelizeSubscriptionRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Tariff.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Tariff.ts
@@ -2,22 +2,18 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { ITariffRepository } from '../../../interfaces/repositories.js';
 import type { TariffQueryString } from '../../../interfaces/queries/Tariff.js';
 import { Tariff } from '../model/Tariff/Tariffs.js';
-import { Sequelize } from 'sequelize-typescript';
-import type { BootstrapConfig } from '@citrineos/base';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { Connector } from '../model/Location/Connector.js';
 
 export class SequelizeTariffRepository
   extends SequelizeRepository<Tariff>
   implements ITariffRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, Tariff.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Tariff.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async findByConnectorId(tenantId: number, connectorId: number): Promise<Tariff | undefined> {
@@ -89,3 +85,5 @@ export class SequelizeTariffRepository
     });
   }
 }
+
+export default SequelizeTariffRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/Tenant.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Tenant.ts
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import type { ITenantRepository } from '../../../interfaces/repositories.js';
-import type { BootstrapConfig } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { Tenant } from '../model/Tenant.js';
 
 export class SequelizeTenantRepository
   extends SequelizeRepository<Tenant>
   implements ITenantRepository
 {
-  constructor(config: BootstrapConfig, logger?: Logger<ILogObj>, sequelizeInstance?: Sequelize) {
-    super(config, Tenant.MODEL_NAME, logger, sequelizeInstance);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: Tenant.MODEL_NAME, logger, sequelizeInstance });
   }
 
   async createTenant(tenant: Tenant): Promise<Tenant> {
@@ -27,3 +23,5 @@ export class SequelizeTenantRepository
     return await newTenant.save();
   }
 }
+
+export default SequelizeTenantRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { BootstrapConfig, MeterValueDto, OCPP2_request_types } from '@citrineos/base';
+import type { MeterValueDto, OCPP2_request_types } from '@citrineos/base';
 import {
   ChargingStationSequenceTypeEnum,
   CrudRepository,
@@ -11,9 +11,6 @@ import {
 } from '@citrineos/base';
 import type { WhereOptions } from 'sequelize';
 import { Op } from 'sequelize';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import type {
   IChargingStationSequenceRepository,
   ITransactionEventRepository,
@@ -30,7 +27,7 @@ import { StartTransaction } from '../model/TransactionEvent/StartTransaction.js'
 import { StopTransaction } from '../model/TransactionEvent/StopTransaction.js';
 import { Transaction } from '../model/TransactionEvent/Transaction.js';
 import { TransactionEvent } from '../model/TransactionEvent/TransactionEvent.js';
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { SequelizeChargingStationSequenceRepository } from './ChargingStationSequence.js';
 
 export class SequelizeTransactionEventRepository
@@ -46,69 +43,55 @@ export class SequelizeTransactionEventRepository
   connector: CrudRepository<Connector>;
   chargingStationSequence: IChargingStationSequenceRepository;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    namespace = TransactionEvent.MODEL_NAME,
-    sequelizeInstance?: Sequelize,
-    transaction?: CrudRepository<Transaction>,
-    station?: CrudRepository<ChargingStation>,
-    evse?: CrudRepository<Evse>,
-    meterValue?: CrudRepository<MeterValue>,
-    startTransaction?: CrudRepository<StartTransaction>,
-    stopTransaction?: CrudRepository<StopTransaction>,
-    connector?: CrudRepository<Connector>,
-    chargingStationSequence?: IChargingStationSequenceRepository,
-  ) {
-    super(config, namespace, logger, sequelizeInstance);
-    this.transaction = transaction
-      ? transaction
-      : new SequelizeRepository<Transaction>(
-          config,
-          Transaction.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.evse = evse
-      ? evse
-      : new SequelizeRepository<Evse>(config, Evse.MODEL_NAME, logger, sequelizeInstance);
-    this.station = station
-      ? station
-      : new SequelizeRepository<ChargingStation>(
-          config,
-          ChargingStation.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.meterValue = meterValue
-      ? meterValue
-      : new SequelizeRepository<MeterValue>(
-          config,
-          MeterValue.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.startTransaction = startTransaction
-      ? startTransaction
-      : new SequelizeRepository<StartTransaction>(
-          config,
-          StartTransaction.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.stopTransaction = stopTransaction
-      ? stopTransaction
-      : new SequelizeRepository<StopTransaction>(
-          config,
-          StopTransaction.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
-    this.connector = connector
-      ? connector
-      : new SequelizeRepository<Connector>(config, Connector.MODEL_NAME, logger, sequelizeInstance);
-    this.chargingStationSequence =
-      chargingStationSequence || new SequelizeChargingStationSequenceRepository(config, logger);
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: TransactionEvent.MODEL_NAME, logger, sequelizeInstance });
+    this.transaction = new SequelizeRepository<Transaction>({
+      config,
+      namespace: Transaction.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.evse = new SequelizeRepository<Evse>({
+      config,
+      namespace: Evse.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.station = new SequelizeRepository<ChargingStation>({
+      config,
+      namespace: ChargingStation.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.meterValue = new SequelizeRepository<MeterValue>({
+      config,
+      namespace: MeterValue.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.startTransaction = new SequelizeRepository<StartTransaction>({
+      config,
+      namespace: StartTransaction.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.stopTransaction = new SequelizeRepository<StopTransaction>({
+      config,
+      namespace: StopTransaction.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.connector = new SequelizeRepository<Connector>({
+      config,
+      namespace: Connector.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.chargingStationSequence = new SequelizeChargingStationSequenceRepository({
+      config,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   /**
@@ -853,3 +836,5 @@ export class SequelizeTransactionEventRepository
     );
   }
 }
+
+export default SequelizeTransactionEventRepository;

--- a/packages/core/src/dal/layers/sequelize/repository/VariableMonitoring.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/VariableMonitoring.ts
@@ -2,28 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { SequelizeRepository } from './Base.js';
+import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 import { Component } from '../model/DeviceModel/Component.js';
 import { EventData } from '../model/VariableMonitoring/EventData.js';
 import { Variable } from '../model/DeviceModel/Variable.js';
 import { VariableMonitoring } from '../model/VariableMonitoring/VariableMonitoring.js';
 import { VariableMonitoringStatus } from '../model/VariableMonitoring/VariableMonitoringStatus.js';
 import type { IVariableMonitoringRepository } from '../../../interfaces/repositories.js';
-import type {
-  BootstrapConfig,
-  CallAction,
-  OCPP2_common_types,
-  SetMonitoringStatusEnumType,
-} from '@citrineos/base';
+import type { CallAction, OCPP2_common_types, SetMonitoringStatusEnumType } from '@citrineos/base';
 import {
   CrudRepository,
   OCPP2_0_1,
   OCPP_CallAction,
   SetMonitoringStatusEnum,
 } from '@citrineos/base';
-import { Sequelize } from 'sequelize-typescript';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 
 export class SequelizeVariableMonitoringRepository
   extends SequelizeRepository<VariableMonitoring>
@@ -32,25 +24,20 @@ export class SequelizeVariableMonitoringRepository
   eventData: CrudRepository<EventData>;
   variableMonitoringStatus: CrudRepository<VariableMonitoringStatus>;
 
-  constructor(
-    config: BootstrapConfig,
-    logger?: Logger<ILogObj>,
-    sequelizeInstance?: Sequelize,
-    eventData?: CrudRepository<EventData>,
-    variableMonitoringStatus?: CrudRepository<VariableMonitoringStatus>,
-  ) {
-    super(config, VariableMonitoring.MODEL_NAME, logger, sequelizeInstance);
-    this.eventData = eventData
-      ? eventData
-      : new SequelizeRepository<EventData>(config, EventData.MODEL_NAME, logger, sequelizeInstance);
-    this.variableMonitoringStatus = variableMonitoringStatus
-      ? variableMonitoringStatus
-      : new SequelizeRepository<VariableMonitoringStatus>(
-          config,
-          VariableMonitoringStatus.MODEL_NAME,
-          logger,
-          sequelizeInstance,
-        );
+  constructor({ config, logger, sequelizeInstance }: SequelizeRepositoryDependencies) {
+    super({ config, namespace: VariableMonitoring.MODEL_NAME, logger, sequelizeInstance });
+    this.eventData = new SequelizeRepository<EventData>({
+      config,
+      namespace: EventData.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
+    this.variableMonitoringStatus = new SequelizeRepository<VariableMonitoringStatus>({
+      config,
+      namespace: VariableMonitoringStatus.MODEL_NAME,
+      logger,
+      sequelizeInstance,
+    });
   }
 
   async createOrUpdateByMonitoringDataTypeAndStationId(
@@ -291,3 +278,5 @@ export class SequelizeVariableMonitoringRepository
     );
   }
 }
+
+export default SequelizeVariableMonitoringRepository;

--- a/packages/core/src/dal/test/layers/sequelize/repository/ChargingStationSequence.test.ts
+++ b/packages/core/src/dal/test/layers/sequelize/repository/ChargingStationSequence.test.ts
@@ -7,6 +7,7 @@ import { Sequelize } from 'sequelize-typescript';
 import { ILogObj, Logger } from 'tslog';
 import { ChargingStationSequence } from '../../../../layers/sequelize/model/ChargingStationSequence/ChargingStationSequence';
 import { SequelizeChargingStationSequenceRepository } from '../../../../layers/sequelize/repository/ChargingStationSequence';
+import { createTestContainer, getTestInstance } from '../../../../../test/testContainer.js';
 
 // Mock the util module to avoid circular dependency issues during test loading
 vi.mock('../../../../src/layers/sequelize/util', () => ({
@@ -16,6 +17,7 @@ vi.mock('../../../../src/layers/sequelize/util', () => ({
 }));
 
 describe('SequelizeChargingStationSequenceRepository', () => {
+  const { container } = createTestContainer();
   let repository: SequelizeChargingStationSequenceRepository;
   let mockSequelize: Mocked<Sequelize>;
   let mockTransaction: Mock;
@@ -44,11 +46,11 @@ describe('SequelizeChargingStationSequenceRepository', () => {
 
     mockConfig = {} as BootstrapConfig;
 
-    repository = new SequelizeChargingStationSequenceRepository(
-      mockConfig,
-      mockLogger,
-      mockSequelize,
-    );
+    repository = getTestInstance(container, SequelizeChargingStationSequenceRepository, {
+      config: mockConfig,
+      logger: mockLogger,
+      sequelizeInstance: mockSequelize,
+    });
   });
 
   describe('getNextSequenceValue', () => {

--- a/packages/core/src/modules/Certificates/src/index.ts
+++ b/packages/core/src/modules/Certificates/src/index.ts
@@ -7,3 +7,4 @@ export { CertificatesDataApi } from './module/DataApi.js';
 export type { ICertificatesModuleApi } from './module/interface.js';
 export { CertificatesModule } from './module/module.js';
 export { InstallCertificateHelperService } from './module/installCertificateHelperService.js';
+export { registerCertificatesServices } from './register.js';

--- a/packages/core/src/modules/Certificates/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Certificates/src/module/2/MessageApi.ts
@@ -60,11 +60,13 @@ export class CertificatesOcpp2Api
    * Interface implementation
    */
 
-  @AsMessageEndpoint(OCPP_CallAction.CertificateSigned, (_instance: CertificatesOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'CertificateSignedRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.CertificateSigned,
+    (_instance: CertificatesOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'CertificateSignedRequestSchema',
+      ),
   )
   certificateSigned(
     identifier: string[],
@@ -84,11 +86,13 @@ export class CertificatesOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.InstallCertificate, (_instance: CertificatesOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'InstallCertificateRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.InstallCertificate,
+    (_instance: CertificatesOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'InstallCertificateRequestSchema',
+      ),
   )
   installCertificate(
     identifier: string[],
@@ -116,11 +120,13 @@ export class CertificatesOcpp2Api
     return Promise.all(results);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetInstalledCertificateIds, (_instance: CertificatesOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'GetInstalledCertificateIdsRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetInstalledCertificateIds,
+    (_instance: CertificatesOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'GetInstalledCertificateIdsRequestSchema',
+      ),
   )
   getInstalledCertificateIds(
     identifier: string[],
@@ -140,11 +146,13 @@ export class CertificatesOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.DeleteCertificate, (_instance: CertificatesOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'DeleteCertificateRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.DeleteCertificate,
+    (_instance: CertificatesOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'DeleteCertificateRequestSchema',
+      ),
   )
   deleteCertificate(
     identifier: string[],

--- a/packages/core/src/modules/Certificates/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Certificates/src/module/2/MessageApi.ts
@@ -35,22 +35,34 @@ export class CertificatesOcpp2Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    certificatesModule: CertificatesModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(certificatesModule, server, version, logger);
+  constructor({
+    certificatesModule,
+    server,
+    logger,
+  }: {
+    certificatesModule: CertificatesModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(certificatesModule, server, logger);
+  }
+
+  /**
+   * This API serves both OCPP 2.0.1 and 2.1 from a single instance; each
+   * message endpoint is registered once per version with the version threaded
+   * into schema selection, the route path, and the handler.
+   */
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
   }
 
   /**
    * Interface implementation
    */
 
-  @AsMessageEndpoint(OCPP_CallAction.CertificateSigned, (instance: CertificatesOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.CertificateSigned, (_instance: CertificatesOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'CertificateSignedRequestSchema',
     ),
   )
@@ -59,21 +71,22 @@ export class CertificatesOcpp2Api
     request: OCPP2_request_types.CertificateSignedRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.CertificateSigned,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.InstallCertificate, (instance: CertificatesOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.InstallCertificate, (_instance: CertificatesOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'InstallCertificateRequestSchema',
     ),
   )
@@ -82,6 +95,7 @@ export class CertificatesOcpp2Api
     request: OCPP2_request_types.InstallCertificateRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: Promise<IMessageConfirmation>[] = identifier.map(async (ocppConnectionName) => {
       await this._module.installCertificateHelperService.prepareToInstallCertificate(
@@ -93,7 +107,7 @@ export class CertificatesOcpp2Api
       return this._module.sendCall(
         ocppConnectionName,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.InstallCertificate,
         request,
         callbackUrl,
@@ -102,9 +116,9 @@ export class CertificatesOcpp2Api
     return Promise.all(results);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetInstalledCertificateIds, (instance: CertificatesOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetInstalledCertificateIds, (_instance: CertificatesOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetInstalledCertificateIdsRequestSchema',
     ),
   )
@@ -113,21 +127,22 @@ export class CertificatesOcpp2Api
     request: OCPP2_request_types.GetInstalledCertificateIdsRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetInstalledCertificateIds,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.DeleteCertificate, (instance: CertificatesOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.DeleteCertificate, (_instance: CertificatesOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'DeleteCertificateRequestSchema',
     ),
   )
@@ -136,6 +151,7 @@ export class CertificatesOcpp2Api
     request: OCPP2_request_types.DeleteCertificateRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: Promise<IMessageConfirmation>[] = identifier.map(async (ocppConnectionName) => {
       const certificateHashData = request.certificateHashData;
@@ -162,7 +178,7 @@ export class CertificatesOcpp2Api
       return this._module.sendCall(
         ocppConnectionName,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.DeleteCertificate,
         request,
         callbackUrl,
@@ -178,8 +194,8 @@ export class CertificatesOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.certificates?.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Certificates/src/module/DataApi.ts
+++ b/packages/core/src/modules/Certificates/src/module/DataApi.ts
@@ -65,14 +65,20 @@ export class CertificatesDataApi
    * @param {WebsocketServerConfig[]} websocketServersConfig - Configuration for websocket servers
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    certificatesModule: CertificatesModule,
-    server: FastifyInstance,
-    fileStorage: IFileStorage,
-    websocketServersConfig: WebsocketServerConfig[],
-    logger?: Logger<ILogObj>,
-  ) {
-    super(certificatesModule, server, OCPPVersion.OCPP2_0_1, logger);
+  constructor({
+    certificatesModule,
+    server,
+    fileStorage,
+    websocketServersConfig,
+    logger,
+  }: {
+    certificatesModule: CertificatesModule;
+    server: FastifyInstance;
+    fileStorage: IFileStorage;
+    websocketServersConfig: WebsocketServerConfig[];
+    logger?: Logger<ILogObj>;
+  }) {
+    super(certificatesModule, server, logger);
     this._fileStorage = fileStorage;
     this._websocketServersConfig = websocketServersConfig;
   }

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -48,16 +48,25 @@ export class InstallCertificateHelperService {
   protected fileStorage: IFileStorage;
   protected logger: Logger<ILogObj>;
 
-  constructor(
-    certificateRepository: ICertificateRepository,
-    installedCertificateRepository: IInstalledCertificateRepository,
-    installCertificateAttemptRepository: IInstallCertificateAttemptRepository,
-    deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository,
-    certificateAuthorityService: CertificateAuthorityService,
-    networkConnection: WebsocketNetworkConnection,
-    fileStorage: IFileStorage,
-    logger: Logger<ILogObj>,
-  ) {
+  constructor({
+    certificateRepository,
+    installedCertificateRepository,
+    installCertificateAttemptRepository,
+    deleteCertificateAttemptRepository,
+    certificateAuthorityService,
+    networkConnection,
+    fileStorage,
+    logger,
+  }: {
+    certificateRepository: ICertificateRepository;
+    installedCertificateRepository: IInstalledCertificateRepository;
+    installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
+    deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
+    certificateAuthorityService: CertificateAuthorityService;
+    networkConnection: WebsocketNetworkConnection;
+    fileStorage: IFileStorage;
+    logger: Logger<ILogObj>;
+  }) {
     this.certificateRepository = certificateRepository;
     this.installedCertificateRepository = installedCertificateRepository;
     this.installCertificateAttemptRepository = installCertificateAttemptRepository;

--- a/packages/core/src/modules/Certificates/src/module/module.ts
+++ b/packages/core/src/modules/Certificates/src/module/module.ts
@@ -4,22 +4,17 @@
 import {
   AbstractModule,
   AsHandler,
-  type BootstrapConfig,
   type CallAction,
   ErrorCode,
   EventGroup,
   type HandlerProperties,
-  type ICache,
   type IFileStorage,
   type IMessage,
-  type IMessageHandler,
-  type IMessageSender,
+  type OcppModuleDependencies,
   MessageOrigin,
   OCPP_CallAction,
   OCPP_2_VER_LIST,
   OcppError,
-  OCPPValidator,
-  type SystemConfig,
   OCPP2_response_types,
   OCPP2_request_types,
   OCPP2_common_types,
@@ -44,30 +39,37 @@ import type {
   IInstalledCertificateRepository,
   IOCPPMessageRepository,
 } from '@dal/interfaces/repositories.js';
-import {
-  InstalledCertificate,
-  SequelizeOCPPMessageRepository,
-} from '@dal/layers/sequelize/index.js';
-import { sequelize } from '@dal/index.js';
+import { InstalledCertificate } from '@dal/layers/sequelize/index.js';
+
 import {
   parseCSRForVerification,
   sendOCSPRequest,
   validatePEMEncodedCSR,
-  WebsocketNetworkConnection,
   CertificateAuthorityService,
 } from '@util/index.js';
 import { Crypto } from '@peculiar/webcrypto';
 import jsrsasign from 'jsrsasign';
 import * as pkijs from 'pkijs';
 import { CertificationRequest } from 'pkijs';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { InstallCertificateHelperService } from './installCertificateHelperService.js';
+
+import type { InstallCertificateHelperService } from './installCertificateHelperService.js';
 
 const cryptoEngine = new pkijs.CryptoEngine({
   crypto: new Crypto(),
 });
 pkijs.setEngine('crypto', cryptoEngine as pkijs.ICryptoEngine);
+
+export interface CertificatesModuleDependencies extends OcppModuleDependencies {
+  fileStorage: IFileStorage;
+  deviceModelRepository: IDeviceModelRepository;
+  certificateRepository: ICertificateRepository;
+  installedCertificateRepository: IInstalledCertificateRepository;
+  installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
+  deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  certificateAuthorityService: CertificateAuthorityService;
+  installCertificateHelperService: InstallCertificateHelperService;
+}
 
 /**
  * Component that handles provisioning related messages.
@@ -91,109 +93,38 @@ export class CertificatesModule extends AbstractModule {
   protected _fileStorage: IFileStorage;
   protected _installCertificateHelperService: InstallCertificateHelperService;
 
-  /**
-   * Constructor
-   */
-
-  /**
-   * This is the constructor function that initializes the {@link CertificatesModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {IFileStorage} [fileStorage]  - file storage for persisting certs
-   *
-   * @param {WebsocketNetworkConnection} [networkConnection] - network connection
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize.deviceModelRepository} instance is created and used.
-   *
-   * @param {ICertificateRepository} [certificateRepository] - An optional parameter of type {@link ICertificateRepository} which
-   * represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize.certificateRepository} instance is created and used.
-   *
-   * @param {IInstalledCertificateRepository} [installedCertificateRepository] - An optional parameter of type {@link IInstalledCertificateRepository} which
-   * represents a repository for accessing and manipulating installed certificate data.
-   * If no `installedCertificateRepository` is provided, a default {@link sequelize.InstalledCertificateRepository} instance is created and used.
-   *
-   * @param {IInstallCertificateAttemptRepository} [installCertificateAttemptRepository] - An optional parameter of type {@link IInstallCertificateAttemptRepository} which
-   * represents a repository for accessing and manipulating installed certificate attempt data.
-   * If no `installCertificateAttemptRepository` is provided, a default {@link sequelize.InstallCertificateAttemptRepository} instance is created and used.
-   *
-   * @param {IDeleteCertificateAttemptRepository} [deleteCertificateAttemptRepository] - An optional parameter of type {@link IDeleteCertificateAttemptRepository} which
-   * represents a repository for accessing and manipulating deleted certificate attempt data.
-   * If no `deleteCertificateAttemptRepository` is provided, a default {@link sequelize.DeleteCertificateAttemptRepository} instance is created and used.
-   *
-   * @param {IOCPPMessageRepository} [ocppMessageRepository] - repository to check ocpp messages
-   *
-   * @param {CertificateAuthorityService} [certificateAuthorityService] - An optional parameter of type {@link CertificateAuthorityService} which handles certificate authority operations.
-   *
-   * @param {InstallCertificateHelperService} [installCertificateHelperService] - helper service for installing certificates
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    fileStorage: IFileStorage,
-    networkConnection: WebsocketNetworkConnection,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    deviceModelRepository?: IDeviceModelRepository,
-    certificateRepository?: ICertificateRepository,
-    installedCertificateRepository?: IInstalledCertificateRepository,
-    installCertificateAttemptRepository?: IInstallCertificateAttemptRepository,
-    deleteCertificateAttemptRepository?: IDeleteCertificateAttemptRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-    certificateAuthorityService?: CertificateAuthorityService,
-    installCertificateHelperService?: InstallCertificateHelperService,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    fileStorage,
+    logger,
+    ocppValidator,
+    deviceModelRepository,
+    certificateRepository,
+    installedCertificateRepository,
+    installCertificateAttemptRepository,
+    deleteCertificateAttemptRepository,
+    ocppMessageRepository,
+    certificateAuthorityService,
+    installCertificateHelperService,
+  }: CertificatesModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Certificates, logger, ocppValidator);
 
     this._requests = config.modules.certificates?.requests ?? [];
     this._responses = config.modules.certificates?.responses ?? [];
     this._fileStorage = fileStorage;
 
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, logger);
-    this._certificateRepository =
-      certificateRepository || new sequelize.SequelizeCertificateRepository(config, logger);
-    this._installedCertificateRepository =
-      installedCertificateRepository ||
-      new sequelize.SequelizeInstalledCertificateRepository(config, logger);
-    this._installCertificateAttemptRepository =
-      installCertificateAttemptRepository ||
-      new sequelize.SequelizeInstallCertificateAttemptRepository(config, logger);
-    this._deleteCertificateAttemptRepository =
-      deleteCertificateAttemptRepository ||
-      new sequelize.SequelizeDeleteCertificateAttemptRepository(config, logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
-    this._certificateAuthorityService =
-      certificateAuthorityService || new CertificateAuthorityService(config, cache, this._logger);
+    this._deviceModelRepository = deviceModelRepository;
+    this._certificateRepository = certificateRepository;
+    this._installedCertificateRepository = installedCertificateRepository;
+    this._installCertificateAttemptRepository = installCertificateAttemptRepository;
+    this._deleteCertificateAttemptRepository = deleteCertificateAttemptRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._certificateAuthorityService = certificateAuthorityService;
 
-    this._installCertificateHelperService =
-      installCertificateHelperService ||
-      new InstallCertificateHelperService(
-        this._certificateRepository,
-        this._installedCertificateRepository,
-        this._installCertificateAttemptRepository,
-        this._deleteCertificateAttemptRepository,
-        this._certificateAuthorityService,
-        networkConnection,
-        this._fileStorage,
-        this._logger,
-      );
+    this._installCertificateHelperService = installCertificateHelperService;
   }
 
   get certificateAuthorityService(): CertificateAuthorityService {
@@ -606,3 +537,5 @@ export class CertificatesModule extends AbstractModule {
     this._logger.info(`Verified SignCertRequest for station ${ocppConnectionName} successfully.`);
   }
 }
+
+export default CertificatesModule;

--- a/packages/core/src/modules/Certificates/src/register.ts
+++ b/packages/core/src/modules/Certificates/src/register.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, type AwilixContainer } from 'awilix';
+import { InstallCertificateHelperService } from './module/installCertificateHelperService.js';
+
+/**
+ * Registers the Certificates module's internal services as scoped dependencies.
+ */
+export function registerCertificatesServices(container: AwilixContainer): void {
+  container.register({
+    installCertificateHelperService: asClass(InstallCertificateHelperService).scoped(),
+  });
+}

--- a/packages/core/src/modules/Certificates/test/module/2.0.1/MessageApi.test.ts
+++ b/packages/core/src/modules/Certificates/test/module/2.0.1/MessageApi.test.ts
@@ -15,6 +15,7 @@ import { aDeleteCertificateRequest } from '../../providers/DeleteCertificateRequ
 import { aSystemConfig } from '../../providers/SystemConfig';
 import { mockFastifyInstance } from '../../../vitest.setup';
 import { MOCK_CHARGING_STATION_ID } from '../../providers/ChargingStation';
+import { createTestContainer, getTestInstance } from '../../../../../test/testContainer.js';
 
 const mockSave = vi.fn().mockResolvedValue({ id: 100 });
 let createdDeleteCertificateAttemptInstances: any[] = [];
@@ -57,6 +58,7 @@ const mockDeleteCertificateRepository = {
 const mockSendCall = vi.fn();
 
 describe('CertificatesOcpp201Api', () => {
+  const { container } = createTestContainer();
   let messageApi: CertificatesOcpp2Api;
   let mockCertificatesModule: CertificatesModule;
   const mockInstallCertificateRequest = aInstallCertificateRequest();
@@ -72,7 +74,10 @@ describe('CertificatesOcpp201Api', () => {
       sendCall: mockSendCall,
     } as unknown as CertificatesModule;
 
-    messageApi = new CertificatesOcpp2Api(mockCertificatesModule, mockFastifyInstance);
+    messageApi = getTestInstance(container, CertificatesOcpp2Api, {
+      certificatesModule: mockCertificatesModule,
+      server: mockFastifyInstance,
+    });
   });
 
   describe('installCertificate', () => {

--- a/packages/core/src/modules/Certificates/test/module/DataApi.test.ts
+++ b/packages/core/src/modules/Certificates/test/module/DataApi.test.ts
@@ -9,6 +9,7 @@ import { CertificatesDataApi, CertificatesModule } from '../../src';
 import { aUploadExistingCertificate } from '../providers/UploadExistingCertificateProvider';
 import { mockFastifyInstance, mockFileStorage } from '../../vitest.setup';
 import { MOCK_CHARGING_STATION_ID } from '../providers/ChargingStation';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 // Mock the decorator metadata before importing the class
 vi.mock('reflect-metadata', async (importOriginal) => {
@@ -45,6 +46,7 @@ vi.mock('@citrineos/core', async (importOriginal) => {
 });
 
 describe('CertificatesDataApi', () => {
+  const { container } = createTestContainer();
   let dataApi: CertificatesDataApi;
   let mockCertificatesModule: CertificatesModule;
 
@@ -61,12 +63,12 @@ describe('CertificatesDataApi', () => {
       },
     } as any;
 
-    dataApi = new CertificatesDataApi(
-      mockCertificatesModule,
-      mockFastifyInstance,
-      mockFileStorage,
-      [],
-    );
+    dataApi = getTestInstance(container, CertificatesDataApi, {
+      certificatesModule: mockCertificatesModule,
+      server: mockFastifyInstance,
+      fileStorage: mockFileStorage,
+      websocketServersConfig: [],
+    });
   });
 
   describe('uploadExistingCertificate', () => {

--- a/packages/core/src/modules/Certificates/test/module/installCertificateHelperService.test.ts
+++ b/packages/core/src/modules/Certificates/test/module/installCertificateHelperService.test.ts
@@ -16,9 +16,9 @@ import {
   mockFileStorage,
   mockFileStorageGetFile,
   mockFileStorageSaveFile,
-  mockLogger,
 } from '../../vitest.setup';
 import { MOCK_CERTIFICATE } from '../providers/InstallCertificateRequestProvider';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 // Define constants BEFORE mocks to avoid hoisting issues
 const { MOCK_CERT_TYPE_V2G, MOCK_STATUS_REJECTED, MOCK_STATUS_ACCEPTED } = vi.hoisted(() => ({
@@ -132,6 +132,7 @@ vi.mock('../../../../dal/layers/sequelize/index.js', async (importOriginal) => {
 });
 
 describe('InstallCertificateHelperService', () => {
+  const { container, logger } = createTestContainer();
   let service: InstallCertificateHelperService;
   let mockCertificateRepository: ICertificateRepository;
   let mockInstalledCertificateRepository: IInstalledCertificateRepository;
@@ -171,16 +172,15 @@ describe('InstallCertificateHelperService', () => {
     mockCertificateAuthorityService = {} as any;
     mockNetworkConnection = {} as any;
 
-    service = new InstallCertificateHelperService(
-      mockCertificateRepository,
-      mockInstalledCertificateRepository,
-      mockInstallCertificateAttemptRepository,
-      mockDeleteCertificateAttemptRepository,
-      mockCertificateAuthorityService,
-      mockNetworkConnection,
-      mockFileStorage,
-      mockLogger,
-    );
+    service = getTestInstance(container, InstallCertificateHelperService, {
+      certificateRepository: mockCertificateRepository,
+      installedCertificateRepository: mockInstalledCertificateRepository,
+      installCertificateAttemptRepository: mockInstallCertificateAttemptRepository,
+      deleteCertificateAttemptRepository: mockDeleteCertificateAttemptRepository,
+      certificateAuthorityService: mockCertificateAuthorityService,
+      networkConnection: mockNetworkConnection,
+      fileStorage: mockFileStorage,
+    });
 
     vi.spyOn(service, 'getCertificateHash').mockReturnValue(mockHash);
   });
@@ -495,7 +495,7 @@ describe('InstallCertificateHelperService', () => {
         MOCK_STATUS_ACCEPTED as any,
       );
 
-      expect(mockLogger.error).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         'Failed to retrieve certificate file from storage for certificate',
         {
           certificateFileId: 'file123',

--- a/packages/core/src/modules/Configuration/src/index.ts
+++ b/packages/core/src/modules/Configuration/src/index.ts
@@ -7,3 +7,4 @@ export { ConfigurationOcpp2Api } from './module/2/MessageApi.js';
 export { ConfigurationOcpp16Api } from './module/1.6/MessageApi.js';
 export type { IConfigurationModuleApi } from './module/interface.js';
 export { ConfigurationModule } from './module/module.js';
+export { registerConfigurationServices } from './register.js';

--- a/packages/core/src/modules/Configuration/src/module/1.6/MessageApi.ts
+++ b/packages/core/src/modules/Configuration/src/module/1.6/MessageApi.ts
@@ -32,12 +32,20 @@ export class ConfigurationOcpp16Api
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - Optional logger instance.
    */
-  constructor(
-    ConfigurationComponent: ConfigurationModule,
-    server: FastifyInstance,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(ConfigurationComponent, server, OCPPVersion.OCPP1_6, logger);
+  constructor({
+    configurationModule,
+    server,
+    logger,
+  }: {
+    configurationModule: ConfigurationModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(configurationModule, server, logger);
+  }
+
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP1_6];
   }
 
   @AsMessageEndpoint(OCPP_CallAction.TriggerMessage, OCPP1_6.TriggerMessageRequestSchema)
@@ -306,8 +314,8 @@ export class ConfigurationOcpp16Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.configuration.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Configuration/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Configuration/src/module/2/MessageApi.ts
@@ -43,20 +43,34 @@ export class ConfigurationOcpp2Api
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - Optional logger instance.
    */
-  constructor(
-    ConfigurationComponent: ConfigurationModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(ConfigurationComponent, server, version, logger);
+  constructor({
+    configurationModule,
+    server,
+    logger,
+  }: {
+    configurationModule: ConfigurationModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    // The OCPP version is no longer instance state — it is supplied per route /
+    // per request via supportedVersions() and the handler `version` parameter.
+    super(configurationModule, server, logger);
+  }
+
+  /**
+   * This API serves both OCPP 2.0.1 and 2.1 from a single instance; each
+   * message endpoint is registered once per version with the version threaded
+   * into schema selection, the route path, and the handler.
+   */
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
   }
 
   @AsMessageEndpoint(
     OCPP_CallAction.SetNetworkProfile,
-    (instance: ConfigurationOcpp2Api) =>
+    (_instance: ConfigurationOcpp2Api, version) =>
       getOcpp2Schema(
-        (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
         'SetNetworkProfileRequestSchema',
       ),
     {
@@ -67,8 +81,9 @@ export class ConfigurationOcpp2Api
     identifier: string[],
     request: OCPP2_request_types.SetNetworkProfileRequest,
     callbackUrl?: string,
-    extraQueries?: Record<string, any>,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
+    extraQueries?: Record<string, any>,
   ): Promise<IMessageConfirmation[]> {
     const correlationId = uuidv4();
     if (extraQueries) {
@@ -94,7 +109,7 @@ export class ConfigurationOcpp2Api
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.SetNetworkProfile,
       request,
       callbackUrl,
@@ -102,9 +117,9 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearDisplayMessage, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ClearDisplayMessage, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ClearDisplayMessageRequestSchema',
     ),
   )
@@ -113,21 +128,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.ClearDisplayMessageRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.ClearDisplayMessage,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetDisplayMessages, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetDisplayMessages, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetDisplayMessagesRequestSchema',
     ),
   )
@@ -136,21 +152,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.GetDisplayMessagesRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetDisplayMessages,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.PublishFirmware, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.PublishFirmware, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'PublishFirmwareRequestSchema',
     ),
   )
@@ -159,21 +176,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.PublishFirmwareRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.PublishFirmware,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetDisplayMessage, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetDisplayMessage, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetDisplayMessageRequestSchema',
     ),
   )
@@ -182,6 +200,7 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.SetDisplayMessageRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const messageInfo = request.message as OCPP2_common_types.MessageInfoType;
 
@@ -202,16 +221,16 @@ export class ConfigurationOcpp2Api
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.SetDisplayMessage,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.UnpublishFirmware, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.UnpublishFirmware, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'UnpublishFirmwareRequestSchema',
     ),
   )
@@ -220,21 +239,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.UnpublishFirmwareRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.UnpublishFirmware,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.UpdateFirmware, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.UpdateFirmware, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'UpdateFirmwareRequestSchema',
     ),
   )
@@ -243,21 +263,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.UpdateFirmwareRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.UpdateFirmware,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.Reset, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.Reset, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ResetRequestSchema',
     ),
   )
@@ -266,21 +287,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.ResetRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.Reset,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ChangeAvailability, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ChangeAvailability, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ChangeAvailabilityRequestSchema',
     ),
   )
@@ -289,21 +311,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.ChangeAvailabilityRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.ChangeAvailability,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.TriggerMessage, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.TriggerMessage, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'TriggerMessageRequestSchema',
     ),
   )
@@ -312,21 +335,22 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.TriggerMessageRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.TriggerMessage,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.DataTransfer, (instance: ConfigurationOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.DataTransfer, (_instance: ConfigurationOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'DataTransferRequestSchema',
     ),
   )
@@ -335,12 +359,13 @@ export class ConfigurationOcpp2Api
     request: OCPP2_request_types.DataTransferRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: Promise<IMessageConfirmation>[] = identifier.map((ocppConnectionName) =>
       this._module.sendCall(
         ocppConnectionName,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.DataTransfer,
         request,
         callbackUrl,
@@ -355,8 +380,8 @@ export class ConfigurationOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.configuration.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Configuration/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Configuration/src/module/2/MessageApi.ts
@@ -117,11 +117,13 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearDisplayMessage, (_instance: ConfigurationOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'ClearDisplayMessageRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.ClearDisplayMessage,
+    (_instance: ConfigurationOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'ClearDisplayMessageRequestSchema',
+      ),
   )
   clearDisplayMessage(
     identifier: string[],
@@ -141,11 +143,13 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetDisplayMessages, (_instance: ConfigurationOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'GetDisplayMessagesRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetDisplayMessages,
+    (_instance: ConfigurationOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'GetDisplayMessagesRequestSchema',
+      ),
   )
   getDisplayMessages(
     identifier: string[],
@@ -189,11 +193,13 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetDisplayMessage, (_instance: ConfigurationOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'SetDisplayMessageRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.SetDisplayMessage,
+    (_instance: ConfigurationOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'SetDisplayMessageRequestSchema',
+      ),
   )
   async setDisplayMessage(
     identifier: string[],
@@ -228,11 +234,13 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.UnpublishFirmware, (_instance: ConfigurationOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'UnpublishFirmwareRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.UnpublishFirmware,
+    (_instance: ConfigurationOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'UnpublishFirmwareRequestSchema',
+      ),
   )
   unpublishFirmware(
     identifier: string[],
@@ -300,11 +308,13 @@ export class ConfigurationOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ChangeAvailability, (_instance: ConfigurationOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'ChangeAvailabilityRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.ChangeAvailability,
+    (_instance: ConfigurationOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'ChangeAvailabilityRequestSchema',
+      ),
   )
   changeAvailability(
     identifier: string[],

--- a/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
+++ b/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
@@ -31,12 +31,17 @@ export class BootNotificationService {
   protected _logger: Logger<ILogObj>;
   protected _config: Configuration;
 
-  constructor(
-    bootRepository: IBootRepository,
-    cache: ICache,
-    config: Configuration,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    bootRepository,
+    cache,
+    config,
+    logger,
+  }: {
+    bootRepository: IBootRepository;
+    cache: ICache;
+    config: Configuration;
+    logger: Logger<ILogObj>;
+  }) {
     this._bootRepository = bootRepository;
     this._cache = cache;
     this._config = config;

--- a/packages/core/src/modules/Configuration/src/module/DataApi.ts
+++ b/packages/core/src/modules/Configuration/src/module/DataApi.ts
@@ -61,12 +61,16 @@ export class ConfigurationDataApi
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - Optional logger instance.
    */
-  constructor(
-    ConfigurationComponent: ConfigurationModule,
-    server: FastifyInstance,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(ConfigurationComponent, server, null, logger);
+  constructor({
+    configurationModule,
+    server,
+    logger,
+  }: {
+    configurationModule: ConfigurationModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(configurationModule, server, logger);
   }
 
   @AsDataEndpoint(

--- a/packages/core/src/modules/Configuration/src/module/DeviceModelService.ts
+++ b/packages/core/src/modules/Configuration/src/module/DeviceModelService.ts
@@ -9,7 +9,7 @@ import { VariableAttribute } from '@dal/layers/sequelize/index.js';
 export class DeviceModelService {
   protected _deviceModelRepository: IDeviceModelRepository;
 
-  constructor(deviceModelRepository: IDeviceModelRepository) {
+  constructor({ deviceModelRepository }: { deviceModelRepository: IDeviceModelRepository }) {
     this._deviceModelRepository = deviceModelRepository;
   }
 

--- a/packages/core/src/modules/Configuration/src/module/module.ts
+++ b/packages/core/src/modules/Configuration/src/module/module.ts
@@ -2,21 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
-  BootstrapConfig,
   CallAction,
   ClearMessageStatusEnumType,
   HandlerProperties,
-  ICache,
   IMessage,
   IMessageConfirmation,
-  IMessageHandler,
-  IMessageSender,
   IWebsocketConnection,
+  OcppModuleDependencies,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
   RegistrationStatusEnumType,
-  SystemConfig,
 } from '@citrineos/base';
 import {
   AbstractModule,
@@ -37,7 +33,6 @@ import {
   OCPP_2_VER_LIST,
   OCPP_CallAction,
   OcppError,
-  OCPPValidator,
   OCPPVersion,
   RegistrationStatusEnum,
   ResetEnum,
@@ -45,7 +40,7 @@ import {
   SetVariableStatusEnum,
   type DisplayMessageStatusEnumType,
 } from '@citrineos/base';
-import { sequelize } from '@dal/index.js';
+
 import type {
   IBootRepository,
   IChangeConfigurationRepository,
@@ -61,18 +56,27 @@ import {
   ChargingStation,
   ChargingStationNetworkProfile,
   Component,
-  SequelizeChangeConfigurationRepository,
-  SequelizeChargingStationSequenceRepository,
-  SequelizeOCPPMessageRepository,
   ServerNetworkProfile,
   SetNetworkProfile,
 } from '@dal/layers/sequelize/index.js';
 import { IdGenerator, validateMessageContentType } from '@util/index.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { v4 as uuidv4 } from 'uuid';
-import { BootNotificationService } from './BootNotificationService.js';
-import { DeviceModelService } from './DeviceModelService.js';
+
+import type { BootNotificationService } from './BootNotificationService.js';
+import type { DeviceModelService } from './DeviceModelService.js';
+
+export interface ConfigurationModuleDependencies extends OcppModuleDependencies {
+  bootRepository: IBootRepository;
+  deviceModelRepository: IDeviceModelRepository;
+  messageInfoRepository: IMessageInfoRepository;
+  locationRepository: ILocationRepository;
+  changeConfigurationRepository: IChangeConfigurationRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  idGenerator: IdGenerator;
+  tenantRepository: ITenantRepository;
+  configurationDeviceModelService: DeviceModelService;
+  bootNotificationService: BootNotificationService;
+}
 
 /**
  * Component that handles Configuration related messages.
@@ -86,99 +90,41 @@ export class ConfigurationModule extends AbstractModule {
   protected _bootService: BootNotificationService;
   private _idGenerator: IdGenerator;
 
-  /**
-   * This is the constructor function that initializes the {@link ConfigurationModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system-wide logger settings and will serve as the parent logger for any subcomponent logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {IBootRepository} [bootRepository] - An optional parameter of type {@link IBootRepository} which represents a repository for accessing and manipulating authorization data.
-   * If no `bootRepository` is provided, a default {@link SequelizeBootRepository} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is created and used.
-   *
-   * @param {IMessageInfoRepository} [messageInfoRepository] - An optional parameter of type {@link messageInfoRepository} which
-   * represents a repository for accessing and manipulating message info data. If no `messageInfoRepository` is provided, a default
-   * {@link SequelizeMessageInfoRepository} instance is created and used.
-   *
-   * @param {ILocationRepository} [locationRepository] - An optional parameter of type {@link locationRepository} which
-   * represents a repository for accessing and manipulating location data. If no `locationRepository` is provided, a default
-   * {@link SequelizeLocationRepository} instance is created and used.
-   *
-   * @param {IChangeConfigurationRepository} [changeConfigurationRepository] - An optional parameter of type {@link IChangeConfigurationRepository} which
-   * represents a repository for accessing and manipulating change configuration data. If no `changeConfigurationRepository` is provided, a default
-   * {@link SequelizeChangeConfigurationRepository} instance is created and used.
-   *
-   * @param {IOCPPMessageRepository} [ocppMessageRepository] - An optional parameter of type {@link IOCPPMessageRepository} which
-   * represents a repository for accessing and manipulating call message data. If no `ocppMessageRepository` is provided, a default
-   * {@link SequelizeOCPPMessageRepository} instance is created and used.
-   *
-   * @param {IdGenerator} [idGenerator] - An optional parameter of type {@link IdGenerator} which
-   * represents a generator for ids.
-   *
-   *If no `deviceModelRepository` is provided, a default {@link sequelize:messageInfoRepository} instance is created and used.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    bootRepository?: IBootRepository,
-    deviceModelRepository?: IDeviceModelRepository,
-    messageInfoRepository?: IMessageInfoRepository,
-    locationRepository?: ILocationRepository,
-    changeConfigurationRepository?: IChangeConfigurationRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-    idGenerator?: IdGenerator,
-    tenantRepository?: ITenantRepository,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    bootRepository,
+    deviceModelRepository,
+    messageInfoRepository,
+    locationRepository,
+    changeConfigurationRepository,
+    ocppMessageRepository,
+    idGenerator,
+    tenantRepository,
+    configurationDeviceModelService,
+    bootNotificationService,
+  }: ConfigurationModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Configuration, logger, ocppValidator);
 
     this._requests = config.modules.configuration.requests;
     this._responses = config.modules.configuration.responses;
 
-    this._bootRepository =
-      bootRepository || new sequelize.SequelizeBootRepository(config, this._logger);
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, this._logger);
-    this._messageInfoRepository =
-      messageInfoRepository || new sequelize.SequelizeMessageInfoRepository(config, this._logger);
-    this._locationRepository =
-      locationRepository || new sequelize.SequelizeLocationRepository(config, this._logger);
-    this._changeConfigurationRepository =
-      changeConfigurationRepository ||
-      new SequelizeChangeConfigurationRepository(config, this._logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
+    this._bootRepository = bootRepository;
+    this._deviceModelRepository = deviceModelRepository;
+    this._messageInfoRepository = messageInfoRepository;
+    this._locationRepository = locationRepository;
+    this._changeConfigurationRepository = changeConfigurationRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._tenantRepository = tenantRepository;
 
-    this._tenantRepository =
-      tenantRepository || new sequelize.SequelizeTenantRepository(config, this._logger);
+    this._deviceModelService = configurationDeviceModelService;
+    this._bootService = bootNotificationService;
 
-    this._deviceModelService = new DeviceModelService(this._deviceModelRepository);
-
-    this._bootService = new BootNotificationService(
-      this._bootRepository,
-      this._cache,
-      this._config.modules.configuration,
-      this._logger,
-    );
-
-    this._idGenerator =
-      idGenerator ||
-      new IdGenerator(new SequelizeChargingStationSequenceRepository(config, this._logger));
+    this._idGenerator = idGenerator;
   }
 
   protected _tenantRepository: ITenantRepository;
@@ -1121,3 +1067,5 @@ export class ConfigurationModule extends AbstractModule {
     }
   }
 }
+
+export default ConfigurationModule;

--- a/packages/core/src/modules/Configuration/src/register.ts
+++ b/packages/core/src/modules/Configuration/src/register.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, asFunction, type AwilixContainer } from 'awilix';
+import { BootNotificationService } from './module/BootNotificationService.js';
+import { DeviceModelService } from './module/DeviceModelService.js';
+
+/**
+ * Registers the Configuration module's internal services as scoped dependencies.
+ * The service classes stay private to this package — only this registrar is exported.
+ */
+export function registerConfigurationServices(container: AwilixContainer): void {
+  container.register({
+    configurationDeviceModelService: asClass(DeviceModelService).scoped(),
+    // BootNotificationService takes the narrowed module config, not the full `config` token.
+    bootNotificationService: asFunction(
+      ({ bootRepository, cache, config, logger }) =>
+        new BootNotificationService({
+          bootRepository,
+          cache,
+          config: config.modules.configuration,
+          logger,
+        }),
+    ).scoped(),
+  });
+}

--- a/packages/core/src/modules/Configuration/test/module/BootNotificationService.test.ts
+++ b/packages/core/src/modules/Configuration/test/module/BootNotificationService.test.ts
@@ -7,10 +7,12 @@ import { ICache, OCPP1_6, OCPP2_0_1, SystemConfig } from '@citrineos/base';
 import { aValidBootConfig } from '../providers/BootConfigProvider.js';
 import { aMessageConfirmation, MOCK_REQUEST_ID } from '../providers/SendCall.js';
 import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 type Configuration = SystemConfig['modules']['configuration'];
 
 describe('BootService', () => {
+  const { container } = createTestContainer();
   let mockBootRepository: Mocked<IBootRepository>;
   let mockCache: Mocked<ICache>;
   let mockConfig: Mocked<Configuration>;
@@ -46,7 +48,11 @@ describe('BootService', () => {
       },
     };
 
-    bootService = new BootNotificationService(mockBootRepository, mockCache, mockConfig);
+    bootService = getTestInstance(container, BootNotificationService, {
+      bootRepository: mockBootRepository,
+      cache: mockCache,
+      config: mockConfig,
+    });
   });
 
   afterEach(() => {

--- a/packages/core/src/modules/Configuration/test/module/MessageApi.test.ts
+++ b/packages/core/src/modules/Configuration/test/module/MessageApi.test.ts
@@ -62,8 +62,9 @@ describe('ConfigurationOcpp2Api', () => {
         [MOCK_STATION_ID_1],
         mockRequest,
         undefined,
-        extraQueries,
         MOCK_TENANT_ID,
+        OCPPVersion.OCPP2_0_1,
+        extraQueries,
       );
 
       expect(SetNetworkProfile.build).toHaveBeenCalledTimes(1);
@@ -87,8 +88,9 @@ describe('ConfigurationOcpp2Api', () => {
         [MOCK_STATION_ID_1, MOCK_STATION_ID_2],
         mockRequest,
         undefined,
-        extraQueries,
         MOCK_TENANT_ID,
+        OCPPVersion.OCPP2_0_1,
+        extraQueries,
       );
 
       expect(SetNetworkProfile.build).toHaveBeenCalledTimes(2);
@@ -107,8 +109,8 @@ describe('ConfigurationOcpp2Api', () => {
         [MOCK_STATION_ID_1],
         mockRequest,
         undefined,
-        undefined,
         MOCK_TENANT_ID,
+        OCPPVersion.OCPP2_0_1,
       );
 
       expect(SetNetworkProfile.build).not.toHaveBeenCalled();
@@ -121,8 +123,8 @@ describe('ConfigurationOcpp2Api', () => {
         [MOCK_STATION_ID_1, MOCK_STATION_ID_2],
         mockRequest,
         undefined,
-        undefined,
         MOCK_TENANT_ID,
+        OCPPVersion.OCPP2_0_1,
       );
 
       expect(mockSendCall).toHaveBeenCalledTimes(2);

--- a/packages/core/src/modules/EVDriver/src/index.ts
+++ b/packages/core/src/modules/EVDriver/src/index.ts
@@ -7,3 +7,4 @@ export { EVDriverOcpp16Api } from './module/1.6/MessageApi.js';
 export { EVDriverDataApi } from './module/DataApi.js';
 export type { IEVDriverModuleApi } from './module/interface.js';
 export { EVDriverModule } from './module/module.js';
+export { registerEVDriverServices } from './register.js';

--- a/packages/core/src/modules/EVDriver/src/module/1.6/MessageApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/1.6/MessageApi.ts
@@ -28,8 +28,20 @@ export class EVDriverOcpp16Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger for logging.
    */
-  constructor(evDriverModule: EVDriverModule, server: FastifyInstance, logger?: Logger<ILogObj>) {
-    super(evDriverModule, server, OCPPVersion.OCPP1_6, logger);
+  constructor({
+    evDriverModule,
+    server,
+    logger,
+  }: {
+    evDriverModule: EVDriverModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(evDriverModule, server, logger);
+  }
+
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP1_6];
   }
 
   @AsMessageEndpoint(
@@ -125,8 +137,8 @@ export class EVDriverOcpp16Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
@@ -39,22 +39,32 @@ export class EVDriverOcpp2Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger for logging.
    */
-  constructor(
-    evDriverModule: EVDriverModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(evDriverModule, server, version, logger);
-    if (version === OCPPVersion.OCPP2_1) {
+  constructor({
+    evDriverModule,
+    server,
+    logger,
+  }: {
+    evDriverModule: EVDriverModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(evDriverModule, server, logger);
+    // The C25 web-payment endpoint is 2.1-only, but its path is version-agnostic
+    // (POST /evdriver/webpayment/initiate, not under /ocpp/<v>/). Register it once
+    // since this single instance serves 2.1.
+    if (this.supportedVersions.includes(OCPPVersion.OCPP2_1)) {
       this._registerInitiateWebPaymentRoute();
     }
   }
 
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
+  }
+
   //TODO: 2.1 needs extended code for this request
-  @AsMessageEndpoint(OCPP_CallAction.RequestStartTransaction, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.RequestStartTransaction, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'RequestStartTransactionRequestSchema',
     ),
   )
@@ -63,6 +73,7 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.RequestStartTransactionRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: IMessageConfirmation[] = [];
 
@@ -71,7 +82,7 @@ export class EVDriverOcpp2Api
 
       // F07: Store transactionLimit in cache for remote start with fixed cost, energy, SoC or time
       // The limit will be retrieved when TransactionEvent(Started) arrives with matching remoteStartId
-      if (this._ocppVersion === OCPPVersion.OCPP2_1 && request.customData?.transactionLimit) {
+      if (version === OCPPVersion.OCPP2_1 && request.customData?.transactionLimit) {
         try {
           const transactionLimit = request.customData
             .transactionLimit as OCPP2_1.TransactionLimitType;
@@ -169,7 +180,7 @@ export class EVDriverOcpp2Api
         const confirmation = await this._module.sendCall(
           i,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.RequestStartTransaction,
           request,
           callbackUrl,
@@ -195,9 +206,9 @@ export class EVDriverOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.RequestStopTransaction, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.RequestStopTransaction, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'RequestStopTransactionRequestSchema',
     ),
   )
@@ -206,21 +217,22 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.RequestStopTransactionRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.RequestStopTransaction,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.CancelReservation, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.CancelReservation, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'CancelReservationRequestSchema',
     ),
   )
@@ -229,6 +241,7 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.CancelReservationRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     try {
       // Attempt to load the reservations for each station ID
@@ -259,7 +272,7 @@ export class EVDriverOcpp2Api
         this._module,
         identifiers,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.CancelReservation,
         request,
         callbackUrl,
@@ -278,9 +291,9 @@ export class EVDriverOcpp2Api
     }
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ReserveNow, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ReserveNow, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ReserveNowRequestSchema',
     ),
   )
@@ -332,9 +345,9 @@ export class EVDriverOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.UnlockConnector, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.UnlockConnector, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'UnlockConnectorRequestSchema',
     ),
   )
@@ -343,21 +356,22 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.UnlockConnectorRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.UnlockConnector,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearCache, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ClearCache, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ClearCacheRequestSchema',
     ),
   )
@@ -366,21 +380,22 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.ClearCacheRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.ClearCache,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SendLocalList, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SendLocalList, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SendLocalListRequestSchema',
     ),
   )
@@ -389,6 +404,7 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.SendLocalListRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: IMessageConfirmation[] = [];
 
@@ -406,7 +422,7 @@ export class EVDriverOcpp2Api
         const confirmation = await this._module.sendCall(
           i,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.SendLocalList,
           request,
           callbackUrl,
@@ -425,9 +441,9 @@ export class EVDriverOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetLocalListVersion, (instance: EVDriverOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetLocalListVersion, (_instance: EVDriverOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetLocalListVersionRequestSchema',
     ),
   )
@@ -436,12 +452,13 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.GetLocalListVersionRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetLocalListVersion,
       request,
       callbackUrl,
@@ -605,8 +622,8 @@ export class EVDriverOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.evdriver.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
@@ -62,11 +62,13 @@ export class EVDriverOcpp2Api
   }
 
   //TODO: 2.1 needs extended code for this request
-  @AsMessageEndpoint(OCPP_CallAction.RequestStartTransaction, (_instance: EVDriverOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'RequestStartTransactionRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.RequestStartTransaction,
+    (_instance: EVDriverOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'RequestStartTransactionRequestSchema',
+      ),
   )
   async requestStartTransaction(
     identifier: string[],
@@ -206,11 +208,13 @@ export class EVDriverOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.RequestStopTransaction, (_instance: EVDriverOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'RequestStopTransactionRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.RequestStopTransaction,
+    (_instance: EVDriverOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'RequestStopTransactionRequestSchema',
+      ),
   )
   async requestStopTransaction(
     identifier: string[],

--- a/packages/core/src/modules/EVDriver/src/module/DataApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/DataApi.ts
@@ -30,8 +30,16 @@ export class EVDriverDataApi
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger for logging.
    */
-  constructor(evDriverModule: EVDriverModule, server: FastifyInstance, logger?: Logger<ILogObj>) {
-    super(evDriverModule, server, null, logger);
+  constructor({
+    evDriverModule,
+    server,
+    logger,
+  }: {
+    evDriverModule: EVDriverModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(evDriverModule, server, logger);
   }
 
   @AsDataEndpoint(OCPP2_Namespace.LocalListVersion, HttpMethod.Get, ChargingStationKeyQuerySchema)

--- a/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
+++ b/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
@@ -18,10 +18,13 @@ export class LocalAuthListService {
   protected _localAuthListRepository: ILocalAuthListRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
 
-  constructor(
-    localAuthListRepository: ILocalAuthListRepository,
-    deviceModelRepository: IDeviceModelRepository,
-  ) {
+  constructor({
+    localAuthListRepository,
+    deviceModelRepository,
+  }: {
+    localAuthListRepository: ILocalAuthListRepository;
+    deviceModelRepository: IDeviceModelRepository;
+  }) {
     this._localAuthListRepository = localAuthListRepository;
     this._deviceModelRepository = deviceModelRepository;
   }

--- a/packages/core/src/modules/EVDriver/src/module/module.ts
+++ b/packages/core/src/modules/EVDriver/src/module/module.ts
@@ -3,22 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 import type {
   AuthorizationStatusEnumType,
-  BootstrapConfig,
   CallAction,
   HandlerProperties,
   IAuthorizer,
-  ICache,
   IMessage,
   IMessageContext,
-  IMessageHandler,
-  IMessageSender,
   IVatProvider,
+  OcppModuleDependencies,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
   ReservationUpdateStatusEnumType,
   ReserveNowStatusEnumType,
-  SystemConfig,
 } from '@citrineos/base';
 import {
   AbstractModule,
@@ -40,7 +36,6 @@ import {
   OCPP_2_VER_LIST,
   OCPP_CallAction,
   OcppError,
-  OCPPValidator,
   OCPPVersion,
   RequestStartStopStatusEnum,
   ReservationUpdateStatusEnum,
@@ -62,21 +57,35 @@ import {
   OCPP1_6_Mapper,
   OCPP2_0_1_Mapper,
   OCPP2_1_Mapper,
-  SequelizeChargingStationSequenceRepository,
   VariableAttribute,
 } from '@dal/layers/sequelize/index.js';
-import { sequelize } from '@dal/index.js';
+
 import {
   CertificateAuthorityService,
   IdGenerator,
-  RealTimeAuthorizer,
   validateIdToken,
   validateOcpp21IdToken,
-  ViesVatProvider,
 } from '@util/index.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { LocalAuthListService } from './LocalAuthListService.js';
+
+import type { LocalAuthListService } from './LocalAuthListService.js';
+
+export interface EVDriverModuleDependencies extends OcppModuleDependencies {
+  authorizationRepository: IAuthorizationRepository;
+  localAuthListRepository: ILocalAuthListRepository;
+  deviceModelRepository: IDeviceModelRepository;
+  tariffRepository: ITariffRepository;
+  transactionEventRepository: ITransactionEventRepository;
+  chargingProfileRepository: IChargingProfileRepository;
+  reservationRepository: IReservationRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  locationRepository: ILocationRepository;
+  certificateAuthorityService: CertificateAuthorityService;
+  realTimeAuthorizer: IAuthorizer;
+  authorizers: IAuthorizer[];
+  idGenerator: IdGenerator;
+  localAuthListService: LocalAuthListService;
+  viesVatProvider: IVatProvider;
+}
 
 /**
  * Component that handles provisioning related messages.
@@ -96,141 +105,50 @@ export class EVDriverModule extends AbstractModule {
   private _vatProvider?: IVatProvider;
   private _idGenerator: IdGenerator;
 
-  /**
-   * This is the constructor function that initializes the {@link EVDriverModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {OCPPValidator} [ocppValidator] - An optional parameter of type {@link OCPPValidator} used to validate
-   * incoming and outgoing OCPP messages against their JSON schemas. If no `ocppValidator` is provided, a default
-   * instance is created and used.
-   *
-   * @param {IAuthorizationRepository} [authorizeRepository] - An optional parameter of type {@link IAuthorizationRepository} which represents a repository for accessing and manipulating Authorization data.
-   * If no `authorizeRepository` is provided, a default {@link sequelize:AuthorizationRepository} instance is created and used.
-   *
-   * @param {ILocalAuthListRepository} [localAuthListRepository] - An optional parameter of type {@link ILocalAuthListRepository} which represents a repository for accessing and manipulating Local Authorization List data.
-   * If no `localAuthListRepository` is provided, a default {@link sequelize:localAuthListRepository} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is
-   * created and used.
-   *
-   * @param {ITariffRepository} [tariffRepository] - An optional parameter of type {@link ITariffRepository} which
-   * represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:tariffRepository} instance is
-   * created and used.
-   *
-   * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository}
-   * which represents a repository for accessing and manipulating transaction data.
-   * If no `transactionEventRepository` is provided, a default {@link sequelize:transactionEventRepository} instance is
-   * created and used.
-   *
-   * @param {IChargingProfileRepository} [chargingProfileRepository] - An optional parameter of type {@link IChargingProfileRepository}
-   * which represents a repository for accessing and manipulating charging profile data.
-   * If no `chargingProfileRepository` is provided, a default {@link sequelize:chargingProfileRepository} instance is created and used.
-   *
-   * @param {IReservationRepository} [reservationRepository] - An optional parameter of type {@link IReservationRepository}
-   * which represents a repository for accessing and manipulating reservation data.
-   * If no `reservationRepository` is provided, a default {@link sequelize:reservationRepository} instance is created and used.
-   *
-   * @param {IOCPPMessageRepository} [ocppMessageRepository]  - An optional parameter of type {@link IOCPPMessageRepository}
-   * which represents a repository for accessing and manipulating ocppMessage data.
-   * If no `ocppMessageRepository` is provided, a default {@link sequelize:ocppMessageRepository} instance is created and used.
-   *
-   * @param {ILocationRepository} [locationRepository] - An optional parameter of type {@link ILocationRepository} which represents a repository for accessing and manipulating location and charging station data.
-   * If no `locationRepository` is provided, a default {@link sequelize:locationRepository} instance is
-   * created and used.
-   *
-   * @param {CertificateAuthorityService} [certificateAuthorityService] - An optional parameter of
-   * type {@link CertificateAuthorityService} which handles certificate authority operations.
-   *
-   * @param {IAuthorizer} [realTimeAuthorizer] - An optional parameter of type {@link IAuthorizer} which represents
-   * a real-time authorizer that can be used to authorize real-time requests.
-   *
-   * @param {IAuthorizer[]} [authorizers] - An optional parameter of type {@link IAuthorizer[]} which represents
-   * a list of authorizers that can be used to authorize requests.
-   *
-   * @param {IdGenerator} [idGenerator] - An optional parameter of type {@link IdGenerator} which generates
-   * unique identifiers.
-   *
-   * @param {IVatProvider} [vatProvider] - An optional parameter of type {@link IVatProvider} which find vat info
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    authorizeRepository?: IAuthorizationRepository,
-    localAuthListRepository?: ILocalAuthListRepository,
-    deviceModelRepository?: IDeviceModelRepository,
-    tariffRepository?: ITariffRepository,
-    transactionEventRepository?: ITransactionEventRepository,
-    chargingProfileRepository?: IChargingProfileRepository,
-    reservationRepository?: IReservationRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-    locationRepository?: ILocationRepository,
-    certificateAuthorityService?: CertificateAuthorityService,
-    realTimeAuthorizer?: IAuthorizer,
-    authorizers?: IAuthorizer[],
-    idGenerator?: IdGenerator,
-    vatProvider?: IVatProvider,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    authorizationRepository,
+    localAuthListRepository,
+    deviceModelRepository,
+    tariffRepository,
+    transactionEventRepository,
+    chargingProfileRepository,
+    reservationRepository,
+    ocppMessageRepository,
+    locationRepository,
+    certificateAuthorityService,
+    realTimeAuthorizer,
+    authorizers,
+    idGenerator,
+    localAuthListService,
+    viesVatProvider,
+  }: EVDriverModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.EVDriver, logger, ocppValidator);
 
     this._requests = config.modules.evdriver.requests;
     this._responses = config.modules.evdriver.responses;
 
-    this._authorizeRepository =
-      authorizeRepository || new sequelize.SequelizeAuthorizationRepository(config, logger);
-    this._localAuthListRepository =
-      localAuthListRepository || new sequelize.SequelizeLocalAuthListRepository(config, logger);
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, logger);
-    this._tariffRepository =
-      tariffRepository || new sequelize.SequelizeTariffRepository(config, logger);
-    this._transactionEventRepository =
-      transactionEventRepository ||
-      new sequelize.SequelizeTransactionEventRepository(config, logger);
-    this._chargingProfileRepository =
-      chargingProfileRepository || new sequelize.SequelizeChargingProfileRepository(config, logger);
-    this._reservationRepository =
-      reservationRepository || new sequelize.SequelizeReservationRepository(config, logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new sequelize.SequelizeOCPPMessageRepository(config, logger);
-    this._locationRepository =
-      locationRepository || new sequelize.SequelizeLocationRepository(config, logger);
+    this._authorizeRepository = authorizationRepository;
+    this._localAuthListRepository = localAuthListRepository;
+    this._deviceModelRepository = deviceModelRepository;
+    this._tariffRepository = tariffRepository;
+    this._transactionEventRepository = transactionEventRepository;
+    this._chargingProfileRepository = chargingProfileRepository;
+    this._reservationRepository = reservationRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._locationRepository = locationRepository;
+    this._certificateAuthorityService = certificateAuthorityService;
 
-    this._certificateAuthorityService =
-      certificateAuthorityService || new CertificateAuthorityService(config, cache, logger);
+    this._localAuthListService = localAuthListService;
 
-    this._localAuthListService = new LocalAuthListService(
-      this._localAuthListRepository,
-      this._deviceModelRepository,
-    );
-
-    const _realTimeAuthorizer =
-      realTimeAuthorizer ||
-      new RealTimeAuthorizer(this._locationRepository, this.config, this._logger);
-    this._authorizers = [_realTimeAuthorizer, ...(authorizers || [])];
-
-    this._idGenerator =
-      idGenerator ||
-      new IdGenerator(new SequelizeChargingStationSequenceRepository(config, this._logger));
-
-    this._vatProvider = vatProvider || new ViesVatProvider();
+    this._authorizers = [realTimeAuthorizer, ...authorizers];
+    this._idGenerator = idGenerator;
+    this._vatProvider = viesVatProvider;
   }
 
   protected _authorizeRepository: IAuthorizationRepository;
@@ -1240,3 +1158,5 @@ export class EVDriverModule extends AbstractModule {
     this._logger.debug('ClearCacheResponse received:', message, props);
   }
 }
+
+export default EVDriverModule;

--- a/packages/core/src/modules/EVDriver/src/register.ts
+++ b/packages/core/src/modules/EVDriver/src/register.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, type AwilixContainer } from 'awilix';
+import { ViesVatProvider } from '@util/index.js';
+import { LocalAuthListService } from './module/LocalAuthListService.js';
+
+/**
+ * Registers the EVDriver module's internal services as scoped dependencies.
+ * The service classes stay private to this package — only this registrar is exported.
+ */
+export function registerEVDriverServices(container: AwilixContainer): void {
+  container.register({
+    localAuthListService: asClass(LocalAuthListService).scoped(),
+    viesVatProvider: asClass(ViesVatProvider).scoped(),
+  });
+}

--- a/packages/core/src/modules/EVDriver/test/module/LocalAuthListService.test.ts
+++ b/packages/core/src/modules/EVDriver/test/module/LocalAuthListService.test.ts
@@ -13,8 +13,10 @@ import {
 import { LocalAuthListService } from '../../src/module/LocalAuthListService.js';
 import { DEFAULT_TENANT_ID, OCPP2_0_1 } from '@citrineos/base';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('LocalAuthListService', () => {
+  const { container } = createTestContainer();
   let mockLocalAuthListRepository: Mocked<ILocalAuthListRepository>;
   let mockDeviceModelRepository: Mocked<IDeviceModelRepository>;
   let localAuthListService: LocalAuthListService;
@@ -42,10 +44,10 @@ describe('LocalAuthListService', () => {
       readAllByQuerystring: vi.fn(),
     } as unknown as Mocked<IDeviceModelRepository>;
 
-    localAuthListService = new LocalAuthListService(
-      mockLocalAuthListRepository,
-      mockDeviceModelRepository,
-    );
+    localAuthListService = getTestInstance(container, LocalAuthListService, {
+      localAuthListRepository: mockLocalAuthListRepository,
+      deviceModelRepository: mockDeviceModelRepository,
+    });
   });
 
   it('should persist SendLocalListRequest and return the SendLocalList, validating input arguments', async () => {

--- a/packages/core/src/modules/Monitoring/src/index.ts
+++ b/packages/core/src/modules/Monitoring/src/index.ts
@@ -6,3 +6,4 @@ export { MonitoringOcpp2Api } from './module/2/MessageApi.js';
 export { MonitoringDataApi } from './module/DataApi.js';
 export type { IMonitoringModuleApi } from './module/interface.js';
 export { MonitoringModule } from './module/module.js';
+export { registerMonitoringServices } from './register.js';

--- a/packages/core/src/modules/Monitoring/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Monitoring/src/module/2/MessageApi.ts
@@ -67,11 +67,13 @@ export class MonitoringOcpp2Api
     return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetVariableMonitoring, (_instance: MonitoringOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'SetVariableMonitoringRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.SetVariableMonitoring,
+    (_instance: MonitoringOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'SetVariableMonitoringRequestSchema',
+      ),
   )
   async setVariableMonitoring(
     identifier: string[],
@@ -166,11 +168,13 @@ export class MonitoringOcpp2Api
     return confirmations;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearVariableMonitoring, (_instance: MonitoringOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'ClearVariableMonitoringRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.ClearVariableMonitoring,
+    (_instance: MonitoringOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'ClearVariableMonitoringRequestSchema',
+      ),
   )
   async clearVariableMonitoring(
     identifier: string[],

--- a/packages/core/src/modules/Monitoring/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Monitoring/src/module/2/MessageApi.ts
@@ -44,18 +44,32 @@ export class MonitoringOcpp2Api
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    monitoringModule: MonitoringModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(monitoringModule, server, version, logger);
+  constructor({
+    monitoringModule,
+    server,
+    logger,
+  }: {
+    monitoringModule: MonitoringModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    // The OCPP version is no longer instance state — it is supplied per route /
+    // per request via supportedVersions() and the handler `version` parameter.
+    super(monitoringModule, server, logger);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetVariableMonitoring, (instance: MonitoringOcpp2Api) =>
+  /**
+   * This API serves both OCPP 2.0.1 and 2.1 from a single instance; each
+   * message endpoint is registered once per version with the version threaded
+   * into schema selection, the route path, and the handler.
+   */
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
+  }
+
+  @AsMessageEndpoint(OCPP_CallAction.SetVariableMonitoring, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetVariableMonitoringRequestSchema',
     ),
   )
@@ -64,6 +78,7 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.SetVariableMonitoringRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     // For each station, check request size, process monitoring data, and handle batch sending
     const confirmations: IMessageConfirmation[] = [];
@@ -132,7 +147,7 @@ export class MonitoringOcpp2Api
         const result = await this.processBatches(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.SetVariableMonitoring,
           { setMonitoringData },
           'setMonitoringData',
@@ -151,9 +166,9 @@ export class MonitoringOcpp2Api
     return confirmations;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearVariableMonitoring, (instance: MonitoringOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ClearVariableMonitoring, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ClearVariableMonitoringRequestSchema',
     ),
   )
@@ -162,6 +177,7 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.ClearVariableMonitoringRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const confirmations: IMessageConfirmation[] = [];
 
@@ -203,7 +219,7 @@ export class MonitoringOcpp2Api
         const result = await this.processBatches(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.ClearVariableMonitoring,
           { id: ids },
           'id',
@@ -222,9 +238,9 @@ export class MonitoringOcpp2Api
     return confirmations;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetMonitoringLevel, (instance: MonitoringOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetMonitoringLevel, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetMonitoringLevelRequestSchema',
     ),
   )
@@ -233,21 +249,22 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.SetMonitoringLevelRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.SetMonitoringLevel,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetMonitoringBase, (instance: MonitoringOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetMonitoringBase, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetMonitoringBaseRequestSchema',
     ),
   )
@@ -256,21 +273,22 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.SetMonitoringBaseRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.SetMonitoringBase,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetVariables, (instance: MonitoringOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetVariables, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetVariablesRequestSchema',
     ),
   )
@@ -279,6 +297,7 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.SetVariablesRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const confirmations: IMessageConfirmation[] = [];
 
@@ -307,7 +326,7 @@ export class MonitoringOcpp2Api
         const result = await this.processBatches(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.SetVariables,
           { setVariableData },
           'setVariableData',
@@ -326,9 +345,9 @@ export class MonitoringOcpp2Api
     return confirmations;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetVariables, (instance: MonitoringOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetVariables, (_instance: MonitoringOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetVariablesRequestSchema',
     ),
   )
@@ -337,6 +356,7 @@ export class MonitoringOcpp2Api
     request: OCPP2_request_types.GetVariablesRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const confirmations: IMessageConfirmation[] = [];
 
@@ -373,7 +393,7 @@ export class MonitoringOcpp2Api
         const result = await this.processBatches(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.GetVariables,
           { getVariableData },
           'getVariableData',
@@ -453,8 +473,8 @@ export class MonitoringOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.monitoring.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Monitoring/src/module/DataApi.ts
+++ b/packages/core/src/modules/Monitoring/src/module/DataApi.ts
@@ -43,12 +43,16 @@ export class MonitoringDataApi
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    monitoringModule: MonitoringModule,
-    server: FastifyInstance,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(monitoringModule, server, null, logger);
+  constructor({
+    monitoringModule,
+    server,
+    logger,
+  }: {
+    monitoringModule: MonitoringModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(monitoringModule, server, logger);
   }
 
   @AsDataEndpoint(

--- a/packages/core/src/modules/Monitoring/src/module/MonitoringService.ts
+++ b/packages/core/src/modules/Monitoring/src/module/MonitoringService.ts
@@ -10,10 +10,13 @@ export class MonitoringService {
   protected _variableMonitoringRepository: IVariableMonitoringRepository;
   protected _logger: Logger<ILogObj>;
 
-  constructor(
-    variableMonitoringRepository: IVariableMonitoringRepository,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    variableMonitoringRepository,
+    logger,
+  }: {
+    variableMonitoringRepository: IVariableMonitoringRepository;
+    logger: Logger<ILogObj>;
+  }) {
     this._variableMonitoringRepository = variableMonitoringRepository;
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })

--- a/packages/core/src/modules/Monitoring/src/module/module.ts
+++ b/packages/core/src/modules/Monitoring/src/module/module.ts
@@ -6,7 +6,6 @@ import {
   AsHandler,
   AttributeEnum,
   type AttributeEnumType,
-  type BootstrapConfig,
   type CallAction,
   ChargingStationSequenceTypeEnum,
   EventGroup,
@@ -15,39 +14,39 @@ import {
   GenericStatusEnum,
   type GenericStatusEnumType,
   type HandlerProperties,
-  type ICache,
   type IMessage,
-  type IMessageHandler,
-  type IMessageSender,
+  type OcppModuleDependencies,
   MessageOrigin,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
-  OCPPValidator,
   SetVariableStatusEnum,
-  type SystemConfig,
 } from '@citrineos/base';
 import {
   Component,
   type IDeviceModelRepository,
   type IOCPPMessageRepository,
   type IVariableMonitoringRepository,
-  SequelizeChargingStationSequenceRepository,
-  SequelizeDeviceModelRepository,
-  SequelizeOCPPMessageRepository,
-  SequelizeVariableMonitoringRepository,
   Variable,
   type VariableAttribute,
 } from '@dal/index.js';
 import { IdGenerator } from '@util/index.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { MonitoringService } from './MonitoringService.js';
-import { DeviceModelService } from './services.js';
+
+import type { MonitoringService } from './MonitoringService.js';
+import type { DeviceModelService } from './services.js';
 
 type SetVariableDataMap = { [key: string]: OCPP2_common_types.SetVariableDataType };
+
+export interface MonitoringModuleDependencies extends OcppModuleDependencies {
+  deviceModelRepository: IDeviceModelRepository;
+  variableMonitoringRepository: IVariableMonitoringRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  idGenerator: IdGenerator;
+  monitoringDeviceModelService: DeviceModelService;
+  monitoringService: MonitoringService;
+}
 
 /**
  * Component that handles monitoring related messages.
@@ -65,67 +64,33 @@ export class MonitoringModule extends AbstractModule {
   protected _ocppMessageRepository: IOCPPMessageRepository;
   private _idGenerator: IdGenerator;
 
-  /**
-   * This is the constructor function that initializes the {@link MonitoringModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system-wide logger settings and will serve as the parent logger for any subcomponent logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link SequelizeDeviceModelRepository} instance is created and used.
-   *
-   * @param {IVariableMonitoringRepository} [variableMonitoringRepository] - An optional parameter of type {@link IVariableMonitoringRepository}
-   * which represents a repository for accessing and manipulating variable monitoring data.
-   * If no `variableMonitoringRepository` is provided, a default {@link SequelizeVariableMonitoringRepository}
-   * instance is created and used.
-   *
-   * @param {IdGenerator} [idGenerator] - An optional parameter of type {@link IdGenerator} which
-   * represents a generator for ids.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    deviceModelRepository?: IDeviceModelRepository,
-    variableMonitoringRepository?: IVariableMonitoringRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-    idGenerator?: IdGenerator,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    deviceModelRepository,
+    variableMonitoringRepository,
+    ocppMessageRepository,
+    idGenerator,
+    monitoringDeviceModelService,
+    monitoringService,
+  }: MonitoringModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Monitoring, logger, ocppValidator);
 
     this._requests = config.modules.monitoring.requests;
     this._responses = config.modules.monitoring.responses;
 
-    this._deviceModelRepository =
-      deviceModelRepository || new SequelizeDeviceModelRepository(config, this._logger);
-    this._variableMonitoringRepository =
-      variableMonitoringRepository ||
-      new SequelizeVariableMonitoringRepository(config, this._logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
+    this._deviceModelRepository = deviceModelRepository;
+    this._variableMonitoringRepository = variableMonitoringRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
 
-    this._deviceModelService = new DeviceModelService(this._deviceModelRepository);
-    this._monitoringService = new MonitoringService(
-      this._variableMonitoringRepository,
-      this._logger,
-    );
+    this._deviceModelService = monitoringDeviceModelService;
+    this._monitoringService = monitoringService;
 
-    this._idGenerator =
-      idGenerator ||
-      new IdGenerator(new SequelizeChargingStationSequenceRepository(config, this._logger));
+    this._idGenerator = idGenerator;
   }
 
   get deviceModelRepository(): IDeviceModelRepository {
@@ -502,3 +467,5 @@ export class MonitoringModule extends AbstractModule {
     return `${componentName}-${componentInstance}-${variableName}-${variableInstance}`;
   }
 }
+
+export default MonitoringModule;

--- a/packages/core/src/modules/Monitoring/src/module/services.ts
+++ b/packages/core/src/modules/Monitoring/src/module/services.ts
@@ -9,7 +9,7 @@ import { VariableAttribute } from '@dal/layers/sequelize/index.js';
 export class DeviceModelService {
   protected _deviceModelRepository: IDeviceModelRepository;
 
-  constructor(deviceModelRepository: IDeviceModelRepository) {
+  constructor({ deviceModelRepository }: { deviceModelRepository: IDeviceModelRepository }) {
     this._deviceModelRepository = deviceModelRepository;
   }
 

--- a/packages/core/src/modules/Monitoring/src/register.ts
+++ b/packages/core/src/modules/Monitoring/src/register.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, type AwilixContainer } from 'awilix';
+import { MonitoringService } from './module/MonitoringService.js';
+import { DeviceModelService } from './module/services.js';
+
+/**
+ * Registers the Monitoring module's internal services as scoped dependencies.
+ * The service classes stay private to this package — only this registrar is exported.
+ */
+export function registerMonitoringServices(container: AwilixContainer): void {
+  container.register({
+    monitoringDeviceModelService: asClass(DeviceModelService).scoped(),
+    monitoringService: asClass(MonitoringService).scoped(),
+  });
+}

--- a/packages/core/src/modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
+++ b/packages/core/src/modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
@@ -115,7 +115,10 @@ function makeRepos() {
   return {
     deviceModelRepo: new SequelizeDeviceModelRepository({ config, sequelizeInstance }),
     ocppMessageRepo: new SequelizeOCPPMessageRepository({ config, sequelizeInstance }),
-    variableMonitoringRepo: new SequelizeVariableMonitoringRepository({ config, sequelizeInstance }),
+    variableMonitoringRepo: new SequelizeVariableMonitoringRepository({
+      config,
+      sequelizeInstance,
+    }),
   };
 }
 
@@ -251,7 +254,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       });
       await seedSetVariablesRequest([data1, data2]);
 
-
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
         OCPP_CONNECTION_NAME,
@@ -271,7 +273,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         d.attributeType = undefined;
       });
       await seedSetVariablesRequest([data]);
-
 
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
@@ -293,7 +294,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       await seedSetVariablesRequest([data], 'other-corr-id');
       // No message seeded for CORRELATION_ID
 
-
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
         OCPP_CONNECTION_NAME,
@@ -314,7 +314,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       const component = await seedComponent('Connector');
       const variable = await seedVariable('MaxVoltage');
       const seeded = await seedVariableAttribute(component.id, variable.id, '120');
-
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,
@@ -338,7 +337,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
     it('creates a new VariableAttribute in the DB when none exists', async () => {
       await seedBase();
       // No Component, Variable, or VariableAttribute seeded
-
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,
@@ -375,7 +373,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         '7200',
         OCPP2_0_1.AttributeEnumType.Actual,
       );
-
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,

--- a/packages/core/src/modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
+++ b/packages/core/src/modules/Monitoring/test/module/MonitoringModule.SetVariables.test.ts
@@ -26,7 +26,10 @@ import {
   VariableAttribute,
   VariableStatus,
 } from '@dal/index.js';
+import { asValue } from 'awilix';
 import { MonitoringModule } from '../../src/module/module.js';
+import { registerMonitoringServices } from '../../src/register.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import {
   aSetVariableData,
   aSetVariableResult,
@@ -48,6 +51,7 @@ const CORRELATION_ID = 'corr-abc-123';
 
 let pgContainer: StartedTestContainer;
 let sequelizeInstance: Sequelize;
+let module: MonitoringModule;
 
 beforeAll(async () => {
   pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
@@ -87,6 +91,10 @@ beforeAll(async () => {
   VariableAttribute.hasMany(VariableStatus, { foreignKey: 'variableAttributeId' });
   VariableStatus.belongsTo(VariableAttribute, { foreignKey: 'variableAttributeId' });
   await sequelizeInstance.sync({ force: true });
+
+  // The module is stateless across tests (each test truncates + seeds the DB and
+  // asserts on return values / DB state, not on mocks), so build it once.
+  module = makeModule();
 }, 90_000);
 
 afterAll(async () => {
@@ -105,40 +113,32 @@ beforeEach(async () => {
 function makeRepos() {
   const config = {} as BootstrapConfig;
   return {
-    deviceModelRepo: new SequelizeDeviceModelRepository(config, undefined, sequelizeInstance),
-    ocppMessageRepo: new SequelizeOCPPMessageRepository(config, undefined, sequelizeInstance),
-    variableMonitoringRepo: new SequelizeVariableMonitoringRepository(
-      config,
-      undefined,
-      sequelizeInstance,
-    ),
+    deviceModelRepo: new SequelizeDeviceModelRepository({ config, sequelizeInstance }),
+    ocppMessageRepo: new SequelizeOCPPMessageRepository({ config, sequelizeInstance }),
+    variableMonitoringRepo: new SequelizeVariableMonitoringRepository({ config, sequelizeInstance }),
   };
 }
 
 function makeModule(): MonitoringModule {
   const { deviceModelRepo, ocppMessageRepo, variableMonitoringRepo } = makeRepos();
 
-  const mockConfig = { modules: { monitoring: { requests: [], responses: [] } } } as any;
-  const mockLogger = {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    getSubLogger: vi.fn().mockReturnThis(),
-  } as any;
-
-  return new MonitoringModule(
-    mockConfig,
-    /* cache */ {} as any,
-    /* sender */ {} as any,
-    /* handler */ { module: null } as any,
-    mockLogger,
-    /* ocppValidator */ { validate: vi.fn().mockResolvedValue(undefined) } as any,
-    deviceModelRepo,
-    variableMonitoringRepo,
-    ocppMessageRepo,
-    /* idGenerator */ { generateRequestId: vi.fn().mockResolvedValue(1) } as any,
-  );
+  // Build the module through the container so its internal services resolve via
+  // registerMonitoringServices (the production DI wiring) from the real repos.
+  // asValue is untyped, so the infra mocks need no casts.
+  const { container } = createTestContainer();
+  container.register({
+    config: asValue({ modules: { monitoring: { requests: [], responses: [] } } }),
+    cache: asValue({}),
+    sender: asValue({}),
+    handler: asValue({ module: null }),
+    ocppValidator: asValue({ validate: vi.fn().mockResolvedValue(undefined) }),
+    deviceModelRepository: asValue(deviceModelRepo),
+    variableMonitoringRepository: asValue(variableMonitoringRepo),
+    ocppMessageRepository: asValue(ocppMessageRepo),
+    idGenerator: asValue({ generateRequestId: vi.fn().mockResolvedValue(1) }),
+  });
+  registerMonitoringServices(container);
+  return getTestInstance(container, MonitoringModule, {});
 }
 
 // ---------------------------------------------------------------------------
@@ -225,7 +225,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
     it('returns an empty map when no OCPPMessage exists for the correlation id', async () => {
       await seedBase();
       // No OCPPMessage seeded
-      const module = makeModule();
 
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
@@ -252,7 +251,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       });
       await seedSetVariablesRequest([data1, data2]);
 
-      const module = makeModule();
 
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
@@ -274,7 +272,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       });
       await seedSetVariablesRequest([data]);
 
-      const module = makeModule();
 
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
@@ -296,7 +293,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       await seedSetVariablesRequest([data], 'other-corr-id');
       // No message seeded for CORRELATION_ID
 
-      const module = makeModule();
 
       const map = await (module as any).getSetVariablesDataMapFromOriginalSetVariablesRequest(
         TENANT_ID,
@@ -319,7 +315,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       const variable = await seedVariable('MaxVoltage');
       const seeded = await seedVariableAttribute(component.id, variable.id, '120');
 
-      const module = makeModule();
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,
@@ -344,7 +339,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
       await seedBase();
       // No Component, Variable, or VariableAttribute seeded
 
-      const module = makeModule();
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,
@@ -382,7 +376,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         OCPP2_0_1.AttributeEnumType.Actual,
       );
 
-      const module = makeModule();
 
       const result = await (module as any).getExistingOrCreateVariableAttribute(
         TENANT_ID,
@@ -425,7 +418,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         r.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
       });
 
-      const module = makeModule();
       await (module as any).handleSetVariableResultType(
         TENANT_ID,
         OCPP_CONNECTION_NAME,
@@ -466,7 +458,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         r.attributeType = OCPP2_0_1.AttributeEnumType.Actual;
       });
 
-      const module = makeModule();
       await (module as any).handleSetVariableResultType(
         TENANT_ID,
         OCPP_CONNECTION_NAME,
@@ -506,7 +497,6 @@ describe('MonitoringModule – SetVariables response handling', () => {
         r.attributeStatus = OCPP2_0_1.SetVariableStatusEnumType.Accepted;
       });
 
-      const module = makeModule();
       await (module as any).handleSetVariableResultType(
         TENANT_ID,
         OCPP_CONNECTION_NAME,
@@ -543,7 +533,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
         }),
       ]);
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -582,7 +572,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
         }),
       ]);
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -624,7 +614,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
         }),
       ]);
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -663,7 +653,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
       const varAttr = await seedVariableAttribute(component.id, variable.id, '120');
       // Intentionally do NOT seed an OCPPMessage
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -702,7 +692,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
         }),
       ]);
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -763,7 +753,7 @@ describe('MonitoringModule – SetVariables response handling', () => {
         }),
       ]);
 
-      await (makeModule() as any)._handleSetVariables(
+      await (module as any)._handleSetVariables(
         aSetVariablesResponseMessage(
           aSetVariablesResponse((r) => {
             r.setVariableResult = [
@@ -803,21 +793,18 @@ describe('MonitoringModule – SetVariables response handling', () => {
 
   describe('getSetVariableDataMapKey', () => {
     it('produces consistent keys for the same inputs', () => {
-      const module = makeModule();
       const key1 = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
       const key2 = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
       expect(key1).toBe(key2);
     });
 
     it('differentiates keys by instance value', () => {
-      const module = makeModule();
       const keyNoInstance = (module as any).getSetVariableDataMapKey('Comp', null, 'Var', null);
       const keyWithInstance = (module as any).getSetVariableDataMapKey('Comp', '1', 'Var', null);
       expect(keyNoInstance).not.toBe(keyWithInstance);
     });
 
     it('returns a string in the expected format', () => {
-      const module = makeModule();
       const key = (module as any).getSetVariableDataMapKey(
         'MyComponent',
         'inst',

--- a/packages/core/src/modules/Monitoring/test/module/MonitoringService.test.ts
+++ b/packages/core/src/modules/Monitoring/test/module/MonitoringService.test.ts
@@ -6,8 +6,10 @@ import { MonitoringService } from '../../src/module/MonitoringService.js';
 import { DEFAULT_TENANT_ID, OCPP2_0_1 } from '@citrineos/base';
 import { aClearMonitoringResult } from '../providers/Monitoring.js';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('MonitoringService', () => {
+  const { container } = createTestContainer();
   let mockVariableMonitoringRepository: Mocked<IVariableMonitoringRepository>;
   let monitoringService: MonitoringService;
 
@@ -16,7 +18,9 @@ describe('MonitoringService', () => {
       rejectVariableMonitoringByIdAndStationId: vi.fn(),
     } as unknown as Mocked<IVariableMonitoringRepository>;
 
-    monitoringService = new MonitoringService(mockVariableMonitoringRepository);
+    monitoringService = getTestInstance(container, MonitoringService, {
+      variableMonitoringRepository: mockVariableMonitoringRepository,
+    });
   });
 
   describe('processClearMonitoringResult', () => {

--- a/packages/core/src/modules/OcppRouter/src/module/DataApi.ts
+++ b/packages/core/src/modules/OcppRouter/src/module/DataApi.ts
@@ -2,10 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
-  BootstrapConfig,
   IMessageRouter,
   INetworkConnection,
-  SystemConfig,
   WebsocketServerConfig,
 } from '@citrineos/base';
 import {
@@ -22,7 +20,6 @@ import {
   OCPP1_6_Namespace,
   OCPP2_Namespace,
 } from '@citrineos/base';
-import { sequelize } from '@dal/index.js';
 import type {
   ChargingStationKeyQuerystring,
   ConnectionDeleteQuerystring,
@@ -62,32 +59,35 @@ export class AdminApi extends AbstractModuleApi<IMessageRouter> implements IAdmi
   private _serverNetworkProfileRepository: IServerNetworkProfileRepository;
 
   /**
-   * Constructs a new instance of the class.
+   * Constructs a new instance of the class. Resolved by the container (PROXY
+   * injection) — `router` is the OcppRouter module this API is bound to.
    *
-   * @param {IMessageRouter} ocppRouter - The OcppRouter module.
+   * @param {IMessageRouter} router - The OcppRouter module.
    * @param {INetworkConnection} networkConnection - The network connection instance.
    * @param {FastifyInstance} server - The Fastify server instance.
-   * @param {BootstrapConfig & SystemConfig} config - The configuration instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
-   * @param {ISubscriptionRepository} [subscriptionRepository] - The subscription repository instance.
-   * @param {IServerNetworkProfileRepository} [serverNetworkProfileRepository] - The server network profile repository instance.
+   * @param {ISubscriptionRepository} subscriptionRepository - The subscription repository instance.
+   * @param {IServerNetworkProfileRepository} serverNetworkProfileRepository - The server network profile repository instance.
    */
-  constructor(
-    ocppRouter: IMessageRouter,
-    networkConnection: INetworkConnection,
-    server: FastifyInstance,
-    config: BootstrapConfig & SystemConfig,
-    logger?: Logger<ILogObj>,
-    subscriptionRepository?: ISubscriptionRepository,
-    serverNetworkProfileRepository?: IServerNetworkProfileRepository,
-  ) {
-    super(ocppRouter, server, null, logger);
+  constructor({
+    router,
+    networkConnection,
+    server,
+    logger,
+    subscriptionRepository,
+    serverNetworkProfileRepository,
+  }: {
+    router: IMessageRouter;
+    networkConnection: INetworkConnection;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+    subscriptionRepository: ISubscriptionRepository;
+    serverNetworkProfileRepository: IServerNetworkProfileRepository;
+  }) {
+    super(router, server, logger);
     this._networkConnection = networkConnection;
-    this._subscriptionRepository =
-      subscriptionRepository || new sequelize.SequelizeSubscriptionRepository(config, this._logger);
-    this._serverNetworkProfileRepository =
-      serverNetworkProfileRepository ||
-      new sequelize.SequelizeServerNetworkProfileRepository(config, this._logger);
+    this._subscriptionRepository = subscriptionRepository;
+    this._serverNetworkProfileRepository = serverNetworkProfileRepository;
   }
 
   @AsDataEndpoint(Namespace.TlsReload, HttpMethod.Post, TlsReloadQuerySchema)

--- a/packages/core/src/modules/OcppRouter/src/module/DataApi.ts
+++ b/packages/core/src/modules/OcppRouter/src/module/DataApi.ts
@@ -1,11 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type {
-  IMessageRouter,
-  INetworkConnection,
-  WebsocketServerConfig,
-} from '@citrineos/base';
+import type { IMessageRouter, INetworkConnection, WebsocketServerConfig } from '@citrineos/base';
 import {
   AbstractModuleApi,
   AsDataEndpoint,

--- a/packages/core/src/modules/OcppRouter/src/module/router.ts
+++ b/packages/core/src/modules/OcppRouter/src/module/router.ts
@@ -41,7 +41,6 @@ import {
   RetryMessageError,
 } from '@citrineos/base';
 import type { ILocationRepository } from '@dal/interfaces/repositories.js';
-import { sequelize } from '@dal/index.js';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { v4 as uuidv4 } from 'uuid';
@@ -77,26 +76,35 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
    * @param {Logger<ILogObj>} [logger] - the logger object (optional)
    * @param {OCPPValidator} [ocppValidator] - the OCPPValidator instance, for message validation (optional)
    */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    dispatcher: WebhookDispatcher,
-    networkHook: (identifier: string, message: string) => Promise<void>,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    locationRepository?: ILocationRepository,
-  ) {
-    super(config, cache, handler, sender, networkHook, logger, ocppValidator);
+  constructor({
+    config,
+    cache,
+    routerSender,
+    routerHandler,
+    webhookDispatcher,
+    networkHook,
+    logger,
+    ocppValidator,
+    locationRepository,
+  }: {
+    config: BootstrapConfig & SystemConfig;
+    cache: ICache;
+    routerSender: IMessageSender;
+    routerHandler: IMessageHandler;
+    webhookDispatcher: WebhookDispatcher;
+    networkHook: (identifier: string, message: string) => Promise<void>;
+    logger: Logger<ILogObj>;
+    ocppValidator: OCPPValidator;
+    locationRepository: ILocationRepository;
+  }) {
+    super(config, cache, routerHandler, routerSender, networkHook, logger, ocppValidator);
 
     this._cache = cache;
-    this._sender = sender;
-    this._handler = handler;
-    this._webhookDispatcher = dispatcher;
+    this._sender = routerSender;
+    this._handler = routerHandler;
+    this._webhookDispatcher = webhookDispatcher;
     this._networkHook = networkHook;
-    this._locationRepository =
-      locationRepository || new sequelize.SequelizeLocationRepository(config, logger);
+    this._locationRepository = locationRepository;
   }
 
   async doesChargingStationExistByStationId(
@@ -971,3 +979,5 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
     return action;
   }
 }
+
+export default MessageRouterImpl;

--- a/packages/core/src/modules/OcppRouter/src/module/webhook.dispatcher.ts
+++ b/packages/core/src/modules/OcppRouter/src/module/webhook.dispatcher.ts
@@ -43,13 +43,19 @@ export class WebhookDispatcher {
   protected _onMessageCallbacks: Map<string, OnMessageCallback[]> = new Map();
   protected _sentMessageCallbacks: Map<string, OnSentMessageCallback[]> = new Map();
 
-  constructor(
-    ocppMessageRepository: IOCPPMessageRepository,
-    subscriptionRepository: ISubscriptionRepository,
-    cache: ICache,
-    logger?: Logger<ILogObj>,
-    config?: BootstrapConfig & SystemConfig,
-  ) {
+  constructor({
+    ocppMessageRepository,
+    subscriptionRepository,
+    cache,
+    logger,
+    config,
+  }: {
+    ocppMessageRepository: IOCPPMessageRepository;
+    subscriptionRepository: ISubscriptionRepository;
+    cache: ICache;
+    logger?: Logger<ILogObj>;
+    config?: BootstrapConfig & SystemConfig;
+  }) {
     this._ocppMessageRepository = ocppMessageRepository;
     this._subscriptionRepository = subscriptionRepository;
     this._cache = cache;
@@ -480,3 +486,5 @@ export type OnSentMessageCallback = (
   message: string,
   info?: Map<string, string>,
 ) => Promise<boolean>;
+
+export default WebhookDispatcher;

--- a/packages/core/src/modules/OcppRouter/test/module/MessageRouterImpl.test.ts
+++ b/packages/core/src/modules/OcppRouter/test/module/MessageRouterImpl.test.ts
@@ -33,6 +33,7 @@ import type { ILocationRepository } from '@citrineos/core';
 import { afterEach, beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { MessageRouterImpl } from '../../src/module/router.js';
 import { WebhookDispatcher } from '../../src/module/webhook.dispatcher.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -106,6 +107,7 @@ function buildMockLocationRepository(): Mocked<ILocationRepository> {
 // ─── Test Suite ────────────────────────────────────────────────────────────────
 
 describe('MessageRouterImpl', () => {
+  const { container } = createTestContainer();
   let config: any;
   let cache: Mocked<ICache>;
   let sender: Mocked<IMessageSender>;
@@ -124,17 +126,16 @@ describe('MessageRouterImpl', () => {
     networkHook = vi.fn().mockResolvedValue(undefined);
     locationRepository = buildMockLocationRepository();
 
-    router = new MessageRouterImpl(
+    router = getTestInstance(container, MessageRouterImpl, {
       config,
       cache,
-      sender,
-      handler,
-      dispatcher,
+      routerSender: sender,
+      routerHandler: handler,
+      webhookDispatcher: dispatcher,
       networkHook,
-      undefined, // logger
-      undefined, // ajv
+      ocppValidator: undefined,
       locationRepository,
-    );
+    });
   });
 
   afterEach(() => {

--- a/packages/core/src/modules/OcppRouter/test/module/WebhookDispatcher.test.ts
+++ b/packages/core/src/modules/OcppRouter/test/module/WebhookDispatcher.test.ts
@@ -18,9 +18,11 @@ import {
 import { faker } from '@faker-js/faker';
 import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 import { WebhookDispatcher } from '../../src';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import { aSubscription } from '../providers/SubscriptionProvider.js';
 
 describe('WebhookDispatcher', () => {
+  const { container } = createTestContainer();
   const fetch = vi.fn(() =>
     Promise.resolve({
       ok: true,
@@ -57,7 +59,12 @@ describe('WebhookDispatcher', () => {
       remove: vi.fn().mockResolvedValue(true),
     } as unknown as Mocked<ICache>;
 
-    webhookDispatcher = new WebhookDispatcher(ocppMessageRepository, subscriptionRepository, cache);
+    webhookDispatcher = getTestInstance(container, WebhookDispatcher, {
+      ocppMessageRepository,
+      subscriptionRepository,
+      cache,
+      config: undefined,
+    });
   });
 
   afterEach(() => {

--- a/packages/core/src/modules/Reporting/src/index.ts
+++ b/packages/core/src/modules/Reporting/src/index.ts
@@ -6,3 +6,4 @@ export { ReportingOcpp16Api } from './module/1.6/MessageApi.js';
 export { ReportingOcpp2Api } from './module/2/MessageApi.js';
 export type { IReportingModuleApi } from './module/interface.js';
 export { ReportingModule } from './module/module.js';
+export { registerReportingServices } from './register.js';

--- a/packages/core/src/modules/Reporting/src/module/1.6/MessageApi.ts
+++ b/packages/core/src/modules/Reporting/src/module/1.6/MessageApi.ts
@@ -31,8 +31,20 @@ export class ReportingOcpp16Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(reportingModule: ReportingModule, server: FastifyInstance, logger?: Logger<ILogObj>) {
-    super(reportingModule, server, OCPPVersion.OCPP1_6, logger);
+  constructor({
+    reportingModule,
+    server,
+    logger,
+  }: {
+    reportingModule: ReportingModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(reportingModule, server, logger);
+  }
+
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP1_6];
   }
 
   @AsMessageEndpoint(OCPP_CallAction.GetDiagnostics, OCPP1_6.GetDiagnosticsRequestSchema)
@@ -62,8 +74,8 @@ export class ReportingOcpp16Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.reporting.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Reporting/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Reporting/src/module/2/MessageApi.ts
@@ -40,18 +40,25 @@ export class ReportingOcpp2Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    reportingModule: ReportingModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(reportingModule, server, version, logger);
+  constructor({
+    reportingModule,
+    server,
+    logger,
+  }: {
+    reportingModule: ReportingModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(reportingModule, server, logger);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetBaseReport, (instance: ReportingOcpp2Api) =>
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
+  }
+
+  @AsMessageEndpoint(OCPP_CallAction.GetBaseReport, (_instance: ReportingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetBaseReportRequestSchema',
     ),
   )
@@ -60,21 +67,22 @@ export class ReportingOcpp2Api
     request: OCPP2_request_types.GetBaseReportRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetBaseReport,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetReport, (instance: ReportingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetReport, (_instance: ReportingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetReportRequestSchema',
     ),
   )
@@ -83,6 +91,7 @@ export class ReportingOcpp2Api
     request: OCPP2_request_types.GetReportRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation> {
     // if request size is bigger than BytesPerMessageGetReport, return error
     const bytesPerMessageGetReport =
@@ -107,7 +116,7 @@ export class ReportingOcpp2Api
       return await this._module.sendCall(
         identifier,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.GetReport,
         request,
         callbackUrl,
@@ -135,7 +144,7 @@ export class ReportingOcpp2Api
         const batchResult = await this._module.sendCall(
           identifier,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.GetReport,
           { ...request, componentVariable: batch } as OCPP2_request_types.GetReportRequest,
           callbackUrl,
@@ -158,9 +167,9 @@ export class ReportingOcpp2Api
     return { success: true, payload: confirmations };
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetMonitoringReport, (instance: ReportingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetMonitoringReport, (_instance: ReportingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetMonitoringReportRequestSchema',
     ),
   )
@@ -169,6 +178,7 @@ export class ReportingOcpp2Api
     request: OCPP2_request_types.GetMonitoringReportRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation> {
     // If monitoringCriteria & componentVariable are both empty, just call once
     const componentVariable =
@@ -179,7 +189,7 @@ export class ReportingOcpp2Api
       return await this._module.sendCall(
         identifier,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.GetMonitoringReport,
         request,
         callbackUrl,
@@ -206,7 +216,7 @@ export class ReportingOcpp2Api
         const batchResult = await this._module.sendCall(
           identifier,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.GetMonitoringReport,
           {
             ...request,
@@ -231,9 +241,9 @@ export class ReportingOcpp2Api
     return { success: true, payload: confirmations };
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetLog, (instance: ReportingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetLog, (_instance: ReportingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetLogRequestSchema',
     ),
   )
@@ -242,21 +252,22 @@ export class ReportingOcpp2Api
     request: OCPP2_request_types.GetLogRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetLog,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.CustomerInformation, (instance: ReportingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.CustomerInformation, (_instance: ReportingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'CustomerInformationRequestSchema',
     ),
   )
@@ -265,12 +276,13 @@ export class ReportingOcpp2Api
     request: OCPP2_request_types.CustomerInformationRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.CustomerInformation,
       request,
       callbackUrl,
@@ -284,8 +296,8 @@ export class ReportingOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.reporting.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Reporting/src/module/module.ts
+++ b/packages/core/src/modules/Reporting/src/module/module.ts
@@ -2,18 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
-  BootstrapConfig,
   CallAction,
   GenericDeviceModelStatusEnumType,
   HandlerProperties,
-  ICache,
   IMessage,
-  IMessageHandler,
-  IMessageSender,
+  OcppModuleDependencies,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
-  SystemConfig,
 } from '@citrineos/base';
 import {
   AbstractModule,
@@ -27,11 +23,10 @@ import {
   OCPP_2_VER_LIST,
   OCPP_CallAction,
   OcppError,
-  OCPPValidator,
   OCPPVersion,
   SetVariableStatusEnum,
 } from '@citrineos/base';
-import { sequelize } from '@dal/index.js';
+
 import type {
   IDeviceModelRepository,
   IOCPPMessageRepository,
@@ -39,9 +34,16 @@ import type {
   IVariableMonitoringRepository,
 } from '@dal/interfaces/repositories.js';
 import { Component, Variable } from '@dal/layers/sequelize/model/DeviceModel/index.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { DeviceModelService } from './services.js';
+
+import type { DeviceModelService } from './services.js';
+
+export interface ReportingModuleDependencies extends OcppModuleDependencies {
+  deviceModelRepository: IDeviceModelRepository;
+  securityEventRepository: ISecurityEventRepository;
+  variableMonitoringRepository: IVariableMonitoringRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  reportingDeviceModelService: DeviceModelService;
+}
 
 /**
  * Component that handles provisioning related messages.
@@ -69,57 +71,29 @@ export class ReportingModule extends AbstractModule {
   protected _variableMonitoringRepository: IVariableMonitoringRepository;
   protected _ocppMessageRepository: IOCPPMessageRepository;
 
-  /**
-   * This is the constructor function that initializes the {@link ReportingModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is created and used.
-   *
-   * @param {ISecurityEventRepository} [securityEventRepository] - An optional parameter of type {@link ISecurityEventRepository} which represents a repository for accessing security event notification data.
-   *
-   * @param {IVariableMonitoringRepository} [variableMonitoringRepository] - An optional parameter of type {@link IVariableMonitoringRepository} which represents a repository for accessing and manipulating monitoring data.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    deviceModelRepository?: IDeviceModelRepository,
-    securityEventRepository?: ISecurityEventRepository,
-    variableMonitoringRepository?: IVariableMonitoringRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    deviceModelRepository,
+    securityEventRepository,
+    variableMonitoringRepository,
+    ocppMessageRepository,
+    reportingDeviceModelService,
+  }: ReportingModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Reporting, logger, ocppValidator);
 
     this._requests = config.modules.reporting.requests;
     this._responses = config.modules.reporting.responses;
 
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, this._logger);
-    this._securityEventRepository =
-      securityEventRepository ||
-      new sequelize.SequelizeSecurityEventRepository(config, this._logger);
-    this._variableMonitoringRepository =
-      variableMonitoringRepository ||
-      new sequelize.SequelizeVariableMonitoringRepository(config, this._logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new sequelize.SequelizeOCPPMessageRepository(config, this._logger);
-    this._deviceModelService = new DeviceModelService(this._deviceModelRepository);
+    this._deviceModelRepository = deviceModelRepository;
+    this._securityEventRepository = securityEventRepository;
+    this._variableMonitoringRepository = variableMonitoringRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._deviceModelService = reportingDeviceModelService;
   }
 
   /**
@@ -450,3 +424,5 @@ export class ReportingModule extends AbstractModule {
     this._logger.debug('GetDiagnostics response received:', message, props);
   }
 }
+
+export default ReportingModule;

--- a/packages/core/src/modules/Reporting/src/module/services.ts
+++ b/packages/core/src/modules/Reporting/src/module/services.ts
@@ -8,7 +8,7 @@ import { OCPP2_0_1 } from '@citrineos/base';
 export class DeviceModelService {
   protected _deviceModelRepository: IDeviceModelRepository;
 
-  constructor(deviceModelRepository: IDeviceModelRepository) {
+  constructor({ deviceModelRepository }: { deviceModelRepository: IDeviceModelRepository }) {
     this._deviceModelRepository = deviceModelRepository;
   }
 

--- a/packages/core/src/modules/Reporting/src/register.ts
+++ b/packages/core/src/modules/Reporting/src/register.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, type AwilixContainer } from 'awilix';
+import { DeviceModelService } from './module/services.js';
+
+/**
+ * Registers the Reporting module's internal services as scoped dependencies.
+ * The service classes stay private to this package — only this registrar is exported.
+ */
+export function registerReportingServices(container: AwilixContainer): void {
+  container.register({
+    reportingDeviceModelService: asClass(DeviceModelService).scoped(),
+  });
+}

--- a/packages/core/src/modules/SmartCharging/src/module/1.6/MessageApi.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/1.6/MessageApi.ts
@@ -31,12 +31,20 @@ export class SmartChargingOcpp16Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    smartChargingModule: SmartChargingModule,
-    server: FastifyInstance,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(smartChargingModule, server, OCPPVersion.OCPP1_6, logger);
+  constructor({
+    smartChargingModule,
+    server,
+    logger,
+  }: {
+    smartChargingModule: SmartChargingModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(smartChargingModule, server, logger);
+  }
+
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP1_6];
   }
 
   @AsMessageEndpoint(OCPP_CallAction.SetChargingProfile, OCPP1_6.SetChargingProfileRequestSchema)
@@ -115,8 +123,8 @@ export class SmartChargingOcpp16Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.smartcharging?.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/SmartCharging/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/2/MessageApi.ts
@@ -44,18 +44,25 @@ export class SmartChargingOcpp2Api
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(
-    smartChargingModule: SmartChargingModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(smartChargingModule, server, version, logger);
+  constructor({
+    smartChargingModule,
+    server,
+    logger,
+  }: {
+    smartChargingModule: SmartChargingModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(smartChargingModule, server, logger);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearChargingProfile, (instance: SmartChargingOcpp2Api) =>
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
+  }
+
+  @AsMessageEndpoint(OCPP_CallAction.ClearChargingProfile, (_instance: SmartChargingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ClearChargingProfileRequestSchema',
     ),
   )
@@ -64,6 +71,7 @@ export class SmartChargingOcpp2Api
     request: OCPP2_request_types.ClearChargingProfileRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const responses: IMessageConfirmation[] = [];
 
@@ -118,7 +126,7 @@ export class SmartChargingOcpp2Api
       const response = await this._module.sendCall(
         ocppConnectionName,
         tenantId,
-        this._ocppVersion ?? DEFAULT_VERSION,
+        version,
         OCPP_CallAction.ClearChargingProfile,
         request,
         callbackUrl,
@@ -130,9 +138,9 @@ export class SmartChargingOcpp2Api
     return responses;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetChargingProfiles, (instance: SmartChargingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetChargingProfiles, (_instance: SmartChargingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetChargingProfilesRequestSchema',
     ),
   )
@@ -141,6 +149,7 @@ export class SmartChargingOcpp2Api
     request: OCPP2_request_types.GetChargingProfilesRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const chargingProfile = request.chargingProfile;
 
@@ -196,7 +205,7 @@ export class SmartChargingOcpp2Api
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.GetChargingProfiles,
       request,
       callbackUrl,
@@ -204,9 +213,9 @@ export class SmartChargingOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetChargingProfile, (instance: SmartChargingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetChargingProfile, (_instance: SmartChargingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetChargingProfileRequestSchema',
     ),
   )
@@ -215,6 +224,7 @@ export class SmartChargingOcpp2Api
     request: OCPP2_request_types.SetChargingProfileRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     // Process each station individually
     return Promise.all(
@@ -507,7 +517,7 @@ export class SmartChargingOcpp2Api
         return this._module.sendCall(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.SetChargingProfile,
           request,
           callbackUrl,
@@ -516,9 +526,9 @@ export class SmartChargingOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearedChargingLimit, (instance: SmartChargingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.ClearedChargingLimit, (_instance: SmartChargingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'ClearedChargingLimitRequestSchema',
     ),
   )
@@ -527,21 +537,22 @@ export class SmartChargingOcpp2Api
     request: OCPP2_request_types.ClearedChargingLimitRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version,
       OCPP_CallAction.ClearedChargingLimit,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetCompositeSchedule, (instance: SmartChargingOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetCompositeSchedule, (_instance: SmartChargingOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetCompositeScheduleRequestSchema',
     ),
   )
@@ -550,6 +561,7 @@ export class SmartChargingOcpp2Api
     request: OCPP2_request_types.GetCompositeScheduleRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return Promise.all(
       identifier.map(async (ocppConnectionName) => {
@@ -585,7 +597,7 @@ export class SmartChargingOcpp2Api
         return this._module.sendCall(
           ocppConnectionName,
           tenantId,
-          this._ocppVersion ?? DEFAULT_VERSION,
+          version,
           OCPP_CallAction.GetCompositeSchedule,
           request,
           callbackUrl,
@@ -601,9 +613,9 @@ export class SmartChargingOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.smartcharging?.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 
   /**

--- a/packages/core/src/modules/SmartCharging/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/2/MessageApi.ts
@@ -60,11 +60,13 @@ export class SmartChargingOcpp2Api
     return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearChargingProfile, (_instance: SmartChargingOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'ClearChargingProfileRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.ClearChargingProfile,
+    (_instance: SmartChargingOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'ClearChargingProfileRequestSchema',
+      ),
   )
   async clearChargingProfile(
     identifier: string[],
@@ -138,11 +140,13 @@ export class SmartChargingOcpp2Api
     return responses;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetChargingProfiles, (_instance: SmartChargingOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'GetChargingProfilesRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetChargingProfiles,
+    (_instance: SmartChargingOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'GetChargingProfilesRequestSchema',
+      ),
   )
   async getChargingProfiles(
     identifier: string[],
@@ -213,11 +217,13 @@ export class SmartChargingOcpp2Api
     return results;
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetChargingProfile, (_instance: SmartChargingOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'SetChargingProfileRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.SetChargingProfile,
+    (_instance: SmartChargingOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'SetChargingProfileRequestSchema',
+      ),
   )
   async setChargingProfile(
     identifier: string[],
@@ -526,11 +532,13 @@ export class SmartChargingOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.ClearedChargingLimit, (_instance: SmartChargingOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'ClearedChargingLimitRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.ClearedChargingLimit,
+    (_instance: SmartChargingOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'ClearedChargingLimitRequestSchema',
+      ),
   )
   clearedChargingLimit(
     identifier: string[],
@@ -550,11 +558,13 @@ export class SmartChargingOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetCompositeSchedule, (_instance: SmartChargingOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'GetCompositeScheduleRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetCompositeSchedule,
+    (_instance: SmartChargingOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'GetCompositeScheduleRequestSchema',
+      ),
   )
   async getCompositeSchedule(
     identifier: string[],

--- a/packages/core/src/modules/SmartCharging/src/module/module.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/module.ts
@@ -2,19 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
-  BootstrapConfig,
   CallAction,
   ChargingRateUnitEnumType,
   HandlerProperties,
-  ICache,
   IMessage,
-  IMessageHandler,
-  IMessageSender,
-  SystemConfig,
+  OcppModuleDependencies,
   OCPP2_request_types,
   OCPP2_response_types,
   OCPP2_common_types,
-  OCPPValidator,
 } from '@citrineos/base';
 import {
   AbstractModule,
@@ -43,15 +38,21 @@ import type {
 } from '@dal/interfaces/repositories.js';
 import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
 import * as OCPP2_0_1_Mapper from '@dal/layers/sequelize/mapper/2.0.1/index.js';
-import { sequelize } from '@dal/index.js';
-import { SequelizeChargingStationSequenceRepository } from '@dal/layers/sequelize/index.js';
+
 import { Transaction } from '@dal/layers/sequelize/model/TransactionEvent/index.js';
 import { IdGenerator } from '@util/util/idGenerator.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
+
 import type { ISmartCharging } from './smartCharging/SmartCharging.js';
-import { InternalSmartCharging } from './smartCharging/InternalSmartCharging.js';
 import type { CompositeScheduleInput } from '@/dal/layers/sequelize/mapper/2.0.1/ChargingProfileMapper.js';
+
+export interface SmartChargingModuleDependencies extends OcppModuleDependencies {
+  transactionEventRepository: ITransactionEventRepository;
+  deviceModelRepository: IDeviceModelRepository;
+  chargingProfileRepository: IChargingProfileRepository;
+  smartChargingService: ISmartCharging;
+  idGenerator: IdGenerator;
+  ocppMessageRepository: IOCPPMessageRepository;
+}
 
 /**
  * Component that handles provisioning related messages.
@@ -74,80 +75,31 @@ export class SmartChargingModule extends AbstractModule {
 
   private _idGenerator: IdGenerator;
 
-  /**
-   * Constructor
-   */
-
-  /**
-   * This is the constructor function that initializes the {@link SmartChargingModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository}
-   * which represents a repository for accessing and manipulating transaction data.
-   * If no `transactionEventRepository` is provided, a default {@link sequelize:transactionEventRepository} instance is created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository}
-   * which represents a repository for accessing and manipulating variable data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is created and used.
-   *
-   * @param {IChargingProfileRepository} [chargingProfileRepository] - An optional parameter of type {@link IChargingProfileRepository}
-   * which represents a repository for accessing and manipulating charging profile data.
-   * If no `chargingProfileRepository` is provided, a default {@link sequelize:chargingProfileRepository} instance is created and used.
-   *
-   * @param {ISmartCharging} [smartChargingService] - An optional parameter of type {@link ISmartCharging} which
-   * provides smart charging functionalities, e.g., calculation and validation.
-   *
-   * @param {IdGenerator} [idGenerator] - An optional parameter of type {@link IdGenerator} which
-   * represents a generator for ids.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    transactionEventRepository?: ITransactionEventRepository,
-    deviceModelRepository?: IDeviceModelRepository,
-    chargingProfileRepository?: IChargingProfileRepository,
-    smartChargingService?: ISmartCharging,
-    idGenerator?: IdGenerator,
-    ocppMessageRepository?: IOCPPMessageRepository,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    transactionEventRepository,
+    deviceModelRepository,
+    chargingProfileRepository,
+    smartChargingService,
+    idGenerator,
+    ocppMessageRepository,
+  }: SmartChargingModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.SmartCharging, logger, ocppValidator);
 
     this._requests = config.modules.smartcharging?.requests ?? [];
     this._responses = config.modules.smartcharging?.responses ?? [];
 
-    this._transactionEventRepository =
-      transactionEventRepository ||
-      new sequelize.SequelizeTransactionEventRepository(config, this._logger);
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, this._logger);
-    this._chargingProfileRepository =
-      chargingProfileRepository ||
-      new sequelize.SequelizeChargingProfileRepository(config, this._logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new sequelize.SequelizeOCPPMessageRepository(config, this._logger);
-
-    this._smartChargingService =
-      smartChargingService || new InternalSmartCharging(this._chargingProfileRepository);
-
-    this._idGenerator =
-      idGenerator ||
-      new IdGenerator(new SequelizeChargingStationSequenceRepository(config, this._logger));
+    this._transactionEventRepository = transactionEventRepository;
+    this._deviceModelRepository = deviceModelRepository;
+    this._chargingProfileRepository = chargingProfileRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._smartChargingService = smartChargingService;
+    this._idGenerator = idGenerator;
   }
 
   get transactionEventRepository(): ITransactionEventRepository {
@@ -685,3 +637,5 @@ export class SmartChargingModule extends AbstractModule {
     }
   }
 }
+
+export default SmartChargingModule;

--- a/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
@@ -16,7 +16,13 @@ export class InternalSmartCharging implements ISmartCharging {
   protected _chargingProfileRepository: IChargingProfileRepository;
   protected readonly _logger: Logger<ILogObj>;
 
-  constructor({ chargingProfileRepository, logger }: { chargingProfileRepository: IChargingProfileRepository; logger: Logger<ILogObj> }) {
+  constructor({
+    chargingProfileRepository,
+    logger,
+  }: {
+    chargingProfileRepository: IChargingProfileRepository;
+    logger: Logger<ILogObj>;
+  }) {
     this._chargingProfileRepository = chargingProfileRepository;
     this._logger = logger.getSubLogger({ name: this.constructor.name });
   }

--- a/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
@@ -16,11 +16,9 @@ export class InternalSmartCharging implements ISmartCharging {
   protected _chargingProfileRepository: IChargingProfileRepository;
   protected readonly _logger: Logger<ILogObj>;
 
-  constructor(chargingProfileRepository: IChargingProfileRepository, logger?: Logger<ILogObj>) {
+  constructor({ chargingProfileRepository, logger }: { chargingProfileRepository: IChargingProfileRepository; logger: Logger<ILogObj> }) {
     this._chargingProfileRepository = chargingProfileRepository;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
   }
 
   /**
@@ -257,3 +255,5 @@ export class InternalSmartCharging implements ISmartCharging {
     }
   }
 }
+
+export default InternalSmartCharging;

--- a/packages/core/src/modules/Tenant/src/module/DataApi.ts
+++ b/packages/core/src/modules/Tenant/src/module/DataApi.ts
@@ -20,8 +20,16 @@ export class TenantDataApi extends AbstractModuleApi<TenantModule> implements IT
    * @param {FastifyInstance} server - The Fastify server instance.
    * @param {Logger<ILogObj>} [logger] - The logger instance.
    */
-  constructor(tenantModule: TenantModule, server: FastifyInstance, logger?: Logger<ILogObj>) {
-    super(tenantModule, server, null, logger);
+  constructor({
+    tenantModule,
+    server,
+    logger,
+  }: {
+    tenantModule: TenantModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(tenantModule, server, logger);
   }
 
   /**

--- a/packages/core/src/modules/Tenant/src/module/module.ts
+++ b/packages/core/src/modules/Tenant/src/module/module.ts
@@ -1,19 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type {
-  BootstrapConfig,
-  CallAction,
-  ICache,
-  IMessageHandler,
-  IMessageSender,
-  SystemConfig,
-} from '@citrineos/base';
-import { AbstractModule, EventGroup, OCPPValidator } from '@citrineos/base';
+import type { CallAction, OcppModuleDependencies } from '@citrineos/base';
+import { AbstractModule, EventGroup } from '@citrineos/base';
 import type { ITenantRepository } from '@dal/interfaces/repositories.js';
-import { SequelizeTenantRepository } from '@dal/layers/sequelize/index.js';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
+
+export interface TenantModuleDependencies extends OcppModuleDependencies {
+  tenantRepository: ITenantRepository;
+}
 
 export class TenantModule extends AbstractModule {
   /**
@@ -23,47 +17,24 @@ export class TenantModule extends AbstractModule {
   _responses: CallAction[] = [];
   protected _tenantRepository: ITenantRepository;
 
-  /**
-   * Constructor
-   */
-
-  /**
-   * This is the constructor function that initializes the {@link TenantModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {ITenantRepository} [tenantRepository] - An optional parameter of type {@link ITenantRepository}
-   * which represents a repository for tenant data.
-   * If no `tenantRepository` is provided, a default {@link sequelize:tenantRepository} instance is created and used.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    tenantRepository?: ITenantRepository,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    tenantRepository,
+  }: TenantModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Tenant, logger, ocppValidator);
     this._requests = config.modules.tenant.requests;
     this._responses = config.modules.tenant.responses;
-
-    this._tenantRepository = tenantRepository || new SequelizeTenantRepository(config, logger);
+    this._tenantRepository = tenantRepository;
   }
 
   get tenantRepository(): ITenantRepository {
     return this._tenantRepository;
   }
 }
+
+export default TenantModule;

--- a/packages/core/src/modules/Transactions/src/index.ts
+++ b/packages/core/src/modules/Transactions/src/index.ts
@@ -6,3 +6,4 @@ export { TransactionsOcpp2Api } from './module/2/MessageApi.js';
 export { TransactionsDataApi } from './module/DataApi.js';
 export type { ITransactionsModuleApi } from './module/interface.js';
 export { TransactionsModule } from './module/module.js';
+export { registerTransactionsServices } from './register.js';

--- a/packages/core/src/modules/Transactions/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Transactions/src/module/2/MessageApi.ts
@@ -84,11 +84,13 @@ export class TransactionsOcpp2Api
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetTransactionStatus, (_instance: TransactionsOcpp2Api, version) =>
-    getOcpp2Schema(
-      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
-      'GetTransactionStatusRequestSchema',
-    ),
+  @AsMessageEndpoint(
+    OCPP_CallAction.GetTransactionStatus,
+    (_instance: TransactionsOcpp2Api, version) =>
+      getOcpp2Schema(
+        (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+        'GetTransactionStatusRequestSchema',
+      ),
   )
   getTransactionStatus(
     identifier: string[],

--- a/packages/core/src/modules/Transactions/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Transactions/src/module/2/MessageApi.ts
@@ -35,23 +35,34 @@ export class TransactionsOcpp2Api
   /**
    * Constructor for the class.
    *
-   * @param {TransactionsModule} transactionModule - The transaction module.
+   * @param {TransactionsModule} transactionsModule - The transaction module.
    * @param {FastifyInstance} server - The server instance.
-   * @param {OCPPVersion} version - The OCPP version
    * @param {Logger<ILogObj>} [logger] - Optional logger.
    */
-  constructor(
-    transactionModule: TransactionsModule,
-    server: FastifyInstance,
-    version: OCPPVersion = DEFAULT_VERSION,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(transactionModule, server, version, logger);
+  constructor({
+    transactionsModule,
+    server,
+    logger,
+  }: {
+    transactionsModule: TransactionsModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(transactionsModule, server, logger);
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.CostUpdated, (instance: TransactionsOcpp2Api) =>
+  /**
+   * This API serves both OCPP 2.0.1 and 2.1 from a single instance; each
+   * message endpoint is registered once per version with the version threaded
+   * into schema selection, the route path, and the handler.
+   */
+  protected get supportedVersions(): OCPPVersion[] {
+    return [OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1];
+  }
+
+  @AsMessageEndpoint(OCPP_CallAction.CostUpdated, (_instance: TransactionsOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'CostUpdatedRequestSchema',
     ),
   )
@@ -60,21 +71,22 @@ export class TransactionsOcpp2Api
     request: OCPP2_request_types.CostUpdatedRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version ?? DEFAULT_VERSION,
       OCPP_CallAction.CostUpdated,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.GetTransactionStatus, (instance: TransactionsOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.GetTransactionStatus, (_instance: TransactionsOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? DEFAULT_VERSION) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'GetTransactionStatusRequestSchema',
     ),
   )
@@ -83,21 +95,22 @@ export class TransactionsOcpp2Api
     request: OCPP2_request_types.GetTransactionStatusRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     return packageGroupCall(
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? DEFAULT_VERSION,
+      version ?? DEFAULT_VERSION,
       OCPP_CallAction.GetTransactionStatus,
       request,
       callbackUrl,
     );
   }
 
-  @AsMessageEndpoint(OCPP_CallAction.SetDefaultTariff, (instance: TransactionsOcpp2Api) =>
+  @AsMessageEndpoint(OCPP_CallAction.SetDefaultTariff, (_instance: TransactionsOcpp2Api, version) =>
     getOcpp2Schema(
-      (instance._ocppVersion ?? OCPPVersion.OCPP2_1) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
+      (version ?? OCPPVersion.OCPP2_1) as Exclude<OCPPVersion, OCPPVersion.OCPP1_6>,
       'SetDefaultTariffRequestSchema',
     ),
   )
@@ -106,6 +119,7 @@ export class TransactionsOcpp2Api
     request: OCPP2_1.SetDefaultTariffRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const validation = validateTariffConditionsTimeFields(request.tariff);
     if (!validation.isValid) {
@@ -115,7 +129,7 @@ export class TransactionsOcpp2Api
       this._module,
       identifier,
       tenantId,
-      this._ocppVersion ?? OCPPVersion.OCPP2_1,
+      version ?? OCPPVersion.OCPP2_1,
       OCPP_CallAction.SetDefaultTariff,
       request,
       callbackUrl,
@@ -129,8 +143,8 @@ export class TransactionsOcpp2Api
    * @param {CallAction} input - The input {@link CallAction}.
    * @return {string} - The generated URL path.
    */
-  protected _toMessagePath(input: CallAction): string {
+  protected _toMessagePath(input: CallAction, version?: OCPPVersion | null): string {
     const endpointPrefix = this._module.config.modules.transactions.endpointPrefix;
-    return super._toMessagePath(input, endpointPrefix);
+    return super._toMessagePath(input, version, endpointPrefix);
   }
 }

--- a/packages/core/src/modules/Transactions/src/module/CostCalculator.ts
+++ b/packages/core/src/modules/Transactions/src/module/CostCalculator.ts
@@ -14,11 +14,15 @@ export class CostCalculator {
   private readonly _tariffRepository: ITariffRepository;
   private readonly _transactionService: TransactionService;
 
-  constructor(
-    tariffRepository: ITariffRepository,
-    transactionService: TransactionService,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    tariffRepository,
+    transactionService,
+    logger,
+  }: {
+    tariffRepository: ITariffRepository;
+    transactionService: TransactionService;
+    logger: Logger<ILogObj>;
+  }) {
     this._tariffRepository = tariffRepository;
     this._transactionService = transactionService;
     this._logger = logger

--- a/packages/core/src/modules/Transactions/src/module/CostNotifier.ts
+++ b/packages/core/src/modules/Transactions/src/module/CostNotifier.ts
@@ -1,29 +1,50 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
+import type { OCPPVersionType } from '@citrineos/base';
 import type { ITransactionEventRepository } from '@dal/interfaces/repositories.js';
 import { Transaction } from '@dal/layers/sequelize/model/TransactionEvent/index.js';
-import { AbstractModule, OCPP_CallAction, OCPPVersion } from '@citrineos/base';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { CostCalculator } from './CostCalculator.js';
 import { Scheduler } from './Scheduler.js';
 
+/** The computed cost update to send to a charging station. */
+export interface CostUpdate {
+  ocppConnectionName: string;
+  tenantId: number;
+  totalCost: number;
+  transactionId: string;
+  protocol: OCPPVersionType;
+}
+
+/**
+ * Sends a computed {@link CostUpdate} to the charging station. Supplied by the
+ * Transactions module (which owns the OCPP send semantics) so that
+ * {@link CostNotifier} does not hold a back-reference to the module.
+ */
+export type CostUpdatedNotifier = (update: CostUpdate) => Promise<void>;
+
 export class CostNotifier extends Scheduler {
   private readonly _transactionEventRepository: ITransactionEventRepository;
-  private readonly _module: AbstractModule;
   private readonly _costCalculator: CostCalculator;
+  private readonly _notifyCostUpdated: CostUpdatedNotifier;
 
-  constructor(
-    module: AbstractModule,
-    transactionEventRepository: ITransactionEventRepository,
-    costCalculator: CostCalculator,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    transactionEventRepository,
+    costCalculator,
+    costUpdatedNotifier,
+    logger,
+  }: {
+    transactionEventRepository: ITransactionEventRepository;
+    costCalculator: CostCalculator;
+    costUpdatedNotifier: CostUpdatedNotifier;
+    logger: Logger<ILogObj>;
+  }) {
     super(logger);
     this._transactionEventRepository = transactionEventRepository;
-    this._module = module;
     this._costCalculator = costCalculator;
+    this._notifyCostUpdated = costUpdatedNotifier;
   }
 
   /**
@@ -41,18 +62,23 @@ export class CostNotifier extends Scheduler {
     transactionId: string,
     tenantId: number,
     intervalSeconds: number,
+    protocol: OCPPVersionType,
   ): void {
     this._logger.debug(
       `Scheduling periodic cost notifications for ${ocppConnectionName} station, ${transactionId} transaction, ${tenantId} tenant`,
     );
     this.schedule(
       this._key(ocppConnectionName, transactionId),
-      () => this._tryNotify(ocppConnectionName, transactionId, tenantId),
+      () => this._tryNotify(ocppConnectionName, transactionId, tenantId, protocol),
       intervalSeconds,
     );
   }
 
-  async calculateCostAndNotify(transaction: Transaction, tenantId: number): Promise<void> {
+  async calculateCostAndNotify(
+    transaction: Transaction,
+    tenantId: number,
+    protocol: OCPPVersionType,
+  ): Promise<void> {
     const cost = await this._costCalculator.calculateTotalCost(
       tenantId,
       transaction.connectorId,
@@ -65,22 +91,24 @@ export class CostNotifier extends Scheduler {
       transaction.id,
     );
 
-    await this._module.sendCall(
-      transaction.ocppConnectionName,
+    await this._notifyCostUpdated({
+      ocppConnectionName: transaction.ocppConnectionName,
       tenantId,
-      OCPPVersion.OCPP2_0_1,
-      OCPP_CallAction.CostUpdated,
-      {
-        totalCost: cost,
-        transactionId: transaction.transactionId,
-      },
-    );
+      totalCost: cost,
+      transactionId: transaction.transactionId,
+      protocol,
+    });
     this._logger.debug(
       `Sent CostUpdated call for ${transaction.transactionId} transaction with ${cost} cost`,
     );
   }
 
-  private async _tryNotify(ocppConnectionName: string, transactionId: string, tenantId: number) {
+  private async _tryNotify(
+    ocppConnectionName: string,
+    transactionId: string,
+    tenantId: number,
+    protocol: OCPPVersionType,
+  ) {
     try {
       const transaction =
         await this._transactionEventRepository.readTransactionByStationIdAndTransactionId(
@@ -105,7 +133,7 @@ export class CostNotifier extends Scheduler {
         return;
       }
 
-      await this.calculateCostAndNotify(transaction, tenantId);
+      await this.calculateCostAndNotify(transaction, tenantId, protocol);
     } catch (error) {
       this._logger.error(`Failed to send CostUpdated call for ${transactionId} transaction`, error);
       this.unschedule(this._key(ocppConnectionName, transactionId));

--- a/packages/core/src/modules/Transactions/src/module/DataApi.ts
+++ b/packages/core/src/modules/Transactions/src/module/DataApi.ts
@@ -36,16 +36,20 @@ export class TransactionsDataApi
   /**
    * Constructor for the class.
    *
-   * @param {TransactionsModule} transactionModule - The transaction module.
+   * @param {TransactionsModule} transactionsModule - The transaction module.
    * @param {FastifyInstance} server - The server instance.
    * @param {Logger<ILogObj>} [logger] - Optional logger.
    */
-  constructor(
-    transactionModule: TransactionsModule,
-    server: FastifyInstance,
-    logger?: Logger<ILogObj>,
-  ) {
-    super(transactionModule, server, null, logger);
+  constructor({
+    transactionsModule,
+    server,
+    logger,
+  }: {
+    transactionsModule: TransactionsModule;
+    server: FastifyInstance;
+    logger?: Logger<ILogObj>;
+  }) {
+    super(transactionsModule, server, logger);
   }
 
   @AsDataEndpoint(Namespace.TransactionType, HttpMethod.Get, TransactionEventQuerySchema)

--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -25,13 +25,19 @@ export class StatusNotificationService {
   protected _cache: ICache;
   protected _logger: Logger<ILogObj>;
 
-  constructor(
-    componentRepository: CrudRepository<Component>,
-    deviceModelRepository: IDeviceModelRepository,
-    locationRepository: ILocationRepository,
-    cache: ICache,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    componentRepository,
+    deviceModelRepository,
+    locationRepository,
+    cache,
+    logger,
+  }: {
+    componentRepository: CrudRepository<Component>;
+    deviceModelRepository: IDeviceModelRepository;
+    locationRepository: ILocationRepository;
+    cache: ICache;
+    logger?: Logger<ILogObj>;
+  }) {
     this._componentRepository = componentRepository;
     this._deviceModelRepository = deviceModelRepository;
     this._locationRepository = locationRepository;

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -43,18 +43,27 @@ export class TransactionService {
   private _logger: Logger<ILogObj>;
   private _authorizers: IAuthorizer[];
 
-  constructor(
-    transactionEventRepository: ITransactionEventRepository,
-    authorizeRepository: IAuthorizationRepository,
-    locationRepository: ILocationRepository,
-    reservationRepository: IReservationRepository,
-    ocppMessageRepository: IOCPPMessageRepository,
-    realTimeAuthorizer: IAuthorizer,
-    authorizers?: IAuthorizer[],
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    transactionEventRepository,
+    authorizationRepository,
+    locationRepository,
+    reservationRepository,
+    ocppMessageRepository,
+    realTimeAuthorizer,
+    authorizers,
+    logger,
+  }: {
+    transactionEventRepository: ITransactionEventRepository;
+    authorizationRepository: IAuthorizationRepository;
+    locationRepository: ILocationRepository;
+    reservationRepository: IReservationRepository;
+    ocppMessageRepository: IOCPPMessageRepository;
+    realTimeAuthorizer: IAuthorizer;
+    authorizers?: IAuthorizer[];
+    logger: Logger<ILogObj>;
+  }) {
     this._transactionEventRepository = transactionEventRepository;
-    this._authorizeRepository = authorizeRepository;
+    this._authorizeRepository = authorizationRepository;
     this._locationRepository = locationRepository;
     this._reservationRepository = reservationRepository;
     this._ocppMessageRepository = ocppMessageRepository;

--- a/packages/core/src/modules/Transactions/src/module/module.ts
+++ b/packages/core/src/modules/Transactions/src/module/module.ts
@@ -2,19 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import type {
-  BootstrapConfig,
   CallAction,
   HandlerProperties,
-  IAuthorizer,
-  ICache,
-  IFileStorage,
   IMessage,
-  IMessageHandler,
-  IMessageSender,
   MeterValueDto,
+  OcppModuleDependencies,
   OCPP2_request_types,
   OCPP2_response_types,
-  SystemConfig,
 } from '@citrineos/base';
 import {
   AbstractModule,
@@ -22,7 +16,6 @@ import {
   AttributeEnum,
   AuthorizationStatusEnum,
   CacheNamespace,
-  CrudRepository,
   ErrorCode,
   EventGroup,
   MessageOrigin,
@@ -31,7 +24,6 @@ import {
   OCPP_2_VER_LIST,
   OCPP_CallAction,
   OcppError,
-  OCPPValidator,
   OCPPVersion,
   TariffSetStatusEnum,
   TransactionEventEnum,
@@ -43,30 +35,40 @@ import type {
   IDeviceModelRepository,
   ILocationRepository,
   IOCPPMessageRepository,
-  IReservationRepository,
   ITariffRepository,
   ITransactionEventRepository,
 } from '@dal/interfaces/repositories.js';
-import { SequelizeOCPPMessageRepository } from '@dal/layers/sequelize/index.js';
 import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
 import { Authorization } from '@dal/layers/sequelize/model/Authorization/index.js';
 import { ChargingSchedule } from '@dal/layers/sequelize/model/ChargingProfile/index.js';
-import { Component, VariableAttribute } from '@dal/layers/sequelize/model/DeviceModel/index.js';
+import { VariableAttribute } from '@dal/layers/sequelize/model/DeviceModel/index.js';
 import { Tariff } from '@dal/layers/sequelize/model/Tariff/Tariffs.js';
 import {
   StartTransaction,
   Transaction,
 } from '@dal/layers/sequelize/model/TransactionEvent/index.js';
-import { SequelizeRepository } from '@dal/layers/sequelize/repository/Base.js';
-import { RealTimeAuthorizer } from '@util/authorizer/RealTimeAuthorizer.js';
-import { SignedMeterValuesUtil } from '@util/security/SignedMeterValuesUtil.js';
+import type { SignedMeterValuesUtil } from '@util/security/SignedMeterValuesUtil.js';
 import { Op } from 'sequelize';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
-import { CostCalculator } from './CostCalculator.js';
-import { CostNotifier } from './CostNotifier.js';
-import { StatusNotificationService } from './StatusNotificationService.js';
-import { TransactionService } from './TransactionService.js';
+
+import type { CostCalculator } from './CostCalculator.js';
+import type { CostNotifier } from './CostNotifier.js';
+import type { StatusNotificationService } from './StatusNotificationService.js';
+import type { TransactionService } from './TransactionService.js';
+
+export interface TransactionsModuleDependencies extends OcppModuleDependencies {
+  transactionEventRepository: ITransactionEventRepository;
+  authorizationRepository: IAuthorizationRepository;
+  deviceModelRepository: IDeviceModelRepository;
+  locationRepository: ILocationRepository;
+  tariffRepository: ITariffRepository;
+  ocppMessageRepository: IOCPPMessageRepository;
+  chargingProfileRepository: IChargingProfileRepository;
+  transactionService: TransactionService;
+  statusNotificationService: StatusNotificationService;
+  costCalculator: CostCalculator;
+  costNotifier: CostNotifier;
+  signedMeterValuesUtil: SignedMeterValuesUtil;
+}
 
 /**
  * Component that handles transaction related messages.
@@ -78,20 +80,13 @@ export class TransactionsModule extends AbstractModule {
   protected _transactionEventRepository: ITransactionEventRepository;
   protected _authorizeRepository: IAuthorizationRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
-  protected _componentRepository: CrudRepository<Component>;
   protected _locationRepository: ILocationRepository;
   protected _tariffRepository: ITariffRepository;
-  protected _reservationRepository: IReservationRepository;
   protected _ocppMessageRepository: IOCPPMessageRepository;
   protected _chargingProfileRepository: IChargingProfileRepository;
 
   protected _transactionService: TransactionService;
   protected _statusNotificationService: StatusNotificationService;
-
-  protected _fileStorage: IFileStorage;
-
-  private readonly _authorizers: IAuthorizer[];
-  private readonly _realTimeAuthorizer: IAuthorizer;
 
   private readonly _signedMeterValuesUtil: SignedMeterValuesUtil;
   private _costNotifier: CostNotifier;
@@ -100,168 +95,47 @@ export class TransactionsModule extends AbstractModule {
   private readonly _sendCostUpdatedOnMeterValue: boolean | undefined;
   private readonly _costUpdatedInterval: number | undefined;
 
-  /**
-   * This is the constructor function that initializes the {@link TransactionsModule}.
-   *
-   * @param {BootstrapConfig & SystemConfig} config - The `config` contains configuration settings for the module.
-   *
-   * @param {ICache} [cache] - The cache instance which is shared among the modules & Central System to pass information such as blacklisted actions or boot status.
-   *
-   * @param {IFileStorage} [fileStorage] - The `fileStorage` allows access to the configured file storage.
-   *
-   * @param {IMessageSender} [sender] - The `sender` parameter is an optional parameter that represents an instance of the {@link IMessageSender} interface.
-   * It is used to send messages from the central system to external systems or devices. If no `sender` is provided, a default {@link RabbitMqSender} instance is created and used.
-   *
-   * @param {IMessageHandler} [handler] - The `handler` parameter is an optional parameter that represents an instance of the {@link IMessageHandler} interface.
-   * It is used to handle incoming messages and dispatch them to the appropriate methods or functions. If no `handler` is provided, a default {@link RabbitMqReceiver} instance is created and used.
-   *
-   * @param {Logger<ILogObj>} [logger] - The `logger` parameter is an optional parameter that represents an instance of {@link Logger<ILogObj>}.
-   * It is used to propagate system-wide logger settings and will serve as the parent logger for any sub-component logging. If no `logger` is provided, a default {@link Logger<ILogObj>} instance is created and used.
-   *
-   * @param {OCPPValidator}[ocppValidator] - An optional parameter that represents an instance of {@link OCPPValidator} used to validate and sanitize incoming OCPP request and response payloads against
-   * the schema. If no `ocppValidator` is provided, a default {@link OCPPValidator} instance is created and used.
-   *
-   * @param {ITransactionEventRepository} [transactionEventRepository] - An optional parameter of type {@link ITransactionEventRepository} which represents a repository for accessing and manipulating transaction event data.
-   * If no `transactionEventRepository` is provided, a default {@link sequelize:transactionEventRepository} instance
-   * is created and used.
-   *
-   * @param {IAuthorizationRepository} [authorizeRepository] - An optional parameter of type {@link IAuthorizationRepository} which represents a repository for accessing and manipulating authorization data.
-   * If no `authorizeRepository` is provided, a default {@link sequelize:authorizeRepository} instance is
-   * created and used.
-   *
-   * @param {IDeviceModelRepository} [deviceModelRepository] - An optional parameter of type {@link IDeviceModelRepository} which represents a repository for accessing and manipulating variable attribute data.
-   * If no `deviceModelRepository` is provided, a default {@link sequelize:deviceModelRepository} instance is
-   * created and used.
-   *
-   * @param {CrudRepository<Component>} [componentRepository] - An optional parameter of type {@link CrudRepository<Component>} which represents a repository for accessing and manipulating component data.
-   * If no `componentRepository` is provided, a default {@link sequelize:componentRepository} instance is
-   * created and used.
-   *
-   * @param {ILocationRepository} [locationRepository] - An optional parameter of type {@link ILocationRepository} which represents a repository for accessing and manipulating location and charging station data.
-   * If no `locationRepository` is provided, a default {@link sequelize:locationRepository} instance is
-   * created and used.
-   *
-   * @param {CrudRepository<Component>} [componentRepository] - An optional parameter of type {@link CrudRepository<Component>} which represents a repository for accessing and manipulating component data.
-   * If no `componentRepository` is provided, a default {@link sequelize:componentRepository} instance is
-   * created and used.
-   *
-   * @param {ILocationRepository} [locationRepository] - An optional parameter of type {@link ILocationRepository} which represents a repository for accessing and manipulating location and charging station data.
-   * If no `locationRepository` is provided, a default {@link sequelize:locationRepository} instance is
-   * created and used.
-   *
-   * @param {ITariffRepository} [tariffRepository] - An optional parameter of type {@link ITariffRepository} which
-   * represents a repository for accessing and manipulating tariff data.
-   * If no `tariffRepository` is provided, a default {@link sequelize:tariffRepository} instance is
-   * created and used.
-   *
-   * @param {IReservationRepository} [reservationRepository] - An optional parameter of type {@link IReservationRepository}
-   * which represents a repository for accessing and manipulating reservation data.
-   * If no `reservationRepository` is provided, a default {@link sequelize:reservationRepository} instance is created and used.
-   *
-   * @param {IOCPPMessageRepository} [ocppMessageRepository] - An optional parameter of type {@link IOCPPMessageRepository}
-   * which represents a repository for accessing and manipulating OCPP Message data.
-   * If no `ocppMessageRepository` is provided, a default {@link sequelize:ocppMessageRepository} instance is created and used.
-   *
-   * @param {IAuthorizer[]} [authorizers] - An optional parameter of type {@link IAuthorizer[]} which represents
-   * a list of authorizers that can be used to authorize requests.
-   *
-   * @param {IAuthorizer} [realTimeAuthorizer] - An optional parameter of type {@link IAuthorizer} which represents
-   * a real-time authorizer that can be used to authorize real-time requests.
-   *
-   * @param {IChargingProfileRepository} [chargingProfileRepository] - An optional parameter of type {@link IChargingProfileRepository}
-   * which represents a repository for accessing and manipulating charging profile Message data.
-   * If no `chargingProfileRepository` is provided, a default {@link sequelize:chargingProfileRepository} instance is created and used.
-   */
-  constructor(
-    config: BootstrapConfig & SystemConfig,
-    cache: ICache,
-    fileStorage: IFileStorage,
-    sender: IMessageSender,
-    handler: IMessageHandler,
-    logger?: Logger<ILogObj>,
-    ocppValidator?: OCPPValidator,
-    transactionEventRepository?: ITransactionEventRepository,
-    authorizeRepository?: IAuthorizationRepository,
-    deviceModelRepository?: IDeviceModelRepository,
-    componentRepository?: CrudRepository<Component>,
-    locationRepository?: ILocationRepository,
-    tariffRepository?: ITariffRepository,
-    reservationRepository?: IReservationRepository,
-    ocppMessageRepository?: IOCPPMessageRepository,
-    realTimeAuthorizer?: IAuthorizer,
-    authorizers?: IAuthorizer[],
-    chargingProfileRepository?: IChargingProfileRepository,
-  ) {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    transactionEventRepository,
+    authorizationRepository,
+    deviceModelRepository,
+    locationRepository,
+    tariffRepository,
+    ocppMessageRepository,
+    chargingProfileRepository,
+    transactionService,
+    statusNotificationService,
+    costCalculator,
+    costNotifier,
+    signedMeterValuesUtil,
+  }: TransactionsModuleDependencies) {
     super(config, cache, handler, sender, EventGroup.Transactions, logger, ocppValidator);
 
     this._requests = config.modules.transactions.requests;
     this._responses = config.modules.transactions.responses;
 
-    this._fileStorage = fileStorage;
+    this._transactionEventRepository = transactionEventRepository;
+    this._authorizeRepository = authorizationRepository;
+    this._deviceModelRepository = deviceModelRepository;
+    this._locationRepository = locationRepository;
+    this._tariffRepository = tariffRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
+    this._chargingProfileRepository = chargingProfileRepository;
 
-    this._transactionEventRepository =
-      transactionEventRepository ||
-      new sequelize.SequelizeTransactionEventRepository(config, logger);
-    this._authorizeRepository =
-      authorizeRepository || new sequelize.SequelizeAuthorizationRepository(config, logger);
-    this._deviceModelRepository =
-      deviceModelRepository || new sequelize.SequelizeDeviceModelRepository(config, logger);
-    this._componentRepository =
-      componentRepository ||
-      new SequelizeRepository<Component>(config, Component.MODEL_NAME, logger);
-    this._locationRepository =
-      locationRepository || new sequelize.SequelizeLocationRepository(config, logger);
-    this._tariffRepository =
-      tariffRepository || new sequelize.SequelizeTariffRepository(config, logger);
-    this._reservationRepository =
-      reservationRepository || new sequelize.SequelizeReservationRepository(config, logger);
-    this._ocppMessageRepository =
-      ocppMessageRepository || new SequelizeOCPPMessageRepository(config, this._logger);
-    this._chargingProfileRepository =
-      chargingProfileRepository ||
-      new sequelize.SequelizeChargingProfileRepository(config, this._logger);
-
-    this._authorizers = authorizers || [];
-    this._realTimeAuthorizer =
-      realTimeAuthorizer ||
-      new RealTimeAuthorizer(this._locationRepository, this.config, this._logger);
-
-    this._signedMeterValuesUtil = new SignedMeterValuesUtil(fileStorage, config, this._logger);
+    this._transactionService = transactionService;
+    this._statusNotificationService = statusNotificationService;
+    this._costCalculator = costCalculator;
+    this._costNotifier = costNotifier;
+    this._signedMeterValuesUtil = signedMeterValuesUtil;
 
     this._sendCostUpdatedOnMeterValue = config.modules.transactions.sendCostUpdatedOnMeterValue;
     this._costUpdatedInterval = config.modules.transactions.costUpdatedInterval;
-
-    this._transactionService = new TransactionService(
-      this._transactionEventRepository,
-      this._authorizeRepository,
-      this._locationRepository,
-      this._reservationRepository,
-      this._ocppMessageRepository,
-      this._realTimeAuthorizer,
-      this._authorizers,
-      this._logger,
-    );
-
-    this._statusNotificationService = new StatusNotificationService(
-      this._componentRepository,
-      this._deviceModelRepository,
-      this._locationRepository,
-      this._cache,
-      this._logger,
-    );
-
-    this._costCalculator = new CostCalculator(
-      this._tariffRepository,
-      this._transactionService,
-      this._logger,
-    );
-
-    this._costNotifier = new CostNotifier(
-      this,
-      this._transactionEventRepository,
-      this._costCalculator,
-      this._logger,
-    );
   }
 
   get transactionEventRepository(): ITransactionEventRepository {
@@ -553,6 +427,7 @@ export class TransactionsModule extends AbstractModule {
           transactionId,
           message.context.tenantId,
           this._costUpdatedInterval,
+          message.protocol,
         );
       }
     } else {
@@ -876,6 +751,7 @@ export class TransactionsModule extends AbstractModule {
         await this._costNotifier.calculateCostAndNotify(
           activeTransaction,
           message.context.tenantId,
+          message.protocol,
         );
       }
     } else {
@@ -1799,3 +1675,5 @@ export class TransactionsModule extends AbstractModule {
     }
   }
 }
+
+export default TransactionsModule;

--- a/packages/core/src/modules/Transactions/src/register.ts
+++ b/packages/core/src/modules/Transactions/src/register.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, asFunction, type AwilixContainer } from 'awilix';
+import { OCPP_CallAction } from '@citrineos/base';
+import { SignedMeterValuesUtil } from '@util/security/SignedMeterValuesUtil.js';
+import { CostCalculator } from './module/CostCalculator.js';
+import { CostNotifier, type CostUpdatedNotifier } from './module/CostNotifier.js';
+import { StatusNotificationService } from './module/StatusNotificationService.js';
+import { TransactionService } from './module/TransactionService.js';
+import type { TransactionsModule } from './module/module.js';
+
+/**
+ * Registers the Transactions module's internal services as scoped dependencies.
+ */
+export function registerTransactionsServices(container: AwilixContainer): void {
+  container.register({
+    transactionService: asClass(TransactionService).scoped(),
+    statusNotificationService: asClass(StatusNotificationService).scoped(),
+    costCalculator: asClass(CostCalculator).scoped(),
+    costNotifier: asClass(CostNotifier).scoped(),
+    signedMeterValuesUtil: asClass(SignedMeterValuesUtil).scoped(),
+    // Breaks the former CostNotifier→module cycle: this closure reads `transactionsModule`
+    // only when invoked at runtime (deferred), so there is no construction-time resolution
+    // cycle. The param annotation keeps `sendCall` fully type-checked.
+    costUpdatedNotifier: asFunction(
+      (deps: { transactionsModule: TransactionsModule }): CostUpdatedNotifier =>
+        async ({ ocppConnectionName, tenantId, totalCost, transactionId, protocol }) => {
+          await deps.transactionsModule.sendCall(
+            ocppConnectionName,
+            tenantId,
+            protocol,
+            OCPP_CallAction.CostUpdated,
+            { totalCost, transactionId },
+          );
+        },
+    ).scoped(),
+  });
+}

--- a/packages/core/src/modules/Transactions/test/module/CostCalculator.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/CostCalculator.test.ts
@@ -25,7 +25,10 @@ describe('CostCalculator', () => {
       recalculateTotalKwh: vi.fn(),
     } as unknown as Mocked<TransactionService>;
 
-    costCalculator = getTestInstance(container, CostCalculator, { tariffRepository, transactionService });
+    costCalculator = getTestInstance(container, CostCalculator, {
+      tariffRepository,
+      transactionService,
+    });
   });
 
   afterEach(() => {

--- a/packages/core/src/modules/Transactions/test/module/CostCalculator.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/CostCalculator.test.ts
@@ -5,11 +5,13 @@ import { DEFAULT_TENANT_ID } from '@citrineos/base';
 import { ITariffRepository, Tariff } from '@citrineos/core';
 import { faker } from '@faker-js/faker';
 import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import { CostCalculator } from '../../src/module/CostCalculator.js';
 import { TransactionService } from '../../src/module/TransactionService.js';
 import { aTariff } from '../providers/Tariff.js';
 
 describe('CostCalculator', () => {
+  const { container } = createTestContainer();
   let tariffRepository: Mocked<ITariffRepository>;
   let transactionService: Mocked<TransactionService>;
   let costCalculator: CostCalculator;
@@ -23,7 +25,7 @@ describe('CostCalculator', () => {
       recalculateTotalKwh: vi.fn(),
     } as unknown as Mocked<TransactionService>;
 
-    costCalculator = new CostCalculator(tariffRepository, transactionService);
+    costCalculator = getTestInstance(container, CostCalculator, { tariffRepository, transactionService });
   });
 
   afterEach(() => {

--- a/packages/core/src/modules/Transactions/test/module/CostNotifier.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/CostNotifier.test.ts
@@ -2,17 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { ITransactionEventRepository, Transaction } from '@citrineos/core';
-import { AbstractModule, DEFAULT_TENANT_ID, OCPP_CallAction, OCPPVersion } from '@citrineos/base';
+import { DEFAULT_TENANT_ID, OCPPVersion } from '@citrineos/base';
 import { CostCalculator } from '../../src/module/CostCalculator.js';
-import { CostNotifier } from '../../src/module/CostNotifier.js';
+import { CostNotifier, CostUpdatedNotifier } from '../../src/module/CostNotifier.js';
 import { aTransaction } from '../providers/TransactionProvider.js';
-import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, Mock, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('CostNotifier', () => {
+  const { container } = createTestContainer();
   const anyTenantId = DEFAULT_TENANT_ID;
+  const anyProtocol = OCPPVersion.OCPP2_0_1;
 
   let transactionEventRepository: Mocked<ITransactionEventRepository>;
-  let module: Mocked<AbstractModule>;
+  let costUpdatedNotifier: Mock<CostUpdatedNotifier>;
   let costCalculator: Mocked<CostCalculator>;
   let costNotifier: CostNotifier;
 
@@ -24,29 +27,29 @@ describe('CostNotifier', () => {
       updateTransactionTotalCostById: vi.fn(),
     } as unknown as Mocked<ITransactionEventRepository>;
 
-    module = {
-      sendCall: vi.fn(),
-    } as unknown as Mocked<AbstractModule>;
+    costUpdatedNotifier = vi.fn();
 
     costCalculator = {
       calculateTotalCost: vi.fn(),
     } as unknown as Mocked<CostCalculator>;
 
-    costNotifier = new CostNotifier(module, transactionEventRepository, costCalculator);
+    costNotifier = getTestInstance(container, CostNotifier, {
+      transactionEventRepository,
+      costCalculator,
+      costUpdatedNotifier,
+    });
   });
 
   afterEach(() => {
     transactionEventRepository.readTransactionByStationIdAndTransactionId.mockReset();
-    module.sendCall.mockReset();
+    costUpdatedNotifier.mockReset();
     costCalculator.calculateTotalCost.mockReset();
     vi.clearAllTimers();
   });
 
   describe('notifyWhileActive', () => {
     beforeEach(() => {
-      module.sendCall.mockResolvedValue({
-        success: true,
-      });
+      costUpdatedNotifier.mockResolvedValue(undefined);
     });
 
     it('should periodically send cost updates', async () => {
@@ -58,23 +61,24 @@ describe('CostNotifier', () => {
         transaction.transactionId,
         anyTenantId,
         intervalSeconds,
+        anyProtocol,
       );
 
-      expect(module.sendCall).toHaveBeenCalledTimes(0);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(0);
 
       const firstTotalCost = givenTotalCost(3.41);
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(1);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(1);
       assertLastCostUpdatedCall(transaction, anyTenantId, firstTotalCost);
 
       const secondTotalCost = givenTotalCost(6.84);
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(2);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(2);
       assertLastCostUpdatedCall(transaction, anyTenantId, secondTotalCost);
 
       const thirdTotalCost = givenTotalCost(11.14);
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(3);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(3);
       assertLastCostUpdatedCall(transaction, anyTenantId, thirdTotalCost);
     });
 
@@ -87,19 +91,20 @@ describe('CostNotifier', () => {
         transaction.transactionId,
         anyTenantId,
         intervalSeconds,
+        anyProtocol,
       );
 
-      expect(module.sendCall).toHaveBeenCalledTimes(0);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(0);
 
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(1);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(2);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(2);
 
       givenTransaction({ ...transaction, isActive: false } as Transaction);
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(2);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(2);
     });
 
     it('should not duplicate schedules for the same station and transaction', async () => {
@@ -111,6 +116,7 @@ describe('CostNotifier', () => {
         transaction.transactionId,
         anyTenantId,
         intervalSeconds,
+        anyProtocol,
       );
 
       costNotifier.notifyWhileActive(
@@ -118,10 +124,11 @@ describe('CostNotifier', () => {
         transaction.transactionId,
         anyTenantId,
         intervalSeconds,
+        anyProtocol,
       );
 
       await vi.advanceTimersByTimeAsync(intervalSeconds * 1000);
-      expect(module.sendCall).toHaveBeenCalledTimes(1);
+      expect(costUpdatedNotifier).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -130,16 +137,13 @@ describe('CostNotifier', () => {
     tenantId: number,
     totalCost: number,
   ) {
-    expect(module.sendCall).toHaveBeenLastCalledWith(
-      transaction.ocppConnectionName,
+    expect(costUpdatedNotifier).toHaveBeenLastCalledWith({
+      ocppConnectionName: transaction.ocppConnectionName,
       tenantId,
-      OCPPVersion.OCPP2_0_1,
-      OCPP_CallAction.CostUpdated,
-      {
-        totalCost: totalCost,
-        transactionId: transaction.transactionId,
-      },
-    );
+      totalCost,
+      transactionId: transaction.transactionId,
+      protocol: anyProtocol,
+    });
   }
 
   function givenTotalCost(cost: number) {

--- a/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
@@ -7,13 +7,8 @@ import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import type {
   BootstrapConfig,
-  CrudRepository,
-  IAuthorizer,
   ICache,
-  IFileStorage,
   IMessage,
-  IMessageHandler,
-  IMessageSender,
   OcppRequest,
   SystemConfig,
 } from '@citrineos/base';
@@ -29,16 +24,10 @@ import {
   OCPPVersion,
   TransactionEventEnum,
 } from '@citrineos/base';
-import type {
-  IAuthorizationRepository,
-  IDeviceModelRepository,
-  ILocationRepository,
-  IOCPPMessageRepository,
-  IReservationRepository,
-  ITariffRepository,
-  ITransactionEventRepository,
-} from '../../../../dal/interfaces/repositories.js';
+import { asValue } from 'awilix';
+import type { ITransactionEventRepository } from '@citrineos/core';
 import { TransactionsModule } from '../../src/module/module.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
   SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
@@ -108,6 +97,7 @@ function makeMessage<T extends OcppRequest>(
 }
 
 describe('F07 - Remote start with fixed cost, energy, SoC or time', () => {
+  const { container } = createTestContainer();
   let module: TransactionsModule;
   let transactionEventRepository: Partial<ITransactionEventRepository>;
   let mockCache: Partial<ICache>;
@@ -129,51 +119,39 @@ describe('F07 - Remote start with fixed cost, energy, SoC or time', () => {
     const config = makeConfig();
     const logger = new Logger<ILogObj>({ name: 'test', minLevel: 6 });
 
-    const mockHandler = {
-      subscribe: vi.fn().mockResolvedValue(true),
-      set module(_: any) {},
-    } as unknown as IMessageHandler;
+    // Register the module's dependencies as untyped values (asValue needs no casts).
+    // Repos carry only the methods the handler touches; the module's injected
+    // services are mocked at the boundary.
+    container.register({
+      config: asValue(config),
+      logger: asValue(logger),
+      cache: asValue(mockCache),
+      sender: asValue({ sendResponse: vi.fn().mockResolvedValue({ success: true }) }),
+      handler: asValue({ subscribe: vi.fn().mockResolvedValue(true), set module(_: unknown) {} }),
+      ocppValidator: asValue(undefined),
+      transactionEventRepository: asValue(transactionEventRepository),
+      authorizationRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      deviceModelRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      locationRepository: asValue({}),
+      tariffRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      ocppMessageRepository: asValue({ readOnlyOneByQuery: vi.fn().mockResolvedValue(null) }),
+      chargingProfileRepository: asValue({ readAllByQuery: vi.fn().mockResolvedValue([]) }),
+      transactionService: asValue({
+        authorizeOcpp21IdToken: vi
+          .fn()
+          .mockResolvedValue({ idTokenInfo: { status: AuthorizationStatusEnum.Accepted } }),
+        authorizeOcpp201IdToken: vi
+          .fn()
+          .mockResolvedValue({ idTokenInfo: { status: AuthorizationStatusEnum.Accepted } }),
+        deactivateReservation: vi.fn().mockResolvedValue(undefined),
+      }),
+      statusNotificationService: asValue({}),
+      costCalculator: asValue({}),
+      costNotifier: asValue({}),
+      signedMeterValuesUtil: asValue({ validateMeterValues: vi.fn().mockResolvedValue(true) }),
+    });
 
-    const mockSender = {
-      sendResponse: vi.fn().mockResolvedValue({ success: true }),
-    } as unknown as IMessageSender;
-
-    module = new TransactionsModule(
-      config,
-      mockCache as ICache,
-      {} as IFileStorage,
-      mockSender,
-      mockHandler,
-      logger,
-      undefined,
-      transactionEventRepository as ITransactionEventRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IAuthorizationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IDeviceModelRepository,
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as CrudRepository<any>,
-      {} as ILocationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as ITariffRepository,
-      {
-        updateAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as IReservationRepository,
-      {
-        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
-      } as unknown as IOCPPMessageRepository,
-      {
-        authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
-      } as unknown as IAuthorizer,
-      undefined, // authorizers
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as any, // chargingProfileRepository
-    );
+    module = getTestInstance(container, TransactionsModule, {});
 
     sendCallResultSpy = vi
       .spyOn(module, 'sendCallResultWithMessage')

--- a/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/F07.RemoteStartWithLimit.test.ts
@@ -5,13 +5,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type {
-  BootstrapConfig,
-  ICache,
-  IMessage,
-  OcppRequest,
-  SystemConfig,
-} from '@citrineos/base';
+import type { BootstrapConfig, ICache, IMessage, OcppRequest, SystemConfig } from '@citrineos/base';
 import {
   AuthorizationStatusEnum,
   CacheNamespace,
@@ -22,7 +16,6 @@ import {
   OCPP2_1,
   OCPP_CallAction,
   OCPPVersion,
-  TransactionEventEnum,
 } from '@citrineos/base';
 import { asValue } from 'awilix';
 import type { ITransactionEventRepository } from '@citrineos/core';
@@ -224,8 +217,6 @@ describe('F07 - Remote start with fixed cost, energy, SoC or time', () => {
         maxTime: 7200, // 2 hours in seconds
         maxSoC: 80, // 80%
       };
-      const cacheKey = `remotestart:${DEFAULT_TENANT_ID}:station-001:${remoteStartId}`;
-
       (mockCache.get as any).mockResolvedValue(JSON.stringify(transactionLimit));
 
       (

--- a/packages/core/src/modules/Transactions/test/module/I09.GetTariffs.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/I09.GetTariffs.test.ts
@@ -5,20 +5,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type {
-  BootstrapConfig,
-  CrudRepository,
-  IAuthorizer,
-  ICache,
-  IFileStorage,
-  IMessage,
-  IMessageHandler,
-  IMessageSender,
-  OcppRequest,
-  SystemConfig,
-} from '@citrineos/base';
+import type { BootstrapConfig, IMessage, OcppRequest, SystemConfig } from '@citrineos/base';
 import {
-  AuthorizationStatusEnum,
   DEFAULT_TENANT_ID,
   EventGroup,
   MessageOrigin,
@@ -27,16 +15,10 @@ import {
   OCPP_CallAction,
   OCPPVersion,
 } from '@citrineos/base';
-import type {
-  IAuthorizationRepository,
-  IDeviceModelRepository,
-  ILocationRepository,
-  IOCPPMessageRepository,
-  IReservationRepository,
-  ITariffRepository,
-  ITransactionEventRepository,
-} from '../../../../dal/interfaces/repositories.js';
+import { asValue } from 'awilix';
+import type { ILocationRepository } from '@citrineos/core';
 import { TransactionsModule } from '../../src/module/module.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
   SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
@@ -142,6 +124,7 @@ function makeMessage<T extends OcppRequest>(
 }
 
 describe('I09 - Local Cost Calculation - Get Tariffs', () => {
+  const { container } = createTestContainer();
   let module: TransactionsModule;
   let mockLocationRepository: Partial<ILocationRepository>;
   let mockConnectorFindAll: any;
@@ -173,53 +156,37 @@ describe('I09 - Local Cost Calculation - Get Tariffs', () => {
     const config = makeConfig();
     const logger = new Logger<ILogObj>({ name: 'test', minLevel: 6 });
 
-    const mockHandler = {
-      subscribe: vi.fn().mockResolvedValue(true),
-      set module(_: any) {},
-    } as unknown as IMessageHandler;
-
-    const mockSender = {
-      sendResponse: vi.fn().mockResolvedValue({ success: true }),
-    } as unknown as IMessageSender;
-
-    module = new TransactionsModule(
-      config,
-      {} as ICache,
-      {} as IFileStorage,
-      mockSender,
-      mockHandler,
-      logger,
-      undefined,
-      {
+    // Register the module's dependencies as untyped values (asValue needs no casts).
+    // Repos carry only the methods the handler touches; the module's injected
+    // services are mocked at the boundary.
+    container.register({
+      config: asValue(config),
+      logger: asValue(logger),
+      cache: asValue({}),
+      sender: asValue({ sendResponse: vi.fn().mockResolvedValue({ success: true }) }),
+      handler: asValue({ subscribe: vi.fn().mockResolvedValue(true), set module(_: unknown) {} }),
+      ocppValidator: asValue(undefined),
+      transactionEventRepository: asValue({
         createOrUpdateTransactionByTransactionEventAndStationId: vi.fn(),
-      } as unknown as ITransactionEventRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IAuthorizationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IDeviceModelRepository,
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as CrudRepository<any>,
-      mockLocationRepository as ILocationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as ITariffRepository,
-      {
-        updateAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as IReservationRepository,
-      {
-        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
-      } as unknown as IOCPPMessageRepository,
-      {
-        authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
-      } as unknown as IAuthorizer,
-      undefined,
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as any,
-    );
+      }),
+      authorizationRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      deviceModelRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      locationRepository: asValue(mockLocationRepository),
+      tariffRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      ocppMessageRepository: asValue({ readOnlyOneByQuery: vi.fn().mockResolvedValue(null) }),
+      chargingProfileRepository: asValue({ readAllByQuery: vi.fn().mockResolvedValue([]) }),
+      transactionService: asValue({
+        authorizeOcpp21IdToken: vi.fn().mockResolvedValue({}),
+        authorizeOcpp201IdToken: vi.fn().mockResolvedValue({}),
+        deactivateReservation: vi.fn().mockResolvedValue(undefined),
+      }),
+      statusNotificationService: asValue({}),
+      costCalculator: asValue({}),
+      costNotifier: asValue({}),
+      signedMeterValuesUtil: asValue({ validateMeterValues: vi.fn().mockResolvedValue(true) }),
+    });
+
+    module = getTestInstance(container, TransactionsModule, {});
   });
 
   describe('I09.FR.03 - No tariffs returns NoTariff status', () => {

--- a/packages/core/src/modules/Transactions/test/module/PrepaidAuthorization.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/PrepaidAuthorization.test.ts
@@ -20,10 +20,12 @@ import { anAuthorization } from '../providers/AuthorizationProvider.js';
 import { anIdToken } from '../providers/IdTokenProvider.js';
 
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import { aMessageContext } from '../providers/MessageContextProvider.js';
 import { aTransactionEventRequest } from '../providers/TransactionProvider.js';
 
 describe('C17 - Prepaid Card Authorization', () => {
+  const { container } = createTestContainer();
   let transactionService: TransactionService;
   let authorizationRepository: Mocked<IAuthorizationRepository>;
   let transactionEventRepository: Mocked<ITransactionEventRepository>;
@@ -61,15 +63,15 @@ describe('C17 - Prepaid Card Authorization', () => {
       authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
     } as Mocked<IAuthorizer>;
 
-    transactionService = new TransactionService(
+    transactionService = getTestInstance(container, TransactionService, {
       transactionEventRepository,
       authorizationRepository,
       locationRepository,
       reservationRepository,
       ocppMessageRepository,
       realTimeAuthorizer,
-      [authorizer],
-    );
+      authorizers: [authorizer],
+    });
   });
 
   describe('C17.FR.01 - Prepaid token with positive balance (OCPP 2.1)', () => {

--- a/packages/core/src/modules/Transactions/test/module/StatusNotificationService.integration.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/StatusNotificationService.integration.test.ts
@@ -53,11 +53,10 @@ beforeAll(async () => {
   await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
   await sequelizeInstance.sync({ force: true });
 
-  locationRepository = new SequelizeLocationRepository(
-    {} as BootstrapConfig,
-    undefined,
+  locationRepository = new SequelizeLocationRepository({
+    config: {} as BootstrapConfig,
     sequelizeInstance,
-  );
+  });
 }, 90_000);
 
 afterAll(async () => {
@@ -149,12 +148,12 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
 
     // The service needs ComponentRepository and DeviceModelRepository, but the
     // 1.6 path doesn't use them. Stubs are sufficient.
-    const service = new StatusNotificationService(
-      { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
-      { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+    const service = new StatusNotificationService({
+      componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
       locationRepository,
       cache,
-    );
+    });
 
     await expect(
       service.processOcpp16StatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
@@ -218,12 +217,12 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
       get: vi.fn().mockResolvedValue(JSON.stringify(websocketConnection)),
     } as unknown as ICache;
 
-    const service = new StatusNotificationService(
-      { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
-      { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+    const service = new StatusNotificationService({
+      componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
       locationRepository,
       cache,
-    );
+    });
 
     await expect(
       service.processOcpp16StatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {

--- a/packages/core/src/modules/Transactions/test/module/StatusNotificationService.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/StatusNotificationService.test.ts
@@ -4,6 +4,7 @@
 import { CrudRepository, DEFAULT_TENANT_ID } from '@citrineos/base';
 import { Component, IDeviceModelRepository, ILocationRepository } from '@citrineos/core';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import { StatusNotification } from '../../../../dal/layers/sequelize/index.js';
 import { StatusNotificationService } from '../../src/module/StatusNotificationService.js';
 import {
@@ -56,6 +57,7 @@ vi.mock('../../../../dal/layers/sequelize/model/Location/index.js', async (impor
 });
 
 describe('StatusNotificationService', () => {
+  const { container } = createTestContainer();
   let statusNotificationService: StatusNotificationService;
   let componentRepository: Mocked<CrudRepository<Component>>;
   let deviceModelRepository: Mocked<IDeviceModelRepository>;
@@ -88,12 +90,12 @@ describe('StatusNotificationService', () => {
       get: vi.fn().mockResolvedValue(JSON.stringify(mockConnection)),
     } as unknown as Mocked<ICache>;
 
-    statusNotificationService = new StatusNotificationService(
+    statusNotificationService = getTestInstance(container, StatusNotificationService, {
       componentRepository,
       deviceModelRepository,
       locationRepository,
       cache,
-    );
+    });
   });
 
   it('should save StatusNotification for Charging Station because Charging Station exists', async () => {

--- a/packages/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionLimit.test.ts
@@ -2,20 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type {
-  BootstrapConfig,
-  CrudRepository,
-  IAuthorizer,
-  ICache,
-  IFileStorage,
-  IMessage,
-  IMessageHandler,
-  IMessageSender,
-  OcppRequest,
-  SystemConfig,
-} from '@citrineos/base';
+import type { BootstrapConfig, IMessage, OcppRequest, SystemConfig } from '@citrineos/base';
 import {
-  AuthorizationStatusEnum,
   DEFAULT_TENANT_ID,
   EventGroup,
   MessageOrigin,
@@ -24,19 +12,13 @@ import {
   OCPP_CallAction,
   OCPPVersion,
 } from '@citrineos/base';
+import { asValue } from 'awilix';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type {
-  IAuthorizationRepository,
-  IDeviceModelRepository,
-  ILocationRepository,
-  IOCPPMessageRepository,
-  IReservationRepository,
-  ITariffRepository,
-  ITransactionEventRepository,
-} from '../../../../dal/interfaces/repositories.js';
+import type { ITransactionEventRepository } from '@citrineos/core';
 import { TransactionsModule } from '../../src/module/module.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
   SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
@@ -106,6 +88,7 @@ function makeMessage<T extends OcppRequest>(
 }
 
 describe('TransactionsModule - E16 Transaction Limits', () => {
+  const { container } = createTestContainer();
   let module: TransactionsModule;
   let transactionEventRepository: Partial<ITransactionEventRepository>;
   let sendCallResultSpy: any;
@@ -119,55 +102,35 @@ describe('TransactionsModule - E16 Transaction Limits', () => {
     const config = makeConfig();
     const logger = new Logger<ILogObj>({ name: 'test', minLevel: 6 });
 
-    const mockHandler = {
-      subscribe: vi.fn().mockResolvedValue(true),
-      set module(_: any) {},
-    } as unknown as IMessageHandler;
+    // Register the module's dependencies as untyped values (asValue needs no casts).
+    // Repos carry only the methods the handler touches; the module's injected
+    // services are mocked at the boundary.
+    container.register({
+      config: asValue(config),
+      logger: asValue(logger),
+      cache: asValue({ get: vi.fn().mockResolvedValue(null) }),
+      sender: asValue({ sendResponse: vi.fn().mockResolvedValue({ success: true }) }),
+      handler: asValue({ subscribe: vi.fn().mockResolvedValue(true), set module(_: unknown) {} }),
+      ocppValidator: asValue(undefined),
+      transactionEventRepository: asValue(transactionEventRepository),
+      authorizationRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      deviceModelRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      locationRepository: asValue({}),
+      tariffRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      ocppMessageRepository: asValue({ readOnlyOneByQuery: vi.fn().mockResolvedValue(null) }),
+      chargingProfileRepository: asValue({ readAllByQuery: vi.fn().mockResolvedValue([]) }),
+      transactionService: asValue({
+        authorizeOcpp21IdToken: vi.fn().mockResolvedValue({}),
+        authorizeOcpp201IdToken: vi.fn().mockResolvedValue({}),
+        deactivateReservation: vi.fn().mockResolvedValue(undefined),
+      }),
+      statusNotificationService: asValue({}),
+      costCalculator: asValue({}),
+      costNotifier: asValue({}),
+      signedMeterValuesUtil: asValue({ validateMeterValues: vi.fn().mockResolvedValue(true) }),
+    });
 
-    const mockSender = {
-      sendResponse: vi.fn().mockResolvedValue({ success: true }),
-    } as unknown as IMessageSender;
-
-    const mockCache = {
-      get: vi.fn().mockResolvedValue(null),
-    } as unknown as ICache;
-
-    module = new TransactionsModule(
-      config,
-      mockCache,
-      {} as IFileStorage,
-      mockSender,
-      mockHandler,
-      logger,
-      undefined,
-      transactionEventRepository as ITransactionEventRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IAuthorizationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IDeviceModelRepository,
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as CrudRepository<any>,
-      {} as ILocationRepository,
-      {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as ITariffRepository,
-      {
-        updateAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as IReservationRepository,
-      {
-        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
-      } as unknown as IOCPPMessageRepository,
-      {
-        authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
-      } as unknown as IAuthorizer,
-      undefined, // authorizers
-      {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as any, // chargingProfileRepository
-    );
+    module = getTestInstance(container, TransactionsModule, {});
 
     sendCallResultSpy = vi
       .spyOn(module, 'sendCallResultWithMessage')

--- a/packages/core/src/modules/Transactions/test/module/TransactionService.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionService.test.ts
@@ -21,10 +21,12 @@ import { anIdToken } from '../providers/IdTokenProvider.js';
 
 import { faker } from '@faker-js/faker';
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 import { aMessageContext } from '../providers/MessageContextProvider.js';
 import { aTransaction, aTransactionEventRequest } from '../providers/TransactionProvider.js';
 
 describe('TransactionService', () => {
+  const { container } = createTestContainer();
   let transactionService: TransactionService;
   let authorizationRepository: Mocked<IAuthorizationRepository>;
   let transactionEventRepository: Mocked<ITransactionEventRepository>;
@@ -61,15 +63,15 @@ describe('TransactionService', () => {
       authorize: vi.fn(),
     } as Mocked<IAuthorizer>;
 
-    transactionService = new TransactionService(
+    transactionService = getTestInstance(container, TransactionService, {
       transactionEventRepository,
       authorizationRepository,
       locationRepository,
       reservationRepository,
       ocppMessageRepository,
       realTimeAuthorizer,
-      [authorizer],
-    );
+      authorizers: [authorizer],
+    });
   });
 
   it('should return Unknown status when authorizations length is not 1', async () => {
@@ -317,14 +319,15 @@ describe('TransactionService', () => {
         authorize: vi.fn(),
       } as Mocked<IAuthorizer>;
 
-      transactionService = new TransactionService(
+      transactionService = getTestInstance(container, TransactionService, {
         transactionEventRepository,
-        {} as unknown as IAuthorizationRepository,
+        authorizationRepository: {} as unknown as IAuthorizationRepository,
         locationRepository,
-        {} as unknown as IReservationRepository,
-        {} as unknown as IOCPPMessageRepository,
+        reservationRepository: {} as unknown as IReservationRepository,
+        ocppMessageRepository: {} as unknown as IOCPPMessageRepository,
         realTimeAuthorizer,
-      );
+        authorizers: [],
+      });
     });
 
     describe('OCPP 2.0.1 — EVSEType identifier', () => {

--- a/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
@@ -5,20 +5,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type {
-  BootstrapConfig,
-  CrudRepository,
-  IAuthorizer,
-  ICache,
-  IFileStorage,
-  IMessage,
-  IMessageHandler,
-  IMessageSender,
-  OcppRequest,
-  SystemConfig,
-} from '@citrineos/base';
+import type { BootstrapConfig, IMessage, OcppRequest, SystemConfig } from '@citrineos/base';
 import {
-  AuthorizationStatusEnum,
   DEFAULT_TENANT_ID,
   EventGroup,
   MessageOrigin,
@@ -28,16 +16,14 @@ import {
   OCPP_CallAction,
   OCPPVersion,
 } from '@citrineos/base';
+import { asValue } from 'awilix';
 import type {
   IAuthorizationRepository,
-  IDeviceModelRepository,
   ILocationRepository,
-  IOCPPMessageRepository,
-  IReservationRepository,
-  ITariffRepository,
   ITransactionEventRepository,
 } from '@dal/interfaces/repositories.js';
 import { TransactionsModule } from '../../src/module/module.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
   SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
@@ -107,6 +93,7 @@ function makeMessage<T extends OcppRequest>(
 }
 
 describe('TransactionsModule - _handleTransactionEvent and _handleOcpp16StartTransaction deactivate triggers', () => {
+  const { container } = createTestContainer();
   let module: TransactionsModule;
   let transactionEventRepository: Partial<ITransactionEventRepository>;
   let locationRepository: Partial<ILocationRepository>;
@@ -139,60 +126,48 @@ describe('TransactionsModule - _handleTransactionEvent and _handleOcpp16StartTra
     const config = makeConfig();
     const logger = new Logger<ILogObj>({ name: 'test', minLevel: 6 });
 
-    const mockHandler = {
-      subscribe: vi.fn().mockResolvedValue(true),
-      shutdown: vi.fn(),
-      set module(_: any) {},
-    } as unknown as IMessageHandler;
+    // Register the module's dependencies as untyped values (asValue needs no casts).
+    // Repos carry only the methods the handlers touch; the module's injected
+    // services are mocked at the boundary. authorizeOcpp16IdToken must return
+    // Accepted so the 1.6 StartTransaction path reaches the deactivate call.
+    container.register({
+      config: asValue(config),
+      logger: asValue(logger),
+      cache: asValue({ get: vi.fn().mockResolvedValue(null), set: vi.fn().mockResolvedValue(true) }),
+      sender: asValue({
+        sendResponse: vi.fn().mockResolvedValue({ success: true }),
+        sendRequest: vi.fn().mockResolvedValue({ success: true }),
+        shutdown: vi.fn(),
+      }),
+      handler: asValue({
+        subscribe: vi.fn().mockResolvedValue(true),
+        shutdown: vi.fn(),
+        set module(_: unknown) {},
+      }),
+      ocppValidator: asValue(undefined),
+      transactionEventRepository: asValue(transactionEventRepository),
+      authorizationRepository: asValue(authorizationRepository),
+      deviceModelRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      locationRepository: asValue(locationRepository),
+      tariffRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      ocppMessageRepository: asValue({ readOnlyOneByQuery: vi.fn().mockResolvedValue(null) }),
+      chargingProfileRepository: asValue({ readAllByQuery: vi.fn().mockResolvedValue([]) }),
+      transactionService: asValue({
+        authorizeOcpp16IdToken: vi.fn().mockResolvedValue({
+          idTagInfo: { status: OCPP1_6.StartTransactionResponseStatus.Accepted },
+        }),
+        authorizeOcpp21IdToken: vi.fn().mockResolvedValue({}),
+        authorizeOcpp201IdToken: vi.fn().mockResolvedValue({}),
+        deactivateReservation: vi.fn().mockResolvedValue(undefined),
+        deactivateOtherActiveTransactionsAtEvse: vi.fn().mockResolvedValue(undefined),
+      }),
+      statusNotificationService: asValue({}),
+      costCalculator: asValue({}),
+      costNotifier: asValue({}),
+      signedMeterValuesUtil: asValue({ validateMeterValues: vi.fn().mockResolvedValue(true) }),
+    });
 
-    const mockSender = {
-      sendResponse: vi.fn().mockResolvedValue({ success: true }),
-      sendRequest: vi.fn().mockResolvedValue({ success: true }),
-      shutdown: vi.fn(),
-    } as unknown as IMessageSender;
-
-    const mockCache = {
-      get: vi.fn().mockResolvedValue(null),
-      set: vi.fn().mockResolvedValue(true),
-    } as unknown as ICache;
-
-    const mockFileStorage = {} as IFileStorage;
-    const mockRealTimeAuthorizer = {
-      authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
-    } as unknown as IAuthorizer;
-
-    module = new TransactionsModule(
-      config,
-      mockCache,
-      mockFileStorage,
-      mockSender,
-      mockHandler,
-      logger,
-      /* ocppValidator */ undefined,
-      transactionEventRepository as ITransactionEventRepository,
-      authorizationRepository as IAuthorizationRepository,
-      /* deviceModelRepository */ {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IDeviceModelRepository,
-      /* componentRepository */ {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as CrudRepository<any>,
-      locationRepository as ILocationRepository,
-      /* tariffRepository */ {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as ITariffRepository,
-      /* reservationRepository */ {
-        updateAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as IReservationRepository,
-      /* ocppMessageRepository */ {
-        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
-      } as unknown as IOCPPMessageRepository,
-      mockRealTimeAuthorizer,
-      /* authorizers */ undefined,
-      /* chargingProfileRepository */ {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as any,
-    );
+    module = getTestInstance(container, TransactionsModule, {});
 
     vi.spyOn(module, 'sendCallResultWithMessage').mockResolvedValue({ success: true });
 

--- a/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionsModule.deactivate.test.ts
@@ -133,7 +133,10 @@ describe('TransactionsModule - _handleTransactionEvent and _handleOcpp16StartTra
     container.register({
       config: asValue(config),
       logger: asValue(logger),
-      cache: asValue({ get: vi.fn().mockResolvedValue(null), set: vi.fn().mockResolvedValue(true) }),
+      cache: asValue({
+        get: vi.fn().mockResolvedValue(null),
+        set: vi.fn().mockResolvedValue(true),
+      }),
       sender: asValue({
         sendResponse: vi.fn().mockResolvedValue({ success: true }),
         sendRequest: vi.fn().mockResolvedValue({ success: true }),

--- a/packages/core/src/modules/Transactions/test/module/TransactionsModule.endedTransaction.test.ts
+++ b/packages/core/src/modules/Transactions/test/module/TransactionsModule.endedTransaction.test.ts
@@ -7,10 +7,7 @@ import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import type {
   BootstrapConfig,
-  CrudRepository,
-  IAuthorizer,
   ICache,
-  IFileStorage,
   IMessage,
   IMessageHandler,
   IMessageSender,
@@ -27,16 +24,10 @@ import {
   OCPP_CallAction,
   OCPPVersion,
 } from '@citrineos/base';
-import type {
-  IAuthorizationRepository,
-  IDeviceModelRepository,
-  ILocationRepository,
-  IOCPPMessageRepository,
-  IReservationRepository,
-  ITariffRepository,
-  ITransactionEventRepository,
-} from '@dal/interfaces/repositories.js';
+import type { ITransactionEventRepository } from '@dal/interfaces/repositories.js';
 import { TransactionsModule } from '../../src/module/module.js';
+import { asValue } from 'awilix';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 vi.mock('@util/security/SignedMeterValuesUtil.js', () => ({
   SignedMeterValuesUtil: vi.fn().mockImplementation(() => ({
@@ -102,6 +93,7 @@ function makeMessage<T extends OcppRequest>(payload: T, action: string): IMessag
 }
 
 describe('TransactionsModule - ended transaction guard', () => {
+  const { container } = createTestContainer();
   let module: TransactionsModule;
   let transactionEventRepository: Partial<ITransactionEventRepository>;
   let sendCallResultSpy: ReturnType<typeof vi.spyOn>;
@@ -140,42 +132,33 @@ describe('TransactionsModule - ended transaction guard', () => {
       set: vi.fn().mockResolvedValue(true),
     } as unknown as ICache;
 
-    module = new TransactionsModule(
-      config,
-      mockCache,
-      {} as IFileStorage,
-      mockSender,
-      mockHandler,
-      logger,
-      /* ocppValidator */ undefined,
-      transactionEventRepository as ITransactionEventRepository,
-      /* authorizeRepository */ {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IAuthorizationRepository,
-      /* deviceModelRepository */ {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as IDeviceModelRepository,
-      /* componentRepository */ {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as CrudRepository<any>,
-      /* locationRepository */ {} as ILocationRepository,
-      /* tariffRepository */ {
-        readAllByQuerystring: vi.fn().mockResolvedValue([]),
-      } as unknown as ITariffRepository,
-      /* reservationRepository */ {
-        updateAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as IReservationRepository,
-      /* ocppMessageRepository */ {
-        readOnlyOneByQuery: vi.fn().mockResolvedValue(null),
-      } as unknown as IOCPPMessageRepository,
-      /* realTimeAuthorizer */ {
-        authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
-      } as unknown as IAuthorizer,
-      /* authorizers */ undefined,
-      /* chargingProfileRepository */ {
-        readAllByQuery: vi.fn().mockResolvedValue([]),
-      } as unknown as any,
-    );
+    container.register({
+      config: asValue(config),
+      logger: asValue(logger),
+      cache: asValue(mockCache),
+      sender: asValue(mockSender),
+      handler: asValue(mockHandler),
+      ocppValidator: asValue(undefined),
+      transactionEventRepository: asValue(transactionEventRepository),
+      authorizationRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      deviceModelRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      locationRepository: asValue({}),
+      tariffRepository: asValue({ readAllByQuerystring: vi.fn().mockResolvedValue([]) }),
+      ocppMessageRepository: asValue({ readOnlyOneByQuery: vi.fn().mockResolvedValue(null) }),
+      chargingProfileRepository: asValue({ readAllByQuery: vi.fn().mockResolvedValue([]) }),
+      transactionService: asValue({
+        authorizeOcpp21IdToken: vi.fn().mockResolvedValue({}),
+        authorizeOcpp201IdToken: vi.fn().mockResolvedValue({}),
+        deactivateReservation: vi.fn().mockResolvedValue(undefined),
+        deactivateOtherActiveTransactionsAtEvse: vi.fn().mockResolvedValue(undefined),
+      }),
+      statusNotificationService: asValue({}),
+      costCalculator: asValue({}),
+      costNotifier: asValue({}),
+      signedMeterValuesUtil: asValue({ validateMeterValues: vi.fn().mockResolvedValue(true) }),
+    });
+
+    module = getTestInstance(container, TransactionsModule, {});
 
     sendCallResultSpy = vi
       .spyOn(module, 'sendCallResultWithMessage')

--- a/packages/core/src/test/testContainer.ts
+++ b/packages/core/src/test/testContainer.ts
@@ -1,6 +1,13 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
 // SPDX-License-Identifier: Apache-2.0
-import { asClass, asValue, createContainer, InjectionMode, type AwilixContainer, type Constructor } from 'awilix';
+import {
+  asClass,
+  asValue,
+  createContainer,
+  InjectionMode,
+  type AwilixContainer,
+  type Constructor,
+} from 'awilix';
 import { vi, type Mock } from 'vitest';
 
 type AnyClass = Constructor<object>;
@@ -23,10 +30,9 @@ export type MockLogger = {
 };
 
 function makeDefaultLogger(): MockLogger {
-  // Two-step assignment lets the arrow function close over `logger` before it's
-  // assigned, which is safe because getSubLogger is never called during construction.
-  let logger: MockLogger;
-  logger = {
+  // getSubLogger returns the same mock; the self-reference is safe because the
+  // arrow is never called during construction.
+  const logger: MockLogger = {
     debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),

--- a/packages/core/src/test/testContainer.ts
+++ b/packages/core/src/test/testContainer.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+// SPDX-License-Identifier: Apache-2.0
+import { asClass, asValue, createContainer, InjectionMode, type AwilixContainer, type Constructor } from 'awilix';
+import { vi, type Mock } from 'vitest';
+
+type AnyClass = Constructor<object>;
+
+// The deps object the class constructor destructures. Partial because logger is pre-registered
+// and Awilix strict:true enforces any other missing dep at resolve time.
+type Deps<T extends AnyClass> = Partial<ConstructorParameters<T>[0]>;
+
+const TARGET_KEY = '__target';
+
+export type MockLogger = {
+  debug: Mock;
+  info: Mock;
+  warn: Mock;
+  error: Mock;
+  fatal: Mock;
+  trace: Mock;
+  // Real function so it survives vi.restoreAllMocks() between tests.
+  getSubLogger: (...args: unknown[]) => MockLogger;
+};
+
+function makeDefaultLogger(): MockLogger {
+  // Two-step assignment lets the arrow function close over `logger` before it's
+  // assigned, which is safe because getSubLogger is never called during construction.
+  let logger: MockLogger;
+  logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    getSubLogger: () => logger,
+  };
+  return logger;
+}
+
+function toValueResolvers(deps: Record<string, unknown>) {
+  return Object.fromEntries(Object.entries(deps).map(([key, value]) => [key, asValue(value)]));
+}
+
+/**
+ * Creates a shared Awilix container for a test file, pre-registered with a
+ * vi.fn()-based mock logger. Returns both the container and the logger so tests
+ * can assert on log calls without any type cast.
+ *
+ * Usage (top of describe block):
+ *   const { container, logger } = createTestContainer();
+ */
+export function createTestContainer(): { container: AwilixContainer; logger: MockLogger } {
+  const container = createContainer({ injectionMode: InjectionMode.PROXY, strict: true });
+  const logger = makeDefaultLogger();
+  container.register({ logger: asValue(logger) });
+  return { container, logger };
+}
+
+/**
+ * Registers the given class and its mocks into the shared container, then
+ * resolves and returns the instance. Call this in beforeEach to get a fresh
+ * instance each test (re-registration overwrites the previous entry).
+ *
+ * Usage:
+ *   service = getTestInstance(container, BasicAuthenticationFilter, {
+ *     deviceModelRepository: mockRepo,
+ *   });
+ */
+export function getTestInstance<T extends AnyClass>(
+  container: AwilixContainer,
+  instance: T,
+  mocks: Deps<T>,
+): InstanceType<T> {
+  container.register({
+    ...toValueResolvers(mocks as Record<string, unknown>),
+    [TARGET_KEY]: asClass(instance),
+  });
+  return container.resolve<InstanceType<T>>(TARGET_KEY);
+}

--- a/packages/core/src/util/authorizer/RealTimeAuthorizer.ts
+++ b/packages/core/src/util/authorizer/RealTimeAuthorizer.ts
@@ -42,16 +42,18 @@ export class RealTimeAuthorizer implements IAuthorizer {
   private readonly _logger: Logger<ILogObj>;
   private readonly _oidcTokenProvider?: OidcTokenProvider;
 
-  constructor(
-    locationRepository: ILocationRepository,
-    config: SystemConfig,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    locationRepository,
+    config,
+    logger,
+  }: {
+    locationRepository: ILocationRepository;
+    config: SystemConfig;
+    logger: Logger<ILogObj>;
+  }) {
     this._locationRepository = locationRepository;
     this._config = config;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
     if (config.oidcClient) {
       this._oidcTokenProvider = new OidcTokenProvider(config.oidcClient, this._logger);
     }
@@ -217,3 +219,5 @@ export class RealTimeAuthorizer implements IAuthorizer {
     return result;
   }
 }
+
+export default RealTimeAuthorizer;

--- a/packages/core/src/util/certificate/CertificateAuthority.ts
+++ b/packages/core/src/util/certificate/CertificateAuthority.ts
@@ -31,7 +31,6 @@ import type {
 } from './client/interface.js';
 import OCSPRequest = jsrsasign.KJUR.asn1.ocsp.OCSPRequest;
 import Request = jsrsasign.KJUR.asn1.ocsp.Request;
-import { LocalStorage } from '@/util/index.js';
 const cryptoEngine = new pkijs.CryptoEngine({
   crypto: new Crypto(),
 });
@@ -41,33 +40,27 @@ export class CertificateAuthorityService {
   private readonly _v2gClient: IV2GCertificateAuthorityClient;
   private readonly _chargingStationClientPromise: Promise<IChargingStationCertificateAuthorityClient>;
   private readonly _logger: Logger<ILogObj>;
-  private readonly _cache: ICache;
-  private readonly _config: SystemConfig;
   private readonly _fileStorage: IFileStorage;
 
-  constructor(
-    config: SystemConfig,
-    cache: ICache,
-    logger?: Logger<ILogObj>,
-    chargingStationClient?: IChargingStationCertificateAuthorityClient,
-    v2gClient?: IV2GCertificateAuthorityClient,
-    fileStorage?: IFileStorage,
-  ) {
-    this._config = config;
-    this._cache = cache;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
-    this._fileStorage = fileStorage || new LocalStorage('', '', undefined, this._logger);
-    this._v2gClient =
-      v2gClient || CertificateAuthorityService._instantiateV2GClient(config, cache, logger);
-    this._chargingStationClientPromise = chargingStationClient
-      ? Promise.resolve(chargingStationClient)
-      : CertificateAuthorityService._instantiateChargingStationClient(
-          config,
-          this._fileStorage,
-          logger,
-        );
+  constructor({
+    config,
+    cache,
+    logger,
+    fileStorage,
+  }: {
+    config: SystemConfig;
+    cache: ICache;
+    logger: Logger<ILogObj>;
+    fileStorage: IFileStorage;
+  }) {
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
+    this._fileStorage = fileStorage;
+    this._v2gClient = CertificateAuthorityService._instantiateV2GClient(config, cache, logger);
+    this._chargingStationClientPromise = CertificateAuthorityService._instantiateChargingStationClient(
+      config,
+      this._fileStorage,
+      logger,
+    );
   }
 
   /**
@@ -294,20 +287,20 @@ export class CertificateAuthorityService {
     return certificateChain;
   }
 
-  private static _instantiateV2GClient(
+  protected static _instantiateV2GClient(
     config: SystemConfig,
     cache: ICache,
     logger?: Logger<ILogObj>,
   ): IV2GCertificateAuthorityClient {
     switch (config.util.certificateAuthority.v2gCA.name) {
       case 'hubject':
-        return new Hubject(config, cache, logger);
+        return new Hubject({ config, cache, logger });
       default:
         throw new Error(`Unsupported V2G CA: ${config.util.certificateAuthority.v2gCA.name}`);
     }
   }
 
-  private static async _instantiateChargingStationClient(
+  protected static async _instantiateChargingStationClient(
     config: SystemConfig,
     fileStorage: IFileStorage,
     logger?: Logger<ILogObj>,
@@ -322,3 +315,5 @@ export class CertificateAuthorityService {
     }
   }
 }
+
+export default CertificateAuthorityService;

--- a/packages/core/src/util/certificate/CertificateAuthority.ts
+++ b/packages/core/src/util/certificate/CertificateAuthority.ts
@@ -56,11 +56,12 @@ export class CertificateAuthorityService {
     this._logger = logger.getSubLogger({ name: this.constructor.name });
     this._fileStorage = fileStorage;
     this._v2gClient = CertificateAuthorityService._instantiateV2GClient(config, cache, logger);
-    this._chargingStationClientPromise = CertificateAuthorityService._instantiateChargingStationClient(
-      config,
-      this._fileStorage,
-      logger,
-    );
+    this._chargingStationClientPromise =
+      CertificateAuthorityService._instantiateChargingStationClient(
+        config,
+        this._fileStorage,
+        logger,
+      );
   }
 
   /**

--- a/packages/core/src/util/certificate/client/hubject.ts
+++ b/packages/core/src/util/certificate/client/hubject.ts
@@ -27,7 +27,15 @@ export class Hubject implements IV2GCertificateAuthorityClient {
   private static readonly AUTH_TOKEN_CACHE_KEY = 'HUBJECT_AUTH_TOKEN';
   private static readonly AUTH_TOKEN_CACHE_NAMESPACE = 'hubject';
 
-  constructor(config: SystemConfig, cache: ICache, logger?: Logger<ILogObj>) {
+  constructor({
+    config,
+    cache,
+    logger,
+  }: {
+    config: SystemConfig;
+    cache: ICache;
+    logger?: Logger<ILogObj>;
+  }) {
     const hubjectConfig = config.util.certificateAuthority.v2gCA.hubject;
     if (!hubjectConfig) {
       throw new Error('Missing Hubject configuration');

--- a/packages/core/src/util/networkconnection/WebsocketNetworkConnection.ts
+++ b/packages/core/src/util/networkconnection/WebsocketNetworkConnection.ts
@@ -69,29 +69,34 @@ export class WebsocketNetworkConnection implements INetworkConnection {
   ) => Promise<boolean>;
   private _getMaxChargingStationsForTenant?: (tenantId: number) => Promise<number | null>;
 
-  constructor(
-    config: SystemConfig,
-    cache: ICache,
-    authenticator: IAuthenticator,
-    router: IMessageRouter,
-    fileStorage: IFileStorage,
-    logger?: Logger<ILogObj>,
-    doesChargingStationExistByStationId?: (
-      tenantId: number,
-      ocppConnectionName: string,
-    ) => Promise<boolean>,
-    getMaxChargingStationsForTenant?: (tenantId: number) => Promise<number | null>,
-    connectionManager?: IConnectionManager,
-  ) {
+  constructor({
+    config,
+    cache,
+    authenticator,
+    router,
+    fileStorage,
+    logger,
+    doesChargingStationExistByStationId,
+    getMaxChargingStationsForTenant,
+    connectionManager,
+  }: {
+    config: SystemConfig;
+    cache: ICache;
+    authenticator: IAuthenticator;
+    router: IMessageRouter;
+    fileStorage: IFileStorage;
+    logger: Logger<ILogObj>;
+    doesChargingStationExistByStationId: (tenantId: number, ocppConnectionName: string) => Promise<boolean>;
+    getMaxChargingStationsForTenant: (tenantId: number) => Promise<number | null>;
+    connectionManager: IConnectionManager;
+  }) {
     this._getMaxChargingStationsForTenant = getMaxChargingStationsForTenant;
     this._cache = cache;
     this._config = config;
     this._doesChargingStationExistByStationId = doesChargingStationExistByStationId;
     this._connectionManager = connectionManager;
     this._fileStorage = fileStorage;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
     this._authenticator = authenticator;
     router.networkHook = this.sendMessage.bind(this);
     this._router = router;
@@ -857,3 +862,5 @@ export class WebsocketNetworkConnection implements INetworkConnection {
     });
   }
 }
+
+export default WebsocketNetworkConnection;

--- a/packages/core/src/util/networkconnection/authenticator/Authenticator.ts
+++ b/packages/core/src/util/networkconnection/authenticator/Authenticator.ts
@@ -19,20 +19,24 @@ export class Authenticator implements IAuthenticator {
   private _networkProfileFilter: NetworkProfileFilter;
   private _basicAuthenticationFilter: BasicAuthenticationFilter;
 
-  constructor(
-    unknownStationFilter: UnknownStationFilter,
-    connectedStationFilter: ConnectedStationFilter,
-    networkProfileFilter: NetworkProfileFilter,
-    basicAuthenticationFilter: BasicAuthenticationFilter,
-    logger?: Logger<ILogObj>,
-  ) {
+  constructor({
+    unknownStationFilter,
+    connectedStationFilter,
+    networkProfileFilter,
+    basicAuthenticationFilter,
+    logger,
+  }: {
+    unknownStationFilter: UnknownStationFilter;
+    connectedStationFilter: ConnectedStationFilter;
+    networkProfileFilter: NetworkProfileFilter;
+    basicAuthenticationFilter: BasicAuthenticationFilter;
+    logger: Logger<ILogObj>;
+  }) {
     this._unknownStationFilter = unknownStationFilter;
     this._connectedStationFilter = connectedStationFilter;
     this._networkProfileFilter = networkProfileFilter;
     this._basicAuthenticationFilter = basicAuthenticationFilter;
-    this._logger = logger
-      ? logger.getSubLogger({ name: this.constructor.name })
-      : new Logger<ILogObj>({ name: this.constructor.name });
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
   }
 
   async authenticate(
@@ -52,3 +56,5 @@ export class Authenticator implements IAuthenticator {
     return { identifier };
   }
 }
+
+export default Authenticator;

--- a/packages/core/src/util/networkconnection/authenticator/BasicAuthenticationFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/BasicAuthenticationFilter.ts
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { AuthenticationOptions } from '@citrineos/base';
 import { OCPP2_0_1 } from '@citrineos/base';
-import type { IDeviceModelRepository } from '@dal/interfaces/repositories.js';
+import type { VariableAttribute } from '@dal/layers/sequelize/model/DeviceModel/VariableAttribute.js';
+import type { VariableAttributeQuerystring } from '@dal/interfaces/queries/VariableAttribute.js';
 import { IncomingMessage } from 'http';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
@@ -15,10 +16,23 @@ import { UpgradeAuthenticationError } from './errors/AuthenticationError.js';
  * Filter used to authenticate incoming HTTP requests based on basic authorization header.
  * It only applies when the security profile is set to 1 or 2.
  */
-export class BasicAuthenticationFilter extends AuthenticatorFilter {
-  private _deviceModelRepository: IDeviceModelRepository;
+interface IDeviceModelLookup {
+  readAllByQuerystring(
+    tenantId: number,
+    query: VariableAttributeQuerystring,
+  ): Promise<VariableAttribute[]>;
+}
 
-  constructor(deviceModelRepository: IDeviceModelRepository, logger?: Logger<ILogObj>) {
+export class BasicAuthenticationFilter extends AuthenticatorFilter {
+  private _deviceModelRepository: IDeviceModelLookup;
+
+  constructor({
+    deviceModelRepository,
+    logger,
+  }: {
+    deviceModelRepository: IDeviceModelLookup;
+    logger: Logger<ILogObj>;
+  }) {
     super(logger);
     this._deviceModelRepository = deviceModelRepository;
   }
@@ -69,3 +83,5 @@ export class BasicAuthenticationFilter extends AuthenticatorFilter {
       });
   }
 }
+
+export default BasicAuthenticationFilter;

--- a/packages/core/src/util/networkconnection/authenticator/ConnectedStationFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/ConnectedStationFilter.ts
@@ -15,7 +15,7 @@ import { UpgradeAuthenticationError } from './errors/AuthenticationError.js';
 export class ConnectedStationFilter extends AuthenticatorFilter {
   private _cache: ICache;
 
-  constructor(cache: ICache, logger?: Logger<ILogObj>) {
+  constructor({ cache, logger }: { cache: ICache; logger: Logger<ILogObj> }) {
     super(logger);
     this._cache = cache;
   }
@@ -40,3 +40,5 @@ export class ConnectedStationFilter extends AuthenticatorFilter {
     }
   }
 }
+
+export default ConnectedStationFilter;

--- a/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
@@ -20,7 +20,13 @@ import { UpgradeAuthenticationError } from './errors/AuthenticationError.js';
 export class NetworkProfileFilter extends AuthenticatorFilter {
   private _deviceModelRepository: IDeviceModelRepository;
 
-  constructor({ deviceModelRepository, logger }: { deviceModelRepository: IDeviceModelRepository; logger: Logger<ILogObj> }) {
+  constructor({
+    deviceModelRepository,
+    logger,
+  }: {
+    deviceModelRepository: IDeviceModelRepository;
+    logger: Logger<ILogObj>;
+  }) {
     super(logger);
     this._deviceModelRepository = deviceModelRepository;
   }

--- a/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
@@ -20,7 +20,7 @@ import { UpgradeAuthenticationError } from './errors/AuthenticationError.js';
 export class NetworkProfileFilter extends AuthenticatorFilter {
   private _deviceModelRepository: IDeviceModelRepository;
 
-  constructor(deviceModelRepository: IDeviceModelRepository, logger?: Logger<ILogObj>) {
+  constructor({ deviceModelRepository, logger }: { deviceModelRepository: IDeviceModelRepository; logger: Logger<ILogObj> }) {
     super(logger);
     this._deviceModelRepository = deviceModelRepository;
   }
@@ -120,3 +120,5 @@ export class NetworkProfileFilter extends AuthenticatorFilter {
     return true;
   }
 }
+
+export default NetworkProfileFilter;

--- a/packages/core/src/util/networkconnection/authenticator/UnknownStationFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/UnknownStationFilter.ts
@@ -3,20 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type { ILocationRepository } from '@dal/interfaces/repositories.js';
 import { IncomingMessage } from 'http';
 import { AuthenticatorFilter } from './AuthenticatorFilter.js';
 import type { AuthenticationOptions } from '@citrineos/base';
 import { UpgradeUnknownError } from './errors/UnknownError.js';
+
+interface IStationExistenceChecker {
+  doesChargingStationExistByStationId(tenantId: number, ocppConnectionName: string): Promise<boolean>;
+}
 
 /**
  * Filter used to block connections from charging stations that are not recognized in the system.
  * It only applies when unknown charging stations are not allowed.
  */
 export class UnknownStationFilter extends AuthenticatorFilter {
-  private _locationRepository: ILocationRepository;
+  private _locationRepository: IStationExistenceChecker;
 
-  constructor(locationRepository: ILocationRepository, logger?: Logger<ILogObj>) {
+  constructor({ locationRepository, logger }: { locationRepository: IStationExistenceChecker; logger: Logger<ILogObj> }) {
     super(logger);
     this._locationRepository = locationRepository;
   }
@@ -39,3 +42,5 @@ export class UnknownStationFilter extends AuthenticatorFilter {
     }
   }
 }
+
+export default UnknownStationFilter;

--- a/packages/core/src/util/networkconnection/authenticator/UnknownStationFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/UnknownStationFilter.ts
@@ -9,7 +9,10 @@ import type { AuthenticationOptions } from '@citrineos/base';
 import { UpgradeUnknownError } from './errors/UnknownError.js';
 
 interface IStationExistenceChecker {
-  doesChargingStationExistByStationId(tenantId: number, ocppConnectionName: string): Promise<boolean>;
+  doesChargingStationExistByStationId(
+    tenantId: number,
+    ocppConnectionName: string,
+  ): Promise<boolean>;
 }
 
 /**
@@ -19,7 +22,13 @@ interface IStationExistenceChecker {
 export class UnknownStationFilter extends AuthenticatorFilter {
   private _locationRepository: IStationExistenceChecker;
 
-  constructor({ locationRepository, logger }: { locationRepository: IStationExistenceChecker; logger: Logger<ILogObj> }) {
+  constructor({
+    locationRepository,
+    logger,
+  }: {
+    locationRepository: IStationExistenceChecker;
+    logger: Logger<ILogObj>;
+  }) {
     super(logger);
     this._locationRepository = locationRepository;
   }

--- a/packages/core/src/util/queue/rabbit-mq/ChannelManager.ts
+++ b/packages/core/src/util/queue/rabbit-mq/ChannelManager.ts
@@ -11,13 +11,20 @@ export class RabbitMQChannelManager {
 
   protected _logger: Logger<ILogObj>;
 
-  constructor(
-    private connectionManager: RabbitMQConnectionManager,
-    logger?: Logger<ILogObj>,
-  ) {
+  private connectionManager: RabbitMQConnectionManager;
+
+  constructor({
+    connectionManager,
+    logger,
+  }: {
+    connectionManager: RabbitMQConnectionManager;
+    logger?: Logger<ILogObj>;
+  }) {
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
       : new Logger<ILogObj>({ name: this.constructor.name });
+
+    this.connectionManager = connectionManager;
 
     // Recreate channels on reconnection
     connectionManager.on('connected', () => {

--- a/packages/core/src/util/queue/rabbit-mq/ConnectionManager.ts
+++ b/packages/core/src/util/queue/rabbit-mq/ConnectionManager.ts
@@ -13,12 +13,21 @@ export class RabbitMQConnectionManager extends AbstractConnectionManager<amqp.Co
   private reconnectDelay = 1000; // Start with 1 second
   private reconnectTimer: NodeJS.Timeout | null = null;
 
-  constructor(
-    private maxReconnectDelay: number,
-    private url: string,
-    logger?: Logger<ILogObj>,
-  ) {
+  private maxReconnectDelay: number;
+  private url: string;
+
+  constructor({
+    maxReconnectDelay,
+    amqpUrl,
+    logger,
+  }: {
+    maxReconnectDelay: number;
+    amqpUrl: string;
+    logger?: Logger<ILogObj>;
+  }) {
     super(logger);
+    this.maxReconnectDelay = maxReconnectDelay;
+    this.url = amqpUrl;
   }
 
   async connect(): Promise<amqp.Connection> {

--- a/packages/core/src/util/queue/rabbit-mq/receiver.ts
+++ b/packages/core/src/util/queue/rabbit-mq/receiver.ts
@@ -47,13 +47,19 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
   protected _instanceConsumerTags: string[] = [];
   protected _instanceBindings = new Map<string, Array<Record<string, string>>>();
 
-  constructor(
-    config: SystemConfig,
-    channelManager: RabbitMQChannelManager,
-    logger?: Logger<ILogObj>,
-    module?: IModule,
-    routerMode?: boolean,
-  ) {
+  constructor({
+    config,
+    channelManager,
+    logger,
+    module,
+    routerMode,
+  }: {
+    config: SystemConfig;
+    channelManager: RabbitMQChannelManager;
+    logger?: Logger<ILogObj>;
+    module?: IModule;
+    routerMode?: boolean;
+  }) {
     super(logger, module);
     this._channelManager = channelManager;
     const exchange = config.util.messageBroker.amqp?.exchange;

--- a/packages/core/src/util/security/SignedMeterValuesUtil.ts
+++ b/packages/core/src/util/security/SignedMeterValuesUtil.ts
@@ -34,15 +34,19 @@ export class SignedMeterValuesUtil {
    * @param {Logger<ILogObj>} [logger] - The `logger` represents an instance of {@link Logger<ILogObj>}.
    *
    */
-  constructor(
-    fileStorage: IFileStorage,
-    config: BootstrapConfig & SystemConfig,
-    logger: Logger<ILogObj>,
-  ) {
+  constructor({
+    fileStorage,
+    config,
+    logger,
+  }: {
+    fileStorage: IFileStorage;
+    config: BootstrapConfig & SystemConfig;
+    logger: Logger<ILogObj>;
+  }) {
     this._fileStorage = fileStorage;
     this._logger = logger;
     this._chargingStationSecurityInfoRepository =
-      new sequelize.SequelizeChargingStationSecurityInfoRepository(config, logger);
+      new sequelize.SequelizeChargingStationSecurityInfoRepository({ config, logger });
 
     this._signedMeterValuesConfiguration =
       config.modules.transactions.signedMeterValuesConfiguration;

--- a/packages/core/src/util/test/authorizer/RealTimeAuthorizer.test.ts
+++ b/packages/core/src/util/test/authorizer/RealTimeAuthorizer.test.ts
@@ -13,6 +13,7 @@ import type { Authorization } from '@dal/layers/sequelize/index.js';
 import type { ILocationRepository } from '@dal/interfaces/repositories.js';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { RealTimeAuthorizer } from '../../authorizer/RealTimeAuthorizer.js';
+import { createTestContainer, getTestInstance } from '../../../test/testContainer.js';
 
 function buildMockLocationRepository(chargingStation: unknown): Mocked<ILocationRepository> {
   return {
@@ -47,6 +48,7 @@ const evse = { id: 10 } as EvseDto;
 const connector = { id: 100 } as ConnectorDto;
 
 describe('RealTimeAuthorizer', () => {
+  const { container } = createTestContainer();
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -62,7 +64,10 @@ describe('RealTimeAuthorizer', () => {
   it('does not throw when ChargingStation has no Location (locationId is null)', async () => {
     const chargingStation = { locationId: null, evses: [] };
     const repo = buildMockLocationRepository(chargingStation);
-    const authorizer = new RealTimeAuthorizer(repo, {} as SystemConfig);
+    const authorizer = getTestInstance(container, RealTimeAuthorizer, {
+      locationRepository: repo,
+      config: {} as SystemConfig,
+    });
 
     const result = await authorizer.authorize(
       buildAuthorization(),

--- a/packages/core/src/util/test/certificate/CertificateAuthority.test.ts
+++ b/packages/core/src/util/test/certificate/CertificateAuthority.test.ts
@@ -5,6 +5,7 @@ import { IFileStorage, OCPP2_0_1, SystemConfig } from '@citrineos/base';
 import { faker } from '@faker-js/faker';
 import { KJUR } from 'jsrsasign';
 import { beforeAll, describe, expect, it, Mock, Mocked, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../test/testContainer.js';
 import * as CertificateUtil from '../../certificate/CertificateUtil.js';
 import {
   IChargingStationCertificateAuthorityClient,
@@ -29,6 +30,7 @@ vi.spyOn(KJUR.asn1.ocsp.OCSPUtil, 'getOCSPResponseInfo').mockImplementation(() =
 });
 
 describe('CertificateAuthorityService', () => {
+  const { container } = createTestContainer();
   let mockV2GClient: Mocked<IV2GCertificateAuthorityClient>;
   let mockChargingStationClient: Mocked<IChargingStationCertificateAuthorityClient>;
   let mockSystemConfig: Mocked<SystemConfig>;
@@ -52,14 +54,29 @@ describe('CertificateAuthorityService', () => {
 
     mockCertUtil = CertificateUtil as Mocked<typeof CertificateUtil>;
 
-    certificateAuthorityService = new CertificateAuthorityService(
-      mockSystemConfig,
-      new MemoryCache(),
-      undefined,
-      mockChargingStationClient,
-      mockV2GClient,
-      undefined as unknown as IFileStorage,
+    type WithFactoryHooks = typeof CertificateAuthorityService & {
+      _instantiateV2GClient: (...args: unknown[]) => IV2GCertificateAuthorityClient;
+      _instantiateChargingStationClient: (...args: unknown[]) => Promise<IChargingStationCertificateAuthorityClient>;
+    };
+
+    vi.spyOn(CertificateAuthorityService as WithFactoryHooks, '_instantiateV2GClient').mockReturnValue(mockV2GClient);
+    vi.spyOn(CertificateAuthorityService as WithFactoryHooks, '_instantiateChargingStationClient').mockReturnValue(
+      Promise.resolve(mockChargingStationClient),
     );
+
+    const fileStorage: IFileStorage = {
+      saveFile: vi.fn() as IFileStorage['saveFile'],
+      getFile: vi.fn() as IFileStorage['getFile'],
+      exists: vi.fn() as IFileStorage['exists'],
+      createDirectory: vi.fn() as IFileStorage['createDirectory'],
+      deleteFile: vi.fn() as IFileStorage['deleteFile'],
+    };
+
+    certificateAuthorityService = getTestInstance(container, CertificateAuthorityService, {
+      config: mockSystemConfig,
+      cache: new MemoryCache(),
+      fileStorage,
+    });
   });
 
   describe('getCertificateChain', () => {

--- a/packages/core/src/util/test/certificate/CertificateAuthority.test.ts
+++ b/packages/core/src/util/test/certificate/CertificateAuthority.test.ts
@@ -56,13 +56,19 @@ describe('CertificateAuthorityService', () => {
 
     type WithFactoryHooks = typeof CertificateAuthorityService & {
       _instantiateV2GClient: (...args: unknown[]) => IV2GCertificateAuthorityClient;
-      _instantiateChargingStationClient: (...args: unknown[]) => Promise<IChargingStationCertificateAuthorityClient>;
+      _instantiateChargingStationClient: (
+        ...args: unknown[]
+      ) => Promise<IChargingStationCertificateAuthorityClient>;
     };
 
-    vi.spyOn(CertificateAuthorityService as WithFactoryHooks, '_instantiateV2GClient').mockReturnValue(mockV2GClient);
-    vi.spyOn(CertificateAuthorityService as WithFactoryHooks, '_instantiateChargingStationClient').mockReturnValue(
-      Promise.resolve(mockChargingStationClient),
-    );
+    vi.spyOn(
+      CertificateAuthorityService as WithFactoryHooks,
+      '_instantiateV2GClient',
+    ).mockReturnValue(mockV2GClient);
+    vi.spyOn(
+      CertificateAuthorityService as WithFactoryHooks,
+      '_instantiateChargingStationClient',
+    ).mockReturnValue(Promise.resolve(mockChargingStationClient));
 
     const fileStorage: IFileStorage = {
       saveFile: vi.fn() as IFileStorage['saveFile'],

--- a/packages/core/src/util/test/certificate/client/Hubject.integration.test.ts
+++ b/packages/core/src/util/test/certificate/client/Hubject.integration.test.ts
@@ -40,7 +40,7 @@ describe.skip('Integration Tests (requires real credentials)', () => {
         throw new Error('HUBJECT_CLIENT_ID environment variable not set');
       }
 
-      hubject = new Hubject(systemConfig, cache, logger);
+      hubject = new Hubject({ config: systemConfig, cache, logger });
     });
 
     it('should get root certificates from real API', async () => {

--- a/packages/core/src/util/test/certificate/client/Hubject.test.ts
+++ b/packages/core/src/util/test/certificate/client/Hubject.test.ts
@@ -10,8 +10,6 @@ import {
   SystemConfig,
 } from '@citrineos/base';
 import { faker } from '@faker-js/faker';
-import type { ILogObj } from 'tslog';
-import { Logger } from 'tslog';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { Hubject } from '../../../certificate/client/hubject.js';
 import { MemoryCache } from '../../../index.js';
@@ -20,8 +18,10 @@ import {
   aValidSignedContractData,
   HUBJECT_DEFAULT_AUTH_TOKEN,
 } from '../../providers/Hubject.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('Hubject', () => {
+  const { container } = createTestContainer();
   const mockBaseURL = 'https://hubject.base.test';
   const mockTokenURL = 'https://hubject.token.test';
   const mockBearerToken = 'Bearer ' + HUBJECT_DEFAULT_AUTH_TOKEN;
@@ -29,13 +29,11 @@ describe('Hubject', () => {
   const mockClientSecret = 'test-client-secret';
 
   let systemConfig: SystemConfig;
-  let logger: Logger<ILogObj>;
   let cache: MemoryCache;
   let hubject: Hubject;
 
   beforeEach(() => {
     global.fetch = vi.fn();
-    logger = new Logger<ILogObj>();
     cache = new MemoryCache();
     systemConfig = {
       util: {
@@ -52,7 +50,7 @@ describe('Hubject', () => {
         },
       },
     } as any;
-    hubject = new Hubject(systemConfig, cache, logger);
+    hubject = getTestInstance(container, Hubject, { config: systemConfig, cache });
   });
 
   afterEach(() => {
@@ -89,7 +87,7 @@ describe('Hubject', () => {
         },
       } as SystemConfig;
 
-      const hubjectWithDefaults = new Hubject(defaultConfig, cache, logger);
+      const hubjectWithDefaults = getTestInstance(container, Hubject, { config: defaultConfig, cache });
 
       const token = await (hubjectWithDefaults as any)._getAuthorizationToken();
 

--- a/packages/core/src/util/test/certificate/client/Hubject.test.ts
+++ b/packages/core/src/util/test/certificate/client/Hubject.test.ts
@@ -87,7 +87,10 @@ describe('Hubject', () => {
         },
       } as SystemConfig;
 
-      const hubjectWithDefaults = getTestInstance(container, Hubject, { config: defaultConfig, cache });
+      const hubjectWithDefaults = getTestInstance(container, Hubject, {
+        config: defaultConfig,
+        cache,
+      });
 
       const token = await (hubjectWithDefaults as any)._getAuthorizationToken();
 

--- a/packages/core/src/util/test/networkconnection/authenticator/BasicAuthenticationFilter.test.ts
+++ b/packages/core/src/util/test/networkconnection/authenticator/BasicAuthenticationFilter.test.ts
@@ -1,29 +1,23 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { IDeviceModelRepository, VariableAttribute } from '@citrineos/core';
+import { VariableAttribute } from '@citrineos/core';
 import { DEFAULT_TENANT_ID, OCPP2_0_1 } from '@citrineos/base';
 import { faker } from '@faker-js/faker';
 import { aBasicAuthPasswordVariable } from '../../providers/VariableAttributeProvider.js';
 import { BasicAuthenticationFilter } from '../../../index.js';
 import { aRequestWithAuthorization, basicAuth } from '../../providers/IncomingMessageProvider.js';
 import { anAuthenticationOptions } from '../../providers/AuthenticationOptionsProvider.js';
-import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('BasicAuthenticationFilter', () => {
+  const { container } = createTestContainer();
   const password = 'SEPtwLckb5QD5on0EXcCAmuQVmJ*bu3ZXmA:Clt3';
   const anotherPassword = '_Oec8yF4r1hH6ildo4yvM25:SU2hpL*jobDskYos';
 
-  let deviceModelRepository: Mocked<IDeviceModelRepository>;
-  let filter: BasicAuthenticationFilter;
-
-  beforeEach(() => {
-    deviceModelRepository = {
-      readAllByQuerystring: vi.fn(),
-    } as unknown as Mocked<IDeviceModelRepository>;
-
-    filter = new BasicAuthenticationFilter(deviceModelRepository);
-  });
+  const deviceModelRepository = { readAllByQuerystring: vi.fn() };
+  const filter = getTestInstance(container, BasicAuthenticationFilter, { deviceModelRepository });
 
   afterEach(() => {
     deviceModelRepository.readAllByQuerystring.mockReset();

--- a/packages/core/src/util/test/networkconnection/authenticator/ConnectedStationFilter.test.ts
+++ b/packages/core/src/util/test/networkconnection/authenticator/ConnectedStationFilter.test.ts
@@ -6,19 +6,23 @@ import { aRequest } from '../../providers/IncomingMessageProvider.js';
 import { anAuthenticationOptions } from '../../providers/AuthenticationOptionsProvider.js';
 import { CacheNamespace, createIdentifier, DEFAULT_TENANT_ID, ICache } from '@citrineos/base';
 import { ConnectedStationFilter } from '../../../index.js';
-import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { afterEach, describe, expect, it, Mock, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('ConnectedStationFilter', () => {
-  let cache: Mocked<ICache>;
-  let filter: ConnectedStationFilter;
-
-  beforeEach(() => {
-    cache = {
-      get: vi.fn(),
-    } as unknown as Mocked<ICache>;
-
-    filter = new ConnectedStationFilter(cache);
-  });
+  const { container } = createTestContainer();
+  const cache = {
+    exists: vi.fn() as ICache['exists'],
+    existsAnyInNamespace: vi.fn() as ICache['existsAnyInNamespace'],
+    remove: vi.fn() as ICache['remove'],
+    onChange: vi.fn() as ICache['onChange'],
+    get: vi.fn() as Mock & ICache['get'],
+    set: vi.fn() as ICache['set'],
+    setIfNotExist: vi.fn() as ICache['setIfNotExist'],
+    updateExpiration: vi.fn() as ICache['updateExpiration'],
+    ping: vi.fn() as ICache['ping'],
+  };
+  const filter = getTestInstance(container, ConnectedStationFilter, { cache });
 
   afterEach(() => {
     cache.get.mockReset();

--- a/packages/core/src/util/test/networkconnection/authenticator/UnknownStationFilter.test.ts
+++ b/packages/core/src/util/test/networkconnection/authenticator/UnknownStationFilter.test.ts
@@ -1,25 +1,18 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { ILocationRepository } from '@citrineos/core';
 import { faker } from '@faker-js/faker';
 import { UnknownStationFilter } from '../../../index.js';
 import { aRequest } from '../../providers/IncomingMessageProvider.js';
 import { anAuthenticationOptions } from '../../providers/AuthenticationOptionsProvider.js';
 import { DEFAULT_TENANT_ID } from '@citrineos/base';
-import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('UnknownStationFilter', () => {
-  let locationRepository: Mocked<ILocationRepository>;
-  let filter: UnknownStationFilter;
-
-  beforeEach(() => {
-    locationRepository = {
-      doesChargingStationExistByStationId: vi.fn(),
-    } as unknown as Mocked<ILocationRepository>;
-
-    filter = new UnknownStationFilter(locationRepository);
-  });
+  const { container } = createTestContainer();
+  const locationRepository = { doesChargingStationExistByStationId: vi.fn() };
+  const filter = getTestInstance(container, UnknownStationFilter, { locationRepository });
 
   afterEach(() => {
     locationRepository.doesChargingStationExistByStationId.mockReset();

--- a/packages/core/src/util/test/providers/RabbitMqProvider.ts
+++ b/packages/core/src/util/test/providers/RabbitMqProvider.ts
@@ -21,7 +21,11 @@ import type { RabbitMQChannelManager } from '../../queue/rabbit-mq/ChannelManage
 export function aSystemConfigWithAmqp(override?: {
   exchange?: string;
   instanceIdentifier?: string;
+  noAmqp?: boolean;
 }): SystemConfig {
+  if (override?.noAmqp) {
+    return { util: { messageBroker: { amqp: undefined } } } as unknown as SystemConfig;
+  }
   return {
     util: {
       messageBroker: {

--- a/packages/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
+++ b/packages/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
@@ -266,7 +266,10 @@ describe('RabbitMqReceiver', () => {
 
     beforeEach(() => {
       receiver = new RabbitMqReceiver({
-        config: aSystemConfigWithAmqp({ exchange: EXCHANGE, instanceIdentifier: `${instanceId}-${uid}` }),
+        config: aSystemConfigWithAmqp({
+          exchange: EXCHANGE,
+          instanceIdentifier: `${instanceId}-${uid}`,
+        }),
         channelManager,
         routerMode: true,
       });

--- a/packages/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
+++ b/packages/core/src/util/test/queue/rabbit-mq/receiver.integration.test.ts
@@ -159,8 +159,8 @@ let uid: string;
 
 beforeEach(async () => {
   uid = Date.now().toString(36);
-  connectionManager = new RabbitMQConnectionManager(5_000, amqpUrl);
-  channelManager = new RabbitMQChannelManager(connectionManager);
+  connectionManager = new RabbitMQConnectionManager({ maxReconnectDelay: 5_000, amqpUrl });
+  channelManager = new RabbitMQChannelManager({ connectionManager });
   // Mirror production startup: connect before any subscribe() calls so the
   // initial 'connected' event fires while _moduleSubscriptions/_instanceQueueReady
   // are still empty, and _onReconnect is a no-op on first connect.
@@ -190,10 +190,10 @@ describe('RabbitMqReceiver', () => {
 
   describe('MODULE_MODE — broker state', () => {
     beforeEach(() => {
-      receiver = new RabbitMqReceiver(
-        aSystemConfigWithAmqp({ exchange: EXCHANGE }),
+      receiver = new RabbitMqReceiver({
+        config: aSystemConfigWithAmqp({ exchange: EXCHANGE }),
         channelManager,
-      );
+      });
     });
 
     it('should create a durable, auto-delete queue named after the identifier', async () => {
@@ -265,13 +265,11 @@ describe('RabbitMqReceiver', () => {
     const instanceId = `router-integration`;
 
     beforeEach(() => {
-      receiver = new RabbitMqReceiver(
-        aSystemConfigWithAmqp({ exchange: EXCHANGE, instanceIdentifier: `${instanceId}-${uid}` }),
+      receiver = new RabbitMqReceiver({
+        config: aSystemConfigWithAmqp({ exchange: EXCHANGE, instanceIdentifier: `${instanceId}-${uid}` }),
         channelManager,
-        undefined,
-        undefined,
-        /* routerMode */ true,
-      );
+        routerMode: true,
+      });
     });
 
     it('should create a single durable, non-auto-delete instance queue', async () => {

--- a/packages/core/src/util/test/queue/rabbit-mq/receiver.test.ts
+++ b/packages/core/src/util/test/queue/rabbit-mq/receiver.test.ts
@@ -13,8 +13,10 @@ import {
   aMockConnectionManager,
   aSystemConfigWithAmqp,
 } from '../../providers/RabbitMqProvider.js';
+import { createTestContainer, getTestInstance } from '../../../../test/testContainer.js';
 
 describe('RabbitMqReceiver', () => {
+  const { container } = createTestContainer();
   // ---------------------------------------------------------------------------
   // MODULE_MODE — default behaviour, no routerMode flag
   // Each identifier gets its own dedicated queue and consumer(s).
@@ -27,17 +29,23 @@ describe('RabbitMqReceiver', () => {
     beforeEach(() => {
       mockChannel = aMockAmqpChannel();
       mockChannelManager = aMockChannelManager(mockChannel);
-      receiver = new RabbitMqReceiver(aSystemConfigWithAmqp(), mockChannelManager);
+      receiver = getTestInstance(container, RabbitMqReceiver, {
+        config: aSystemConfigWithAmqp(),
+        channelManager: mockChannelManager,
+        module: undefined,
+        routerMode: undefined,
+      });
     });
 
     describe('constructor', () => {
       it('should throw when AMQP exchange is not configured', () => {
-        expect(
-          () =>
-            new RabbitMqReceiver(
-              { util: { messageBroker: { amqp: undefined } } } as any,
-              mockChannelManager,
-            ),
+        expect(() =>
+          getTestInstance(container, RabbitMqReceiver, {
+            config: aSystemConfigWithAmqp({ noAmqp: true }),
+            channelManager: mockChannelManager,
+            module: undefined,
+            routerMode: undefined,
+          }),
         ).toThrow('RabbitMQ exchange is not configured');
       });
 
@@ -178,13 +186,12 @@ describe('RabbitMqReceiver', () => {
       mockChannel = aMockAmqpChannel();
       mockConnectionManager = aMockConnectionManager();
       mockChannelManager = aMockChannelManager(mockChannel, mockConnectionManager);
-      receiver = new RabbitMqReceiver(
-        aSystemConfigWithAmqp({ instanceIdentifier: 'pod-1' }),
-        mockChannelManager,
-        undefined,
-        undefined,
-        /* routerMode */ true,
-      );
+      receiver = getTestInstance(container, RabbitMqReceiver, {
+        config: aSystemConfigWithAmqp({ instanceIdentifier: 'pod-1' }),
+        channelManager: mockChannelManager,
+        module: undefined,
+        routerMode: true,
+      });
     });
 
     describe('constructor', () => {
@@ -198,13 +205,12 @@ describe('RabbitMqReceiver', () => {
       });
 
       it('should fall back to a timestamp-based name when instanceIdentifier is absent', async () => {
-        const fallbackReceiver = new RabbitMqReceiver(
-          aSystemConfigWithAmqp(), // no instanceIdentifier
-          mockChannelManager,
-          undefined,
-          undefined,
-          true,
-        );
+        const fallbackReceiver = getTestInstance(container, RabbitMqReceiver, {
+          config: aSystemConfigWithAmqp(),
+          channelManager: mockChannelManager,
+          module: undefined,
+          routerMode: true,
+        });
 
         await fallbackReceiver.subscribe('charger-1', undefined, { ocppConnectionName: 'CS001' });
 
@@ -215,13 +221,12 @@ describe('RabbitMqReceiver', () => {
       });
 
       it('should NOT activate router mode when routerMode is false', async () => {
-        const moduleReceiver = new RabbitMqReceiver(
-          aSystemConfigWithAmqp({ instanceIdentifier: 'pod-1' }),
-          mockChannelManager,
-          undefined,
-          undefined,
-          false,
-        );
+        const moduleReceiver = getTestInstance(container, RabbitMqReceiver, {
+          config: aSystemConfigWithAmqp({ instanceIdentifier: 'pod-1' }),
+          channelManager: mockChannelManager,
+          module: undefined,
+          routerMode: false,
+        });
 
         await moduleReceiver.subscribe('ModuleX', [OCPP_CallAction.BootNotification], {});
 
@@ -376,7 +381,12 @@ describe('RabbitMqReceiver', () => {
 
     beforeEach(() => {
       mockChannel = aMockAmqpChannel();
-      receiver = new RabbitMqReceiver(aSystemConfigWithAmqp(), aMockChannelManager(mockChannel));
+      receiver = getTestInstance(container, RabbitMqReceiver, {
+        config: aSystemConfigWithAmqp(),
+        channelManager: aMockChannelManager(mockChannel),
+        module: undefined,
+        routerMode: undefined,
+      });
       // Prevent handle() from throwing due to no registered handlers
       vi.spyOn(receiver, 'handle').mockResolvedValue(undefined);
     });

--- a/packages/core/src/util/util/idGenerator.ts
+++ b/packages/core/src/util/util/idGenerator.ts
@@ -7,8 +7,8 @@ import type { IChargingStationSequenceRepository } from '@dal/interfaces/reposit
 export class IdGenerator {
   private _stationSequenceRepository: IChargingStationSequenceRepository;
 
-  constructor(stationSequenceRepository: IChargingStationSequenceRepository) {
-    this._stationSequenceRepository = stationSequenceRepository;
+  constructor({ chargingStationSequenceRepository }: { chargingStationSequenceRepository: IChargingStationSequenceRepository }) {
+    this._stationSequenceRepository = chargingStationSequenceRepository;
   }
 
   async generateRequestId(
@@ -19,3 +19,5 @@ export class IdGenerator {
     return this._stationSequenceRepository.getNextSequenceValue(tenantId, ocppConnectionName, type);
   }
 }
+
+export default IdGenerator;

--- a/packages/core/src/util/util/idGenerator.ts
+++ b/packages/core/src/util/util/idGenerator.ts
@@ -7,7 +7,11 @@ import type { IChargingStationSequenceRepository } from '@dal/interfaces/reposit
 export class IdGenerator {
   private _stationSequenceRepository: IChargingStationSequenceRepository;
 
-  constructor({ chargingStationSequenceRepository }: { chargingStationSequenceRepository: IChargingStationSequenceRepository }) {
+  constructor({
+    chargingStationSequenceRepository,
+  }: {
+    chargingStationSequenceRepository: IChargingStationSequenceRepository;
+  }) {
     this._stationSequenceRepository = chargingStationSequenceRepository;
   }
 

--- a/packages/core/src/util/vatProvider/ViesVatProvider.ts
+++ b/packages/core/src/util/vatProvider/ViesVatProvider.ts
@@ -28,7 +28,7 @@ interface ViesErrorResponse {
 export class ViesVatProvider implements IVatProvider {
   private readonly _logger: Logger<ILogObj>;
 
-  constructor(logger?: Logger<ILogObj>) {
+  constructor({ logger }: { logger?: Logger<ILogObj> } = {}) {
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
       : new Logger<ILogObj>({ name: this.constructor.name });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       '@fastify/cors':
         specifier: 10.1.0
         version: 10.1.0
+      awilix:
+        specifier: ^13.0.3
+        version: 13.0.5
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
@@ -734,6 +737,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.0
         version: 8.5.4
+      awilix:
+        specifier: ^13.0.3
+        version: 13.0.5
       drizzle-kit:
         specifier: ^0.31.0
         version: 0.31.10
@@ -4932,6 +4938,10 @@ packages:
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  awilix@13.0.5:
+    resolution: {integrity: sha512-ORtca6suBdYA1FyTzqHEZDvEuUwo3lPDDBRm7GrzHgi6STESzJKdBtpqfTzObdMj1NGQUWX6k26E3EbQaGJX5Q==}
+    engines: {node: '>=20.0.0'}
 
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
@@ -14286,6 +14296,10 @@ snapshots:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
 
+  awilix@13.0.5:
+    dependencies:
+      fast-glob: 3.3.3
+
   axe-core@4.12.1: {}
 
   axios@1.16.0(debug@4.4.3):
@@ -15486,7 +15500,7 @@ snapshots:
       '@typescript-eslint/parser': 8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.16.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.16.0(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.16.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.16.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.16.0(jiti@2.7.0))
@@ -15510,7 +15524,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.16.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -15525,14 +15539,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.16.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.16.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.16.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -15547,7 +15561,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.16.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0)))(eslint@9.16.0(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.16.0(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Major implementation changes to the way we instantiate our objects throughout the project.

Wire the application through a single Awilix container so every layer —
system config, repositories, services, modules, RabbitMQ, and the DB
instance — is resolved through it rather than hand-constructed.

- Composition root: buildContainer() in apps/Server/src/container.ts,
  split into per-layer registrars (primitives, messaging, repositories,
  services, module services, network, modules, module APIs).
- Per-module registrars (<module>/src/register.ts) wire each module's
  internal services as scoped; the service classes stay package-private,
  dissolving the three same-named DeviceModelService collisions.
- Repositories and shared services use destructured constructors as
  singletons; each module and its APIs resolve in a per-module child scope.
- Messaging: scoped sender/handler per module, a singleton
  routerSender/routerHandler pair for the router, all wrapped in
  BrokerAwareMessageSender.
- Break the CostNotifier->module cycle with a deferred costUpdatedNotifier
  closure that reads the module lazily at call time. To expand upon this, the issue was
  that the CostNotifier depended on the TransactionModule but the TransactionModule 
  depended on the CostNotifier. We created a middle-man costUpdatedNotifier that 
  only depends on TransactionModule after it's instantiated to avoid this problem. 
  Alternatively we could have refactored this functionality but that is way out of scope.
- Protocol changed to parameter: AbstractModuleApi.supportedVersions
  lets one API instance serve OCPP 2.0.1 and 2.1 from versioned routes instead of 
  being built into the class.
- Containerize AdminApi and the API auth provider; reshape the bootstrap
  into two phases (build primitives + container, then resolve/wire) with a
  MODULE_INITS table replacing the per-module init wrappers and switch.
- Extract shared dependency-type interfaces (SequelizeRepositoryDependencies,
  OcppModuleDependencies + per-module XModuleDependencies) to cut repeated
  inline constructor types. Awilix expects you to type the destructured injected objects
  and for the aforementioned classes there was a lot of overlap in types so we interfaced them.
- Add a PROXY-mode test container: packages/core/src/test/testContainer.ts:
  createTestContainer / getTestInstance ---> these allow you to create test instances much easier.
- Added DEPENDENCY_INJECTION.md README for the DI, tweaked README slightly. 