### PR TITLE
Add support for native OCPP RabbitMQ gateway plugin

### DIFF
--- a/apps/ocpp-server/src/citrineOSServer.ts
+++ b/apps/ocpp-server/src/citrineOSServer.ts
@@ -13,6 +13,7 @@ import type {
   IMessageRouter,
   IModule,
   IModuleApi,
+  INetworkConnection,
   SystemConfig,
 } from '@citrineos/base';
 import {
@@ -36,7 +37,6 @@ import {
   RedisCache,
   sequelize,
   Sequelize,
-  WebsocketNetworkConnection,
 } from '@citrineos/core';
 import cors from '@fastify/cors';
 import { type JsonSchemaToTsProvider } from '@fastify/type-provider-json-schema-to-ts';
@@ -77,7 +77,7 @@ export class CitrineOSServer {
   protected eventGroup?: EventGroup;
   protected _authenticator?: IAuthenticator;
   protected _router?: IMessageRouter;
-  protected _networkConnection?: WebsocketNetworkConnection;
+  protected _networkConnection?: INetworkConnection;
 
   protected readonly appName: string;
   protected _isShuttingDown = false;

--- a/apps/ocpp-server/src/config/envs/docker.ts
+++ b/apps/ocpp-server/src/config/envs/docker.ts
@@ -190,6 +190,18 @@ export function createDockerConfig() {
         exposeMessage: true,
       },
       networkConnection: {
+        // Station traffic is consumed from the rabbitmq_web_ocpp broker gateway
+        // (the amqp-broker compose service ships the plugin). Stations connect to
+        // ws://amqp-broker:19520/ocpp/%2F/<stationId>. Remove this block to fall
+        // back to the in-process websocket servers below.
+        ocppGateway: {
+          exchange: 'amq.topic',
+          queue: 'rabbit_queue_ocpp_gateway',
+          tenantId: DEFAULT_TENANT_ID,
+          allowUnknownChargingStations: true,
+          presenceTimeoutSeconds: 3600,
+          prefetch: 50,
+        },
         websocketServers: [
           {
             id: '0',

--- a/apps/ocpp-server/src/config/envs/local.ts
+++ b/apps/ocpp-server/src/config/envs/local.ts
@@ -192,6 +192,17 @@ export function createLocalConfig() {
         exposeMessage: true,
       },
       networkConnection: {
+        // Uncomment to consume station traffic from the rabbitmq_web_ocpp
+        // broker gateway instead of the in-process websocket servers below.
+        // Stations then connect to the broker (default ws://<broker>:19520/ocpp/<vhost>/<stationId>).
+        // ocppGateway: {
+        //   exchange: 'amq.topic',
+        //   queue: 'rabbit_queue_ocpp_gateway',
+        //   tenantId: DEFAULT_TENANT_ID,
+        //   allowUnknownChargingStations: true,
+        //   presenceTimeoutSeconds: 3600,
+        //   prefetch: 50,
+        // },
         websocketServers: [
           {
             id: '0',

--- a/apps/ocpp-server/src/container.ts
+++ b/apps/ocpp-server/src/container.ts
@@ -70,6 +70,7 @@ import type { IApiAuthProvider } from '@citrineos/base';
 
 // -- Network Connection --
 import {
+  AmqpNetworkConnection,
   Authenticator,
   UnknownStationFilter,
   ConnectedStationFilter,
@@ -163,7 +164,7 @@ export function buildContainer(config: BootstrapConfig & SystemConfig, prebuilt:
   registerRepositories(container);
   registerServices(container);
   registerModuleServices(container);
-  registerNetwork(container);
+  registerNetwork(container, config);
   registerModules(container);
   registerModuleApis(container);
 
@@ -255,9 +256,17 @@ function registerMessaging(container: AwilixContainer): void {
           logger,
         ),
     ).singleton(),
+    // Router mode (single shared queue, per-charger bindings, constant consumer
+    // count) fits the gateway transport, where station registrations would
+    // otherwise create per-station queues and consumers.
     routerHandler: asFunction(
       ({ config, channelManager, logger }) =>
-        new RabbitMqReceiver({ config, channelManager, logger }),
+        new RabbitMqReceiver({
+          config,
+          channelManager,
+          logger,
+          routerMode: !!config.util.networkConnection.ocppGateway,
+        }),
     ).singleton(),
   });
 }
@@ -343,7 +352,7 @@ function registerServices(container: AwilixContainer): void {
 // ============================================================
 // Network connection
 // ============================================================
-function registerNetwork(container: AwilixContainer): void {
+function registerNetwork(container: AwilixContainer, config: SystemConfig): void {
   container.register({
     networkHook: asValue(async (_identifier: string, _message: string) => {}),
 
@@ -367,7 +376,11 @@ function registerNetwork(container: AwilixContainer): void {
     authenticator: asClass(Authenticator).singleton(),
     webhookDispatcher: asClass(WebhookDispatcher).singleton(),
     router: asClass(MessageRouterImpl).singleton(),
-    networkConnection: asClass(WebsocketNetworkConnection).singleton(),
+    // Station traffic transport: in-process websocket servers by default, or the
+    // broker-terminated rabbitmq_web_ocpp gateway when ocppGateway is configured.
+    networkConnection: config.util.networkConnection.ocppGateway
+      ? asClass(AmqpNetworkConnection).singleton()
+      : asClass(WebsocketNetworkConnection).singleton(),
     adminApi: asClass(AdminApi).singleton(),
   });
 }

--- a/apps/ocpp-server/src/health/HealthCheckService.ts
+++ b/apps/ocpp-server/src/health/HealthCheckService.ts
@@ -2,9 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ICache } from '@citrineos/base';
+import type { ICache, INetworkConnection } from '@citrineos/base';
 import type { Sequelize } from '@citrineos/core';
-import { RabbitMQConnectionManager, WebsocketNetworkConnection } from '@citrineos/core';
+import {
+  AmqpNetworkConnection,
+  RabbitMQConnectionManager,
+  WebsocketNetworkConnection,
+} from '@citrineos/core';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 
@@ -19,7 +23,7 @@ export class HealthCheckService {
   private readonly _logger: Logger<ILogObj>;
 
   constructor(
-    private readonly _networkConnection: WebsocketNetworkConnection | null | undefined,
+    private readonly _networkConnection: INetworkConnection | null | undefined,
     private readonly _connectionManager: RabbitMQConnectionManager | null | undefined,
     private readonly _cache: ICache,
     private readonly _sequelizeInstance: Sequelize,
@@ -82,7 +86,7 @@ export class HealthCheckService {
     const checks: Record<string, CheckResult> = {};
     let pass = true;
 
-    if (this._networkConnection) {
+    if (this._networkConnection instanceof WebsocketNetworkConnection) {
       for (const [id, server] of this._networkConnection.getHttpServers()) {
         if (server.listening) {
           checks[`websocket:${id}`] = { status: 'pass' };
@@ -90,6 +94,16 @@ export class HealthCheckService {
           checks[`websocket:${id}`] = { status: 'fail', error: 'server not listening' };
           pass = false;
         }
+      }
+    } else if (this._networkConnection instanceof AmqpNetworkConnection) {
+      // The broker connectivity check below only proves the AMQP connection is
+      // up; the gateway consumer can be dead on a live connection (e.g. after
+      // a channel-level error), so probe the consumer itself.
+      if (this._networkConnection.isConsuming()) {
+        checks['ocppGateway'] = { status: 'pass' };
+      } else {
+        checks['ocppGateway'] = { status: 'fail', error: 'gateway consumer not active' };
+        pass = false;
       }
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,13 +99,17 @@ services:
         condition: service_healthy
 
   amqp-broker:
-    image: rabbitmq:3-management
+    image: ghcr.io/vampirebyte/rabbitmq-web-ocpp:4.3.1-ocpp
     ports:
       - 15672:15672
       - 5672:5672
+      - 19520:19520
     environment:
       RABBITMQ_DEFAULT_USER: "guest"
       RABBITMQ_DEFAULT_PASS: "guest"
+    configs:
+      - source: rabbitmq-conf
+        target: /etc/rabbitmq/conf.d/20-web-ocpp.conf
     volumes:
       - ./apps/ocpp-server/data/rabbitmq:/var/lib/rabbitmq
     healthcheck:
@@ -195,6 +199,12 @@ services:
       timeout: 10s
       retries: 20
       start_period: 15s
+
+configs:
+  rabbitmq-conf:
+    content: |
+      # Let EVSEs connect without HTTP basic auth credentials.
+      web_ocpp.allow_anonymous = true
 
 # Name the default network `citrineos` so it is stable and project-independent.
 networks:

--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -104,7 +104,12 @@ export {
   systemConfigInputSchema,
   systemConfigSchema,
 } from './src/config/types.js';
-export type { RbacRules, SystemConfig, WebsocketServerConfig } from './src/config/types.js';
+export type {
+  OcppGatewayConfig,
+  RbacRules,
+  SystemConfig,
+  WebsocketServerConfig,
+} from './src/config/types.js';
 
 // Utils
 

--- a/packages/base/src/config/types.ts
+++ b/packages/base/src/config/types.ts
@@ -54,6 +54,27 @@ export const websocketServerInputSchema = z.object({
   forceProtocol: z.enum(OCPP_VERSION_LIST).optional(),
 });
 
+// Configuration for consuming charging station traffic from a broker-terminated
+// websocket gateway (the rabbitmq_web_ocpp plugin) instead of running a
+// websocket server in-process. Stations connect to the broker; the plugin
+// publishes raw OCPP-J frames to a topic exchange with routing key
+// `<protocol>.<action>.<req|conf|error>` and reply_to = the station id, and
+// delivers CSMS frames published with routing key = the station id.
+export const ocppGatewayInputSchema = z.object({
+  // Topic exchange the plugin publishes to and per-station queues bind on.
+  // Must match the plugin's web_ocpp.exchange setting.
+  exchange: z.string().default('amq.topic'),
+  // Shared inbound queue for station->CSMS traffic; instances are competing consumers.
+  queue: z.string().default('rabbit_queue_ocpp_gateway'),
+  // Tenant that stations connecting through the broker vhost belong to.
+  tenantId: z.number().optional(),
+  allowUnknownChargingStations: z.boolean().default(false),
+  // Backstop TTL for connection presence; refreshed by any inbound traffic.
+  // Offline is normally detected via the plugin's synthetic StatusNotification.
+  presenceTimeoutSeconds: z.number().int().min(60).default(3600),
+  prefetch: z.number().int().min(1).default(50),
+});
+
 export const HUBJECT_DEFAULT_BASEURL = 'https://open.plugncharge-test.hubject.com';
 export const HUBJECT_DEFAULT_TOKENURL =
   'https://hubject.stoplight.io/api/v1/projects/cHJqOjk0NTg5/nodes/6bb8b3bc79c2e-authorization-token';
@@ -251,6 +272,7 @@ export const systemConfigInputSchema = z.object({
       .optional(),
     networkConnection: z.object({
       websocketServers: z.array(websocketServerInputSchema.optional()),
+      ocppGateway: ocppGatewayInputSchema.optional(),
     }),
     certificateAuthority: z.object({
       v2gCA: z
@@ -566,6 +588,7 @@ export const systemConfigSchema = z
         })
         .optional(),
       networkConnection: z.object({
+        ocppGateway: ocppGatewayInputSchema.optional(),
         websocketServers: z.array(websocketServerSchema).refine((array) => {
           const idsSeen = new Set<string>();
           return array.filter((obj) => {
@@ -671,4 +694,5 @@ export const RbacRulesSchema = TenantSchema;
 export type RbacRules = z.infer<typeof RbacRulesSchema>;
 
 export type WebsocketServerConfig = z.infer<typeof websocketServerSchema>;
+export type OcppGatewayConfig = z.infer<typeof ocppGatewayInputSchema>;
 export type SystemConfig = z.infer<typeof systemConfigSchema>;

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -5,6 +5,7 @@ import {
   type CertificateDto,
   type CertificateUseEnumType,
   type IFileStorage,
+  type INetworkConnection,
   type InstallCertificateStatusEnumType,
   OCPP2_0_1,
   type WebsocketServerConfig,
@@ -27,7 +28,6 @@ import {
   type CertificateAuthorityService,
   extractCertificateDetails,
   generateCSR,
-  WebsocketNetworkConnection,
 } from '@util/index.js';
 import jsrsasign from 'jsrsasign';
 import { type ILogObj, Logger } from 'tslog';
@@ -44,7 +44,7 @@ export class InstallCertificateHelperService {
   protected installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
   protected deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
   protected certificateAuthorityService: CertificateAuthorityService;
-  protected networkConnection: WebsocketNetworkConnection;
+  protected networkConnection: INetworkConnection;
   protected fileStorage: IFileStorage;
   protected logger: Logger<ILogObj>;
 
@@ -63,7 +63,7 @@ export class InstallCertificateHelperService {
     installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
     deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
     certificateAuthorityService: CertificateAuthorityService;
-    networkConnection: WebsocketNetworkConnection;
+    networkConnection: INetworkConnection;
     fileStorage: IFileStorage;
     logger: Logger<ILogObj>;
   }) {

--- a/packages/core/src/modules/OcppRouter/src/module/webhook.dispatcher.ts
+++ b/packages/core/src/modules/OcppRouter/src/module/webhook.dispatcher.ts
@@ -74,6 +74,12 @@ export class WebhookDispatcher {
 
   async register(tenantId: number, ocppConnectionName: string) {
     const identifier = createIdentifier(tenantId, ocppConnectionName);
+    if (this._identifiers.has(identifier)) {
+      // Idempotent re-register: subscriptions are kept fresh by
+      // _refreshSubscriptions, and onConnect callbacks must not re-fire
+      // for a connection that never closed.
+      return;
+    }
     try {
       await this._loadSubscriptionsForConnection(tenantId, ocppConnectionName);
       await Promise.all(
@@ -157,19 +163,28 @@ export class WebhookDispatcher {
     const messageId = rpcMessage[1];
     const origin = MessageOrigin.ChargingStation;
 
-    const messageRecord = await this._ocppMessageRepository.createOCPPMessage(tenantId, {
-      tenantId: tenantId,
-      ocppConnectionName: ocppConnectionName,
-      correlationId: messageId,
-      origin: origin,
-      state: state,
-      action: action,
-      protocol: protocol as OCPPVersion,
-      message: rpcMessage,
-      timestamp: timestamp,
-    });
+    // Message auditing must not fail the OCPP call itself: the insert can be
+    // rejected e.g. for a station whose very first BootNotification is still
+    // being provisioned (the populate_station_id trigger raises when no
+    // ChargingStations row exists yet).
+    let messageRecord;
+    try {
+      messageRecord = await this._ocppMessageRepository.createOCPPMessage(tenantId, {
+        tenantId: tenantId,
+        ocppConnectionName: ocppConnectionName,
+        correlationId: messageId,
+        origin: origin,
+        state: state,
+        action: action,
+        protocol: protocol as OCPPVersion,
+        message: rpcMessage,
+        timestamp: timestamp,
+      });
+    } catch (error) {
+      this._logger.error(`Failed to persist OCPP message for ${identifier}`, error);
+    }
 
-    if (action === undefined) {
+    if (action === undefined && messageRecord) {
       this._logger.debug(
         `Using action from stored message for correlationId ${messageId} and tenantId ${tenantId}: ${messageRecord.action}`,
       );

--- a/packages/core/src/util/networkconnection/AmqpNetworkConnection.ts
+++ b/packages/core/src/util/networkconnection/AmqpNetworkConnection.ts
@@ -1,0 +1,451 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  ICache,
+  IMessageRouter,
+  INetworkConnection,
+  IWebsocketConnection,
+  OcppGatewayConfig,
+  SystemConfig,
+} from '@citrineos/base';
+import {
+  CacheNamespace,
+  createIdentifier,
+  DEFAULT_TENANT_ID,
+  getStationIdFromIdentifier,
+  OCPPVersion,
+} from '@citrineos/base';
+import type * as amqplib from 'amqplib';
+import type { ILogObj } from 'tslog';
+import { Logger } from 'tslog';
+import type { RabbitMQChannelManager } from '../queue/rabbit-mq/ChannelManager.js';
+
+// Routing key protocol atoms used by the rabbitmq_web_ocpp plugin, mapped to
+// the OCPP subprotocol names used throughout CitrineOS. The plugin also
+// accepts ocpp1.2/1.5/2.0 stations; their traffic is dropped here as those
+// versions are not supported by CitrineOS.
+const PROTOCOL_BY_ROUTING_ATOM: Record<string, OCPPVersion> = {
+  ocpp16: OCPPVersion.OCPP1_6,
+  ocpp201: OCPPVersion.OCPP2_0_1,
+  ocpp21: OCPPVersion.OCPP2_1,
+};
+
+/**
+ * {@link INetworkConnection} implementation for broker-terminated websockets
+ * via the rabbitmq_web_ocpp plugin. Charging stations connect to RabbitMQ
+ * directly; the plugin publishes each inbound OCPP-J frame to a topic exchange
+ * with routing key `<protocol>.<action>.<req|conf|error>`, `reply_to` set to
+ * the station id and `correlation_id` set to the OCPP messageId. Frames
+ * published to that exchange with routing key `<station id>` are delivered to
+ * the station's websocket via its durable `ocpp.<station id>` queue.
+ *
+ * All instances consume one shared queue as competing consumers — no instance
+ * owns a socket, so no per-station routing back to a specific instance is
+ * needed; request/response correlation lives in the shared cache.
+ *
+ * Connection presence is event-driven: any inbound frame from a station that
+ * has no entry in the Connections cache namespace registers it with the
+ * router; the plugin's synthetic offline StatusNotification (vendorId
+ * "rabbitmq", vendorErrorCode "Offline", connectorId 0) deregisters it and is
+ * not forwarded to modules. A TTL refreshed by inbound traffic acts as a
+ * backstop for the rare case where the broker dies without emitting the
+ * synthetic offline frame.
+ */
+export class AmqpNetworkConnection implements INetworkConnection {
+  private static readonly CHANNEL_ID = 'ocpp-gateway';
+  private static readonly INBOUND_BINDINGS = ['*.*.req', '*.*.conf', '*.*.error'];
+  private static readonly CONSUMER_RESTART_DELAY_MS = 5000;
+
+  protected _cache: ICache;
+  protected _logger: Logger<ILogObj>;
+  private readonly _gatewayConfig: OcppGatewayConfig;
+  private readonly _channelManager: RabbitMQChannelManager;
+  private readonly _router: IMessageRouter;
+  private readonly _doesChargingStationExistByStationId?: (
+    tenantId: number,
+    ocppConnectionName: string,
+  ) => Promise<boolean>;
+  private _consumerTag?: string;
+  private _restartTimer?: NodeJS.Timeout;
+  private _shutdownRequested = false;
+
+  constructor({
+    config,
+    cache,
+    router,
+    channelManager,
+    logger,
+    doesChargingStationExistByStationId,
+  }: {
+    config: SystemConfig;
+    cache: ICache;
+    router: IMessageRouter;
+    channelManager: RabbitMQChannelManager;
+    logger: Logger<ILogObj>;
+    doesChargingStationExistByStationId: (
+      tenantId: number,
+      ocppConnectionName: string,
+    ) => Promise<boolean>;
+  }) {
+    const gatewayConfig = config.util.networkConnection.ocppGateway;
+    if (!gatewayConfig) {
+      throw new Error('AmqpNetworkConnection requires util.networkConnection.ocppGateway config');
+    }
+    this._gatewayConfig = gatewayConfig;
+    this._cache = cache;
+    this._channelManager = channelManager;
+    this._doesChargingStationExistByStationId = doesChargingStationExistByStationId;
+    this._logger = logger.getSubLogger({ name: this.constructor.name });
+    router.networkHook = this.sendMessage.bind(this);
+    this._router = router;
+
+    this._channelManager.getConnectionManager().on('connected', () => {
+      this._consumerTag = undefined;
+      this._startConsuming().catch((error) => {
+        this._logger.error('Failed to restart OCPP gateway consumer after reconnect', error);
+        this._scheduleConsumerRestart();
+      });
+    });
+
+    this._startConsuming().catch((error) => {
+      this._logger.error('Failed to start OCPP gateway consumer', error);
+      this._scheduleConsumerRestart();
+    });
+  }
+
+  /**
+   * Send a raw OCPP-J frame to the charging station identified by the identifier.
+   * Publishes to the gateway exchange with routing key = station id; the plugin
+   * routes it into the station's ocpp.<station id> queue and down its websocket.
+   */
+  async sendMessage(identifier: string, message: string): Promise<void> {
+    const stationId = getStationIdFromIdentifier(identifier);
+    const channel = await this._channelManager.getChannel(AmqpNetworkConnection.CHANNEL_ID);
+
+    let correlationId: string | undefined;
+    try {
+      correlationId = JSON.parse(message)[1];
+    } catch {
+      // Router only hands over already-validated frames; guard regardless.
+    }
+
+    const published = channel.publish(
+      this._gatewayConfig.exchange,
+      stationId,
+      Buffer.from(message, 'utf-8'),
+      {
+        contentType: 'application/json',
+        contentEncoding: 'utf-8',
+        correlationId,
+      },
+    );
+    if (!published) {
+      throw new Error(`Failed to publish message to gateway for ${identifier}`);
+    }
+  }
+
+  bindNetworkHook(): (identifier: string, message: string) => Promise<void> {
+    return (identifier: string, message: string) => this.sendMessage(identifier, message);
+  }
+
+  /**
+   * The websocket lives in the broker; it cannot be closed from here.
+   * Only the router registration and cached presence are cleaned up.
+   * Closing the socket itself requires broker-side action (e.g. rabbitmqctl close_connection
+   * or implement curl -X DELETE 'http://localhost:15672/api/connections/192.168.65.1%3A27187%20-%3E%20172.27.0.4%3A19520').
+   */
+  async disconnect(tenantId: number, ocppConnectionName: string): Promise<boolean> {
+    this._logger.warn(
+      `Disconnect requested for ${tenantId}:${ocppConnectionName}: the websocket is terminated ` +
+        `by the broker and cannot be closed by CitrineOS; deregistering only.`,
+    );
+    const identifier = createIdentifier(tenantId, ocppConnectionName);
+    await this._cache.remove(identifier, CacheNamespace.Connections);
+    return await this._router.deregisterConnection(tenantId, ocppConnectionName);
+  }
+
+  /**
+   * Stops consuming station traffic. Stations stay connected to the broker and
+   * their frames stay queued for the remaining (or next) CitrineOS instances,
+   * so no connections are deregistered here.
+   */
+  async shutdown(): Promise<void> {
+    this._shutdownRequested = true;
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer);
+      this._restartTimer = undefined;
+    }
+    if (this._consumerTag) {
+      const channel = await this._channelManager.getChannel(AmqpNetworkConnection.CHANNEL_ID);
+      await channel.cancel(this._consumerTag);
+      this._consumerTag = undefined;
+    }
+    await this._channelManager.closeChannel(AmqpNetworkConnection.CHANNEL_ID);
+  }
+
+  private async _startConsuming(): Promise<void> {
+    if (this._shutdownRequested || this._consumerTag) {
+      return;
+    }
+    const { exchange, queue, prefetch } = this._gatewayConfig;
+    const channel = await this._channelManager.getChannel(AmqpNetworkConnection.CHANNEL_ID);
+
+    // amq.* exchanges are broker-predeclared and cannot be re-asserted.
+    if (exchange.startsWith('amq.')) {
+      await channel.checkExchange(exchange);
+    } else {
+      await channel.assertExchange(exchange, 'topic', { durable: true });
+    }
+
+    await channel.assertQueue(queue, { durable: true, autoDelete: false, exclusive: false });
+    for (const bindingKey of AmqpNetworkConnection.INBOUND_BINDINGS) {
+      await channel.bindQueue(queue, exchange, bindingKey);
+    }
+    await channel.prefetch(prefetch);
+
+    const { consumerTag } = await channel.consume(queue, (message) => {
+      if (!message) {
+        this._logger.warn('Gateway consumer cancelled by broker');
+        this._consumerTag = undefined;
+        this._scheduleConsumerRestart();
+        return;
+      }
+      this._onMessage(message, channel).catch((error) => {
+        this._logger.error('Unexpected error handling gateway message', error);
+      });
+    });
+    // A channel can die while the connection stays up (e.g. a precondition
+    // failure); the connection-level 'connected' handler never fires then, so
+    // restart from here as well.
+    channel.once('close', () => {
+      this._consumerTag = undefined;
+      this._scheduleConsumerRestart();
+    });
+    this._consumerTag = consumerTag;
+    this._logger.info(
+      `Consuming station traffic from queue '${queue}' bound to exchange '${exchange}'`,
+    );
+  }
+
+  /**
+   * True while this instance holds an active consumer on the gateway queue —
+   * the transport-level readiness signal, analogous to the websocket
+   * transport's listening HTTP servers.
+   */
+  isConsuming(): boolean {
+    return this._consumerTag !== undefined;
+  }
+
+  private _scheduleConsumerRestart(): void {
+    if (this._shutdownRequested || this._restartTimer) {
+      return;
+    }
+    this._restartTimer = setTimeout(() => {
+      this._restartTimer = undefined;
+      this._startConsuming().catch((error) => {
+        this._logger.error('Failed to restart OCPP gateway consumer', error);
+        this._scheduleConsumerRestart();
+      });
+    }, AmqpNetworkConnection.CONSUMER_RESTART_DELAY_MS);
+  }
+
+  private async _onMessage(
+    message: amqplib.ConsumeMessage,
+    channel: amqplib.Channel,
+  ): Promise<void> {
+    // Processing errors must not requeue: the router replies to malformed
+    // Calls with a CallError itself, and redelivery would just loop.
+    try {
+      const [protocolAtom, action, direction] = message.fields.routingKey.split('.');
+      const stationId = message.properties.replyTo;
+      if (!stationId) {
+        this._logger.warn(
+          `Discarding gateway message without reply_to (routing key ${message.fields.routingKey})`,
+        );
+        return;
+      }
+
+      const protocol = PROTOCOL_BY_ROUTING_ATOM[protocolAtom];
+      if (!protocol) {
+        this._logger.warn(
+          `Discarding message from ${stationId} with unsupported OCPP version '${protocolAtom}'`,
+        );
+        return;
+      }
+
+      const tenantId = this._gatewayConfig.tenantId ?? DEFAULT_TENANT_ID;
+      const identifier = createIdentifier(tenantId, stationId);
+      const frame = message.content.toString('utf-8');
+
+      if (
+        direction === 'req' &&
+        action === 'StatusNotification' &&
+        this._isSyntheticOffline(frame)
+      ) {
+        await this._onStationOffline(tenantId, stationId, identifier);
+        return;
+      }
+
+      const online = await this._refreshPresence(tenantId, stationId, identifier, protocol);
+      if (!online) {
+        return; // unknown station or failed registration; frame dropped
+      }
+
+      const timestamp = message.properties.timestamp
+        ? new Date(message.properties.timestamp * 1000)
+        : new Date();
+      await this._router.onMessage(identifier, frame, timestamp, protocol);
+    } catch (error) {
+      this._logger.error('Error processing gateway message', error);
+    } finally {
+      channel.ack(message);
+    }
+  }
+
+  /**
+   * Ensures the station is registered as connected, refreshing the presence
+   * TTL on every inbound frame. Returns false if the frame should be dropped.
+   *
+   * Registration happens on the first frame even when the station has no DB
+   * row yet (its first BootNotification creates it in the Configuration
+   * module) — the cache entry carries allowUnknownChargingStations for the
+   * boot handler, and the AMQP subscriptions must exist for the
+   * BootNotificationResponse to reach the router. Only the isOnline update
+   * inside registerConnection is skipped for a missing row, so the entry is
+   * flagged and the flag resolved on a later frame once the row exists.
+   */
+  private async _refreshPresence(
+    tenantId: number,
+    stationId: string,
+    identifier: string,
+    protocol: OCPPVersion,
+  ): Promise<boolean> {
+    const { presenceTimeoutSeconds, allowUnknownChargingStations } = this._gatewayConfig;
+    const existingJson = await this._cache.get<string>(identifier, CacheNamespace.Connections);
+    if (existingJson) {
+      const refreshedJson = await this._completePendingRegistration(
+        tenantId,
+        stationId,
+        identifier,
+        protocol,
+        existingJson,
+      );
+      await this._cache.set(
+        identifier,
+        refreshedJson,
+        CacheNamespace.Connections,
+        presenceTimeoutSeconds,
+      );
+      return true;
+    }
+
+    const exists = this._doesChargingStationExistByStationId
+      ? await this._doesChargingStationExistByStationId(tenantId, stationId)
+      : true;
+    if (!exists && !allowUnknownChargingStations) {
+      this._logger.warn(`Dropping message from unknown station ${stationId} (tenant ${tenantId})`);
+      return false;
+    }
+
+    const connection: IWebsocketConnection & { onlinePending?: boolean } = {
+      id: AmqpNetworkConnection.CHANNEL_ID,
+      timeConnected: new Date().toISOString(),
+      protocol,
+      allowUnknownChargingStations,
+      // No DB row yet: registerConnection's isOnline update will be skipped;
+      // flag the entry so a later frame re-applies it once the row exists.
+      ...(exists ? {} : { onlinePending: true }),
+    };
+    // Atomic claim: with competing consumers another instance may register the
+    // same station concurrently; the loser just proceeds with its frame.
+    const claimed = await this._cache.setIfNotExist(
+      identifier,
+      JSON.stringify(connection),
+      CacheNamespace.Connections,
+      presenceTimeoutSeconds,
+    );
+    if (!claimed) {
+      return true;
+    }
+
+    const registered = await this._router.registerConnection(tenantId, stationId, protocol);
+    if (!registered) {
+      this._logger.error(`Failed to register connection for ${identifier}`);
+      await this._cache.remove(identifier, CacheNamespace.Connections).catch((error) => {
+        this._logger.error(`Failed to remove connection entry ${identifier} from cache`, error);
+      });
+      return false;
+    }
+    this._logger.info(
+      `Station connected via gateway: ${identifier} (${protocol})` +
+        (exists ? '' : ' — awaiting provisioning to mark it online'),
+    );
+    return true;
+  }
+
+  /**
+   * Resolves the onlinePending flag on a presence entry: once the station row
+   * exists (created by its first BootNotification), re-runs registerConnection
+   * — idempotent, so only the previously-skipped isOnline / protocol update
+   * takes effect. The flag lives in the shared cache so any
+   * competing-consumer instance can resolve it.
+   */
+  private async _completePendingRegistration(
+    tenantId: number,
+    stationId: string,
+    identifier: string,
+    protocol: OCPPVersion,
+    entryJson: string,
+  ): Promise<string> {
+    let entry: IWebsocketConnection & { onlinePending?: boolean };
+    try {
+      entry = JSON.parse(entryJson);
+    } catch {
+      return entryJson;
+    }
+    if (!entry.onlinePending) {
+      return entryJson;
+    }
+    const exists = this._doesChargingStationExistByStationId
+      ? await this._doesChargingStationExistByStationId(tenantId, stationId)
+      : true;
+    if (!exists) {
+      return entryJson;
+    }
+    const registered = await this._router.registerConnection(tenantId, stationId, protocol);
+    if (!registered) {
+      return entryJson;
+    }
+    delete entry.onlinePending;
+    this._logger.info(`Station provisioned and marked online: ${identifier} (${protocol})`);
+    return JSON.stringify(entry);
+  }
+
+  private async _onStationOffline(
+    tenantId: number,
+    stationId: string,
+    identifier: string,
+  ): Promise<void> {
+    this._logger.info(`Station disconnected from gateway: ${identifier}`);
+    await this._cache.remove(identifier, CacheNamespace.Connections);
+    await this._router.deregisterConnection(tenantId, stationId);
+  }
+
+  /**
+   * Detects the plugin's synthetic offline StatusNotification, published on
+   * the station's behalf when its websocket closes for any reason. OCPP 1.6
+   * carries vendorId/vendorErrorCode at the payload root; OCPP 2.x inside
+   * customData.
+   */
+  private _isSyntheticOffline(frame: string): boolean {
+    try {
+      const payload = JSON.parse(frame)[3];
+      const vendorInfo = payload?.customData ?? payload;
+      return vendorInfo?.vendorId === 'rabbitmq' && vendorInfo?.vendorErrorCode === 'Offline';
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/core/src/util/networkconnection/index.ts
+++ b/packages/core/src/util/networkconnection/index.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+export { AmqpNetworkConnection } from './AmqpNetworkConnection.js';
 export { Authenticator } from './authenticator/Authenticator.js';
 export { WebsocketNetworkConnection } from './WebsocketNetworkConnection.js';
 export { BasicAuthenticationFilter } from './authenticator/BasicAuthenticationFilter.js';


### PR DESCRIPTION
We have developed a [plugin](https://github.com/vampirebyte/rabbitmq-web-ocpp) that transforms the RabbitMQ broker deployment into a highly available, highly scalable, native OCPP gateway, removing the need for managing the Websockets from the application side. For production, this separation actually brings deployment benefits (cluster redundancy), terminating TLS and allowing mTLS authentication (SecurityProfile 3), without touching the app/worker side and also decoupling from deploying business logic without disconnecting the EVSE's websocket connection.

Currently in CitrineOS profile 3 is just TLS-level: `requestCert: true`, `rejectUnauthorized: true` against the configured CA — there is no check anywhere that the client cert's identity matches the station id (getPeerCertificate appears nowhere in the connection path). Any charger holding any cert signed by the trusted CA can connect as any station id. 

As references, we have validated and published the code as [RabbitMQ community plugin](https://www.rabbitmq.com/community-plugins), MPL-2.0 license, being currently in the process of certifying it with DEKRA, as we pass all the OCTT tests relevant for the OCPP Security Whitepaper, including mTLS authentication. Docker images are pushed publicly for convince in Github Actions, for development convenience and avoiding building the plugin from source.

<img width="713" height="600" alt="Screenshot 2026-05-21 at 19 54 15" src="https://github.com/user-attachments/assets/b4345e08-ddc1-423c-be27-f012e7447a8c" />

We can support you with further integrations and maintenance, if needed, like actually implementing the per-CP `BasicAuthPassword` parity via `rabbitmq_auth_backend_http` or force-close of the WS via API call, but experienced maintainers could have preferences on how this is done.

After you test it, if you decide to make this default, there is a lot of code that can be removed / cleaned up, like the per-CP binding for each connection (in receiver.ts), now that this is taken care of the plugin itself.

Thank you and looking forward to your review!
R