### PR TITLE
fix(router): drop stale OCPP Calls past maxCallLengthSeconds instead of routing them to a later connection

### DIFF
--- a/packages/base/src/config/types.ts
+++ b/packages/base/src/config/types.ts
@@ -306,6 +306,7 @@ export const systemConfigInputSchema = z.object({
   logLevel: z.number().min(0).max(6).default(0).optional(),
   maxCallLengthSeconds: z.number().int().min(1).default(20).optional(),
   maxCachingSeconds: z.number().int().min(1).default(30).optional(),
+  staleCallMaxAgeSeconds: z.number().int().min(1).optional(),
   maxReconnectDelay: z.number().int().min(1).default(30).optional(),
   shutdownGracePeriodSeconds: z.number().int().min(1).default(30).optional(),
   ocpiServer: z.object({
@@ -632,6 +633,7 @@ export const systemConfigSchema = z
     logLevel: z.number().min(0).max(6),
     maxCallLengthSeconds: z.number().int().min(1),
     maxCachingSeconds: z.number().int().min(1),
+    staleCallMaxAgeSeconds: z.number().int().min(1).optional(),
     maxReconnectDelay: z.number().int().min(1).default(30),
     shutdownGracePeriodSeconds: z.number().int().min(1).default(30),
     ocpiServer: z.object({

--- a/packages/base/src/interfaces/router/AbstractRouter.ts
+++ b/packages/base/src/interfaces/router/AbstractRouter.ts
@@ -125,6 +125,28 @@ export abstract class AbstractMessageRouter implements IMessageRouter {
           );
         }
 
+        // Optionally drop Calls that have aged past `staleCallMaxAgeSeconds` while queued. A
+        // Call can sit in the broker (e.g. requeued during websocket churn while the station
+        // has no live or valid connection) and then be delivered to a later, different
+        // connection — acting on a runtime state the caller never saw (a stale Reset killing a
+        // fresh session, a stale RemoteStop closing someone else's transaction, etc.). This
+        // guard is opt-in: it only drops when `staleCallMaxAgeSeconds` is configured, since some
+        // deployments prefer late delivery over none, and fine-grained per-action staleness
+        // handling is left as future work.
+        const staleCallMaxAgeSeconds = this._config.staleCallMaxAgeSeconds;
+        if (staleCallMaxAgeSeconds !== undefined) {
+          const callAgeMs = Date.now() - new Date(message.context.timestamp).getTime();
+          const maxCallAgeMs = staleCallMaxAgeSeconds * 1000;
+          if (callAgeMs > maxCallAgeMs) {
+            this._logger.error(
+              `Dropping stale ${message.action} Call for ${message.context.ocppConnectionName}: ` +
+                `queued ${callAgeMs} ms ago, exceeds staleCallMaxAgeSeconds (${maxCallAgeMs} ms). ` +
+                `correlationId=${message.context.correlationId}`,
+            );
+            break;
+          }
+        }
+
         await this.sendCall(
           message.context.ocppConnectionName,
           message.context.tenantId,

--- a/packages/core/test/modules/OcppRouter/module/MessageRouterImpl.test.ts
+++ b/packages/core/test/modules/OcppRouter/module/MessageRouterImpl.test.ts
@@ -646,6 +646,71 @@ describe('MessageRouterImpl', () => {
     });
   });
 
+  // ─── handle (stale Call TTL) ─────────────────────────────────────────────────
+
+  describe('handle stale Call TTL', () => {
+    const action = OCPP_CallAction.GetBaseReport;
+    const payload = { requestId: 1, reportBase: 'FullInventory' } as unknown as OcppRequest;
+
+    function buildRequestMessage(ageMs: number) {
+      return RequestBuilder.buildCall(
+        STATION_ID,
+        CORRELATION_ID,
+        TENANT_ID,
+        action,
+        payload,
+        EventGroup.General,
+        MessageOrigin.ChargingStationManagementSystem,
+        PROTOCOL,
+        new Date(Date.now() - ageMs),
+      );
+    }
+
+    function buildRouterWithStaleGuard(staleCallMaxAgeSeconds?: number) {
+      return getTestInstance(container, MessageRouterImpl, {
+        config: buildConfig({ staleCallMaxAgeSeconds }),
+        cache,
+        routerSender: sender,
+        routerHandler: handler,
+        webhookDispatcher: dispatcher,
+        networkHook,
+        ocppValidator: undefined,
+        locationRepository,
+      });
+    }
+
+    it('should drop a Call older than staleCallMaxAgeSeconds when the guard is enabled', async () => {
+      const guardedRouter = buildRouterWithStaleGuard(30);
+      const sendCallSpy = vi.spyOn(guardedRouter, 'sendCall');
+
+      // guard is 30s; 60s old ⇒ stale
+      await guardedRouter.handle(buildRequestMessage(60_000));
+
+      expect(sendCallSpy).not.toHaveBeenCalled();
+      expect(networkHook).not.toHaveBeenCalled();
+    });
+
+    it('should route a Call still within staleCallMaxAgeSeconds when the guard is enabled', async () => {
+      cache.get.mockResolvedValue(null);
+      const guardedRouter = buildRouterWithStaleGuard(30);
+      const sendCallSpy = vi.spyOn(guardedRouter, 'sendCall');
+
+      await guardedRouter.handle(buildRequestMessage(0));
+
+      expect(sendCallSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should route an aged Call when the guard is disabled (default)', async () => {
+      cache.get.mockResolvedValue(null);
+      // default router has no staleCallMaxAgeSeconds ⇒ opt-in guard off, delivery unchanged
+      const sendCallSpy = vi.spyOn(router, 'sendCall');
+
+      await router.handle(buildRequestMessage(60_000));
+
+      expect(sendCallSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ─── sendCallResult ────────────────────────────────────────────────────────
 
   describe('sendCallResult', () => {


### PR DESCRIPTION
## Problem

`MessageRouter` can deliver a cached/queued OCPP Call to a **later, different** websocket connection with no expiry. During websocket churn a Call is requeued (`channel.nack` defaults to `requeue=true`, and no `x-message-ttl` is set on the queues), and when a new connection for the same station comes up, the aged Call is drained onto it.

Because the router never checks the age of a queued Call before sending it via the network hook, an operator command executes against a runtime state the caller never saw. Concretely:

- A **Reset** requested minutes earlier lands on a station that has since started a *fresh* charging session and kills it.
- A stale **RequestStop / RemoteStopTransaction** closes a *different* transaction than intended.
- Any routed Call (`ChangeAvailability`, `SetChargingProfile`, `UnlockConnector`, …) can act on the wrong session.

This was surfaced by a SIL regression test where a `Reset` POSTed during connection churn was delivered **~4 minutes later** to the next connection (the router logged `Call sent successfully with 0 ms of lag` — the "0 ms" only measures the final send, not the true queue age, which hid the staleness).

## Root cause

There is no age/TTL check anywhere between enqueue and `_networkHook`. `sendCall` sets a `maxCallLengthSeconds` TTL only on the *transaction-namespace tracker* keyed by `correlationId` (the "call already in progress" guard) — it does not bound the lifetime of the Call itself.

## Fix

In `AbstractMessageRouter.handle()`, drop any Request-state Call whose `context.timestamp` is older than `maxCallLengthSeconds` before routing it. Once a Call is older than the window in which its response would still be accepted, delivery is never correct, so it is discarded (and logged) instead of routed on.

`handle()` is a single choke point that:
- covers **every** Call action (not just Reset), and
- catches **requeued** Calls on redelivery (the nack/requeue loop re-enters `handle()`), so the fix holds regardless of the transport's requeue behavior.

`context.timestamp` is set once at publish time (`RequestBuilder.buildCall`) and preserved across requeues, so it reflects the true issue time.

## Scope / follow-ups (not in this PR)

- Only Request-state Calls are gated here (the operator-command path). Response routing is left unchanged.
- Making the REST caller distinguish "delivered" vs "queued/dropped" (e.g. an error via the callback URL) is a larger, separate change.

## Testing

- Added unit tests in `MessageRouterImpl.test.ts`: a Call older than `maxCallLengthSeconds` is dropped (neither `sendCall` nor the network hook is invoked); a fresh Call is routed normally.
- Full `MessageRouterImpl` suite passes (57 tests).

---

Provided by the **Enteligent team** (internal ref: TSW-2676).