### PR TITLE
feat(operator-ui): generic extension slot system

### DIFF
--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/page.tsx
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/page.tsx
@@ -4,11 +4,7 @@
 import { getExtension } from '@lib/server/extensions';
 import { ExtensionFrame } from '@lib/client/components/extension-frame/extension-frame';
 
-export default async function ExtensionPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
+export default async function ExtensionPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const extension = getExtension(id);
 

--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/page.tsx
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/page.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { getExtension } from '@lib/server/extensions';
+import { ExtensionFrame } from '@lib/client/components/extension-frame/extension-frame';
+
+export default async function ExtensionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const extension = getExtension(id);
+
+  if (!extension) {
+    return <div className="p-6">Unknown extension: {id}</div>;
+  }
+
+  const apiBase = `/extensions/${id}/proxy`;
+
+  return (
+    <ExtensionFrame
+      bundleUrl={`${apiBase}/extension-bundle.js`}
+      apiBase={apiBase}
+      title={extension.label}
+    />
+  );
+}

--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/[...path]/route.ts
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/[...path]/route.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { NextRequest } from 'next/server';
+import { proxyToExtension } from '@lib/server/extension-proxy';
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return proxyToExtension(req, id);
+}
+
+export {
+  handler as GET,
+  handler as POST,
+  handler as PUT,
+  handler as DELETE,
+  handler as PATCH,
+};

--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/[...path]/route.ts
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/[...path]/route.ts
@@ -4,18 +4,9 @@
 import type { NextRequest } from 'next/server';
 import { proxyToExtension } from '@lib/server/extension-proxy';
 
-async function handler(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+async function handler(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   return proxyToExtension(req, id);
 }
 
-export {
-  handler as GET,
-  handler as POST,
-  handler as PUT,
-  handler as DELETE,
-  handler as PATCH,
-};
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH };

--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/route.ts
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/route.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { NextRequest } from 'next/server';
+import { proxyToExtension } from '@lib/server/extension-proxy';
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  return proxyToExtension(req, id);
+}
+
+export {
+  handler as GET,
+  handler as POST,
+  handler as PUT,
+  handler as DELETE,
+  handler as PATCH,
+};

--- a/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/route.ts
+++ b/apps/operator-ui/src/app/(authenticated)/extensions/[id]/proxy/route.ts
@@ -4,18 +4,9 @@
 import type { NextRequest } from 'next/server';
 import { proxyToExtension } from '@lib/server/extension-proxy';
 
-async function handler(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
+async function handler(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   return proxyToExtension(req, id);
 }
 
-export {
-  handler as GET,
-  handler as POST,
-  handler as PUT,
-  handler as DELETE,
-  handler as PATCH,
-};
+export { handler as GET, handler as POST, handler as PUT, handler as DELETE, handler as PATCH };

--- a/apps/operator-ui/src/app/api/extensions/route.ts
+++ b/apps/operator-ui/src/app/api/extensions/route.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from 'next/server';
+import { getExtensions, toPublicExtension } from '@lib/server/extensions';
+
+export async function GET() {
+  return NextResponse.json(getExtensions().map(toPublicExtension));
+}

--- a/apps/operator-ui/src/app/api/extensions/token/route.ts
+++ b/apps/operator-ui/src/app/api/extensions/token/route.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { encode } from 'next-auth/jwt';
+import authOptions from '@app/api/auth/[...nextauth]/options';
+
+// Short-lived handoff token an embedded extension iframe can present to its
+// own backend (as `Authorization: Bearer <token>`) instead of relying on a
+// shared session cookie. Lets extensions live on a different origin than
+// Operator-UI without breaking single sign-on.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const maxAge = 5 * 60;
+  const token = await encode({
+    token: { email: session.user?.email || session.user?.name || 'operator', purpose: 'extension-handoff' },
+    secret: process.env.NEXTAUTH_SECRET as string,
+    maxAge,
+  });
+
+  return NextResponse.json({ token, expiresIn: maxAge });
+}

