### PR TITLE
fix(Reporting,Configuration): correlate NotifyCustomerInformation and NotifyDisplayMessages by requestId

### DIFF
--- a/packages/core/src/modules/Configuration/src/module/module.ts
+++ b/packages/core/src/modules/Configuration/src/module/module.ts
@@ -59,6 +59,7 @@ import {
   ServerNetworkProfile,
   SetNetworkProfile,
 } from '@dal/layers/sequelize/index.js';
+import { literal, Op } from 'sequelize';
 import { IdGenerator, validateMessageContentType } from '@util/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -439,7 +440,10 @@ export class ConfigurationModule extends AbstractModule {
     message: IMessage<OCPP2_request_types.NotifyDisplayMessagesRequest>,
     props?: HandlerProperties,
   ): Promise<void> {
-    // Validate requestId was provided in a previous GetDisplayMessagesRequest
+    // Validate requestId was provided in a previous GetDisplayMessagesRequest.
+    // OCPPMessages.message holds the raw OCPP frame [messageTypeId, correlationId,
+    // action, payload], so the requestId lives under element 3 of a Call (type 2)
+    // rather than at the top level.
     const requestId = message.payload.requestId;
     const previousRequest = await this._ocppMessageRepository.readAllByQuery(
       message.context.tenantId,
@@ -448,10 +452,9 @@ export class ConfigurationModule extends AbstractModule {
           tenantId: message.context.tenantId,
           ocppConnectionName: message.context.ocppConnectionName,
           action: OCPP_CallAction.GetDisplayMessages,
-          message: {
-            requestId: requestId,
-          },
+          [Op.and]: literal(`"message"->>0 = '2' AND "message"->3->>'requestId' = :requestId`),
         },
+        replacements: { requestId: String(requestId) },
         limit: 1,
       },
       Namespace.OCPPMessage,

--- a/packages/core/src/modules/Reporting/src/module/module.ts
+++ b/packages/core/src/modules/Reporting/src/module/module.ts
@@ -35,6 +35,7 @@ import type {
   IVariableMonitoringRepository,
 } from '@dal/interfaces/repositories.js';
 import { Component, Variable } from '@dal/layers/sequelize/model/DeviceModel/index.js';
+import { literal, Op } from 'sequelize';
 import { isForeignKeyConstraintError } from '@util/errors.js';
 
 import type { DeviceModelService } from './services.js';
@@ -148,7 +149,10 @@ export class ReportingModule extends AbstractModule {
   ): Promise<void> {
     this._logger.debug('NotifyCustomerInformation request received:', message, props);
 
-    // Validate requestId was provided in a previous CustomerInformationRequest
+    // Validate requestId was provided in a previous CustomerInformationRequest.
+    // OCPPMessages.message holds the raw OCPP frame [messageTypeId, correlationId,
+    // action, payload], so the requestId lives under element 3 of a Call (type 2)
+    // rather than at the top level.
     const requestId = message.payload.requestId;
     const previousRequest = await this._ocppMessageRepository.readAllByQuery(
       message.context.tenantId,
@@ -157,10 +161,9 @@ export class ReportingModule extends AbstractModule {
           tenantId: message.context.tenantId,
           ocppConnectionName: message.context.ocppConnectionName,
           action: OCPP_CallAction.CustomerInformation,
-          message: {
-            requestId: requestId,
-          },
+          [Op.and]: literal(`"message"->>0 = '2' AND "message"->3->>'requestId' = :requestId`),
         },
+        replacements: { requestId: String(requestId) },
         limit: 1,
       },
       Namespace.OCPPMessage,


### PR DESCRIPTION
## Summary

`NotifyCustomerInformation` (Reporting) and `NotifyDisplayMessages` (Configuration) are always answered with a CALLERROR, even when the charging station echoes back exactly the `requestId` the CSMS sent:

```
PropertyConstraintViolation: RequestId was not provided in a CustomerInformationRequest.
```

Both handlers validate the notification by looking for the originating request:

```ts
where: {
  tenantId: message.context.tenantId,
  ocppConnectionName: message.context.ocppConnectionName,
  action: OCPP_CallAction.CustomerInformation,
  message: {
    requestId: requestId,
  },
},
```

This expects `OCPPMessages.message` to be an object with a top-level `requestId`. It is not — it stores the raw OCPP frame, an array of `[messageTypeId, correlationId, action, payload]`:

```json
[2, "4c5492c0-4f68-4e47-8868-4db180980150", "CustomerInformation",
 {"clear": false, "report": true, "requestId": 9940, "customerIdentifier": "..."}]
```

A JSONB object match against an array can never match, so the lookup always returns empty and the handler always takes the error branch. This is unconditional: no `NotifyCustomerInformation` or `NotifyDisplayMessages` can ever be accepted.

## Change

Match `requestId` where it actually lives — inside the payload at element 3 of a Call frame:

```ts
[Op.and]: literal(`"message"->>0 = '2' AND "message"->3->>'requestId' = :requestId`),
...
replacements: { requestId: String(requestId) },
```

- `"message"->>0 = '2'` restricts the match to Call frames. Both the request and its CallResult are stored under the same `action`, and the CallResult has no payload at element 3, so this keeps the response row from being considered.
- `requestId` is passed via `replacements` rather than interpolated.
- The comparison is done as text rather than casting to `int`, so a non-numeric value in some other row cannot raise a cast error during the scan.

## Testing

Verified against an EVerest charging station (rev2 hardware, OCPP 2.0.1, negotiated by CitrineOS as `ocpp2.1`), CitrineOS built from this branch. `CustomerInformation` was sent with `requestId: 9950`; the station replied with `NotifyCustomerInformation` carrying the same `requestId`.

| | Before | After |
| --- | --- | --- |
| CSMS reply to `NotifyCustomerInformation` | `CALLERROR PropertyConstraintViolation` | `NotifyCustomerInformationResponse` (`[3, "<id>", {}]`) |

Exercised across all three request variants (`customerIdentifier` with `report`, `customerIdentifier` with `clear`, and `idToken` with `report`); each produced a `NotifyCustomerInformation` that is now accepted.

`NotifyDisplayMessages` carries the identical defect and the identical fix, but I could not exercise it end-to-end: the station under test does not implement the DisplayMessage functional block, so it answers `GetDisplayMessages` with `NotImplemented` and never emits `NotifyDisplayMessages`. That half is by code inspection only.

`tsc --noEmit` over `packages/core` reports the same 309 pre-existing errors before and after this change (the differences are line-number shifts in the two edited files); no new errors are introduced.
