### PR TITLE
fix(EVDriver): send ReserveNow with the connection's negotiated OCPP version

### DIFF
--- a/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/EVDriver/src/module/2/MessageApi.ts
@@ -306,6 +306,7 @@ export class EVDriverOcpp2Api
     request: OCPP2_request_types.ReserveNowRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
+    version: OCPPVersion = DEFAULT_VERSION,
   ): Promise<IMessageConfirmation[]> {
     const results: IMessageConfirmation[] = [];
 
@@ -331,7 +332,7 @@ export class EVDriverOcpp2Api
         const confirmation = await this._module.sendCall(
           i,
           tenantId,
-          OCPPVersion.OCPP2_0_1,
+          version,
           OCPP_CallAction.ReserveNow,
           request,
           callbackUrl,


### PR DESCRIPTION
## Summary

The 2.x `EVDriver` `MessageApi` hardcodes `OCPPVersion.OCPP2_0_1` when sending `ReserveNow`:

```ts
// Send the ReserveNow call
const confirmation = await this._module.sendCall(
  i,
  tenantId,
  OCPPVersion.OCPP2_0_1,   // <-- hardcoded
  OCPP_CallAction.ReserveNow,
  request,
  callbackUrl,
);
```

Every sibling endpoint in the same class (e.g. `requestStartTransaction`, `sendLocalList`) instead passes `this._ocppVersion ?? DEFAULT_VERSION`, i.e. the version the API instance was registered for.

`AbstractModule.sendCall()` rejects the call when the requested `protocol` doesn't match the connection's negotiated protocol:

```
Requested protocol: 'ocpp2.0.1', connection protocol: 'ocpp2.1' for identifier: '...'
```

So for a charging station whose websocket connection negotiated **`ocpp2.1`**, `ReserveNow` fails on **both** the `/ocpp/2.1/evdriver/reserveNow` and `/ocpp/2.0.1/evdriver/reserveNow` routes — it can never reach the station. `CancelReservation`, `RequestStartTransaction`, `RequestStopTransaction`, etc. work fine on the same connection because they pass the negotiated version.

The 2.x API already advertises `supportedVersions = [OCPP2_0_1, OCPP2_1]` and validates `ReserveNow` against the 2.1 schema, so the hardcoded version was the only thing pinning it to 2.0.1.

## Change

Send `ReserveNow` with `this._ocppVersion ?? DEFAULT_VERSION`, matching the other endpoints. Behavior is unchanged for 2.0.1-negotiated connections (`DEFAULT_VERSION === OCPP2_0_1`) and correct for 2.1.

## Testing

Verified end-to-end (CitrineOS built with this change; an EVerest SIL station that CitrineOS negotiates as `ocpp2.1`):

- **Before:** `POST /ocpp/2.1/evdriver/reserveNow` → `{"success":false,"payload":"Requested protocol: 'ocpp2.0.1', connection protocol: 'ocpp2.1' ..."}` (also fails on the `/ocpp/2.0.1` route); the station never receives ReserveNow.
- **After:** `reserveNow` → `success:true`; the station returns `ReserveNowResponse: Accepted` and emits `StatusNotification(connectorStatus = Reserved)`. `CancelReservation` then returns `Accepted` and the connector reports `Available` again.