### PR TITLE
fix(auth): surface IdTokenInfo.groupIdToken in OCPP 2.0.1/2.1 Authorize

### DIFF
--- a/packages/core/src/dal/layers/sequelize/mapper/2.0.1/AuthorizationMapper.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/2.0.1/AuthorizationMapper.ts
@@ -34,6 +34,10 @@ export class AuthorizationMapper {
       language2: authorization.language2,
       personalMessage: authorization.personalMessage,
       customData: authorization.customData,
+      // groupIdToken must be eager-loaded (include groupAuthorization) to be surfaced here.
+      groupIdToken: authorization.groupAuthorization
+        ? AuthorizationMapper.toIdToken(authorization.groupAuthorization)
+        : undefined,
     };
   }
 

--- a/packages/core/src/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.ts
@@ -35,6 +35,10 @@ export class AuthorizationMapper {
       language2: authorization.language2,
       personalMessage: authorization.personalMessage,
       customData: authorization.customData,
+      // groupIdToken must be eager-loaded (include groupAuthorization) to be surfaced here.
+      groupIdToken: authorization.groupAuthorization
+        ? AuthorizationMapper.toIdToken(authorization.groupAuthorization)
+        : undefined,
     };
   }
 

--- a/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
@@ -45,6 +45,8 @@ export class SequelizeAuthorizationRepository
 
     return {
       where,
+      // Eager-load the group Authorization so IdTokenInfo.groupIdToken can be surfaced.
+      include: [{ model: Authorization, as: 'groupAuthorization' }],
     };
   }
 }

--- a/packages/core/test/dal/layers/sequelize/mapper/2.0.1/AuthenticationMapper.test.ts
+++ b/packages/core/test/dal/layers/sequelize/mapper/2.0.1/AuthenticationMapper.test.ts
@@ -43,6 +43,38 @@ describe('AuthenticationMapper', () => {
     });
   });
 
+  describe('toIdTokenInfo', () => {
+    it('should map groupIdToken from the eager-loaded groupAuthorization', () => {
+      const group = aAuthorization((auth) => {
+        auth.idToken = 'GROUP';
+        auth.idTokenType = IdTokenEnum.Central;
+        return auth;
+      });
+      const authorization = aAuthorization((auth) => {
+        auth.groupAuthorization = group;
+        return auth;
+      });
+
+      const result = AuthorizationMapper.toIdTokenInfo(authorization);
+
+      expect(result.groupIdToken).toEqual({
+        customData: group.customData,
+        additionalInfo: group.additionalInfo,
+        idToken: 'GROUP',
+        type: OCPP2_0_1.IdTokenEnumType.Central,
+      });
+    });
+
+    it('should omit groupIdToken when groupAuthorization is not loaded', () => {
+      const authorization = aAuthorization((auth) => {
+        auth.groupAuthorization = undefined;
+        return auth;
+      });
+
+      expect(AuthorizationMapper.toIdTokenInfo(authorization).groupIdToken).toBeUndefined();
+    });
+  });
+
   describe('Enum Mappings', () => {
     describe('toAuthorizationStatusEnumType', () => {
       const statuses: {

--- a/packages/core/test/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.test.ts
+++ b/packages/core/test/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { IdTokenEnum, OCPP2_1 } from '@citrineos/base';
+import { describe, expect, it } from 'vitest';
+import { AuthorizationMapper } from '@dal/layers/sequelize/mapper/2.1';
+import { aAuthorization } from '../../../../providers/Authorization.js';
+
+describe('AuthorizationMapper (2.1)', () => {
+  describe('toIdTokenInfo', () => {
+    it('should map groupIdToken from the eager-loaded groupAuthorization', () => {
+      const group = aAuthorization((auth) => {
+        auth.idToken = 'GROUP';
+        auth.idTokenType = IdTokenEnum.Central;
+        return auth;
+      });
+      const authorization = aAuthorization((auth) => {
+        auth.groupAuthorization = group;
+        return auth;
+      });
+
+      const result = AuthorizationMapper.toIdTokenInfo(authorization);
+
+      expect(result.groupIdToken).toEqual({
+        customData: group.customData,
+        additionalInfo: group.additionalInfo,
+        idToken: 'GROUP',
+        type: OCPP2_1.IdTokenEnumType.Central,
+      });
+    });
+
+    it('should omit groupIdToken when groupAuthorization is not loaded', () => {
+      const authorization = aAuthorization((auth) => {
+        auth.groupAuthorization = undefined;
+        return auth;
+      });
+
+      expect(AuthorizationMapper.toIdTokenInfo(authorization).groupIdToken).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Description

`AuthorizationMapper.toIdTokenInfo` (OCPP 2.0.1 and 2.1) never sets `groupIdToken`, even though:

- the `Authorization` model has a self-referential `groupAuthorization` relation (`groupAuthorizationId` → `Authorization`), and
- the OCPP `IdTokenInfo` type supports `groupIdToken`.

As a result, group membership is silently dropped from `AuthorizeResponse` (and the `IdTokenInfo` embedded in `SendLocalList`), so a charging station can never learn a token's group — breaking group-based concurrent-transaction handling and any group-scoped local-authorization logic on the station side.

## Changes

- `mapper/2.0.1/AuthorizationMapper.ts` and `mapper/2.1/AuthorizationMapper.ts`: `toIdTokenInfo` now maps `groupIdToken` from the related `groupAuthorization` (reusing `toIdToken`) when present.
- `repository/Authorization.ts`: eager-load the `groupAuthorization` association in `_constructQuery` so `toIdTokenInfo` can surface it during the authorize lookup.

Guarded by presence of the relation, so tokens without a group are unaffected (still emit no `groupIdToken`).

## Not included

`IdTokenInfo.evseId` (per-EVSE allow-list) is still not mapped. Unlike `groupIdToken` (which had a backing relation that simply wasn't mapped), there is **no backing column** on `Authorization` for `evseId` — surfacing it needs a schema addition, so it's left for a separate feature PR.

## How tested

- Added a unit test (`packages/core/.../mapper/2.0.1/AuthorizationMapper.test.ts`) covering the `groupIdToken` mapping (present-relation and no-relation cases) — passes under vitest.
- `tsc --noEmit` on `@citrineos/core` passes.
- Verified against a running CitrineOS + an OCPP 2.0.1 charging station: provisioned a member Authorization whose `groupAuthorizationId` points at a group Authorization; `Authorize` response now returns `idTokenInfo.groupIdToken = { idToken, type }` of the group. (Before: field absent.)

## Checklist
- [x] Signed-off-by (DCO)
- [x] SPDX headers unchanged
- [x] Unit test for the mapper mapping
