### PR TITLE
[UI] Fix: 1.6 configuration table and 2.0.1 download csv

### DIFF
--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.configuration.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.configuration.tsx
@@ -137,12 +137,12 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
   const configFilters = useMemo<CrudFilter[]>(
     () => [
       {
-        field: 'id',
+        field: 'ocppConnectionName',
         operator: 'eq',
-        value: station?.id ?? -1,
+        value: station?.ocppConnectionName ?? '',
       },
     ],
-    [station?.id],
+    [station?.ocppConnectionName],
   );
 
   const {
@@ -185,7 +185,7 @@ export const ChargingStationConfiguration: React.FC<ChargingStationConfiguration
     resource: 'VariableAttributes',
     meta: {
       gqlQuery: VARIABLE_ATTRIBUTE_DOWNLOAD_QUERY,
-      gqlVariables: { id },
+      gqlVariables: { stationId: id },
     },
     pagination: {
       mode: 'off',

--- a/apps/operator-ui/src/lib/queries/variable.attributes.ts
+++ b/apps/operator-ui/src/lib/queries/variable.attributes.ts
@@ -51,10 +51,7 @@ export const VARIABLE_ATTRIBUTE_LIST_QUERY = gql`
 
 export const VARIABLE_ATTRIBUTE_DOWNLOAD_QUERY = gql`
   query DownloadVariableAttributes($stationId: Int!) {
-    VariableAttributes(
-      where: { stationId: { _eq: $stationId } }
-      order_by: { createdAt: desc }
-    ) {
+    VariableAttributes(where: { stationId: { _eq: $stationId } }, order_by: { createdAt: desc }) {
       id
       ocppConnectionName
       type

--- a/apps/operator-ui/src/lib/queries/variable.attributes.ts
+++ b/apps/operator-ui/src/lib/queries/variable.attributes.ts
@@ -50,8 +50,11 @@ export const VARIABLE_ATTRIBUTE_LIST_QUERY = gql`
 `;
 
 export const VARIABLE_ATTRIBUTE_DOWNLOAD_QUERY = gql`
-  query DownloadVariableAttributes($id: Int!) {
-    VariableAttributes(where: { id: { _eq: $id } }, order_by: { createdAt: desc }) {
+  query DownloadVariableAttributes($stationId: Int!) {
+    VariableAttributes(
+      where: { stationId: { _eq: $stationId } }
+      order_by: { createdAt: desc }
+    ) {
       id
       ocppConnectionName
       type
@@ -81,7 +84,7 @@ export const VARIABLE_ATTRIBUTE_DOWNLOAD_QUERY = gql`
         updatedAt
       }
     }
-    VariableAttributes_aggregate(where: { id: { _eq: $id } }) {
+    VariableAttributes_aggregate(where: { stationId: { _eq: $stationId } }) {
       aggregate {
         count
       }


### PR DESCRIPTION
### Problem
1. In charging station details page, the configuration table for 1.6 stations is always empty
2. In charging station details page, download csv for 2.0.1 only down 1 variable

### Changes
Update the col names in the queries.

### Tests
1. 1.6 configuration table <img width="1567" height="328" alt="Screenshot 2026-07-27 at 10 04 49 AM" src="https://github.com/user-attachments/assets/af47bc1b-7adf-4c3e-890f-22cc9d80c2bc" />
2. 2.0.1 csv file
   <img width="479" height="175" alt="Screenshot 2026-07-27 at 10 04 37 AM" src="https://github.com/user-attachments/assets/d9c85477-8199-4447-884e-91821730ca53" />