### PR TITLE
fix(Reporting): handle optional GetMonitoringReport filters and return a confirmation array

### DIFF
--- a/packages/core/src/modules/Reporting/src/module/2/MessageApi.ts
+++ b/packages/core/src/modules/Reporting/src/module/2/MessageApi.ts
@@ -108,8 +108,9 @@ export class ReportingOcpp2Api
       return { success: false, payload: errorMsg };
     }
 
-    const componentVariables =
-      request.componentVariable as OCPP2_common_types.ComponentVariableType[];
+    // componentVariable is optional in GetReportRequest.
+    const componentVariables = (request.componentVariable ??
+      []) as OCPP2_common_types.ComponentVariableType[];
 
     if (componentVariables.length === 0) {
       // Send everything in one call
@@ -174,19 +175,23 @@ export class ReportingOcpp2Api
     ),
   )
   async getMonitoringReport(
-    identifier: string,
+    identifier: string[],
     request: OCPP2_request_types.GetMonitoringReportRequest,
     callbackUrl?: string,
     tenantId: number = DEFAULT_TENANT_ID,
     version: OCPPVersion = DEFAULT_VERSION,
-  ): Promise<IMessageConfirmation> {
-    // If monitoringCriteria & componentVariable are both empty, just call once
-    const componentVariable =
-      request.componentVariable as OCPP2_common_types.ComponentVariableType[];
-    const monitoringCriteria = request.monitoringCriteria as MonitoringCriterionEnumType[];
+  ): Promise<IMessageConfirmation[]> {
+    // componentVariable and monitoringCriteria are both optional in
+    // GetMonitoringReportRequest, so default them before reading .length.
+    const componentVariable = (request.componentVariable ??
+      []) as OCPP2_common_types.ComponentVariableType[];
+    const monitoringCriteria = (request.monitoringCriteria ?? []) as MonitoringCriterionEnumType[];
 
-    if (componentVariable.length === 0 && monitoringCriteria.length === 0) {
-      return await this._module.sendCall(
+    // Batching only splits componentVariable, so without it there is nothing to
+    // split - send the request as-is (no filters, or monitoringCriteria only).
+    if (componentVariable.length === 0) {
+      return packageGroupCall(
+        this._module,
         identifier,
         tenantId,
         version,
@@ -196,49 +201,49 @@ export class ReportingOcpp2Api
       );
     }
 
-    // Otherwise, do batching if needed
-    let itemsPerMessageGetReport =
-      await this._module._deviceModelService.getItemsPerMessageByComponentAndVariableInstanceAndStationId(
-        this._componentDeviceDataCtrlr,
-        OCPP_CallAction.GetReport,
-        tenantId,
-        identifier,
-      );
-    itemsPerMessageGetReport =
-      itemsPerMessageGetReport === null ? componentVariable.length : itemsPerMessageGetReport;
-
-    const confirmations = [];
-    for (const [index, batch] of getBatches(
-      componentVariable,
-      itemsPerMessageGetReport,
-    ).entries()) {
-      try {
-        const batchResult = await this._module.sendCall(
-          identifier,
+    const confirmations: IMessageConfirmation[] = [];
+    for (const ocppConnectionName of identifier) {
+      // Otherwise, do batching if needed
+      let itemsPerMessageGetReport =
+        await this._module._deviceModelService.getItemsPerMessageByComponentAndVariableInstanceAndStationId(
+          this._componentDeviceDataCtrlr,
+          OCPP_CallAction.GetReport,
           tenantId,
-          version,
-          OCPP_CallAction.GetMonitoringReport,
-          {
-            ...request,
-            componentVariable: batch,
-          } as OCPP2_request_types.GetMonitoringReportRequest,
-          callbackUrl,
+          ocppConnectionName,
         );
-        confirmations.push({
-          success: batchResult.success,
-          batch: `[${index}:${index + batch.length}]`,
-          message: `${batchResult.payload}`,
-        });
-      } catch (error) {
-        confirmations.push({
-          success: false,
-          batch: `[${index}:${index + batch.length}]`,
-          message: `${error}`,
-        });
+      itemsPerMessageGetReport =
+        itemsPerMessageGetReport === null ? componentVariable.length : itemsPerMessageGetReport;
+
+      for (const [index, batch] of getBatches(
+        componentVariable,
+        itemsPerMessageGetReport,
+      ).entries()) {
+        try {
+          const batchResult = await this._module.sendCall(
+            ocppConnectionName,
+            tenantId,
+            version,
+            OCPP_CallAction.GetMonitoringReport,
+            {
+              ...request,
+              componentVariable: batch,
+            } as OCPP2_request_types.GetMonitoringReportRequest,
+            callbackUrl,
+          );
+          confirmations.push({
+            success: batchResult.success,
+            payload: `${ocppConnectionName} batch [${index}:${index + batch.length}]: ${batchResult.payload}`,
+          });
+        } catch (error) {
+          confirmations.push({
+            success: false,
+            payload: `${ocppConnectionName} batch [${index}:${index + batch.length}]: ${error}`,
+          });
+        }
       }
     }
 
-    return { success: true, payload: confirmations };
+    return confirmations;
   }
 
   @AsMessageEndpoint(OCPP_CallAction.GetLog, (_instance: ReportingOcpp2Api, version) =>


### PR DESCRIPTION
## Summary

`GetMonitoringReport` cannot be sent to a charging station at all — it fails with HTTP 500 both with and without its optional filters, for two independent reasons.

**1. The optional filters are read without defaulting.** Both `componentVariable` and `monitoringCriteria` are optional in `GetMonitoringReportRequest`, but the handler asserts them into arrays and immediately reads `.length`:

```ts
const componentVariable =
  request.componentVariable as OCPP2_common_types.ComponentVariableType[];
const monitoringCriteria = request.monitoringCriteria as MonitoringCriterionEnumType[];

if (componentVariable.length === 0 && monitoringCriteria.length === 0) {
```

The `as` assertion only satisfies the compiler; at runtime the value is `undefined`, so a request omitting either field throws `Cannot read properties of undefined (reading 'length')`.

**2. The endpoint does not follow the message-route contract.** `AbstractModuleApi` passes identifiers as an array and declares a `MessageConfirmationSchemaArray` response:

```ts
const _handler = async (request): Promise<IMessageConfirmation[]> => {
  const identifiers = Array.isArray(identifier) ? identifier : [identifier];
  return method.call(this, identifiers, ...);
};
```

but `getMonitoringReport` still takes `identifier: string` and returns a single `IMessageConfirmation`, so any request that does reach the batching path fails serialization with `The value of 'MessageConfirmationSchemaArray#' does not match schema definition`. `getBaseReport`, `getLog` and `customerInformation` in the same file already use the array contract; this endpoint was not migrated with them.

There is a knock-on effect worth noting: `sendCall` registers the call in the station's in-flight cache *before* the handler throws, and CitrineOS permits only one outstanding call per station (`existsAnyInNamespace`, TTL `maxCallLengthSeconds`). The crashed call keeps that slot until the TTL expires, so unrelated commands issued in the meantime pile into the `Call already in progress` retry path and are dropped while the REST layer still reports `success: true`.

## Change

- Default `componentVariable` and `monitoringCriteria` to `[]` before use.
- Move `getMonitoringReport` to the array contract (`identifier: string[]` → `Promise<IMessageConfirmation[]>`), batching per station.
- Send through `packageGroupCall` when there is no `componentVariable` to split — this also covers the previously broken "monitoringCriteria only" case, which fell into the batching path with nothing to batch and so sent no request at all.
- Emit `payload` as a string, matching `MessageConfirmationSchema` (`payload` is typed `string`; the previous object form serialized to `[object Object]`).
- `getCustomReport` has the identical unguarded read on `componentVariable` and is defaulted the same way. Its batching return shape has the same array-contract mismatch, but that path is not covered by the testing below so it is left unchanged here.

## Testing

Verified end-to-end against an EVerest charging station (rev2 hardware, OCPP 2.0.1, negotiated by CitrineOS as `ocpp2.1`), CitrineOS built from this branch:

| Request | Before | After |
| --- | --- | --- |
| `{"requestId":9930}` (no optional fields) | HTTP 500 `Cannot read properties of undefined (reading 'length')` | `[{"success":true}]`, station replies `GetMonitoringReportResponse {"status":"Accepted"}` |
| `monitoringCriteria` + `componentVariable` | HTTP 500 `MessageConfirmationSchemaArray#` mismatch | `[{"success":true,"payload":"<station> batch [0:1]: ..."}]`, station replies `Accepted` |

In both cases the station now receives the call — confirmed in its OCPP message log — and the follow-up `NotifyMonitoringReport` arrives correctly filtered to the requested variable (`monitor id=1, Periodic, 45.0, severity 7`). Before the change no `GetMonitoringReport` ever reached the station.

`tsc --noEmit` over `packages/core` reports the same 309 pre-existing errors before and after this change (the only differences are line-number shifts in the edited file); no new errors are introduced.
