### PR TITLE
fix(ocpi): compute real CDR cost breakdown instead of TODO stubs

### DIFF
--- a/packages/ocpi-base/src/mapper/CdrMapper.ts
+++ b/packages/ocpi-base/src/mapper/CdrMapper.ts
@@ -17,6 +17,13 @@ import { Logger } from 'tslog';
 import { OcpiGraphqlClient } from '../graphql/index.js';
 import { LocationsService } from '../services/LocationsService.js';
 import type { TariffDto, TransactionDto } from '@citrineos/base';
+import {
+  calculateEnergyCost,
+  calculateFixedCost,
+  calculateTimeCost,
+  calculateTotalCdrCost,
+  calculateTotalTimeHours,
+} from './cdrCost.js';
 
 @Service()
 export class CdrMapper extends BaseTransactionMapper {
@@ -103,16 +110,15 @@ export class CdrMapper extends BaseTransactionMapper {
       tariffs: [ocpiTariff],
       charging_periods: session.charging_periods || [],
       signed_data: await this.getSignedData(session),
-      // TODO: Map based on OCPI Tariff
-      total_cost: this.calculateTotalCost(session.kwh, tariff.pricePerKwh),
-      total_fixed_cost: await this.calculateTotalFixedCost(tariff),
+      total_cost: calculateTotalCdrCost(session, tariff),
+      total_fixed_cost: calculateFixedCost(tariff),
       total_energy: session.kwh,
-      total_energy_cost: await this.calculateTotalEnergyCost(session, tariff),
-      total_time: this.calculateTotalTime(session),
-      total_time_cost: await this.calculateTotalTimeCost(session, tariff),
-      total_parking_time: await this.calculateTotalParkingTime(session),
-      total_parking_cost: await this.calculateTotalParkingCost(session, tariff),
-      total_reservation_cost: await this.calculateTotalReservationCost(session, tariff),
+      total_energy_cost: calculateEnergyCost(session, tariff),
+      total_time: calculateTotalTimeHours(session),
+      total_time_cost: calculateTimeCost(session, tariff),
+      total_parking_time: this.calculateTotalParkingTime(),
+      total_parking_cost: this.calculateTotalParkingCost(),
+      total_reservation_cost: this.calculateTotalReservationCost(),
       remark: this.generateRemark(session),
       invoice_reference_id: await this.generateInvoiceReferenceId(session),
       credit: this.isCredit(session, tariff),
@@ -176,52 +182,19 @@ export class CdrMapper extends BaseTransactionMapper {
     return undefined;
   }
 
-  private async calculateTotalFixedCost(_tariff: any): Promise<Price | undefined> {
-    // TODO: Return total fixed cost if needed
-    return undefined;
-  }
-
-  private async calculateTotalEnergyCost(
-    _session: Session,
-    _tariff: TariffDto,
-  ): Promise<Price | undefined> {
-    // TODO: Return total energy cost if needed
-    return undefined;
-  }
-
-  private calculateTotalTime(session: Session): number {
-    if (session.end_date_time) {
-      return (session.end_date_time.getTime() - session.start_date_time.getTime()) / 3600000; // Convert ms to hours
-    }
+  // The current Tariff model has no parking/reservation price dimensions
+  // (OCPP 2.1's reservationTime/reservationFixed fields are untyped `any`
+  // placeholders and aren't populated), so these stay unsupported rather
+  // than guessing at a calculation with no backing data.
+  private calculateTotalParkingTime(): number {
     return 0;
   }
 
-  private async calculateTotalTimeCost(
-    _session: Session,
-    _tariff: TariffDto,
-  ): Promise<Price | undefined> {
-    // TODO: Return total time cost if needed
+  private calculateTotalParkingCost(): Price | undefined {
     return undefined;
   }
 
-  private async calculateTotalParkingTime(_session: Session): Promise<number> {
-    // TODO: Return total parking time if needed
-    return 0;
-  }
-
-  private async calculateTotalParkingCost(
-    _session: Session,
-    _tariff: TariffDto,
-  ): Promise<Price | undefined> {
-    // TODO: Return total parking cost if needed
-    return undefined;
-  }
-
-  private async calculateTotalReservationCost(
-    _session: Session,
-    _tariff: TariffDto,
-  ): Promise<Price | undefined> {
-    // TODO: Return total reservation cost if needed
+  private calculateTotalReservationCost(): Price | undefined {
     return undefined;
   }
 

--- a/packages/ocpi-base/src/mapper/cdrCost.ts
+++ b/packages/ocpi-base/src/mapper/cdrCost.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TariffDto } from '@citrineos/base';
+import { Money } from '@citrineos/base';
+import type { Price } from '../model/Price.js';
+import type { Session } from '../model/Session.js';
+import { MINUTES_IN_HOUR } from '../util/Consts.js';
+
+export function buildPrice(amount: number, currency: string, taxRate?: number | null): Price {
+  const money = Money.of(amount, currency);
+  const price: Price = { excl_vat: money.roundToCurrencyScale().toNumber() };
+  if (taxRate != null) {
+    price.incl_vat = money
+      .multiply(1 + taxRate / 100)
+      .roundToCurrencyScale()
+      .toNumber();
+  }
+  return price;
+}
+
+/**
+ * Sums a set of already-rounded CDR line-item Prices into one Price, so the
+ * resulting total always reconciles against the sum of its own components.
+ */
+export function sumPrices(currency: string, prices: (Price | undefined)[]): Price {
+  const defined = prices.filter((price): price is Price => price !== undefined);
+  const exclVat = defined.reduce(
+    (total, price) => total.add(Money.of(price.excl_vat, currency)),
+    Money.of(0, currency),
+  );
+  if (!defined.some((price) => price.incl_vat != null)) {
+    return { excl_vat: exclVat.toNumber() };
+  }
+  const inclVat = defined.reduce(
+    (total, price) => total.add(Money.of(price.incl_vat ?? price.excl_vat, currency)),
+    Money.of(0, currency),
+  );
+  return { excl_vat: exclVat.toNumber(), incl_vat: inclVat.toNumber() };
+}
+
+export function calculateTotalTimeHours(session: Session): number {
+  if (session.end_date_time) {
+    return (session.end_date_time.getTime() - session.start_date_time.getTime()) / 3600000;
+  }
+  return 0;
+}
+
+export function calculateFixedCost(tariff: TariffDto): Price | undefined {
+  if (!tariff.pricePerSession) {
+    return undefined;
+  }
+  return buildPrice(tariff.pricePerSession, tariff.currency, tariff.taxRate);
+}
+
+export function calculateEnergyCost(session: Session, tariff: TariffDto): Price {
+  return buildPrice(session.kwh * tariff.pricePerKwh, tariff.currency, tariff.taxRate);
+}
+
+export function calculateTimeCost(session: Session, tariff: TariffDto): Price | undefined {
+  if (!tariff.pricePerMin) {
+    return undefined;
+  }
+  const totalMinutes = calculateTotalTimeHours(session) * MINUTES_IN_HOUR;
+  return buildPrice(totalMinutes * tariff.pricePerMin, tariff.currency, tariff.taxRate);
+}
+
+export function calculateTotalCdrCost(session: Session, tariff: TariffDto): Price {
+  return sumPrices(tariff.currency, [
+    calculateFixedCost(tariff),
+    calculateEnergyCost(session, tariff),
+    calculateTimeCost(session, tariff),
+  ]);
+}

--- a/packages/ocpi-base/test/mapper/cdrCost.test.ts
+++ b/packages/ocpi-base/test/mapper/cdrCost.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { TariffDto } from '@citrineos/base';
+import { describe, expect, it } from 'vitest';
+import { AuthMethod } from '../../src/model/AuthMethod.js';
+import { SessionStatus } from '../../src/model/SessionStatus.js';
+import { TokenType } from '../../src/model/TokenType.js';
+import type { Session } from '../../src/model/Session.js';
+import {
+  calculateEnergyCost,
+  calculateFixedCost,
+  calculateTimeCost,
+  calculateTotalCdrCost,
+} from '../../src/mapper/cdrCost.js';
+
+function aSession(overrides: Partial<Session> = {}): Session {
+  return {
+    country_code: 'DE',
+    party_id: 'ACX',
+    id: 'session-1',
+    start_date_time: new Date('2026-01-01T10:00:00Z'),
+    end_date_time: new Date('2026-01-01T11:30:00Z'), // 90 minutes
+    kwh: 20,
+    cdr_token: {
+      uid: 'token-1',
+      type: TokenType.RFID,
+      contract_id: 'contract-1',
+      country_code: 'DE',
+      party_id: 'ACX',
+    },
+    auth_method: AuthMethod.WHITELIST,
+    authorization_reference: null,
+    location_id: 'location-1',
+    evse_uid: 'evse-1',
+    connector_id: 'connector-1',
+    meter_id: null,
+    currency: 'EUR',
+    charging_periods: [],
+    status: SessionStatus.COMPLETED,
+    last_updated: new Date('2026-01-01T11:30:00Z'),
+    ...overrides,
+  };
+}
+
+function aTariff(overrides: Partial<TariffDto> = {}): TariffDto {
+  return {
+    currency: 'EUR',
+    pricePerKwh: 0.3,
+    ...overrides,
+  } as TariffDto;
+}
+
+describe('cdrCost', () => {
+  it('computes energy cost from kWh and pricePerKwh, rounded down to cents', () => {
+    const price = calculateEnergyCost(aSession({ kwh: 20.999 }), aTariff({ pricePerKwh: 0.301 }));
+    expect(price).toEqual({ excl_vat: 6.32 }); // 20.999 * 0.301 = 6.320699...
+  });
+
+  it('applies taxRate to produce incl_vat alongside excl_vat', () => {
+    const price = calculateEnergyCost(
+      aSession({ kwh: 10 }),
+      aTariff({ pricePerKwh: 1, taxRate: 19 }),
+    );
+    expect(price).toEqual({ excl_vat: 10, incl_vat: 11.9 });
+  });
+
+  it('omits fixed cost when the tariff has no pricePerSession', () => {
+    expect(calculateFixedCost(aTariff())).toBeUndefined();
+  });
+
+  it('includes fixed cost when the tariff has a pricePerSession', () => {
+    const price = calculateFixedCost(aTariff({ pricePerSession: 2.5 }));
+    expect(price).toEqual({ excl_vat: 2.5 });
+  });
+
+  it('omits time cost when the tariff has no pricePerMin', () => {
+    expect(calculateTimeCost(aSession(), aTariff())).toBeUndefined();
+  });
+
+  it('computes time cost from elapsed minutes and pricePerMin', () => {
+    // 90 minute session (10:00 -> 11:30) at 0.05/min = 4.5
+    const price = calculateTimeCost(aSession(), aTariff({ pricePerMin: 0.05 }));
+    expect(price).toEqual({ excl_vat: 4.5 });
+  });
+
+  it('total cost is the sum of fixed + energy + time cost, not energy alone', () => {
+    const tariff = aTariff({ pricePerKwh: 0.3, pricePerMin: 0.05, pricePerSession: 1 });
+    const session = aSession({ kwh: 20 });
+    const total = calculateTotalCdrCost(session, tariff);
+    // fixed: 1, energy: 20 * 0.3 = 6, time: 90 * 0.05 = 4.5 => 11.5
+    expect(total).toEqual({ excl_vat: 11.5 });
+  });
+
+  it('sums incl_vat across components when the tariff has a taxRate', () => {
+    const tariff = aTariff({ pricePerKwh: 0.3, pricePerSession: 1, taxRate: 20 });
+    const total = calculateTotalCdrCost(aSession({ kwh: 10 }), tariff);
+    // energy: 3, fixed: 1 => excl_vat 4, incl_vat 4.8
+    expect(total).toEqual({ excl_vat: 4, incl_vat: 4.8 });
+  });
+});


### PR DESCRIPTION
## A. CDR correctness (`packages/ocpi-base/src/mapper/CdrMapper.ts`)

### OCPI-1: CDR cost breakdown is entirely unimplemented
Only `total_cost` (line 107, `kwh * pricePerKwh`) is computed. Every other cost
field required/optional in the OCPI 2.2.1 CDR object is a stub returning
`undefined` or `0`:
- `total_fixed_cost` — `calculateTotalFixedCost()` (line 179) — TODO, always `undefined`
- `total_energy_cost` — `calculateTotalEnergyCost()` (line 184) — TODO, always `undefined`
- `total_time_cost` — `calculateTotalTimeCost()` (line 199) — TODO, always `undefined`
- `total_parking_time` — `calculateTotalParkingTime()` (line 207) — TODO, always `0`
- `total_parking_cost` — `calculateTotalParkingCost()` (line 212) — TODO, always `undefined`
- `total_reservation_cost` — `calculateTotalReservationCost()` (line 220) — TODO, always `undefined`

Impact: any CDR sent to a roaming eMSP partner under-reports the actual charge
composition. Settlement disputes are likely once a partner tries to reconcile
line items instead of just the flat total.