### PR TITLE
Feature: Add Sign New By Existing Root

### DIFF
--- a/packages/core/src/dal/interfaces/dtos/GenerateCertificateChainRequest.ts
+++ b/packages/core/src/dal/interfaces/dtos/GenerateCertificateChainRequest.ts
@@ -32,6 +32,12 @@ export class GenerateCertificateChainRequest {
   // The file path to store the generated certificate.
   filePath?: string;
   generationScope?: CertificateGenerationScope;
+  // Only relevant when generationScope is FullChain and a root is actually generated.
+  // When true (the default), the new root is signed by the previous root.
+  signWithPreviousRoot?: boolean;
+  // File path of a specific root certificate to sign the new
+  // root with, overriding whichever root would otherwise be used by default.
+  overridePreviousRoot?: string;
 
   constructor(
     organizationName: string,
@@ -44,6 +50,8 @@ export class GenerateCertificateChainRequest {
     pathLen?: number,
     filePath?: string,
     generationScope?: CertificateGenerationScope,
+    signWithPreviousRoot?: boolean,
+    overridePreviousRoot?: string,
   ) {
     this.selfSigned = selfSigned;
     this.organizationName = organizationName;
@@ -55,5 +63,7 @@ export class GenerateCertificateChainRequest {
     this.pathLen = pathLen;
     this.filePath = filePath;
     this.generationScope = generationScope;
+    this.signWithPreviousRoot = signWithPreviousRoot;
+    this.overridePreviousRoot = overridePreviousRoot;
   }
 }

--- a/packages/core/src/dal/interfaces/queries/RootCertificate.ts
+++ b/packages/core/src/dal/interfaces/queries/RootCertificate.ts
@@ -47,6 +47,14 @@ export const GenerateCertificateChainSchema = QuerySchema('GenerateCertificateCh
     key: 'generationScope',
     type: 'string',
   },
+  {
+    key: 'signWithPreviousRoot',
+    type: 'boolean',
+  },
+  {
+    key: 'overridePreviousRoot',
+    type: 'string',
+  },
 ]);
 
 export const InstallRootCertificateSchema = QuerySchema('InstallRootCertificateSchema', [

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import {
+  AttributeEnum,
   BadRequestError,
+  CertificateUseEnum,
   type CertificateDto,
   type CertificateUseEnumType,
   type IFileStorage,
@@ -18,6 +20,7 @@ import {
 import type {
   ICertificateRepository,
   IDeleteCertificateAttemptRepository,
+  IDeviceModelRepository,
   IInstallCertificateAttemptRepository,
   IInstalledCertificateRepository,
 } from '@dal/interfaces/repositories.js';
@@ -33,6 +36,7 @@ import {
   extractCertificateDetails,
   generateCertificate,
   generateCSR,
+  isSignedBy,
   parseCertificateChainPem,
   WebsocketNetworkConnection,
 } from '@util/index.js';
@@ -51,6 +55,7 @@ export class InstallCertificateHelperService {
   protected installedCertificateRepository: IInstalledCertificateRepository;
   protected installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
   protected deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
+  protected deviceModelRepository: IDeviceModelRepository;
   protected certificateAuthorityService: CertificateAuthorityService;
   protected networkConnection: WebsocketNetworkConnection;
   protected fileStorage: IFileStorage;
@@ -61,6 +66,7 @@ export class InstallCertificateHelperService {
     installedCertificateRepository,
     installCertificateAttemptRepository,
     deleteCertificateAttemptRepository,
+    deviceModelRepository,
     certificateAuthorityService,
     networkConnection,
     fileStorage,
@@ -70,6 +76,7 @@ export class InstallCertificateHelperService {
     installedCertificateRepository: IInstalledCertificateRepository;
     installCertificateAttemptRepository: IInstallCertificateAttemptRepository;
     deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
+    deviceModelRepository: IDeviceModelRepository;
     certificateAuthorityService: CertificateAuthorityService;
     networkConnection: WebsocketNetworkConnection;
     fileStorage: IFileStorage;
@@ -79,6 +86,7 @@ export class InstallCertificateHelperService {
     this.installedCertificateRepository = installedCertificateRepository;
     this.installCertificateAttemptRepository = installCertificateAttemptRepository;
     this.deleteCertificateAttemptRepository = deleteCertificateAttemptRepository;
+    this.deviceModelRepository = deviceModelRepository;
     this.certificateAuthorityService = certificateAuthorityService;
     this.networkConnection = networkConnection;
     this.fileStorage = fileStorage;
@@ -92,6 +100,13 @@ export class InstallCertificateHelperService {
     certificateType: CertificateUseEnumType,
     requestId?: number | null,
   ) {
+    await this._verifyAdditionalRootCertificateCheck(
+      tenantId,
+      ocppConnectionName,
+      certificateType,
+      certificate,
+    );
+
     const hash = this.getCertificateHash(certificate);
     const existingPendingInstallCertificateAttempt =
       await this.installCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
@@ -145,6 +160,65 @@ export class InstallCertificateHelperService {
         installCertificateAttempt.requestId = requestId;
       }
       await installCertificateAttempt.save();
+    }
+  }
+
+  /**
+   * OCPP 2.0.1 M05.FR.10: when SecurityCtrlr.AdditionalRootCertificateCheck is true and
+   * the certificate being installed is a CSMSRootCertificate, the new root MUST be
+   * signed by the CSMS root certificate it is replacing. Throws if that's not the case.
+   */
+  private async _verifyAdditionalRootCertificateCheck(
+    tenantId: number,
+    ocppConnectionName: string,
+    certificateType: CertificateUseEnumType,
+    newCertificatePem: string,
+  ): Promise<void> {
+    if (certificateType !== CertificateUseEnum.CSMSRootCertificate) {
+      return;
+    }
+
+    const [additionalRootCertificateCheckAttribute] =
+      await this.deviceModelRepository.readAllByQuerystring(tenantId, {
+        tenantId,
+        ocppConnectionName,
+        component_name: 'SecurityCtrlr',
+        variable_name: 'AdditionalRootCertificateCheck',
+        type: AttributeEnum.Actual,
+      });
+    if (additionalRootCertificateCheckAttribute?.value !== 'true') {
+      return;
+    }
+
+    const previouslyInstalledRoot = await this.installedCertificateRepository.readOnlyOneByQuery(
+      tenantId,
+      {
+        where: {
+          ocppConnectionName,
+          certificateType: CertificateUseEnum.CSMSRootCertificate,
+        },
+      },
+    );
+    if (!previouslyInstalledRoot) {
+      // Nothing installed yet to replace
+      return;
+    }
+    const previousRootCertificate = await previouslyInstalledRoot.$get('certificate');
+    if (!previousRootCertificate?.certificateFileId) {
+      throw new BadRequestError(
+        `Cannot verify AdditionalRootCertificateCheck for ${ocppConnectionName}: the currently installed CSMS root certificate has no certificate file on record to verify the new one against.`,
+      );
+    }
+    const previousRootPem = await this._readPemFile(
+      previousRootCertificate.certificateFileId,
+      'previously installed CSMS root certificate',
+      ocppConnectionName,
+    );
+
+    if (!isSignedBy(newCertificatePem, previousRootPem)) {
+      throw new BadRequestError(
+        `Cannot install new CSMS root certificate for ${ocppConnectionName}: SecurityCtrlr.AdditionalRootCertificateCheck is enabled, so the new root certificate must be signed by the CSMS root certificate it is replacing.`,
+      );
     }
   }
 
@@ -464,7 +538,7 @@ export class InstallCertificateHelperService {
       case CertificateGenerationScope.SubCAAndLeaf:
         return this._generateSubCAAndLeaf(tenantId, websocketConfig, certRequest);
       case CertificateGenerationScope.FullChain:
-        return this._generateFullChain(tenantId, certRequest);
+        return this._generateFullChain(tenantId, websocketConfig, certRequest);
       default:
         throw new BadRequestError(`Unknown generationScope: ${scope}`);
     }
@@ -486,7 +560,7 @@ export class InstallCertificateHelperService {
       rootCACertificateFilePath?: string;
     };
   }> {
-    return this._generateFullChain(tenantId, certRequest);
+    return this._generateFullChain(tenantId, undefined, certRequest);
   }
 
   private async _generateLeafOnly(
@@ -634,6 +708,7 @@ export class InstallCertificateHelperService {
 
   private async _generateFullChain(
     tenantId: number,
+    websocketConfig: WebsocketServerConfig | undefined,
     certRequest: GenerateCertificateChainRequest,
   ): Promise<{
     certificates: Certificate[];
@@ -655,9 +730,28 @@ export class InstallCertificateHelperService {
     let storedRoot: Certificate | undefined;
 
     if (selfSigned) {
+      // OCPP 2.0.1 M05.FR.11: sign the new root with the previous root, so charging stations
+      // with SecurityCtrlr.AdditionalRootCertificateCheck enabled accept it as a valid replacement.
+      // signWithPreviousRoot/overridePreviousRoot only applies to a server-scoped chain; a standalone chain
+      // isn't tied to any server's previous root, so both params are ignored
+      const signWithPreviousRoot = !!websocketConfig && (certRequest.signWithPreviousRoot ?? true);
+      const previousRoot = signWithPreviousRoot
+        ? await this._resolvePreviousRoot(
+            tenantId,
+            certRequest,
+            websocketConfig!.id,
+            websocketConfig,
+          )
+        : undefined;
+
       const rootSerialNumber = moment().valueOf();
       const rootEntity = this._buildRootEntity(certRequest, rootSerialNumber);
-      const [rootCertPem, rootKeyPem] = generateCertificate(rootEntity, this.logger);
+      if (previousRoot) {
+        rootEntity.signedBy = previousRoot.certificateId;
+      }
+      const [rootCertPem, rootKeyPem] = previousRoot
+        ? generateCertificate(rootEntity, this.logger, previousRoot.keyPem, previousRoot.certPem)
+        : generateCertificate(rootEntity, this.logger);
       storedRoot = await this.storeCertificateAndKey(
         tenantId,
         rootEntity,
@@ -855,6 +949,53 @@ export class InstallCertificateHelperService {
   }
 
   /**
+   * Resolves the "previous root". A newly-generated root should be signed by:
+   * `certRequest.overridePreviousRoot` if given, else `websocketConfig`'s currently
+   * configured root. Returns `undefined` if neither is available.
+   */
+  private async _resolvePreviousRoot(
+    tenantId: number,
+    certRequest: GenerateCertificateChainRequest,
+    contextId: string,
+    websocketConfig?: WebsocketServerConfig,
+  ): Promise<{ certPem: string; keyPem: string; certificateId: number } | undefined> {
+    // `overridePreviousRoot` is caller-supplied over the API, so it stays path-validated;
+    // `rootCACertificateFilePath` is config-driven and may be an
+    // absolute path, so it's read as trusted.
+    const previousRootFilePath = certRequest.overridePreviousRoot;
+    const trustedRootFilePath = websocketConfig?.rootCACertificateFilePath;
+    const resolvedFilePath = previousRootFilePath ?? trustedRootFilePath;
+    if (!resolvedFilePath) {
+      return undefined;
+    }
+
+    const certPem = previousRootFilePath
+      ? await this._readPemFile(previousRootFilePath, 'previous root certificate', contextId)
+      : await this._readPemFile(trustedRootFilePath!, 'previous root certificate', contextId, {
+          trusted: true,
+        });
+    const record = await this.certificateRepository.readOnlyOneByQuery(tenantId, {
+      where: { certificateFileHash: this.getCertificateHash(certPem) },
+    });
+    if (!record) {
+      throw new BadRequestError(
+        `Cannot sign the new root certificate for ${contextId} with the previous root at ${resolvedFilePath}: cannot find record from db.`,
+      );
+    }
+    if (!record.privateKeyFileId) {
+      throw new BadRequestError(
+        `Cannot sign the new root certificate for ${contextId} with the previous root at ${resolvedFilePath}: private key cannot be located from db.`,
+      );
+    }
+    const keyPem = await this._readPemFile(
+      record.privateKeyFileId,
+      'previous root private key',
+      contextId,
+    );
+    return { certPem, keyPem, certificateId: record.id };
+  }
+
+  /**
    * Reads and extracts the subCA certificate from a server's currently-configured
    * certificate chain file (chain = leaf + subCA concatenation). This is the only
    * config field relied on to identify a server's current lineage — the optional
@@ -871,6 +1012,7 @@ export class InstallCertificateHelperService {
       config.tlsCertificateChainFilePath,
       'certificate chain',
       config.id,
+      { trusted: true },
     );
     const [, subCACertPem] = parseCertificateChainPem(currentChainPem);
     if (!subCACertPem) {
@@ -885,8 +1027,9 @@ export class InstallCertificateHelperService {
     filePath: string,
     description: string,
     serverId: string,
+    options?: { trusted?: boolean },
   ): Promise<string> {
-    const buffer = await this.fileStorage.getFile(filePath);
+    const buffer = await this.fileStorage.getFile(filePath, undefined, options);
     if (!buffer) {
       throw new BadRequestError(
         `Could not read ${description} for server ${serverId} at ${filePath}`,

--- a/packages/core/src/util/certificate/CertificateUtil.ts
+++ b/packages/core/src/util/certificate/CertificateUtil.ts
@@ -60,6 +60,22 @@ export function parseCertificateChainPem(pem: string): string[] {
 }
 
 /**
+ * Verifies that `certPem` was cryptographically signed by the key corresponding to
+ * `issuerCertPem`
+ */
+export function isSignedBy(certPem: string, issuerCertPem: string): boolean {
+  try {
+    const cert = new X509();
+    cert.readCertPEM(certPem);
+    const issuerCert = new X509();
+    issuerCert.readCertPEM(issuerCertPem);
+    return cert.verifySignature(issuerCert.getPublicKey());
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Decode the pem and extract certificates
  * @param pem - base64 encoded certificate chain string without header and footer
  * @return array of pkijs.CertificateSetItem

--- a/packages/core/test/modules/Certificates/module/installCertificateHelperService.test.ts
+++ b/packages/core/test/modules/Certificates/module/installCertificateHelperService.test.ts
@@ -953,8 +953,14 @@ describe('InstallCertificateHelperService', () => {
           certRequest,
         );
 
-        expect(mockFileStorageGetFile).toHaveBeenCalledWith('chain.pem');
-        expect(mockFileStorageGetFile).toHaveBeenCalledWith('SubCA_Key_existing.pem');
+        expect(mockFileStorageGetFile).toHaveBeenCalledWith('chain.pem', undefined, {
+          trusted: true,
+        });
+        expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+          'SubCA_Key_existing.pem',
+          undefined,
+          undefined,
+        );
         expect(mockParseCertificateChainPem).toHaveBeenCalledWith('oldLeafPem+subCACertPem');
         expect(mockCertificateReadOnlyOneByQuery).toHaveBeenCalledWith(tenantId, {
           where: { certificateFileHash: mockHash },
@@ -1040,9 +1046,19 @@ describe('InstallCertificateHelperService', () => {
           certRequest,
         );
 
-        expect(mockFileStorageGetFile).toHaveBeenCalledWith('chain.pem');
-        expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_existing.pem');
-        expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Key_existing.pem');
+        expect(mockFileStorageGetFile).toHaveBeenCalledWith('chain.pem', undefined, {
+          trusted: true,
+        });
+        expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+          'Root_Certificate_existing.pem',
+          undefined,
+          undefined,
+        );
+        expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+          'Root_Key_existing.pem',
+          undefined,
+          undefined,
+        );
         expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
           1,
           expect.objectContaining({ signedBy: 10, commonName: 'localhost SubCA' }),
@@ -1169,8 +1185,16 @@ describe('InstallCertificateHelperService', () => {
             certRequest,
           );
 
-          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_existing.pem');
-          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Key_existing.pem');
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+            'Root_Certificate_existing.pem',
+            undefined,
+            { trusted: true },
+          );
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+            'Root_Key_existing.pem',
+            undefined,
+            undefined,
+          );
           expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
             1,
             expect.objectContaining({ signedBy: 77 }),
@@ -1206,8 +1230,16 @@ describe('InstallCertificateHelperService', () => {
 
           await service.generateCertificateChain(tenantId, websocketConfig, certRequest);
 
-          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_other.pem');
-          expect(mockFileStorageGetFile).not.toHaveBeenCalledWith('Root_Certificate_current.pem');
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith(
+            'Root_Certificate_other.pem',
+            undefined,
+            undefined,
+          );
+          expect(mockFileStorageGetFile).not.toHaveBeenCalledWith(
+            'Root_Certificate_current.pem',
+            expect.anything(),
+            expect.anything(),
+          );
         });
 
         it('self-signs when signWithPreviousRoot is false, even if a previous root exists', async () => {
@@ -1338,19 +1370,15 @@ describe('InstallCertificateHelperService', () => {
       expect(result.certificates).toHaveLength(3);
     });
 
-    it('signs the new root with overridePreviousRoot when provided', async () => {
+    it('ignores overridePreviousRoot and signWithPreviousRoot, always self-signing', async () => {
+      // A standalone chain isn't tied to any server's previous root, so both fields are
+      // ignored even when explicitly set — it must not attempt to read or sign with them.
       const certRequest = {
         ...baseCertRequest,
         overridePreviousRoot: 'Root_Certificate_other.pem',
+        signWithPreviousRoot: true,
       } as GenerateCertificateChainRequest;
 
-      mockFileStorageGetFile
-        .mockResolvedValueOnce(Buffer.from('otherRootCertPem'))
-        .mockResolvedValueOnce(Buffer.from('otherRootKeyPem'));
-      mockCertificateReadOnlyOneByQuery.mockResolvedValue({
-        id: 88,
-        privateKeyFileId: 'Root_Key_other.pem',
-      });
       mockGenerateCertificate
         .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
         .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
@@ -1358,13 +1386,11 @@ describe('InstallCertificateHelperService', () => {
 
       const result = await service.generateStandaloneFullChain(tenantId, certRequest);
 
-      expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_other.pem');
+      expect(mockFileStorageGetFile).not.toHaveBeenCalled();
       expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ signedBy: 88 }),
+        expect.objectContaining({ commonName: 'localhost Root' }),
         logger,
-        'otherRootKeyPem',
-        'otherRootCertPem',
       );
       expect(result.certificates).toHaveLength(3);
     });

--- a/packages/core/test/modules/Certificates/module/installCertificateHelperService.test.ts
+++ b/packages/core/test/modules/Certificates/module/installCertificateHelperService.test.ts
@@ -7,6 +7,7 @@ import {
   type GenerateCertificateChainRequest,
   type ICertificateRepository,
   type IDeleteCertificateAttemptRepository,
+  type IDeviceModelRepository,
   type IInstallCertificateAttemptRepository,
   type IInstalledCertificateRepository,
   WebsocketNetworkConnection,
@@ -29,6 +30,7 @@ const { MOCK_CERT_TYPE_V2G, MOCK_STATUS_REJECTED, MOCK_STATUS_ACCEPTED } = vi.ho
 const mockExtractCertificateDetails = vi.hoisted(() => vi.fn());
 const mockGenerateCertificate = vi.hoisted(() => vi.fn());
 const mockParseCertificateChainPem = vi.hoisted(() => vi.fn());
+const mockIsSignedBy = vi.hoisted(() => vi.fn());
 
 let createdCertificateInstances: any[] = [];
 let createdInstallCertificateAttemptInstances: any[] = [];
@@ -56,6 +58,7 @@ vi.mock('@util/index.js', async (importOriginal) => {
     extractCertificateDetails: mockExtractCertificateDetails,
     generateCertificate: mockGenerateCertificate,
     parseCertificateChainPem: mockParseCertificateChainPem,
+    isSignedBy: mockIsSignedBy,
   };
 });
 
@@ -142,6 +145,7 @@ describe('InstallCertificateHelperService', () => {
   let mockInstalledCertificateRepository: IInstalledCertificateRepository;
   let mockInstallCertificateAttemptRepository: IInstallCertificateAttemptRepository;
   let mockDeleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
+  let mockDeviceModelRepository: IDeviceModelRepository;
   let mockCertificateAuthorityService: CertificateAuthorityService;
   let mockNetworkConnection: WebsocketNetworkConnection;
 
@@ -152,6 +156,7 @@ describe('InstallCertificateHelperService', () => {
   const mockCertificateReadOnlyOneByQuery = vi.fn();
   const mockInstalledCertificateReadOnlyOneByQuery = vi.fn();
   const mockInstallCertificateAttemptReadOnlyOneByQuery = vi.fn();
+  const mockDeviceModelReadAllByQuerystring = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -172,6 +177,13 @@ describe('InstallCertificateHelperService', () => {
       readOnlyOneByQuery: mockInstallCertificateAttemptReadOnlyOneByQuery,
     } as any;
 
+    // Defaults to an empty result, i.e. AdditionalRootCertificateCheck is unset/disabled,
+    // so existing tests that don't care about M05.FR.10 aren't affected by it.
+    mockDeviceModelReadAllByQuerystring.mockResolvedValue([]);
+    mockDeviceModelRepository = {
+      readAllByQuerystring: mockDeviceModelReadAllByQuerystring,
+    } as any;
+
     mockDeleteCertificateAttemptRepository = {} as any;
     mockCertificateAuthorityService = {} as any;
     mockNetworkConnection = {} as any;
@@ -181,6 +193,7 @@ describe('InstallCertificateHelperService', () => {
       installedCertificateRepository: mockInstalledCertificateRepository,
       installCertificateAttemptRepository: mockInstallCertificateAttemptRepository,
       deleteCertificateAttemptRepository: mockDeleteCertificateAttemptRepository,
+      deviceModelRepository: mockDeviceModelRepository,
       certificateAuthorityService: mockCertificateAuthorityService,
       networkConnection: mockNetworkConnection,
       fileStorage: mockFileStorage,
@@ -352,6 +365,134 @@ describe('InstallCertificateHelperService', () => {
       expect(savedAttempt).toBeDefined();
       expect(savedAttempt.certificateId).toBe(99);
       expect(savedAttempt.save).toHaveBeenCalled();
+    });
+
+    describe('AdditionalRootCertificateCheck (M05.FR.10)', () => {
+      const MOCK_CERT_TYPE_CSMS_ROOT = 'CSMSRootCertificate';
+      const previousRootPemBuffer = Buffer.from('previous-root-pem');
+
+      beforeEach(() => {
+        // Common setup for tests that don't short-circuit on an existing pending attempt.
+        mockInstallCertificateAttemptReadOnlyOneByQuery.mockResolvedValue(undefined);
+        mockExtractCertificateDetails.mockReturnValue({
+          serialNumber: 1,
+          issuerName: 'Test Issuer',
+          organizationName: 'Test Org',
+          commonName: 'localhost',
+          countryName: 'US',
+          validBefore: new Date('2027-02-17'),
+          signatureAlgorithm: 'SHA256withECDSA' as any,
+        });
+        mockCertificateReadOnlyOneByQuery.mockResolvedValue({ id: 1 } as any);
+      });
+
+      it('does not consult the device model for non-CSMSRootCertificate types', async () => {
+        await service.prepareToInstallCertificate(
+          tenantId,
+          ocppConnectionName,
+          MOCK_CERTIFICATE,
+          MOCK_CERT_TYPE_V2G as any,
+        );
+
+        expect(mockDeviceModelReadAllByQuerystring).not.toHaveBeenCalled();
+      });
+
+      it('skips the check when AdditionalRootCertificateCheck is not set to true', async () => {
+        mockDeviceModelReadAllByQuerystring.mockResolvedValue([{ value: 'false' }]);
+
+        await expect(
+          service.prepareToInstallCertificate(
+            tenantId,
+            ocppConnectionName,
+            MOCK_CERTIFICATE,
+            MOCK_CERT_TYPE_CSMS_ROOT as any,
+          ),
+        ).resolves.not.toThrow();
+
+        expect(mockDeviceModelReadAllByQuerystring).toHaveBeenCalledWith(tenantId, {
+          tenantId,
+          ocppConnectionName,
+          component_name: 'SecurityCtrlr',
+          variable_name: 'AdditionalRootCertificateCheck',
+          type: 'Actual',
+        });
+        expect(mockInstalledCertificateReadOnlyOneByQuery).not.toHaveBeenCalled();
+      });
+
+      it('allows the install when no CSMS root is currently installed (initial install)', async () => {
+        mockDeviceModelReadAllByQuerystring.mockResolvedValue([{ value: 'true' }]);
+        mockInstalledCertificateReadOnlyOneByQuery.mockResolvedValue(undefined);
+
+        await expect(
+          service.prepareToInstallCertificate(
+            tenantId,
+            ocppConnectionName,
+            MOCK_CERTIFICATE,
+            MOCK_CERT_TYPE_CSMS_ROOT as any,
+          ),
+        ).resolves.not.toThrow();
+
+        expect(mockIsSignedBy).not.toHaveBeenCalled();
+      });
+
+      it('throws BadRequestError when the installed root record has no certificate file on record', async () => {
+        mockDeviceModelReadAllByQuerystring.mockResolvedValue([{ value: 'true' }]);
+        mockInstalledCertificateReadOnlyOneByQuery.mockResolvedValue({
+          $get: vi.fn().mockResolvedValue(undefined),
+        } as any);
+
+        await expect(
+          service.prepareToInstallCertificate(
+            tenantId,
+            ocppConnectionName,
+            MOCK_CERTIFICATE,
+            MOCK_CERT_TYPE_CSMS_ROOT as any,
+          ),
+        ).rejects.toThrow(BadRequestError);
+      });
+
+      it('throws BadRequestError when the new root is not signed by the previous root', async () => {
+        mockDeviceModelReadAllByQuerystring.mockResolvedValue([{ value: 'true' }]);
+        mockInstalledCertificateReadOnlyOneByQuery.mockResolvedValue({
+          $get: vi.fn().mockResolvedValue({ certificateFileId: 'root-cert-path' }),
+        } as any);
+        mockFileStorageGetFile.mockResolvedValue(previousRootPemBuffer);
+        mockIsSignedBy.mockReturnValue(false);
+
+        await expect(
+          service.prepareToInstallCertificate(
+            tenantId,
+            ocppConnectionName,
+            MOCK_CERTIFICATE,
+            MOCK_CERT_TYPE_CSMS_ROOT as any,
+          ),
+        ).rejects.toThrow(BadRequestError);
+
+        expect(mockIsSignedBy).toHaveBeenCalledWith(
+          MOCK_CERTIFICATE,
+          previousRootPemBuffer.toString(),
+        );
+      });
+
+      it('proceeds with the install when the new root is signed by the previous root', async () => {
+        mockDeviceModelReadAllByQuerystring.mockResolvedValue([{ value: 'true' }]);
+        mockInstalledCertificateReadOnlyOneByQuery.mockResolvedValue({
+          $get: vi.fn().mockResolvedValue({ certificateFileId: 'root-cert-path' }),
+        } as any);
+        mockFileStorageGetFile.mockResolvedValue(previousRootPemBuffer);
+        mockIsSignedBy.mockReturnValue(true);
+
+        await expect(
+          service.prepareToInstallCertificate(
+            tenantId,
+            ocppConnectionName,
+            MOCK_CERTIFICATE,
+            MOCK_CERT_TYPE_CSMS_ROOT as any,
+          ),
+        ).resolves.not.toThrow();
+
+        expect(createdInstallCertificateAttemptInstances).toHaveLength(1);
+      });
     });
   });
 
@@ -998,6 +1139,234 @@ describe('InstallCertificateHelperService', () => {
         expect(result.certificates).toHaveLength(2);
         expect(result.filePaths.rootCACertificateFilePath).toBeUndefined();
       });
+
+      describe('signWithPreviousRoot / overridePreviousRoot (M05.FR.10)', () => {
+        it("signs the new root with the server's currently configured root by default", async () => {
+          const websocketConfig: WebsocketServerConfig = {
+            ...baseWebsocketConfig,
+            rootCACertificateFilePath: 'Root_Certificate_existing.pem',
+          };
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+          } as GenerateCertificateChainRequest;
+
+          mockFileStorageGetFile
+            .mockResolvedValueOnce(Buffer.from('previousRootCertPem'))
+            .mockResolvedValueOnce(Buffer.from('previousRootKeyPem'));
+          mockCertificateReadOnlyOneByQuery.mockResolvedValue({
+            id: 77,
+            privateKeyFileId: 'Root_Key_existing.pem',
+          });
+          mockGenerateCertificate
+            .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+            .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+            .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+          const result = await service.generateCertificateChain(
+            tenantId,
+            websocketConfig,
+            certRequest,
+          );
+
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_existing.pem');
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Key_existing.pem');
+          expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ signedBy: 77 }),
+            logger,
+            'previousRootKeyPem',
+            'previousRootCertPem',
+          );
+          expect(result.certificates).toHaveLength(3);
+        });
+
+        it("uses overridePreviousRoot instead of the server's currently configured root", async () => {
+          const websocketConfig: WebsocketServerConfig = {
+            ...baseWebsocketConfig,
+            rootCACertificateFilePath: 'Root_Certificate_current.pem',
+          };
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+            overridePreviousRoot: 'Root_Certificate_other.pem',
+          } as GenerateCertificateChainRequest;
+
+          mockFileStorageGetFile
+            .mockResolvedValueOnce(Buffer.from('otherRootCertPem'))
+            .mockResolvedValueOnce(Buffer.from('otherRootKeyPem'));
+          mockCertificateReadOnlyOneByQuery.mockResolvedValue({
+            id: 88,
+            privateKeyFileId: 'Root_Key_other.pem',
+          });
+          mockGenerateCertificate
+            .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+            .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+            .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+          await service.generateCertificateChain(tenantId, websocketConfig, certRequest);
+
+          expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_other.pem');
+          expect(mockFileStorageGetFile).not.toHaveBeenCalledWith('Root_Certificate_current.pem');
+        });
+
+        it('self-signs when signWithPreviousRoot is false, even if a previous root exists', async () => {
+          const websocketConfig: WebsocketServerConfig = {
+            ...baseWebsocketConfig,
+            rootCACertificateFilePath: 'Root_Certificate_existing.pem',
+          };
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+            signWithPreviousRoot: false,
+          } as GenerateCertificateChainRequest;
+
+          mockGenerateCertificate
+            .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+            .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+            .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+          await service.generateCertificateChain(tenantId, websocketConfig, certRequest);
+
+          expect(mockFileStorageGetFile).not.toHaveBeenCalled();
+          expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ commonName: 'localhost Root' }),
+            logger,
+          );
+        });
+
+        it('falls back to self-signing when there is no previous root to sign with (bootstrap)', async () => {
+          // baseWebsocketConfig has no rootCACertificateFilePath and certRequest has no
+          // overridePreviousRoot — signWithPreviousRoot defaults to true, but there's
+          // nothing to sign with yet, so this must not throw and must self-sign.
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+          } as GenerateCertificateChainRequest;
+
+          mockGenerateCertificate
+            .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+            .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+            .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+          const result = await service.generateCertificateChain(
+            tenantId,
+            baseWebsocketConfig,
+            certRequest,
+          );
+
+          expect(mockFileStorageGetFile).not.toHaveBeenCalled();
+          expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({ commonName: 'localhost Root' }),
+            logger,
+          );
+          expect(result.certificates).toHaveLength(3);
+        });
+
+        it('throws BadRequestError when the previous root is not tracked in the database', async () => {
+          const websocketConfig: WebsocketServerConfig = {
+            ...baseWebsocketConfig,
+            rootCACertificateFilePath: 'Root_Certificate_existing.pem',
+          };
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+          } as GenerateCertificateChainRequest;
+
+          mockFileStorageGetFile.mockResolvedValueOnce(Buffer.from('previousRootCertPem'));
+          mockCertificateReadOnlyOneByQuery.mockResolvedValue(undefined);
+
+          await expect(
+            service.generateCertificateChain(tenantId, websocketConfig, certRequest),
+          ).rejects.toThrow(BadRequestError);
+        });
+
+        it('throws BadRequestError when the previous root record is missing its private key', async () => {
+          const websocketConfig: WebsocketServerConfig = {
+            ...baseWebsocketConfig,
+            rootCACertificateFilePath: 'Root_Certificate_existing.pem',
+          };
+          const certRequest = {
+            ...baseCertRequest,
+            generationScope: CertificateGenerationScope.FullChain,
+          } as GenerateCertificateChainRequest;
+
+          mockFileStorageGetFile.mockResolvedValueOnce(Buffer.from('previousRootCertPem'));
+          mockCertificateReadOnlyOneByQuery.mockResolvedValue({
+            id: 77,
+            privateKeyFileId: undefined,
+          });
+
+          await expect(
+            service.generateCertificateChain(tenantId, websocketConfig, certRequest),
+          ).rejects.toThrow(BadRequestError);
+        });
+      });
+    });
+  });
+
+  describe('generateStandaloneFullChain', () => {
+    const baseCertRequest = {
+      organizationName: 'Test Org',
+      commonName: 'localhost',
+    } as GenerateCertificateChainRequest;
+
+    beforeEach(() => {
+      mockFileStorageSaveFile.mockImplementation((key: string) => Promise.resolve(key));
+      (mockCertificateRepository.createOrUpdateCertificate as any).mockImplementation(
+        (_tenantId: number, cert: any) =>
+          Promise.resolve(Object.assign(cert, { id: cert.id ?? 999 })),
+      );
+    });
+
+    it('self-signs the root when there is no override and no prior server to reuse', async () => {
+      mockGenerateCertificate
+        .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+        .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+        .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+      const result = await service.generateStandaloneFullChain(tenantId, baseCertRequest);
+
+      expect(mockFileStorageGetFile).not.toHaveBeenCalled();
+      expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ commonName: 'localhost Root' }),
+        logger,
+      );
+      expect(result.certificates).toHaveLength(3);
+    });
+
+    it('signs the new root with overridePreviousRoot when provided', async () => {
+      const certRequest = {
+        ...baseCertRequest,
+        overridePreviousRoot: 'Root_Certificate_other.pem',
+      } as GenerateCertificateChainRequest;
+
+      mockFileStorageGetFile
+        .mockResolvedValueOnce(Buffer.from('otherRootCertPem'))
+        .mockResolvedValueOnce(Buffer.from('otherRootKeyPem'));
+      mockCertificateReadOnlyOneByQuery.mockResolvedValue({
+        id: 88,
+        privateKeyFileId: 'Root_Key_other.pem',
+      });
+      mockGenerateCertificate
+        .mockReturnValueOnce(['newRootCertPem', 'newRootKeyPem'])
+        .mockReturnValueOnce(['newSubCACertPem', 'newSubCAKeyPem'])
+        .mockReturnValueOnce(['newLeafPem', 'newLeafKeyPem']);
+
+      const result = await service.generateStandaloneFullChain(tenantId, certRequest);
+
+      expect(mockFileStorageGetFile).toHaveBeenCalledWith('Root_Certificate_other.pem');
+      expect(mockGenerateCertificate).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ signedBy: 88 }),
+        logger,
+        'otherRootKeyPem',
+        'otherRootCertPem',
+      );
+      expect(result.certificates).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
⚠️ This branch is target to another feature branch, pls merge that one at first and then change the target branch in this PR.
### Context
Support for M05.FR.11. Add 2 new params in generate cert chain endpoint.
- signWithPreviousRoot (true by default)
- overridePreviousRoot (file path, should correspond to a different root certificate than the one currently being used--so that the next root can be signed by a different cert if needed)
### Changes
1. Fix the failure due to path validation when reading the initial certs
2. Extend generate cert chain endpoint with 2 new params
3. Add `_verifyAdditionalRootCertificateCheck` when `AdditionalRootCertificateCheck` is true which is to support M05.FR.11
## Tests
1. Generate and use new cert chain in server. Install the root on charger.  <img width="1199" height="58" alt="root_cert_details" src="https://github.com/user-attachments/assets/c5c15c6d-5c4c-4cd8-9529-24550fcb087e" />
2. Request will sign by previous root and restart service <img width="1275" height="677" alt="signed_by_previous" src="https://github.com/user-attachments/assets/41013275-9913-479f-b9ae-8fc498a651d0" />
3. Verified signed by via openssl <img width="897" height="101" alt="openssl_verify_signed" src="https://github.com/user-attachments/assets/725e0099-335f-44d3-96eb-68b558e32b8a" />
4. Generate standalone cert chain for later test steps <img width="1288" height="407" alt="generate_standalone_certs" src="https://github.com/user-attachments/assets/6947531f-472c-4f6e-9639-bef84c5d96de" />
5. Manually set `AdditionalRootCertificateCheck` to true in db
6. Install standalone root cert and expect fail <img width="1294" height="457" alt="addional_check_failed" src="https://github.com/user-attachments/assets/59aa4472-dbfa-4aa9-82a5-218e682f2ea3" />
7. Install the correct root signed by the previous root <img width="1289" height="388" alt="addional_check_successd" src="https://github.com/user-attachments/assets/63aaff82-7edb-482a-a059-ca0fd710e297" />
8. Override previous root by the standalone root using `overridePreviousRoot` <img width="1292" height="683" alt="override_root" src="https://github.com/user-attachments/assets/9f41b47e-760f-44f7-8b7b-fc3ad9081970" />
9. Verified signed by via openssl <img width="895" height="99" alt="overrid_openssl_verified_sign" src="https://github.com/user-attachments/assets/2b876a6b-ffe4-46bc-b5dd-bce29f582d11" />