### PR TITLE
fix(Reporting,Configuration): accept triggered Log/FirmwareStatusNotification without requestId

### DIFF
--- a/packages/core/src/modules/Configuration/src/module/module.ts
+++ b/packages/core/src/modules/Configuration/src/module/module.ts
@@ -531,19 +531,9 @@ export class ConfigurationModule extends AbstractModule {
 
     // TODO: FirmwareStatusNotification is usually triggered. Ideally, it should be sent to the callbackUrl from the message api that sent the trigger message
 
-    // Validate requestId requirement
-    // requestId is mandatory unless message was triggered by TriggerMessageRequest AND no firmware update is ongoing
-    if (!message.payload.requestId) {
-      await this.sendCallErrorWithMessage(
-        message,
-        new OcppError(
-          message.context.correlationId,
-          ErrorCode.OccurrenceConstraintViolation,
-          'RequestId is required.',
-        ),
-      );
-      return;
-    }
+    // requestId is optional (see the request schema): it is absent when the message was
+    // triggered by a TriggerMessageRequest and there is no firmware update ongoing. Acknowledge
+    // the notification regardless of whether requestId is present.
 
     // Create response
     const response: OCPP2_response_types.FirmwareStatusNotificationResponse = {};

--- a/packages/core/src/modules/Reporting/src/module/module.ts
+++ b/packages/core/src/modules/Reporting/src/module/module.ts
@@ -121,19 +121,10 @@ export class ReportingModule extends AbstractModule {
 
     // TODO: LogStatusNotification is usually triggered. Ideally, it should be sent to the callbackUrl from the message api that sent the trigger message
 
-    // Validate requestId requirement
-    // requestId is mandatory unless message was triggered by TriggerMessageRequest AND no log upload ongoing
-    if (!message.payload.requestId) {
-      await this.sendCallErrorWithMessage(
-        message,
-        new OcppError(
-          message.context.correlationId,
-          ErrorCode.OccurrenceConstraintViolation,
-          'RequestId is required.',
-        ),
-      );
-      return;
-    }
+    // requestId is optional (see the request schema): it is absent when the message was
+    // triggered by a TriggerMessageRequest and there is no log upload ongoing. Acknowledge
+    // the notification regardless of whether requestId is present.
+
     // Create response
     const response: OCPP2_response_types.LogStatusNotificationResponse = {};
 


### PR DESCRIPTION
## Summary

The 2.x `LogStatusNotification` (Reporting) and `FirmwareStatusNotification` (Configuration) handlers reject the message with a CALLERROR whenever `requestId` is absent:

```ts
if (!message.payload.requestId) {
  await this.sendCallErrorWithMessage(
    message,
    new OcppError(message.context.correlationId, ErrorCode.OccurrenceConstraintViolation, 'RequestId is required.'),
  );
  return;
}
```

But `requestId` is **optional** in the request schema (`requestId?: number | null`), and — as each handler's own comment states — it is legitimately absent when the message is *triggered* by a `TriggerMessageRequest` and there is no log upload / firmware update ongoing:

```
// requestId is mandatory unless message was triggered by TriggerMessageRequest AND no log upload ongoing
```

So a charging station that emits a triggered `LogStatusNotification` / `FirmwareStatusNotification` (a normal thing to do in response to `TriggerMessage`) receives a CALLERROR instead of the expected empty response — the code does the opposite of what its comment describes.

## Change

Acknowledge the notification (empty response) regardless of whether `requestId` is present, matching the schema and the documented intent. Both handlers otherwise do nothing with `requestId`, so no behavior is lost.

## Testing

Verified end-to-end (CitrineOS built with this change; an EVerest SIL station that CitrineOS negotiates as `ocpp2.1`, triggered via `TriggerMessage` to emit the notifications with no ongoing operation, i.e. no `requestId`):

- **Before:** `LogStatusNotification` and `FirmwareStatusNotification` each got a `CALLERROR` (`OccurrenceConstraintViolation`, "RequestId is required.").
- **After:** both receive a normal `LogStatusNotificationResponse` / `FirmwareStatusNotificationResponse` (`{}`); no CALLERROR.