### PR TITLE
fix(smart-charging): set startSchedule on auto-generated Absolute TxProfile

### DIFF
--- a/packages/core/src/modules/SmartCharging/src/module/module.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/module.ts
@@ -491,6 +491,11 @@ export class SmartChargingModule extends AbstractModule {
       tenantId,
       ocppConnectionName,
     );
+    // startSchedule SHALL be present when chargingProfileKind is Absolute (OCPP 2.0.1 K01.FR.41);
+    // compliant charging stations reject the profile otherwise.
+    if (!chargingSchedule.startSchedule) {
+      chargingSchedule.startSchedule = new Date().toISOString();
+    }
 
     const chargingProfile = {
       id: await this._chargingProfileRepository.getNextChargingProfileId(

--- a/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
@@ -135,6 +135,9 @@ export class InternalSmartCharging implements ISmartCharging {
 
     const chargingSchedule: OCPP2_0_1.ChargingScheduleType = {
       id: scheduleId,
+      // startSchedule SHALL be present when chargingProfileKind is Absolute (OCPP 2.0.1 K01.FR.41);
+      // compliant charging stations reject the profile otherwise. Matches validFrom below.
+      startSchedule: currentTime.toISOString(),
       duration,
       chargingRateUnit,
       chargingSchedulePeriod,


### PR DESCRIPTION
## Problem

When a charging station reports its charging needs (`NotifyEVChargingNeeds`) or an EV charging schedule (`NotifyEVChargingSchedule`) during an ISO 15118 session, the SmartCharging module automatically generates a `TxProfile` and pushes it back with `SetChargingProfile`. The generated profile sets `chargingProfileKind: Absolute` but the `chargingSchedule` object does **not** include `startSchedule`.

Per OCPP 2.0.1 (**K01.FR.41**), `startSchedule` **SHALL** be present when `chargingProfileKind` is `Absolute` or `Recurring`. A spec-compliant charging station therefore rejects the auto-generated profile:

```
SetChargingProfileResponse: status=Rejected
  reasonCode=InvalidSchedule
  additionalInfo=ChargingProfileMissingRequiredStartSchedule
```

This breaks CitrineOS's automatic smart-charging response on DC / ISO 15118 sessions against any compliant charger.

## Fix

Populate `chargingSchedule.startSchedule` with the current time so the generated profile is spec-valid:

- `InternalSmartCharging.calculateChargingProfile()` — set `startSchedule: currentTime.toISOString()` (matches the `validFrom` the same method already computes).
- `module._generateSetChargingProfileRequest()` — default `startSchedule` to now when the incoming `NotifyEVChargingSchedule` schedule omits it.

## Testing

Verified end-to-end against a live libocpp-based charging station (EVerest, OCPP 2.0.1) doing a DC ISO 15118 session:

- **Before:** charger rejects the auto-generated `TxProfile` with `InvalidSchedule / ChargingProfileMissingRequiredStartSchedule`.
- **After:** charger `Accepts` the profile; `GetCompositeSchedule` reflects the applied limit.

Manual `SetChargingProfile` (Absolute + explicit `startSchedule`), `GetCompositeSchedule`, `GetChargingProfiles`, and `ClearChargingProfile` were unaffected and continue to work.
