### PR TITLE
Add EVerest flags to pnpm citrine command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ CitrineOS is an open-source project aimed at providing a modular server runtime 
 charging infrastructure. This repository (`citrineos-core`) is a **pnpm monorepo** containing the charging station
 management logic, OCPP message routing, the related services, and the operator-facing web UI.
 
-This README covers the repository as a whole: how it is structured, how to install and build it, and how to run the
-full stack. Each application and package also has its own README with deeper, component-specific documentation —
+This README covers the repository as a whole: how it is structured, how to install and build it, and how to run the full
+stack. Each application and package also has its own README with deeper, component-specific documentation —
 see [Repository Structure](#repository-structure) and [Component Documentation](#component-documentation).
 
 All other documentation and the issue tracking can be found in our main repository
@@ -153,12 +153,14 @@ server, the operator UI, RabbitMQ, PostgreSQL, MinIO, and Hasura together. It pi
 profiles for you based on a few flags:
 
 ```shell
-pnpm citrine            # ocpp-server + operator UI, from published ghcr.io images
-pnpm citrine --local    # build the server and UI from local source instead of pulling
-pnpm citrine --solo     # ocpp-server only (no operator UI)
-pnpm citrine --ocpi     # also run the OCPI server
+pnpm citrine                  # ocpp-server + operator UI, from published ghcr.io images
+pnpm citrine --local          # build the server and UI from local source instead of pulling
+pnpm citrine --solo           # ocpp-server only (no operator UI)
+pnpm citrine --ocpi           # also run the OCPI server
+pnpm citrine --everest        # also run EVerest with OCPP 2.x (mutually exclusive with --everest16)
+pnpm citrine --everest16      # also run EVerest with OCPP 1.6 (mutually exclusive with --everest)
 pnpm citrine --local --ocpi   # flags combine freely
-pnpm citrine down       # stop the stack (pass the same flags you started it with)
+pnpm citrine down             # stop the stack (pass the same flags you started it with)
 ```
 
 Published images are the default because most issues users hit come from stale local builds; reach for `--local` when

--- a/apps/ocpp-server/everest/README.md
+++ b/apps/ocpp-server/everest/README.md
@@ -3,10 +3,27 @@
 In the case you don't have a charger that supports OCPP 2.0.1 to experiment with, we can recommend using the Linux
 Foundation Energy project EVerest. [See here](https://github.com/EVerest) for the repository. They have built an open source version of
 charger firmware and also allow for using it as a simulator. They support OCPP 2.0.1 which makes it a great testing
-opportunity with CitrineOS. For the long route of setting up EVerst you can follow their documentation and build
+opportunity with CitrineOS. For the long route of setting up EVerest you can follow their documentation and build
 the project yourself. [See here for Docs](https://everest.github.io/latest/how-to-guides/getting-started/index.html)
 
 # Running EVerest
+
+## From citrineos-core
+Convenience commands are available from the root directory (citrineos-core) to run EVerest that match the commands already
+found in `apps/ocpp-server`:
+
+- `pnpm run start:everest` — starts EVerest for OCPP 2.x (defaults to `OCPP_VERSION=2.1`)
+- `pnpm run start:everest:16` — starts EVerest for OCPP 1.6
+
+Additionally, you can use the `--everest` or `--everest16` flag when running CitrineOS via pnpm:
+
+```
+pnpm citrine --everest
+```
+
+For more information regarding how these commands work under the hood, read the section below.
+
+## From apps/ocpp-server
 
 In order to alleviate some of the complexities that may arise when starting EVerest, we have created
 some helpful commands that should help in getting the EVerest charger simulator running locally and targeting
@@ -59,4 +76,4 @@ To get EVerest running on the side while developing and making changes, you can 
 1. Bring up EVerest with `docker compose --project-name everest-ac-demo --file "docker-compose.ocpp201.yml" up -d`.
 1. Copy over the appropriate device model with `docker cp manager/device_model_storage_citrineos_sp1.db \
 everest-ac-demo-manager-1:/ext/source/build/dist/share/everest/modules/OCPP201/device_model_storage.db`.
-1. Start EVerst having OCPP2.0.1 support with `docker exec everest-ac-demo-manager-1 sh /ext/source/build/run-scripts/run-sil-ocpp201.sh`.
+1. Start EVerest having OCPP2.0.1 support with `docker exec everest-ac-demo-manager-1 sh /ext/source/build/run-scripts/run-sil-ocpp201.sh`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "test:coverage": "vitest run --coverage",
     "clean": "find . -not -path '*/node_modules/*' \\( -type d \\( -name dist -o -name .next \\) -o -name tsconfig.tsbuildinfo \\) -exec rm -rf {} +",
     "fresh": "pnpm run clean && find . -name node_modules -type d -prune -exec rm -rf {} + && rm -f pnpm-lock.yaml && pnpm store prune",
-    "fresh:install": "pnpm run fresh && pnpm install"
+    "fresh:install": "pnpm run fresh && pnpm install",
+    "start:everest": "cd ./apps/ocpp-server && pnpm start:everest",
+    "start:everest:16": "cd ./apps/ocpp-server && pnpm start:everest:16",
+    "stop:everest": "cd ./apps/ocpp-server/everest && docker compose down"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/scripts/stack.mjs
+++ b/scripts/stack.mjs
@@ -46,8 +46,8 @@ function usage() {
   --local      build the server and UI from local source instead of pulling
   --solo       ocpp-server only (no operator UI)
   --ocpi       also run the OCPI server
-  --everest    also run EVerest with OCPP 2.x
-  --everest16  also run EVerest with OCPP 1.6
+  --everest    also run EVerest with OCPP 2.x (mutually exclusive with --everest16)
+  --everest16  also run EVerest with OCPP 1.6 (mutually exclusive with --everest)
   up | down    start (default) or stop the stack — pass the same flags both times
 `);
 }

--- a/scripts/stack.mjs
+++ b/scripts/stack.mjs
@@ -40,7 +40,7 @@ const flags = new Set(argv.filter((a) => a.startsWith('-')));
 const positionals = argv.filter((a) => !a.startsWith('-'));
 
 function usage() {
-  console.log(`Usage: node scripts/stack.mjs [up|down] [--local] [--solo] [--ocpi]
+  console.log(`Usage: node scripts/stack.mjs [up|down] [--local] [--solo] [--ocpi] [--everest] [--everest16]
 
   (no flags)   ocpp-server + operator UI using ghcr.io images
   --local      build the server and UI from local source instead of pulling

--- a/scripts/stack.mjs
+++ b/scripts/stack.mjs
@@ -127,7 +127,7 @@ if (everestPnpmScript) {
   console.log(`> pnpm ${everestPnpmScript}`);
   const everestResult = spawnSync('pnpm', [everestPnpmScript], { stdio: 'inherit', cwd: repoRoot });
   if (everestResult.error) {
-    console.error(`Failed to run pnpm: ${everestResult.error.message}`);
+    console.error(`Failed to start EVerest: ${everestResult.error.message}`);
     process.exit(1);
   }
   process.exit(everestResult.status ?? 1);

--- a/scripts/stack.mjs
+++ b/scripts/stack.mjs
@@ -10,6 +10,8 @@
 //   node scripts/stack.mjs --local         build server + UI from local source
 //   node scripts/stack.mjs --solo          ocpp-server only (no UI)
 //   node scripts/stack.mjs --ocpi          add the OCPI server
+//   node scripts/stack.mjs --everest       add EVerest with OCPP 2.x
+//   node scripts/stack.mjs --everest16     add EVerest with OCPP 1.6
 //   node scripts/stack.mjs --local --ocpi  combine flags freely
 //   node scripts/stack.mjs down            stop the stack (pass the same flags you brought it up with)
 //
@@ -22,7 +24,15 @@ import { dirname, resolve } from 'node:path';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const KNOWN_FLAGS = new Set(['--local', '--solo', '--ocpi', '--help', '-h']);
+const KNOWN_FLAGS = new Set([
+  '--local',
+  '--solo',
+  '--ocpi',
+  '--everest',
+  '--everest16',
+  '--help',
+  '-h',
+]);
 const KNOWN_COMMANDS = new Set(['up', 'down']);
 
 const argv = process.argv.slice(2);
@@ -36,6 +46,8 @@ function usage() {
   --local      build the server and UI from local source instead of pulling
   --solo       ocpp-server only (no operator UI)
   --ocpi       also run the OCPI server
+  --everest    also run EVerest with OCPP 2.x
+  --everest16  also run EVerest with OCPP 1.6
   up | down    start (default) or stop the stack — pass the same flags both times
 `);
 }
@@ -59,9 +71,18 @@ const command = positionals[0] ?? 'up';
 const local = flags.has('--local');
 const solo = flags.has('--solo');
 const ocpi = flags.has('--ocpi');
+const everest = flags.has('--everest');
+const everest16 = flags.has('--everest16');
 
 if (solo && ocpi) {
   console.error('Error: --solo (server only) and --ocpi (add OCPI) are mutually exclusive.');
+  process.exit(1);
+}
+
+if (everest && everest16) {
+  console.error(
+    'Error: --everest (EVerest 2.x) and --everest16 (EVerest 1.6) are mutually exclusive.',
+  );
   process.exit(1);
 }
 
@@ -91,4 +112,25 @@ if (result.error) {
   console.error(`Failed to run docker: ${result.error.message}`);
   process.exit(1);
 }
-process.exit(result.status ?? 1);
+if (result.status !== 0) process.exit(result.status ?? 1);
+
+const everestPnpmScript =
+  command === 'down' && (everest || everest16)
+    ? 'stop:everest'
+    : everest16
+      ? 'start:everest:16'
+      : everest
+        ? 'start:everest'
+        : null;
+
+if (everestPnpmScript) {
+  console.log(`> pnpm ${everestPnpmScript}`);
+  const everestResult = spawnSync('pnpm', [everestPnpmScript], { stdio: 'inherit', cwd: repoRoot });
+  if (everestResult.error) {
+    console.error(`Failed to run pnpm: ${everestResult.error.message}`);
+    process.exit(1);
+  }
+  process.exit(everestResult.status ?? 1);
+}
+
+process.exit(0);


### PR DESCRIPTION
# Description

To make running EVerest alongside CitrineOS more convenient (since right now you have to `cd apps/ocpp-server` before you can run EVerest), the following changes were made in this PR:

1. `pnpm citrine` was given two more flags: one to run EVerest 2.x `--everest` and the other to run EVerest 1.6 `--everest16`. These work with the `down` as well. The script that supports this behavior, stack.mjs, was updated so that it'll wait for the Docker compose command to finish before attempting anything EVerest-related.
2. The root-level package.json was updated with commands to start EVerest 2.x, start EVerest 1.6, and stop EVerest (and these scripts are used to help with the changes above).
3. Relevant READMEs updated with the new flags and commands.

# Example usages

## To run/stop CitrineOS with EVerest 2.x:
```
pnpm citrine --everest
pnpm citrine down --everest
```

## To run/stop CitrineOS with EVerest 1.6:
```
pnpm citrine --everest16
pnpm citrine down --everest16
```

## Stacks with the other flags
```
pnpm citrine --ocpi --everest
pnpm citrine down --ocpi --everest
```

## But you can't run both 2.x and 1.6 together; it'll complain
```
pnpm citrine --everest --everest16

Error: --everest (EVerest 2.x) and --everest16 (EVerest 1.6) are mutually exclusive.
ELIFECYCLE  Command failed with exit code 1.
```