### PR TITLE
fix(Monitoring): stop rejecting NotifyEvent when a station reuses eventId after reboot

### DIFF
--- a/apps/ocpp-server/migrations/20260729000000-drop-eventdata-eventid-unique-constraint.ts
+++ b/apps/ocpp-server/migrations/20260729000000-drop-eventdata-eventid-unique-constraint.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+const TABLE_NAME = 'EventData';
+const CONSTRAINT_NAME = 'EventData_stationName_tenantId_eventId';
+const INDEX_NAME = 'event_data_stationName_tenantId_eventId';
+const COLUMNS = '"ocppConnectionName", "tenantId", "eventId"';
+
+const constraintExists = async (queryInterface: QueryInterface): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name: CONSTRAINT_NAME }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  // eventId is not unique per charging station over time: it is assigned by the
+  // station and restarts from zero whenever the station reboots, so ids are
+  // reused and collide with rows stored before the reboot. Keep the lookup
+  // index, drop the uniqueness.
+  up: async (queryInterface: QueryInterface) => {
+    if (await constraintExists(queryInterface)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+
+    await queryInterface.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "${INDEX_NAME}" ON "${TABLE_NAME}" (${COLUMNS})`,
+      { type: QueryTypes.RAW },
+    );
+  },
+
+  // Restoring uniqueness fails if duplicate (station, tenant, eventId) rows have
+  // accumulated; de-duplicate EventData before rolling back.
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${INDEX_NAME}"`, {
+      type: QueryTypes.RAW,
+    });
+
+    if (!(await constraintExists(queryInterface))) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}" UNIQUE (${COLUMNS})`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+};

--- a/packages/core/src/dal/layers/sequelize/model/VariableMonitoring/EventData.ts
+++ b/packages/core/src/dal/layers/sequelize/model/VariableMonitoring/EventData.ts
@@ -39,16 +39,12 @@ export class EventData extends Model implements EventDataDto {
   declare stationId?: number;
 
   @Index
-  @Column({
-    type: DataType.STRING,
-    unique: 'stationName_tenantId_eventId',
-  })
+  @Column(DataType.STRING)
   declare ocppConnectionName: string;
 
-  @Column({
-    type: DataType.INTEGER,
-    unique: 'stationName_eventId',
-  })
+  // Not unique per station: eventId is assigned by the charging station and
+  // restarts from zero on reboot, so ids are reused across boots.
+  @Column(DataType.INTEGER)
   declare eventId: number;
 
   @Column(DataType.STRING)
@@ -120,7 +116,6 @@ export class EventData extends Model implements EventDataDto {
     allowNull: false,
     onUpdate: 'CASCADE',
     onDelete: 'RESTRICT',
-    unique: 'stationName_tenantId_eventId',
   })
   declare tenantId: number;
 


### PR DESCRIPTION
## Summary

`EventData` carries a unique constraint on `(ocppConnectionName, tenantId, eventId)`:

```sql
ALTER TABLE "EventData" ADD CONSTRAINT "EventData_stationId_tenantId_eventId"
  UNIQUE ("stationId", "tenantId", "eventId")
```

added in `20260330100000-add-charging-station-pk-id.ts` and renamed to `EventData_stationName_tenantId_eventId` in `20260427000000-rename-charging-station-columns.ts`, and mirrored by `unique:` options on the `EventData` model.

That treats `eventId` as unique for a station over all time, but `eventId` is assigned by the *charging station*, and OCPP 2.0.1 does not require it to be globally unique — it identifies an event within a report so that `cause` can reference another event. Implementations commonly derive it from an in-memory counter, so it restarts at zero whenever the station reboots. libocpp, for example, initialises `unique_id(0)` in the monitoring updater and never persists it.

When a station reboots and replays low ids, the insert in `_handleNotifyEvent` raises `SequelizeUniqueConstraintError` and the handler answers the station with a CALLERROR:

```
InternalError: Failed handling message: Validation error
duplicate key value violates unique constraint "EventData_stationName_tenantId_eventId"
```

The failure mode is easy to miss because it is not permanent: events are rejected after each reboot only until the station's counter climbs back past the highest `eventId` already stored for it, after which ingestion silently resumes. In between, monitoring events are lost with no record beyond the CALLERROR.

## Change

- Migration dropping the unique constraint and creating a non-unique index on the same three columns, so lookups by station/tenant keep their index.
- Remove the corresponding `unique:` options from the `EventData` model so `sync` does not recreate the constraint.

Nothing reads `EventData` by `eventId` — the only access path is `createEventDatumByComponentIdAndVariableIdAndStationId`, which inserts — and each row is already identified by its own `id` primary key, so removing uniqueness does not make any existing query ambiguous. Rows continue to be distinguished by `id`, and are queried by station, component, variable, `variableMonitoringId` and `timestamp`.

The `down` migration restores the constraint, and will fail if duplicate rows have accumulated by then; the migration notes that the table must be de-duplicated first.

## Testing

Verified against an EVerest charging station (rev2 hardware, OCPP 2.0.1, negotiated by CitrineOS as `ocpp2.1`) with a periodic variable monitor active, CitrineOS built from this branch.

Reproduction, before the change: with 84 rows already stored for the station (`eventId` 0–83), restarting the station reset its counter to zero. Every subsequent `NotifyEvent` was answered with `InternalError: Failed handling message: Validation error`, and none were persisted.

After the change, the same scenario — 84 rows present, station restarted so it re-sent `eventId` 0 — stored the event normally:

| | Before | After |
| --- | --- | --- |
| `NotifyEvent` with a replayed `eventId` | CALLERROR `InternalError`, row dropped | `NotifyEventResponse`, row stored |
| Unique-constraint errors in the log | one per event | none |

The duplicate `eventId` values coexist as separate rows distinguished by `id`, e.g. `id=1, 13, 237` all with `eventId=0`.

`tsc --noEmit` over `packages/core` reports the same 309 pre-existing errors before and after this change; no new errors are introduced.