--- a/apps/operator-ui/src/app/api/extensions/token/route.ts
+++ b/apps/operator-ui/src/app/api/extensions/token/route.ts
@@ -18,7 +18,10 @@ export async function GET() {
 
   const maxAge = 5 * 60;
   const token = await encode({
-    token: { email: session.user?.email || session.user?.name || 'operator', purpose: 'extension-handoff' },
+    token: {
+      email: session.user?.email || session.user?.name || 'operator',
+      purpose: 'extension-handoff',
+    },
     secret: process.env.NEXTAUTH_SECRET as string,
     maxAge,
   });

--- a/apps/operator-ui/src/lib/client/components/extension-frame/extension-frame.tsx
+++ b/apps/operator-ui/src/lib/client/components/extension-frame/extension-frame.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use client';
+
+import { useEffect, useRef } from 'react';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+
+interface ExtensionMountProps {
+  bundleUrl: string; // e.g. /extensions/{id}/proxy/extension-bundle.js
+  apiBase: string; // e.g. /extensions/{id}/proxy
+  title: string;
+}
+
+// Loads the extension's UI bundle and mounts it directly into this page's
+// own React tree (same process, same DOM) — no iframe, no postMessage.
+// The extension bundle expects `window.React` / `window.ReactDOM` to be the
+// host's own instances, which we set below, so there is exactly one React
+// in the page and hooks/context behave normally.
+export const ExtensionFrame = ({
+  bundleUrl,
+  apiBase,
+  title,
+}: ExtensionMountProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unmount: (() => void) | undefined;
+
+    (window as any).React = React;
+    (window as any).ReactDOM = ReactDOM;
+
+    const getToken = async () => {
+      const res = await fetch('/api/extensions/token');
+      if (!res.ok) throw new Error('failed to obtain extension token');
+      const { token } = await res.json();
+      return token as string;
+    };
+
+    const script = document.createElement('script');
+    script.src = bundleUrl;
+    script.onload = () => {
+      if (cancelled || !containerRef.current) return;
+      const ext = (window as any).OpsToolsExtension;
+      if (ext?.mount) {
+        unmount = ext.mount(containerRef.current, { apiBase, getToken });
+      }
+    };
+    document.body.appendChild(script);
+
+    return () => {
+      cancelled = true;
+      unmount?.();
+      script.remove();
+    };
+  }, [bundleUrl, apiBase]);
+
+  return <div ref={containerRef} aria-label={title} className="p-6" />;
+};

