### PR TITLE
Feature: Generate cert chain when no config exists

### DIFF
--- a/packages/core/src/modules/Certificates/src/module/DataApi.ts
+++ b/packages/core/src/modules/Certificates/src/module/DataApi.ts
@@ -276,6 +276,7 @@ export class CertificatesDataApi
       leafKeyPem,
       subCAKeyPem,
       rootCACertPem,
+      certRequest.filePath,
     );
 
     return responseBody;

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -38,6 +38,9 @@ export const enum PemType {
   Leaf = 'Leaf',
 }
 
+// Default file name used to persist the generated certificate chain
+const DEFAULT_CERT_CHAIN_FILENAME = 'certChain.pem';
+
 export class InstallCertificateHelperService {
   protected certificateRepository: ICertificateRepository;
   protected installedCertificateRepository: IInstalledCertificateRepository;
@@ -386,6 +389,7 @@ export class InstallCertificateHelperService {
    * @param leafKeyPem - Leaf certificate private key PEM string.
    * @param subCAKeyPem - Sub CA private key PEM string.
    * @param rootCACertPem - Root CA certificate PEM string. Only present for self-signed certificate chains.
+   * @param filePath - Optional prefix under which the default (non-TLS-server-scoped) files are stored.
    */
   async saveCertificatesToServerConfigs(
     websocketServersConfig: WebsocketServerConfig[],
@@ -393,14 +397,18 @@ export class InstallCertificateHelperService {
     leafKeyPem: string,
     subCAKeyPem: string,
     rootCACertPem?: string,
+    filePath?: string,
   ): Promise<void> {
     const tlsServers = websocketServersConfig.filter((c) => c.securityProfile >= 2);
+    let chainSavedToServerPath = false;
+
     for (const serverConfig of tlsServers) {
       if (serverConfig.tlsCertificateChainFilePath) {
         await this.fileStorage.saveFile(
           serverConfig.tlsCertificateChainFilePath,
           Buffer.from(certificateChainPem),
         );
+        chainSavedToServerPath = true;
       }
       if (serverConfig.tlsKeyFilePath) {
         await this.fileStorage.saveFile(serverConfig.tlsKeyFilePath, Buffer.from(leafKeyPem));
@@ -418,6 +426,17 @@ export class InstallCertificateHelperService {
         );
       }
       this.logger.info(`Saved TLS certificate files for server ${serverConfig.id}`);
+    }
+
+    // The certificate chain must always be persisted somewhere,
+    // even when no TLS server config claims it,
+    // stored alongside the config file based on configBucketName and filePath if exists.
+    const keyPrefix = filePath ? `${filePath}/` : '';
+    if (!chainSavedToServerPath) {
+      await this.fileStorage.saveFile(
+        `${keyPrefix}${DEFAULT_CERT_CHAIN_FILENAME}`,
+        Buffer.from(certificateChainPem),
+      );
     }
   }
 


### PR DESCRIPTION
### Changes
Make sure the certificate chain is genrated when no server config exists.
### Tests
1. remove profile 2&3 from config <img width="1100" height="127" alt="Screenshot 2026-07-08 at 1 37 21 PM" src="https://github.com/user-attachments/assets/ce4dc5c3-8dcc-4532-8c61-1b1bf2d006db" />
2. the cert chain is still generated. <img width="1081" height="24" alt="Screenshot 2026-07-08 at 1 38 10 PM" src="https://github.com/user-attachments/assets/5d6c627c-b4d2-4919-bbda-98276d9dfe43" /> <img width="1165" height="69" alt="Screenshot 2026-07-08 at 1 38 33 PM" src="https://github.com/user-attachments/assets/77dab470-e427-432b-8027-8b1a7a51bc06" />