### PR TITLE
Fixing docker compose local for naming and nextjs issues.

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -10,7 +10,7 @@ services:
   citrine:
     build:
       context: .
-      dockerfile: ./apps/server/deploy.Dockerfile
+      dockerfile: ./apps/Server/deploy.Dockerfile
     environment:
       APP_NAME: "all"
       APP_ENV: "docker"
@@ -56,6 +56,12 @@ services:
     build:
       context: .
       dockerfile: apps/operator-ui/Dockerfile
+    environment:
+      NEXT_PUBLIC_ADMIN_EMAIL: admin@citrineos.com
+      NEXTAUTH_URL: http://localhost:3000
+      NEXTAUTH_SECRET: test-secret-for-e2e-only
+      ADMIN_PASSWORD: "CitrineOS!"
+      HASURA_ADMIN_SECRET: "CitrineOS!"
     ports:
       - 3000:3000
     depends_on:
@@ -73,7 +79,7 @@ services:
       RABBITMQ_DEFAULT_USER: "guest"
       RABBITMQ_DEFAULT_PASS: "guest"
     volumes:
-      - ./apps/server/data/rabbitmq:/var/lib/rabbitmq
+      - ./apps/Server/data/rabbitmq:/var/lib/rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics -q check_port_connectivity
       interval: 10s
@@ -86,7 +92,7 @@ services:
     ports:
       - 5432:5432
     volumes:
-      - ./apps/server/data/postgresql/pgdata:/var/lib/postgresql/data
+      - ./apps/Server/data/postgresql/pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: citrine
       POSTGRES_USER: citrine
@@ -109,7 +115,7 @@ services:
       MINIO_BROWSER_REDIRECT_URL: http://localhost:9001
       MINIO_SERVER_URL: http://localhost:9000
     volumes:
-      - ./apps/server/data/minio:/data
+      - ./apps/Server/data/minio:/data
     command: server /data --console-address ":9001"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
@@ -132,7 +138,7 @@ services:
   graphql-engine:
     image: hasura/graphql-engine:v2.40.3.cli-migrations-v3
     volumes:
-      - ./apps/server/hasura-metadata:/hasura-metadata
+      - ./apps/Server/hasura-metadata:/hasura-metadata
     ports:
       - 8090:8080
     restart: always
@@ -145,6 +151,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_ENABLE_TELEMETRY: "false"
+      HASURA_GRAPHQL_ADMIN_SECRET: CitrineOS!
       HASURA_GRAPHQL_METADATA_DEFAULTS:
         "{\"backend_configs\":{\"dataconnector\":{\"a\
         thena\":{\"uri\":\"http://data-connector-agent:8081/api/v1/athena\"},\"\


### PR DESCRIPTION
Issues Found:
* lowercase `server` doesn't match case sensitive OS like Linux or Unix based
* Login information not available for using the UI, and can't use the UI without a login. (Couldn't find any documentation to specify otherwise, and found these configs from e2e automation