--- a/apps/operator-ui/src/lib/client/components/extension-frame/extension-frame.tsx
+++ b/apps/operator-ui/src/lib/client/components/extension-frame/extension-frame.tsx
@@ -18,11 +18,7 @@ interface ExtensionMountProps {
 // The extension bundle expects `window.React` / `window.ReactDOM` to be the
 // host's own instances, which we set below, so there is exactly one React
 // in the page and hooks/context behave normally.
-export const ExtensionFrame = ({
-  bundleUrl,
-  apiBase,
-  title,
-}: ExtensionMountProps) => {
+export const ExtensionFrame = ({ bundleUrl, apiBase, title }: ExtensionMountProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/apps/operator-ui/src/lib/client/components/main-menu/main.menu.tsx
+++ b/apps/operator-ui/src/lib/client/components/main-menu/main.menu.tsx
@@ -14,8 +14,10 @@ import {
   HelpCircle,
   Home,
   MapPin,
+  Puzzle,
   Receipt,
   Users,
+  Wrench,
 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
@@ -26,6 +28,7 @@ import { LocaleSwitcher } from '@lib/client/components/locale-switcher';
 import { ConnectionModal } from '@lib/client/components/modals/shared/connection-modal/connection.modal';
 import { LogoutButton } from '@lib/client/components/logout-button';
 import { useTranslate } from '@refinedev/core';
+import type { PublicExtension } from '@lib/server/extensions';
 
 export enum MenuSection {
   OVERVIEW = 'overview',
@@ -47,11 +50,25 @@ interface MenuItem {
   icon: React.ReactNode;
 }
 
+// built-in icon names a manifest can reference; or set "icon" to an https:// image URL
+const extensionIconMap: Record<string, React.ReactNode> = {
+  Wrench: <Wrench className={sidebarIconSize} />,
+  Puzzle: <Puzzle className={sidebarIconSize} />,
+};
+
 export const MainMenu = ({ activeSection }: MainMenuProps) => {
   const [collapsed, setCollapsed] = useState(true);
   const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const [extensions, setExtensions] = useState<PublicExtension[]>([]);
   const menuRef = useRef<HTMLElement>(null);
   const translate = useTranslate();
+
+  useEffect(() => {
+    fetch('/api/extensions')
+      .then((res) => res.json())
+      .then(setExtensions)
+      .catch(() => setExtensions([]));
+  }, []);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -99,6 +116,17 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
       label: translate('TenantPartners.TenantPartners'),
       icon: <Users className={sidebarIconSize} />,
     },
+    // public/extensions/*.json drives this loop; add or remove a manifest file there
+    ...extensions.map((ext) => ({
+      key: `/extensions/${ext.id}`,
+      label: ext.label,
+      icon: ext.icon.startsWith('http') ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={ext.icon} alt="" className={sidebarIconSize} />
+      ) : (
+        (extensionIconMap[ext.icon] ?? <Puzzle className={sidebarIconSize} />)
+      ),
+    })),
   ];
 
   return (
@@ -119,7 +147,7 @@ export const MainMenu = ({ activeSection }: MainMenuProps) => {
         <nav className="flex-1 overflow-y-auto py-2">
           <ul className="space-y-1 px-3">
             {mainMenuItems.map((item) => {
-              const isActive = `/${activeSection}` === item.key;
+              const isActive = item.key.split('/')[1] === activeSection;
               return (
                 <li key={item.key}>
                   <Link

--- a/apps/operator-ui/src/lib/server/extension-proxy.ts
+++ b/apps/operator-ui/src/lib/server/extension-proxy.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest, NextResponse } from 'next/server';
+import { getExtension } from '@lib/server/extensions';
+
+// Forwards the request to the extension's internalUrl, preserving the full
+// original path (including the /extensions/{id}/proxy prefix) because the
+// extension app is itself configured with a matching basePath and expects
+// to see — and strip — that same prefix.
+export async function proxyToExtension(req: NextRequest, id: string) {
+  const extension = getExtension(id);
+  if (!extension) {
+    return NextResponse.json({ error: 'unknown extension' }, { status: 404 });
+  }
+
+  const targetUrl = `${extension.internalUrl}${req.nextUrl.pathname}${req.nextUrl.search}`;
+
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+
+  const hasBody = !['GET', 'HEAD'].includes(req.method);
+
+  const upstream = await fetch(targetUrl, {
+    method: req.method,
+    headers,
+    body: hasBody ? await req.arrayBuffer() : undefined,
+    redirect: 'manual',
+  });
+
+  const responseHeaders = new Headers(upstream.headers);
+  responseHeaders.delete('content-encoding');
+  responseHeaders.delete('content-length');
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}

--- a/apps/operator-ui/src/lib/server/extensions.ts
+++ b/apps/operator-ui/src/lib/server/extensions.ts
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import fs from 'fs';
+import path from 'path';
+
+export interface ExtensionDefinition {
+  id: string;
+  label: string;
+  icon: string; // lucide icon name, or an https:// URL to an image
+  internalUrl: string; // server-only: where Operator-UI proxies this extension's traffic to
+}
+
+export interface PublicExtension {
+  id: string;
+  label: string;
+  icon: string;
+}
+
+// Drop or remove a *.json file here to install/uninstall an extension.
+// No code change, rebuild, or infra/Cloudflare change required; this
+// directory is read on every request, and Operator-UI proxies to
+// `internalUrl` itself, so extensions never need their own public route.
+const EXTENSIONS_DIR = path.join(process.cwd(), 'public', 'extensions');
+
+export function getExtensions(): ExtensionDefinition[] {
+  if (!fs.existsSync(EXTENSIONS_DIR)) return [];
+  return fs
+    .readdirSync(EXTENSIONS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => {
+      const raw = fs.readFileSync(path.join(EXTENSIONS_DIR, f), 'utf-8');
+      return JSON.parse(raw) as ExtensionDefinition;
+    });
+}
+
+export function getExtension(id: string): ExtensionDefinition | undefined {
+  return getExtensions().find((e) => e.id === id);
+}
+
+// internalUrl is server-only; never send it to the browser.
+export function toPublicExtension(e: ExtensionDefinition): PublicExtension {
+  return { id: e.id, label: e.label, icon: e.icon };
+}


### PR DESCRIPTION
## Summary
- Adds a plugin-style mechanism for embedding operator-facing tools inside Operator-UI without editing its code per tool.
- Extensions are declared via `public/extensions/*.json` manifests (`{id, label, icon, internalUrl}`); installing/removing one is just adding/removing a file.
- `/api/extensions` exposes a public-safe list (internalUrl is stripped server-side) that the sidebar renders automatically via a generic loop.
- `/extensions/[id]` dynamically loads the extension's UI bundle and mounts it directly into the page's own React tree (no iframe).
- `/extensions/[id]/proxy/*` is a same-origin reverse proxy to the extension's backend, so extensions never need their own public route or reverse-proxy config.
- `/api/extensions/token` mints a short-lived signed token (reusing `NEXTAUTH_SECRET`) so an extension can call its own API without a separate login screen.

## Scope
This PR only contains the generic mechanism. No specific extension manifest is included.

## Test plan
- [ ] `pnpm --filter @citrineos/operator-ui build`
- [ ] Manually verify existing pages/navigation are unaffected
- [ ] Drop a sample `public/extensions/*.json` manifest and confirm a sidebar item + `/extensions/{id}` route appear with no other code changes
