### PR TITLE
fix flaky e2e tests + parallel chromium lane

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -156,6 +156,7 @@ jobs:
         env:
           CI: 'true'
           NODE_OPTIONS: '--max_old_space_size=4096'
+          E2E_SKIP_BUILD: '1'
           NEXT_PUBLIC_ADMIN_EMAIL: admin@citrineos.com
           ADMIN_PASSWORD: CitrineOS!
           NEXTAUTH_URL: http://localhost:3000
@@ -306,6 +307,7 @@ jobs:
         env:
           CI: 'true'
           NODE_OPTIONS: '--max_old_space_size=4096'
+          E2E_SKIP_BUILD: '1'
           NEXT_PUBLIC_ADMIN_EMAIL: admin@citrineos.com
           ADMIN_PASSWORD: CitrineOS!
           NEXTAUTH_URL: http://localhost:3000

--- a/apps/operator-ui/playwright.config.ts
+++ b/apps/operator-ui/playwright.config.ts
@@ -43,7 +43,11 @@ export default defineConfig({
   globalTeardown: './tests/e2e/auth/global-teardown.ts',
 
   expect: {
-    timeout: 10_000,
+    // Default for every assertion that doesn't pass its own timeout. Most of
+    // the suite asserts on query-bound UI (Refine + Hasura round trips), and
+    // under CI load 10s was regularly too tight — genuinely slow spots get an
+    // explicit 60s at the call site instead.
+    timeout: 30_000,
   },
 
   use: {

--- a/apps/operator-ui/playwright.config.ts
+++ b/apps/operator-ui/playwright.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
+  // A retry-rescued test still fails the job on CI. Green-with-a-flaky-
+  // annotation is how E2E-071 stayed invisible for weeks — the retry remains
+  // as diagnostics (trace/video of both attempts), not as absolution.
+  failOnFlakyTests: isCI,
   // CI runs a production `next start` (managed-server), so the old dev-mode
   // recompile-loop hazard doesn't apply there — 3 workers share the 4-vCPU
   // runner with the docker stack. Local default stays 1: `next dev` compiles

--- a/apps/operator-ui/playwright.config.ts
+++ b/apps/operator-ui/playwright.config.ts
@@ -22,15 +22,16 @@ export default defineConfig({
   testDir: './tests/e2e/specs',
   outputDir: './test-results',
 
-  fullyParallel: true,
+  // File-level parallelism: tests within a file stay sequential, so
+  // same-file tests can never race each other's rows.
+  fullyParallel: false,
   forbidOnly: isCI,
   retries: isCI ? 1 : 0,
-  // workers=1 because the Next.js dev server serves all routes through a
-  // single compiler instance; under workers > 1 the parametric harness
-  // intermittently leaves Refine `useOne(ChargingStations_by_pk)` queries
-  // hanging while the dev server is stuck in a re-compile loop. Sequential
-  // route compilation eliminates the flake at the cost of wall-clock time.
-  workers: 1,
+  // CI runs a production `next start` (managed-server), so the old dev-mode
+  // recompile-loop hazard doesn't apply there — 3 workers share the 4-vCPU
+  // runner with the docker stack. Local default stays 1: `next dev` compiles
+  // routes on demand and does not take concurrency well.
+  workers: process.env.E2E_WORKERS ? Number(process.env.E2E_WORKERS) : isCI ? 3 : 1,
 
   // 150s default test timeout: expectLoaded budgets up to 90s for cold-route
   // Next.js compilation + the useOne(ChargingStation) query under heavy
@@ -56,7 +57,9 @@ export default defineConfig({
     navigationTimeout: 30_000,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // retain-on-failure records every test and discards on pass — several
+    // concurrent encoders don't fit the runner alongside the stack.
+    video: 'on-first-retry',
     locale: 'en-US',
     timezoneId: 'UTC',
     viewport: { width: 1440, height: 900 },

--- a/apps/operator-ui/playwright.config.ts
+++ b/apps/operator-ui/playwright.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
 import dotenv from 'dotenv';
 import { resolve } from 'node:path';
 
-dotenv.config({ path: resolve(__dirname, '.env.test'), override: true });
+dotenv.config({ path: resolve(__dirname, '.env.test') });
 
 const baseURL = process.env.E2E_BASE_URL ?? 'http://localhost:3000';
 const isCI = !!process.env.CI;

--- a/apps/operator-ui/src/lib/client/pages/locations/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/locations/columns.tsx
@@ -203,7 +203,7 @@ export const getLocationFilters = (
       },
       {
         ChargingStations: {
-          [ChargingStationProps.id]: {
+          [ChargingStationProps.ocppConnectionName]: {
             _ilike: filterValue,
           },
         },
@@ -215,7 +215,7 @@ export const getLocationFilters = (
   const chargingStationsFilter = {
     _or: [
       {
-        [ChargingStationProps.id]: {
+        [ChargingStationProps.ocppConnectionName]: {
           _ilike: filterValue,
         },
       },

--- a/apps/operator-ui/tests/e2e/auth/admin.setup.ts
+++ b/apps/operator-ui/tests/e2e/auth/admin.setup.ts
@@ -39,5 +39,21 @@ setup('authenticate as admin and persist storage state', async ({ page }) => {
     'NextAuth session cookie should be set after login',
   ).toBe(true);
 
-  await page.context().storageState({ path: ADMIN_STORAGE_STATE });
+  // The first-login effect writes `firstLoginHelp:1` when it shows the
+  // welcome modal (identity id is always '1' under the generic auth
+  // provider). Both the flag and the dismissal must be in the captured
+  // state: a snapshot taken before the effect fires would put the modal
+  // overlay in front of every test that loads it. expectLoaded() may have
+  // won its race against the dialog, so give the late mount a real window.
+  await page.waitForFunction(() => localStorage.getItem('firstLoginHelp:1') !== null, undefined, {
+    timeout: 30_000,
+  });
+  await overview.dismissWelcomeIfPresent(10_000);
+
+  const state = await page.context().storageState({ path: ADMIN_STORAGE_STATE });
+  const origin = state.origins.find((o) => o.origin.includes('localhost'));
+  expect(
+    origin?.localStorage.some((entry) => entry.name === 'firstLoginHelp:1'),
+    'captured storage state must contain the dismissed-welcome flag',
+  ).toBe(true);
 });

--- a/apps/operator-ui/tests/e2e/auth/admin.setup.ts
+++ b/apps/operator-ui/tests/e2e/auth/admin.setup.ts
@@ -50,10 +50,24 @@ setup('authenticate as admin and persist storage state', async ({ page }) => {
   });
   await overview.dismissWelcomeIfPresent(10_000);
 
+  // Pin the locale so every English-text locator stays valid even if the
+  // app ever grows an Accept-Language fallback.
+  await page.context().addCookies([
+    {
+      name: 'NEXT_LOCALE',
+      value: 'en',
+      url: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
+    },
+  ]);
+
   const state = await page.context().storageState({ path: ADMIN_STORAGE_STATE });
   const origin = state.origins.find((o) => o.origin.includes('localhost'));
   expect(
     origin?.localStorage.some((entry) => entry.name === 'firstLoginHelp:1'),
     'captured storage state must contain the dismissed-welcome flag',
+  ).toBe(true);
+  expect(
+    state.cookies.some((c) => c.name === 'NEXT_LOCALE' && c.value === 'en'),
+    'captured storage state must pin the locale to en',
   ).toBe(true);
 });

--- a/apps/operator-ui/tests/e2e/fixtures/everest.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/everest.ts
@@ -37,10 +37,13 @@ const PLUGIN_CHARGE_COMMAND =
   'sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 3600';
 const DEFAULT_BOOT_TIMEOUT_MS = 90_000;
 // Recovery after a reboot-causing Reset (which reboots the manager container)
-// is slow and variable — empirically >150s in CI — so the per-test online guard
-// waits well beyond the initial-boot budget. The reset describe runs under an
-// extended test timeout so this guard can finish inside a single attempt.
-const RECONNECT_TIMEOUT_MS = 210_000;
+// is slow and variable — empirically >150s in CI, and a recorded run had the
+// reboot outlive the previous 210s ceiling, failing the guard on a station
+// that came back moments later (the retry then passed: the classic E2E-071
+// flake signature). 300s covers the observed worst case with margin; the
+// everestStation fixture's own timeout sits above this so the guard's
+// diagnostic error still fires first.
+const RECONNECT_TIMEOUT_MS = 300_000;
 const POLL_INTERVAL_MS = 2_000;
 // How long to wait for libocpp to materialise the device-model DB on a cold
 // boot before applying the network-profile patch. The DB normally appears a

--- a/apps/operator-ui/tests/e2e/fixtures/everest.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/everest.ts
@@ -37,12 +37,10 @@ const PLUGIN_CHARGE_COMMAND =
   'sleep 1;iec_wait_pwr_ready;sleep 1;draw_power_regulated 16,3;sleep 3600';
 const DEFAULT_BOOT_TIMEOUT_MS = 90_000;
 // Recovery after a reboot-causing Reset (which reboots the manager container)
-// is slow and variable — empirically >150s in CI, and a recorded run had the
-// reboot outlive the previous 210s ceiling, failing the guard on a station
-// that came back moments later (the retry then passed: the classic E2E-071
-// flake signature). 300s covers the observed worst case with margin; the
-// everestStation fixture's own timeout sits above this so the guard's
-// diagnostic error still fires first.
+// is slow and NOT reliably bounded — recorded CI runs blew through 210s and
+// then 300s ceilings, and the manager sometimes wedges outright until its
+// container is restarted. ensureEverestOnline therefore recovers actively at
+// half this budget instead of only waiting; see its comment.
 const RECONNECT_TIMEOUT_MS = 300_000;
 const POLL_INTERVAL_MS = 2_000;
 // How long to wait for libocpp to materialise the device-model DB on a cold
@@ -137,24 +135,48 @@ async function readEverestOnline(api: ApiClient): Promise<boolean | null> {
 
 // Per-test guard for the worker-scoped manager: a destructive command in a
 // prior test (Reset Immediate reboots the manager container) drops cp001's
-// OCPP link, and the station is offline for ~1 minute while it reconnects.
-// Wait for `isOnline` to return true so the next test runs against a live
-// station instead of a rebooting one. Returns immediately when the station
-// is already connected (the common case), so undisrupted tests pay nothing.
+// OCPP link. Returns immediately when the station is already connected (the
+// common case), so undisrupted tests pay nothing. Because the post-reboot
+// reconnect is not reliably bounded and the manager can wedge until its
+// container restarts, the guard waits half the budget passively, then
+// `docker restart`s the manager (a cold boot reconnects in ~15-90s) and
+// waits the other half.
 export async function ensureEverestOnline(timeoutMs = RECONNECT_TIMEOUT_MS): Promise<void> {
   const api = await makeApiClient();
   try {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      if ((await readEverestOnline(api)) === true) return;
-      await delay(POLL_INTERVAL_MS);
-    }
+    if (await waitForOnline(api, timeoutMs / 2)) return;
+    console.warn(
+      `[e2e:everest] ${EVEREST_OCPP_CONNECTION_NAME} still offline after ${timeoutMs / 2}ms — restarting the manager container`,
+    );
+    await restartEverestManager();
+    if (await waitForOnline(api, timeoutMs / 2)) return;
     throw new Error(
-      `EVerest station ${EVEREST_OCPP_CONNECTION_NAME} did not return online within ${timeoutMs}ms`,
+      `EVerest station ${EVEREST_OCPP_CONNECTION_NAME} did not return online within ${timeoutMs}ms (incl. a manager restart)`,
     );
   } finally {
     await api.dispose();
   }
+}
+
+async function waitForOnline(api: ApiClient, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await readEverestOnline(api)) === true) return true;
+    await delay(POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+function restartEverestManager(): Promise<void> {
+  return new Promise<void>((res) => {
+    const proc = spawn(
+      process.platform === 'win32' ? 'docker.exe' : 'docker',
+      ['restart', 'everest-manager-1'],
+      { stdio: 'ignore', shell: process.platform === 'win32' },
+    );
+    proc.on('exit', () => res());
+    proc.on('error', () => res());
+  });
 }
 
 // Spawn `docker compose` directly with the same cwd + env as the upstream

--- a/apps/operator-ui/tests/e2e/fixtures/everest.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/everest.ts
@@ -167,6 +167,25 @@ async function waitForOnline(api: ApiClient, timeoutMs: number): Promise<boolean
   return false;
 }
 
+// Resolves once citrine marks cp001 offline — the observable proof that a
+// reboot-causing command actually executed. Only an explicit false counts;
+// query errors read as "unknown" and keep polling.
+export async function waitForEverestOffline(timeoutMs: number): Promise<void> {
+  const api = await makeApiClient();
+  try {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if ((await readEverestOnline(api)) === false) return;
+      await delay(POLL_INTERVAL_MS);
+    }
+    throw new Error(
+      `EVerest station ${EVEREST_OCPP_CONNECTION_NAME} did not go offline within ${timeoutMs}ms`,
+    );
+  } finally {
+    await api.dispose();
+  }
+}
+
 function restartEverestManager(): Promise<void> {
   return new Promise<void>((res) => {
     const proc = spawn(
@@ -504,7 +523,20 @@ export async function startEverest(options: EverestStartOptions = {}): Promise<E
   const api = await makeApiClient();
   let id: number;
   try {
-    id = await awaitStationOnline(api, EVEREST_OCPP_CONNECTION_NAME, bootTimeoutMs);
+    try {
+      id = await awaitStationOnline(api, EVEREST_OCPP_CONNECTION_NAME, bootTimeoutMs);
+    } catch {
+      // A retry after a failed reset test boots a fresh worker while the
+      // manager is still mid-reboot (or wedged) from the dispatched Reset —
+      // compose up is a no-op on the running stack, so without this the
+      // whole retry chain dies here at the boot budget. Same recovery as
+      // ensureEverestOnline: restart the container, wait once more.
+      console.warn(
+        `[e2e:everest] ${EVEREST_OCPP_CONNECTION_NAME} not up after compose — restarting the manager container`,
+      );
+      await restartEverestManager();
+      id = await awaitStationOnline(api, EVEREST_OCPP_CONNECTION_NAME, bootTimeoutMs * 2);
+    }
     await ensureEverestEvseAndConnector(api, id);
     await ensureEverestAuthorization(api);
   } finally {

--- a/apps/operator-ui/tests/e2e/fixtures/index.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/index.ts
@@ -103,14 +103,15 @@ export const test = base.extend<E2EFixtures, E2EWorkerFixtures>({
   // this waits for it to reconnect before the test runs (no-op when already
   // online). The guard gets its own fixture timeout so the reconnect is
   // billed here, not against the test body — RECONNECT_TIMEOUT_MS alone
-  // would otherwise swallow most of a test's budget.
+  // would otherwise swallow most of a test's budget. The ceiling sits above
+  // RECONNECT_TIMEOUT_MS so the guard's own diagnostic fires first.
   // Specs request `everestStation` exactly as before.
   everestStation: [
     async ({ everestManager }, use) => {
       await ensureEverestOnline();
       await use(everestManager);
     },
-    { timeout: 240_000 },
+    { timeout: 330_000 },
   ],
 });
 

--- a/apps/operator-ui/tests/e2e/fixtures/index.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/index.ts
@@ -91,17 +91,27 @@ export const test = base.extend<E2EFixtures, E2EWorkerFixtures>({
       await use(handle);
       await handle.stop();
     },
-    { scope: 'worker' },
+    // Own timeout: worker setup otherwise bills against the FIRST @everest
+    // test's 180s budget (compose up + profile patch + boot + isOnline can
+    // total 60+90+210s worst case). The internal deadlines still fail first
+    // with their own diagnostics; this is just the ceiling.
+    { scope: 'worker', timeout: 420_000 },
   ],
 
-  // Test-scoped guard over the shared manager. A Reset Immediate in a prior
-  // test reboots the manager, leaving cp001 offline for ~1 minute; this waits
-  // for it to reconnect before the test runs (no-op when already online).
+  // Test-scoped guard over the shared manager. A reboot-causing Reset in a
+  // prior test reboots the manager, leaving cp001 offline for >150s in CI;
+  // this waits for it to reconnect before the test runs (no-op when already
+  // online). The guard gets its own fixture timeout so the reconnect is
+  // billed here, not against the test body — RECONNECT_TIMEOUT_MS alone
+  // would otherwise swallow most of a test's budget.
   // Specs request `everestStation` exactly as before.
-  everestStation: async ({ everestManager }, use) => {
-    await ensureEverestOnline();
-    await use(everestManager);
-  },
+  everestStation: [
+    async ({ everestManager }, use) => {
+      await ensureEverestOnline();
+      await use(everestManager);
+    },
+    { timeout: 240_000 },
+  ],
 });
 
 export { expect } from '@playwright/test';

--- a/apps/operator-ui/tests/e2e/fixtures/index.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/index.ts
@@ -40,28 +40,39 @@ export const test = base.extend<E2EFixtures, E2EWorkerFixtures>({
     await client.dispose();
   },
 
+  // Teardown deletes stay non-fatal (a failed cleanup must not fail the
+  // test), but they log: a silently-broken delete leaks rows for the whole
+  // run and only the name-prefix purge at teardown reclaims them.
   seededLocation: async ({ apiClient }, use) => {
     const location = await seedLocation(apiClient);
     await use(location);
-    await deleteLocation(apiClient, location.id).catch(() => undefined);
+    await deleteLocation(apiClient, location.id).catch((err) => {
+      console.warn(`[e2e:fixtures] deleteLocation(${location.id}) failed:`, err);
+    });
   },
 
   seededStation: async ({ apiClient, seededLocation }, use) => {
     const station = await seedStation(apiClient, seededLocation.id);
     await use(station);
-    await deleteStation(apiClient, station.id).catch(() => undefined);
+    await deleteStation(apiClient, station.id).catch((err) => {
+      console.warn(`[e2e:fixtures] deleteStation(${station.id}) failed:`, err);
+    });
   },
 
   seededTransaction: async ({ apiClient, seededStation }, use) => {
     const transaction = await seedTransaction(apiClient, seededStation.ocppConnectionName);
     await use(transaction);
-    await deleteTransaction(apiClient, transaction.transactionId).catch(() => undefined);
+    await deleteTransaction(apiClient, transaction.transactionId).catch((err) => {
+      console.warn(`[e2e:fixtures] deleteTransaction(${transaction.transactionId}) failed:`, err);
+    });
   },
 
   seededAuthorization: async ({ apiClient }, use) => {
     const authorization = await seedAuthorization(apiClient);
     await use(authorization);
-    await deleteAuthorization(apiClient, authorization.id).catch(() => undefined);
+    await deleteAuthorization(apiClient, authorization.id).catch((err) => {
+      console.warn(`[e2e:fixtures] deleteAuthorization(${authorization.id}) failed:`, err);
+    });
   },
 
   // EVerest is expensive: docker-compose up of multiple containers, then a

--- a/apps/operator-ui/tests/e2e/fixtures/seeded-data.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/seeded-data.ts
@@ -84,8 +84,10 @@ export async function seedLocation(
 }
 
 export async function deleteLocation(api: ApiClient, id: number): Promise<void> {
+  // Hasura exposes Locations.id as Int — declaring it bigint! makes the
+  // mutation fail validation before it runs, so every seeded location leaked.
   await api.gql(
-    `mutation DeleteLocation($id: bigint!) {
+    `mutation DeleteLocation($id: Int!) {
        delete_Locations_by_pk(id: $id) { id }
      }`,
     { id },
@@ -351,16 +353,15 @@ export async function purgeAllE2eRows(api: ApiClient): Promise<void> {
     })
     .catch(() => undefined);
 
-  // Authorizations: e2e seeds use uppercase suffix, so match by idToken prefix
-  // OR by the full e2e- token format. Both shapes are produced by
-  // seedAuthorization(); the regex covers either.
+  // Authorizations: every e2e-seeded token starts with E2E- (the old
+  // "%-RFID" match was over-broad — on a shared DB it would take out any
+  // authorization whose token merely ends in -RFID).
   await api
     .gql(
       `mutation PurgeAuthorizations {
          delete_Authorizations(
            where: { _or: [
              { idToken: { _ilike: "E2E-%" } },
-             { idToken: { _ilike: "%-RFID" } },
              { idToken: { _eq: "_PROBE_E2E_AUTH" } }
            ] }
          ) { affected_rows }
@@ -372,6 +373,26 @@ export async function purgeAllE2eRows(api: ApiClient): Promise<void> {
     .gql(
       `mutation PurgeLocations {
          delete_Locations(where: { name: { _like: "e2e-%" } }) { affected_rows }
+       }`,
+    )
+    .catch(() => undefined);
+
+  // Partners register under the reserved ZZ country code and tariffs under the
+  // XTS test currency (see the partners/tariffs specs) — both markers exist so
+  // rows a crashed run leaves behind can be swept here without touching real
+  // data.
+  await api
+    .gql(
+      `mutation PurgeTenantPartners {
+         delete_TenantPartners(where: { countryCode: { _eq: "ZZ" } }) { affected_rows }
+       }`,
+    )
+    .catch(() => undefined);
+
+  await api
+    .gql(
+      `mutation PurgeTariffs {
+         delete_Tariffs(where: { currency: { _eq: "XTS" } }) { affected_rows }
        }`,
     )
     .catch(() => undefined);

--- a/apps/operator-ui/tests/e2e/fixtures/seeded-data.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/seeded-data.ts
@@ -84,6 +84,20 @@ export async function seedLocation(
 }
 
 export async function deleteLocation(api: ApiClient, id: number): Promise<void> {
+  // A station left behind by a failed test (e.g. a UI-created one whose
+  // inline cleanup never ran) FK-pins the location. Every station under an
+  // e2e location is itself e2e-owned, so clear them first — status rows
+  // before stations, same FK order the purge uses.
+  await api
+    .gql(
+      `mutation ClearLocationStations($locationId: Int!) {
+         delete_StatusNotifications(where: { ChargingStation: { locationId: { _eq: $locationId } } }) { affected_rows }
+         delete_LatestStatusNotifications(where: { ChargingStation: { locationId: { _eq: $locationId } } }) { affected_rows }
+         delete_ChargingStations(where: { locationId: { _eq: $locationId } }) { affected_rows }
+       }`,
+      { locationId: id },
+    )
+    .catch(() => undefined);
   // Hasura exposes Locations.id as Int — declaring it bigint! makes the
   // mutation fail validation before it runs, so every seeded location leaked.
   await api.gql(

--- a/apps/operator-ui/tests/e2e/pages/authorizations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/authorizations/form.page.ts
@@ -43,12 +43,16 @@ export class AuthorizationFormPage {
   }
 
   async gotoNew(): Promise<void> {
-    await this.page.goto(AuthorizationFormPage.newPath);
+    await this.page.goto(AuthorizationFormPage.newPath, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 
   async gotoEdit(id: number | string): Promise<void> {
-    await this.page.goto(AuthorizationFormPage.editPath(id));
+    await this.page.goto(AuthorizationFormPage.editPath(id), {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/authorizations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/authorizations/form.page.ts
@@ -91,10 +91,14 @@ export class AuthorizationFormPage {
 
   async submit(): Promise<void> {
     await this.submitButton.click();
-    await this.page
-      .getByRole('region', { name: /notifications/i })
-      .getByText(/(success|created|updated|saved)/i)
-      .first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // Toast or redirect — the toast auto-dismisses and can be missed under load.
+    await Promise.any([
+      this.page
+        .getByRole('region', { name: /notifications/i })
+        .getByText(/(success|created|updated|saved)/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 }),
+      this.page.waitForURL(/\/authorizations\/\d+$/, { timeout: 30_000 }),
+    ]);
   }
 }

--- a/apps/operator-ui/tests/e2e/pages/authorizations/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/authorizations/list.page.ts
@@ -20,7 +20,9 @@ export class AuthorizationsListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(AuthorizationsListPage.path);
+    await this.page.goto(AuthorizationsListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/authorizations/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/authorizations/list.page.ts
@@ -13,8 +13,9 @@ export class AuthorizationsListPage {
 
   constructor(private readonly page: Page) {
     this.heading = page.getByRole('heading', { name: /^authorizations$/i }).first();
+    // Placeholder is "Search Authorization" (singular).
     this.searchInput = page.getByRole('textbox', {
-      name: /search authorizations/i,
+      name: /search authorization/i,
     });
     this.addButton = page.getByRole('button', { name: /add authorization/i });
   }

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/detail.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/detail.page.ts
@@ -49,20 +49,20 @@ export class ChargingStationDetailPage {
 
   async expectLoaded(): Promise<void> {
     // Detail page is interactive when the command bar's Reset button (always
-    // rendered for any non-deleted station) becomes visible. The 60s budget
-    // covers cold-route Next.js compilation + the useOne(ChargingStation)
-    // query. On heavy concurrency the dev server can hang for the full
-    // window without finishing its response — a one-shot reload unsticks it.
-    // The two attempts cap the wait at 120s but in practice the first
-    // attempt resolves in 5–20s.
+    // rendered for any non-deleted station) becomes visible. Under sustained
+    // load the server can hang for the full window without finishing its
+    // response — a one-shot reload unsticks it. Budgets mirror the overview
+    // page: 45 + 30 reload + 60 = 135s, inside the 150s test timeout (the
+    // old 60+60+60 shape overran it and died as a bare test timeout). In
+    // practice the first attempt resolves in 5–20s.
     try {
       await expect(this.commandBar.resetButton).toBeVisible({
-        timeout: 60_000,
+        timeout: 45_000,
       });
     } catch {
       await this.page.reload({
         waitUntil: 'domcontentloaded',
-        timeout: 60_000,
+        timeout: 30_000,
       });
       await expect(this.commandBar.resetButton).toBeVisible({
         timeout: 60_000,

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
@@ -48,12 +48,16 @@ export class ChargingStationFormPage {
   }
 
   async gotoNew(): Promise<void> {
-    await this.page.goto(ChargingStationFormPage.newPath);
+    await this.page.goto(ChargingStationFormPage.newPath, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 
   async gotoEdit(id: number | string): Promise<void> {
-    await this.page.goto(ChargingStationFormPage.editPath(id));
+    await this.page.goto(ChargingStationFormPage.editPath(id), {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
@@ -82,6 +82,9 @@ export class ChargingStationFormPage {
     const trigger = this.locationCombobox;
     await expect(trigger).toBeEnabled({ timeout: 15_000 });
     await trigger.click();
+    // The dropdown lists only the 5 most recently updated locations, so type
+    // the name to filter server-side before picking.
+    await this.page.keyboard.type(locationName);
     const option = this.page
       .getByRole('option', { name: new RegExp(`^${locationName}\\b`, 'i') })
       .first();

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
@@ -94,10 +94,14 @@ export class ChargingStationFormPage {
 
   async submit(): Promise<void> {
     await this.submitButton.click();
-    await this.page
-      .getByRole('region', { name: /notifications/i })
-      .getByText(/(success|created|updated|saved)/i)
-      .first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // Toast or redirect — the toast auto-dismisses and can be missed under load.
+    await Promise.any([
+      this.page
+        .getByRole('region', { name: /notifications/i })
+        .getByText(/(success|created|updated|saved)/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 }),
+      this.page.waitForURL(/\/charging-stations\/\d+$/, { timeout: 30_000 }),
+    ]);
   }
 }

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/form.page.ts
@@ -81,15 +81,22 @@ export class ChargingStationFormPage {
   async selectLocation(locationName: string): Promise<void> {
     const trigger = this.locationCombobox;
     await expect(trigger).toBeEnabled({ timeout: 15_000 });
-    await trigger.click();
     // The dropdown lists only the 5 most recently updated locations, so type
-    // the name to filter server-side before picking.
-    await this.page.keyboard.type(locationName);
-    const option = this.page
-      .getByRole('option', { name: new RegExp(`^${locationName}\\b`, 'i') })
-      .first();
-    await option.waitFor({ state: 'visible', timeout: 15_000 });
-    await option.click();
+    // the name to filter server-side before picking. The option list refetches
+    // per keystroke (300ms debounced search), and a re-render between locator
+    // resolution and click can recycle the option node into a different
+    // location — so verify the trigger shows the picked name and retry the
+    // whole selection if it doesn't.
+    await expect(async () => {
+      await this.page.keyboard.press('Escape');
+      await trigger.click();
+      await this.page.keyboard.type(locationName);
+      await this.page
+        .getByRole('option', { name: new RegExp(`^${locationName}\\b`, 'i') })
+        .first()
+        .click({ timeout: 5_000 });
+      await expect(trigger).toContainText(locationName, { timeout: 5_000 });
+    }).toPass({ timeout: 60_000 });
   }
 
   async submit(): Promise<void> {

--- a/apps/operator-ui/tests/e2e/pages/charging-stations/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/charging-stations/list.page.ts
@@ -25,7 +25,9 @@ export class ChargingStationsListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(ChargingStationsListPage.path);
+    await this.page.goto(ChargingStationsListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/components/command-bar.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/command-bar.po.ts
@@ -42,11 +42,13 @@ export class CommandBar {
   // by the parametric harness for modals not exposed as primary buttons.
   async openViaOtherCommands(commandNamePattern: RegExp): Promise<void> {
     await this.otherCommandsButton.click();
-    await this.page
+    await this.page.getByRole('dialog').first().waitFor({ state: 'visible', timeout: 30_000 });
+    const entry = this.page
       .getByRole('option', { name: commandNamePattern })
       .or(this.page.getByRole('menuitem', { name: commandNamePattern }))
       .or(this.page.getByRole('button', { name: commandNamePattern }))
-      .first()
-      .click();
+      .first();
+    await entry.waitFor({ state: 'visible', timeout: 30_000 });
+    await entry.click();
   }
 }

--- a/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
@@ -38,7 +38,7 @@ export class ModalHarness {
 
   async expectOpen(): Promise<void> {
     await expect(this.dialog).toBeVisible({ timeout: 15_000 });
-    await expect(this.title).toBeVisible();
+    await expect(this.title).toBeVisible({ timeout: 15_000 });
   }
 
   async expectClosed(): Promise<void> {

--- a/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
@@ -62,11 +62,15 @@ export class ModalHarness {
       .getByRole('combobox')
       .first();
     await trigger.click();
-    await this.page
+    // The option list is a portal fed by a useSelect query — wait for it
+    // instead of clicking into a still-empty popover.
+    const option = this.page
       .getByRole('option', {
         name: optionName instanceof RegExp ? optionName : new RegExp(optionName, 'i'),
       })
-      .click();
+      .first();
+    await option.waitFor({ state: 'visible', timeout: 30_000 });
+    await option.click();
   }
 
   async cancel(): Promise<void> {
@@ -105,6 +109,18 @@ export class ModalHarness {
     // auto-closes depends on the per-modal handler. Both are acceptable
     // observable behaviours per the OCPP command pipeline.
     await expect(toastRegion).toContainText(errorPattern, { timeout });
+  }
+
+  // Submits and asserts the form REJECTED it: a validation message appears
+  // and the dialog stays mounted. A bare dialog-still-visible check passes on
+  // the first poll even if the submit was about to dispatch — this waits for
+  // the positive signal instead.
+  async expectBlockedSubmit(): Promise<void> {
+    await this.submitButton.click();
+    await expect(
+      this.dialog.locator('[role="alert"], [data-slot="form-message"]').first(),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(this.dialog).toBeVisible();
   }
 
   validationError(fieldLabel: RegExp | string): Locator {

--- a/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
@@ -103,24 +103,31 @@ export class ModalHarness {
     await this.submitAndWaitForNewToast(errorPattern, timeout);
   }
 
-  // Tags the toasts already on screen, submits, then waits for a NEW toast
-  // matching the pattern — a leftover toast from an earlier action in the
-  // same test can no longer satisfy the wait.
-  private async submitAndWaitForNewToast(pattern: RegExp, timeout: number): Promise<void> {
-    const toastRegion = this.page.getByRole('region', {
-      name: /notifications/i,
-    });
-    await toastRegion
+  // Tags the toasts already on screen so a leftover toast from an earlier
+  // action in the same test can't satisfy a later wait.
+  async markToastsStale(): Promise<void> {
+    await this.page
+      .getByRole('region', { name: /notifications/i })
       .locator('[data-sonner-toast]')
       .evaluateAll((els) => els.forEach((el) => el.setAttribute('data-e2e-stale', '1')))
       .catch(() => undefined);
-    await this.submitButton.click();
+  }
+
+  // Waits for a toast that appeared after the last markToastsStale() call.
+  async newToastVisible(pattern: RegExp, timeout: number): Promise<void> {
     await expect(
-      toastRegion
+      this.page
+        .getByRole('region', { name: /notifications/i })
         .locator('[data-sonner-toast]:not([data-e2e-stale])')
         .filter({ hasText: pattern })
         .first(),
     ).toBeVisible({ timeout });
+  }
+
+  private async submitAndWaitForNewToast(pattern: RegExp, timeout: number): Promise<void> {
+    await this.markToastsStale();
+    await this.submitButton.click();
+    await this.newToastVisible(pattern, timeout);
   }
 
   // Submits and asserts the form REJECTED it: a validation message appears

--- a/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/modal.po.ts
@@ -90,25 +90,37 @@ export class ModalHarness {
     toastPattern: RegExp = /success|accepted|sent|started|stopped|reset|completed|received/i,
     timeout = 30_000,
   ): Promise<void> {
-    await this.submitButton.click();
-    const toastRegion = this.page.getByRole('region', {
-      name: /notifications/i,
-    });
-    await expect(toastRegion).toContainText(toastPattern, { timeout });
+    await this.submitAndWaitForNewToast(toastPattern, timeout);
   }
 
   async submitExpectingError(
     errorPattern: RegExp = /failed|error|invalid|denied/i,
     timeout = 30_000,
   ): Promise<void> {
-    await this.submitButton.click();
-    const toastRegion = this.page.getByRole('region', {
-      name: /notifications/i,
-    });
     // The destructive toast is the contract; whether the modal stays open or
     // auto-closes depends on the per-modal handler. Both are acceptable
     // observable behaviours per the OCPP command pipeline.
-    await expect(toastRegion).toContainText(errorPattern, { timeout });
+    await this.submitAndWaitForNewToast(errorPattern, timeout);
+  }
+
+  // Tags the toasts already on screen, submits, then waits for a NEW toast
+  // matching the pattern — a leftover toast from an earlier action in the
+  // same test can no longer satisfy the wait.
+  private async submitAndWaitForNewToast(pattern: RegExp, timeout: number): Promise<void> {
+    const toastRegion = this.page.getByRole('region', {
+      name: /notifications/i,
+    });
+    await toastRegion
+      .locator('[data-sonner-toast]')
+      .evaluateAll((els) => els.forEach((el) => el.setAttribute('data-e2e-stale', '1')))
+      .catch(() => undefined);
+    await this.submitButton.click();
+    await expect(
+      toastRegion
+        .locator('[data-sonner-toast]:not([data-e2e-stale])')
+        .filter({ hasText: pattern })
+        .first(),
+    ).toBeVisible({ timeout });
   }
 
   // Submits and asserts the form REJECTED it: a validation message appears

--- a/apps/operator-ui/tests/e2e/pages/locations/detail.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/locations/detail.page.ts
@@ -27,7 +27,9 @@ export class LocationDetailPage {
   }
 
   async goto(id: number | string): Promise<void> {
-    await this.page.goto(LocationDetailPage.path(id));
+    await this.page.goto(LocationDetailPage.path(id), {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/locations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/locations/form.page.ts
@@ -81,12 +81,16 @@ export class LocationFormPage {
   }
 
   async gotoNew(): Promise<void> {
-    await this.page.goto(LocationFormPage.newPath);
+    await this.page.goto(LocationFormPage.newPath, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 
   async gotoEdit(id: number | string): Promise<void> {
-    await this.page.goto(LocationFormPage.editPath(id));
+    await this.page.goto(LocationFormPage.editPath(id), {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/locations/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/locations/form.page.ts
@@ -145,19 +145,20 @@ export class LocationFormPage {
     await input.fill(stateName);
   }
 
-  // Never return while Refine is in-flight. We wait for either the
-  // success-redirect to the detail route OR a success toast.
+  // Never return while Refine is in-flight. The toast fires on the
+  // mutation's onSuccess before redirecting, but it auto-dismisses — so a
+  // stalled test process can miss it entirely. Accept the redirect too; the
+  // end-anchored regex cannot match the /locations/:id/edit entry route.
   async submit(): Promise<void> {
-    // The success-toast wait is the canonical signal — Refine fires the
-    // toast on the mutation's onSuccess BEFORE redirecting. URL-based
-    // waits race with the current route (/locations/:id/edit can match
-    // a permissive `/locations/\d+` regex on entry).
     await this.submitButton.click();
-    await this.page
-      .getByRole('region', { name: /notifications/i })
-      .getByText(/(success|created|updated|saved)/i)
-      .first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    await Promise.any([
+      this.page
+        .getByRole('region', { name: /notifications/i })
+        .getByText(/(success|created|updated|saved)/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 }),
+      this.page.waitForURL(/\/locations\/\d+$/, { timeout: 30_000 }),
+    ]);
   }
 
   async cancel(): Promise<void> {

--- a/apps/operator-ui/tests/e2e/pages/locations/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/locations/list.page.ts
@@ -27,7 +27,9 @@ export class LocationsListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(LocationsListPage.path);
+    await this.page.goto(LocationsListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/login.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/login.page.ts
@@ -20,7 +20,9 @@ export class LoginPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(LoginPage.path);
+    await this.page.goto(LoginPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     // The first visit to /login on a dev server pays the cold-compile cost
     // (20–40s). Production builds are pre-compiled, so this budget is unused
     // on `next start`. Keep it for the dev-mode path that most contributors

--- a/apps/operator-ui/tests/e2e/pages/overview.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/overview.page.ts
@@ -77,42 +77,49 @@ export class OverviewPage {
     // Anchor on the Locations card heading which is rendered statically
     // without a Hasura query dependency. The Charger Online Status heading
     // sits inside a query-bound skeleton and times out when the dev server
-    // is under sustained load. The 60s budget covers Next.js dev-server
-    // cold-route compilation. Tests that need to assert specific KPI
+    // is under sustained load. Tests that need to assert specific KPI
     // headings do so individually in their own expectations, not via this
     // load gate. A one-shot reload retry catches the rare case where the
     // dev server stalls a /overview compile under sustained multi-spec load.
+    // The first attempt is capped at 45s so the reload retry still fits
+    // inside the 150s test budget (45 + 30 reload + 60 leaves headroom);
+    // the old 60+60+60 worst case blew past it and died as a bare timeout.
     try {
-      await Promise.race([
-        this.locationsCardHeading.waitFor({
-          state: 'visible',
-          timeout: 60_000,
-        }),
-        this.welcomeDialog.waitFor({ state: 'visible', timeout: 60_000 }),
-      ]);
-      await this.dismissWelcomeIfPresent();
-      await expect(this.locationsCardHeading).toBeVisible({ timeout: 60_000 });
+      await this.settleOverview(45_000);
     } catch {
       await this.page.reload({
         waitUntil: 'domcontentloaded',
-        timeout: 60_000,
+        timeout: 30_000,
       });
-      await Promise.race([
-        this.locationsCardHeading.waitFor({
-          state: 'visible',
-          timeout: 60_000,
-        }),
-        this.welcomeDialog.waitFor({ state: 'visible', timeout: 60_000 }),
-      ]);
-      await this.dismissWelcomeIfPresent();
-      await expect(this.locationsCardHeading).toBeVisible({ timeout: 60_000 });
+      await this.settleOverview(60_000);
     }
   }
 
-  async dismissWelcomeIfPresent(): Promise<void> {
-    if (await this.welcomeDialog.isVisible().catch(() => false)) {
+  private async settleOverview(timeout: number): Promise<void> {
+    await Promise.race([
+      this.locationsCardHeading.waitFor({ state: 'visible', timeout }),
+      this.welcomeDialog.waitFor({ state: 'visible', timeout }),
+    ]);
+    await this.dismissWelcomeIfPresent();
+    await expect(this.locationsCardHeading).toBeVisible({ timeout });
+  }
+
+  async dismissWelcomeIfPresent(waitMs = 0): Promise<void> {
+    // The dialog mounts from a client effect, so it can appear shortly AFTER
+    // the card heading does. Callers that know the first-login flag is absent
+    // (admin.setup) pass a wait window to catch the late mount; everyone else
+    // keeps the cheap one-shot check — with the flag captured in admin.json
+    // the dialog never appears in ordinary tests.
+    const visible =
+      waitMs > 0
+        ? await this.welcomeDialog
+            .waitFor({ state: 'visible', timeout: waitMs })
+            .then(() => true)
+            .catch(() => false)
+        : await this.welcomeDialog.isVisible().catch(() => false);
+    if (visible) {
       await this.welcomeCloseButton.click();
-      await expect(this.welcomeDialog).toBeHidden();
+      await expect(this.welcomeDialog).toBeHidden({ timeout: 15_000 });
     }
   }
 

--- a/apps/operator-ui/tests/e2e/pages/overview.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/overview.page.ts
@@ -69,7 +69,9 @@ export class OverviewPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(OverviewPage.path);
+    await this.page.goto(OverviewPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/overview.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/overview.page.ts
@@ -76,13 +76,12 @@ export class OverviewPage {
   }
 
   async expectLoaded(): Promise<void> {
-    // Anchor on the Locations card heading which is rendered statically
-    // without a Hasura query dependency. The Charger Online Status heading
-    // sits inside a query-bound skeleton and times out when the dev server
-    // is under sustained load. Tests that need to assert specific KPI
-    // headings do so individually in their own expectations, not via this
-    // load gate. A one-shot reload retry catches the rare case where the
-    // dev server stalls a /overview compile under sustained multi-spec load.
+    // Anchor on the Locations card heading, which renders without a Hasura
+    // query dependency. The Charger Online Status heading sits inside a
+    // query-bound skeleton and times out when the server is under sustained
+    // load. Tests that need to assert specific KPI headings do so
+    // individually in their own expectations, not via this load gate. A
+    // one-shot reload retry catches the rare stalled response.
     // The first attempt is capped at 45s so the reload retry still fits
     // inside the 150s test budget (45 + 30 reload + 60 leaves headroom);
     // the old 60+60+60 worst case blew past it and died as a bare timeout.

--- a/apps/operator-ui/tests/e2e/pages/partners/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/partners/form.page.ts
@@ -48,7 +48,9 @@ export class PartnerFormPage {
   }
 
   async gotoNew(): Promise<void> {
-    await this.page.goto(PartnerFormPage.newPath);
+    await this.page.goto(PartnerFormPage.newPath, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/partners/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/partners/form.page.ts
@@ -76,10 +76,16 @@ export class PartnerFormPage {
 
   async submit(): Promise<void> {
     await this.submitButton.click();
-    await this.page
-      .getByRole('region', { name: /notifications/i })
-      .getByText(/(success|created|updated|saved)/i)
-      .first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // Toast or redirect — the toast auto-dismisses and can be missed under
+    // load. The redirect target includes /authorizations/:id because of the
+    // KNOWN-DRIFT post-create bug documented in the register spec.
+    await Promise.any([
+      this.page
+        .getByRole('region', { name: /notifications/i })
+        .getByText(/(success|created|updated|saved)/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 }),
+      this.page.waitForURL(/\/(partners|authorizations)\/\d+$/, { timeout: 30_000 }),
+    ]);
   }
 }

--- a/apps/operator-ui/tests/e2e/pages/partners/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/partners/list.page.ts
@@ -18,7 +18,9 @@ export class PartnersListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(PartnersListPage.path);
+    await this.page.goto(PartnersListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/tariffs/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/tariffs/form.page.ts
@@ -49,12 +49,16 @@ export class TariffFormPage {
   }
 
   async gotoNew(): Promise<void> {
-    await this.page.goto(TariffFormPage.newPath);
+    await this.page.goto(TariffFormPage.newPath, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 
   async gotoEdit(id: number | string): Promise<void> {
-    await this.page.goto(TariffFormPage.editPath(id));
+    await this.page.goto(TariffFormPage.editPath(id), {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/tariffs/form.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/tariffs/form.page.ts
@@ -87,10 +87,14 @@ export class TariffFormPage {
 
   async submit(): Promise<void> {
     await this.submitButton.click();
-    await this.page
-      .getByRole('region', { name: /notifications/i })
-      .getByText(/(success|created|updated|saved)/i)
-      .first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    // Toast or redirect — the toast auto-dismisses and can be missed under load.
+    await Promise.any([
+      this.page
+        .getByRole('region', { name: /notifications/i })
+        .getByText(/(success|created|updated|saved)/i)
+        .first()
+        .waitFor({ state: 'visible', timeout: 30_000 }),
+      this.page.waitForURL(/\/tariffs\/\d+$/, { timeout: 30_000 }),
+    ]);
   }
 }

--- a/apps/operator-ui/tests/e2e/pages/tariffs/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/tariffs/list.page.ts
@@ -19,7 +19,9 @@ export class TariffsListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(TariffsListPage.path);
+    await this.page.goto(TariffsListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/pages/transactions/list.page.ts
+++ b/apps/operator-ui/tests/e2e/pages/transactions/list.page.ts
@@ -18,7 +18,9 @@ export class TransactionsListPage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto(TransactionsListPage.path);
+    await this.page.goto(TransactionsListPage.path, {
+      waitUntil: 'domcontentloaded',
+    });
     await this.expectLoaded();
   }
 

--- a/apps/operator-ui/tests/e2e/specs/authorizations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/authorizations/crud.spec.ts
@@ -34,6 +34,9 @@ test.describe('authorizations › CRUD', () => {
 
     const list = new AuthorizationsListPage(page);
     await list.goto();
+    // The list sorts idToken ascending with 10 rows per page — search first
+    // so other rows can't paginate ours away.
+    await list.searchInput.fill(idToken);
     await expect(list.rowByIdToken(idToken)).toBeVisible({ timeout: 30_000 });
 
     // Cleanup.

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/charging-session.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/charging-session.spec.ts
@@ -157,7 +157,7 @@ test.describe('charging-stations › live charging session @everest', () => {
 
       // The UI has no live updates; reload to surface the started transaction,
       // which flips the command bar from RemoteStart to RemoteStop.
-      await page.reload({ waitUntil: 'domcontentloaded' });
+      await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
       await detail.expectLoaded();
       await expect(detail.commandBar.remoteStopButton).toBeVisible({
         timeout: 30_000,

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-changeconfig.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-changeconfig.spec.ts
@@ -50,9 +50,8 @@ test.describe('charging-stations › Change Availability + Configuration', () =>
       await detail.commandBar.openViaOtherCommands(/change configuration/i);
       const modal = new ModalHarness(page, /change configuration/i);
       await modal.expectOpen();
-      await modal.submitButton.click();
       // Required Key field is empty — validation keeps the modal mounted.
-      await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+      await modal.expectBlockedSubmit();
     } finally {
       await deleteStation(apiClient, station.id).catch(() => undefined);
       await deleteLocation(apiClient, location.id).catch(() => undefined);

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-datatransfer.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-datatransfer.spec.ts
@@ -34,9 +34,8 @@ test.describe('charging-stations › DataTransfer command', () => {
     await detail.commandBar.openViaOtherCommands(/data transfer/i);
     const modal = new ModalHarness(page, /data transfer/i);
     await modal.expectOpen();
-    await modal.submitButton.click();
     // Vendor Id is required; client-side validation keeps the modal mounted
     // until the operator fills it in.
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-deep-ack.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-deep-ack.spec.ts
@@ -15,7 +15,7 @@ import { ModalHarness } from '../../pages/components/modal.po';
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe('charging-stations › deep command ACKs @everest', () => {
-  test('E2E-093: ClearCache submits and is acknowledged @everest', async ({
+  test('E2E-153: ClearCache submits and is acknowledged @everest', async ({
     page,
     everestStation,
   }) => {
@@ -27,7 +27,7 @@ test.describe('charging-stations › deep command ACKs @everest', () => {
     await modal.submitAndWaitForToast();
   });
 
-  test('E2E-094: GetBaseReport submits and is acknowledged @everest', async ({
+  test('E2E-154: GetBaseReport submits and is acknowledged @everest', async ({
     page,
     everestStation,
   }) => {
@@ -40,7 +40,7 @@ test.describe('charging-stations › deep command ACKs @everest', () => {
     await modal.submitAndWaitForToast();
   });
 
-  test('E2E-095: GetTransactionStatus submits and is acknowledged @everest', async ({
+  test('E2E-155: GetTransactionStatus submits and is acknowledged @everest', async ({
     page,
     everestStation,
   }) => {

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-get-variables.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-get-variables.spec.ts
@@ -37,9 +37,8 @@ test.describe('charging-stations › GetVariables command', () => {
     await detail.commandBar.openViaOtherCommands(/get variables/i);
     const modal = new ModalHarness(page, /get variables/i);
     await modal.expectOpen();
-    await modal.submitButton.click();
     // Component + Variable in the field-array row are required; the form
     // blocks dispatch and keeps the modal mounted.
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-remotestart.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-remotestart.spec.ts
@@ -55,9 +55,8 @@ test.describe('charging-stations › RemoteStart command', () => {
     const modal = new ModalHarness(page, /(remote start|start transaction)/i);
     await modal.expectOpen();
 
-    await modal.submitButton.click();
     // The id token textbox is required; client-side validation rejects the
     // empty submit before the command reaches the OCPP backend.
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-set-variables.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-set-variables.spec.ts
@@ -39,9 +39,8 @@ test.describe('charging-stations › SetVariables command', () => {
     await detail.commandBar.openViaOtherCommands(/set variables/i);
     const modal = new ModalHarness(page, /set variables/i);
     await modal.expectOpen();
-    await modal.submitButton.click();
     // Component + Variable + AttributeValue in the field-array row are
     // required; the form blocks dispatch and keeps the modal mounted.
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-trigger.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-trigger.spec.ts
@@ -37,9 +37,8 @@ test.describe('charging-stations › TriggerMessage command', () => {
     await detail.commandBar.openViaOtherCommands(/trigger message/i);
     const modal = new ModalHarness(page, /trigger message/i);
     await modal.expectOpen();
-    await modal.submitButton.click();
     // Requested-Message is required; the form blocks dispatch and keeps the
     // modal mounted until a value is picked.
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-unlock.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-unlock.spec.ts
@@ -48,6 +48,6 @@ test.describe('charging-stations › UnlockConnector command', () => {
     // stays mounted instead of dispatching to the OCPP backend.
     const connectorCombobox = modal.dialog.getByRole('combobox').first();
     await expect(connectorCombobox).toBeVisible();
-    await expect(modal.dialog).toBeVisible({ timeout: 5_000 });
+    await modal.expectBlockedSubmit();
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands-unlock.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands-unlock.spec.ts
@@ -45,9 +45,12 @@ test.describe('charging-stations › UnlockConnector command', () => {
 
     // The seeded station is created without EVSEs/Connectors. The Connector
     // combobox has no options, so the form cannot be completed and the modal
-    // stays mounted instead of dispatching to the OCPP backend.
+    // stays mounted instead of dispatching to the OCPP backend. This modal
+    // renders no field-level message on an empty submit, so the mounted
+    // dialog is the strongest available signal here.
     const connectorCombobox = modal.dialog.getByRole('combobox').first();
     await expect(connectorCombobox).toBeVisible();
-    await modal.expectBlockedSubmit();
+    await modal.submitButton.click();
+    await expect(modal.dialog).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands.parametric.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands.parametric.spec.ts
@@ -76,25 +76,30 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
         await detail.goto(station.id);
         const modal = new ModalHarness(page, spec.titlePattern);
 
-        // Strategy 1: primary command-bar button.
+        // Strategy 1: primary command-bar button. Only probe for the modal when
+        // the button was actually there to click — most modals have no primary
+        // button, and probing after a no-op click used to burn the full probe
+        // timeout 27 times per run (minutes of dead wait) before falling
+        // through to the dispatcher.
         const primary = page.getByRole('button', {
           name: spec.openButtonNamePattern,
         });
-        if (
-          await primary
-            .first()
-            .isVisible()
-            .catch(() => false)
-        ) {
+        const clickedPrimary = await primary
+          .first()
+          .isVisible()
+          .catch(() => false);
+        if (clickedPrimary) {
           await primary.first().click();
         }
-        // 15s probe: a modal whose form runs useSelect/useList queries can take
-        // well over 5s to mount under CI load, and a too-short probe here turns
-        // a slow open into a silent skip (coverage quietly evaporates).
-        let opened = await modal.title
-          .waitFor({ state: 'visible', timeout: 15_000 })
-          .then(() => true)
-          .catch(() => false);
+        // 30s probe: a modal whose form runs useSelect/useList queries can be
+        // slow to mount under CI load, and a too-short probe here turns a slow
+        // open into a silent skip (coverage quietly evaporates).
+        let opened = clickedPrimary
+          ? await modal.title
+              .waitFor({ state: 'visible', timeout: 30_000 })
+              .then(() => true)
+              .catch(() => false)
+          : false;
 
         // Strategy 2: OtherCommandsModal dispatcher. Matching the modal's own
         // heading guarantees the dispatcher's "Other Commands" dialog is never
@@ -104,7 +109,7 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
             .openViaOtherCommands(spec.openButtonNamePattern)
             .catch(() => undefined);
           opened = await modal.title
-            .waitFor({ state: 'visible', timeout: 15_000 })
+            .waitFor({ state: 'visible', timeout: 30_000 })
             .then(() => true)
             .catch(() => false);
         }
@@ -114,8 +119,13 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
         // (e.g. its trigger moves elsewhere), record a documented skip rather
         // than failing — the operator-critical modals' open/submit paths are
         // hard-asserted by the bespoke E2E-070..E2E-089 specs, so this must
-        // never produce a false red.
+        // never produce a false red. The annotation makes the gap visible in
+        // the junit/github reporters, which render skips without their reason.
         if (!opened) {
+          test.info().annotations.push({
+            type: 'coverage-gap',
+            description: `${spec.name}: not reachable from the charging-station detail page`,
+          });
           test.skip(
             true,
             `${spec.name}: not reachable from the charging-station detail page via primary button or OtherCommands dispatcher.`,

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/commands.parametric.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/commands.parametric.spec.ts
@@ -88,7 +88,13 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
         ) {
           await primary.first().click();
         }
-        let opened = await modal.title.isVisible({ timeout: 5_000 }).catch(() => false);
+        // 15s probe: a modal whose form runs useSelect/useList queries can take
+        // well over 5s to mount under CI load, and a too-short probe here turns
+        // a slow open into a silent skip (coverage quietly evaporates).
+        let opened = await modal.title
+          .waitFor({ state: 'visible', timeout: 15_000 })
+          .then(() => true)
+          .catch(() => false);
 
         // Strategy 2: OtherCommandsModal dispatcher. Matching the modal's own
         // heading guarantees the dispatcher's "Other Commands" dialog is never
@@ -97,7 +103,10 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
           await detail.commandBar
             .openViaOtherCommands(spec.openButtonNamePattern)
             .catch(() => undefined);
-          opened = await modal.title.isVisible({ timeout: 5_000 }).catch(() => false);
+          opened = await modal.title
+            .waitFor({ state: 'visible', timeout: 15_000 })
+            .then(() => true)
+            .catch(() => false);
         }
 
         // Safety net: in practice every station-page modal opens via one of the
@@ -132,7 +141,7 @@ test.describe('charging-stations › parametric modal harness (smoke)', () => {
         } else {
           await page.keyboard.press('Escape');
         }
-        await expect(modal.title).toBeHidden({ timeout: 10_000 });
+        await expect(modal.title).toBeHidden({ timeout: 15_000 });
       } finally {
         if (seededTxnId) {
           await deleteTransaction(apiClient, seededTxnId).catch(() => undefined);

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
@@ -49,8 +49,11 @@ test.describe('charging-stations › CRUD', () => {
   }) => {
     const form = new ChargingStationFormPage(page);
     await form.gotoEdit(seededStation.id);
-    await expect(form.heading).toContainText(/edit charging\s*station/i);
-    await expect(form.nameInput).toHaveValue(seededStation.ocppConnectionName);
+    // The prefill lands after the edit query resolves, later than the heading.
+    await expect(form.heading).toContainText(/edit charging\s*station/i, { timeout: 30_000 });
+    await expect(form.nameInput).toHaveValue(seededStation.ocppConnectionName, {
+      timeout: 30_000,
+    });
 
     // floorLevel is optional and the seed leaves it empty; the Name column is
     // immutable on edit, so floorLevel is the safe mutable target.

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
@@ -27,6 +27,7 @@ test.describe('charging-stations › CRUD', () => {
 
     const list = new ChargingStationsListPage(page);
     await list.goto();
+    await list.searchInput.fill(name);
     await expect(list.rowById(name)).toBeVisible({ timeout: 30_000 });
 
     // Cleanup via apiClient (no UI delete on charging-stations list).

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
@@ -16,7 +16,7 @@ test.describe('charging-stations › CRUD', () => {
     seededLocation,
     apiClient,
   }) => {
-    const name = `e2e-${shortId()}-cp`;
+    const name = `${shortId()}-cp`;
     const form = new ChargingStationFormPage(page);
     await form.gotoNew();
     await form.fill({
@@ -75,7 +75,7 @@ test.describe('charging-stations › CRUD', () => {
   }) => {
     // Inline-seed so the UI delete owns the lifecycle (no fixture-teardown
     // race against the form-driven mutation).
-    const name = `e2e-${shortId()}-cp`;
+    const name = `${shortId()}-cp`;
     const { insert_ChargingStations_one: created } = await apiClient.gql<{
       insert_ChargingStations_one: { id: number };
     }>(

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/crud.spec.ts
@@ -17,30 +17,34 @@ test.describe('charging-stations › CRUD', () => {
     apiClient,
   }) => {
     const name = `${shortId()}-cp`;
-    const form = new ChargingStationFormPage(page);
-    await form.gotoNew();
-    await form.fill({
-      name,
-      locationName: seededLocation.name,
-    });
-    await form.submit();
+    try {
+      const form = new ChargingStationFormPage(page);
+      await form.gotoNew();
+      await form.fill({
+        name,
+        locationName: seededLocation.name,
+      });
+      await form.submit();
 
-    const list = new ChargingStationsListPage(page);
-    await list.goto();
-    await list.searchInput.fill(name);
-    await expect(list.rowById(name)).toBeVisible({ timeout: 30_000 });
-
-    // Cleanup via apiClient (no UI delete on charging-stations list).
-    const { ChargingStations } = await apiClient.gql<{
-      ChargingStations: { id: number }[];
-    }>(
-      `query LookupCS($name: String!) {
-         ChargingStations(where: { ocppConnectionName: { _eq: $name } }) { id }
-       }`,
-      { name },
-    );
-    if (ChargingStations[0]) {
-      await deleteStation(apiClient, ChargingStations[0].id).catch(() => undefined);
+      const list = new ChargingStationsListPage(page);
+      await list.goto();
+      await list.searchInput.fill(name);
+      await expect(list.rowById(name)).toBeVisible({ timeout: 30_000 });
+    } finally {
+      // Cleanup via apiClient (no UI delete on charging-stations list). In a
+      // finally: a failed attempt would otherwise leave the UI-created
+      // station behind, and it FK-pins seededLocation's teardown delete.
+      const { ChargingStations } = await apiClient.gql<{
+        ChargingStations: { id: number }[];
+      }>(
+        `query LookupCS($name: String!) {
+           ChargingStations(where: { ocppConnectionName: { _eq: $name } }) { id }
+         }`,
+        { name },
+      );
+      if (ChargingStations[0]) {
+        await deleteStation(apiClient, ChargingStations[0].id).catch(() => undefined);
+      }
     }
   });
 

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/device-model-sequence.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/device-model-sequence.spec.ts
@@ -95,7 +95,7 @@ test.describe('charging-stations › device model sequence @everest', () => {
 
     // Selectors are populated — reload so the modal picks up the rows, then
     // read a real Component/Variable end-to-end.
-    await page.reload();
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
     await detail.expectLoaded();
     await detail.commandBar.openViaOtherCommands(/get variables/i);
     const getVars = new ModalHarness(page, /get variables/i);

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/list.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/list.spec.ts
@@ -32,7 +32,7 @@ test.describe('charging-stations › list', () => {
     await list.goto();
     await list.searchInput.fill('e2e-nonexistent-cp-XXXXXXXX');
     await expect(list.noResultsMessage).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole('row').filter({ hasText: 'e2e-' })).toHaveCount(0);
+    await expect(list.rowById('e2e-nonexistent-cp-XXXXXXXX')).toHaveCount(0);
   });
 
   test('E2E-045: Online indicator visible on @everest cp001 row @everest', async ({

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/ocpp-ingestion.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/ocpp-ingestion.spec.ts
@@ -14,7 +14,7 @@ import { ChargingStationDetailPage } from '../../pages/charging-stations/detail.
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe('charging-stations › OCPP ingestion @everest', () => {
-  test('E2E-090: BootNotification and StatusNotification are ingested and surfaced @everest', async ({
+  test('E2E-150: BootNotification and StatusNotification are ingested and surfaced @everest', async ({
     page,
     everestStation,
     apiClient,
@@ -58,7 +58,7 @@ test.describe('charging-stations › OCPP ingestion @everest', () => {
     expect(status.aggregate.count).toBeGreaterThan(0);
   });
 
-  test('E2E-091: cp001 detail card shows live Online status from ingested state @everest', async ({
+  test('E2E-151: cp001 detail card shows live Online status from ingested state @everest', async ({
     page,
     everestStation,
   }) => {
@@ -70,7 +70,7 @@ test.describe('charging-stations › OCPP ingestion @everest', () => {
     await expect(detail.statusTag).toHaveText(/online/i, { timeout: 30_000 });
   });
 
-  test('E2E-092: detail card surfaces a real Last-OCPP-Message timestamp @everest', async ({
+  test('E2E-152: detail card surfaces a real Last-OCPP-Message timestamp @everest', async ({
     page,
     everestStation,
   }) => {

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
@@ -11,14 +11,16 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 // A reboot-causing Reset (Immediate always; OnIdle on an idle station) reboots
 // the EVerest manager container, dropping cp001's OCPP link for >150s in CI. The
 // reset tests run LAST in the @everest lane, so the only test that can land on a
-// reconnecting station is the *next* reset test — its per-test everestStation
-// online guard waits for cp001 to come back (RECONNECT_TIMEOUT_MS). Because that
-// reconnect exceeds the default 180s test budget, this describe runs with an
-// extended timeout (so the guard can finish inside one attempt) plus retries as
-// a backstop. The contract under test is that the Reset is ACKnowledged (the
-// success toast); the reboot is a side effect we simply let settle.
+// reconnecting station is the *next* reset test — its everestStation guard waits
+// for cp001 to come back under the fixture's own timeout, so the reconnect no
+// longer eats the test budget (it used to: the guard alone burned 150-210s of
+// the old 240s describe budget and E2E-071 failed its first attempt on nearly
+// every CI run). The body fits the lane default now; retries stay as a backstop
+// for a reconnect that outlives RECONNECT_TIMEOUT_MS. The contract under test is
+// that the Reset is ACKnowledged (the success toast); the reboot is a side
+// effect we simply let settle.
 test.describe('charging-stations › Reset command @everest', () => {
-  test.describe.configure({ retries: 2, timeout: 240_000 });
+  test.describe.configure({ retries: 2 });
 
   test('E2E-070: Reset Hard happy path against EVerest station', async ({
     page,

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
@@ -65,7 +65,8 @@ test.describe('charging-stations › Reset validation + offline', () => {
     await modal.select(/reset type/i, /^onidle$/i);
 
     // Without an active OCPP session, the command pipeline returns a failure.
-    // The modal stays open and an error toast appears.
-    await modal.submitExpectingError();
+    // The modal stays open and an error toast appears. 60s: doomed commands
+    // queue behind the shared core pipeline under load.
+    await modal.submitExpectingError(undefined, 60_000);
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
@@ -5,6 +5,7 @@
 import { test } from '../../fixtures';
 import { ChargingStationDetailPage } from '../../pages/charging-stations/detail.page';
 import { ModalHarness } from '../../pages/components/modal.po';
+import { waitForEverestOffline } from '../../fixtures/everest';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -12,13 +13,23 @@ test.use({ storageState: 'playwright/.auth/admin.json' });
 // the EVerest manager container, dropping cp001's OCPP link for >150s in CI. The
 // reset tests run LAST in the @everest lane, so the only test that can land on a
 // reconnecting station is the *next* reset test — its everestStation guard waits
-// for cp001 to come back under the fixture's own timeout, so the reconnect no
-// longer eats the test budget (it used to: the guard alone burned 150-210s of
-// the old 240s describe budget and E2E-071 failed its first attempt on nearly
-// every CI run). The body fits the lane default now; retries stay as a backstop
-// for a reconnect that outlives RECONNECT_TIMEOUT_MS. The contract under test is
-// that the Reset is ACKnowledged (the success toast); the reboot is a side
-// effect we simply let settle.
+// for cp001 to come back (and restarts the manager if it wedges) under the
+// fixture's own timeout, so the reconnect never eats the test budget.
+//
+// The contract under test is that the Reset was accepted OR observably
+// executed: an immediate reboot can kill the socket before the CALLRESULT
+// flushes, so the ack toast is not guaranteed even on success — the station
+// visibly dropping offline is equally hard proof the command worked (a
+// recorded run rebooted the charger and never showed the toast).
+async function submitResetAndConfirm(modal: ModalHarness): Promise<void> {
+  await modal.markToastsStale();
+  await modal.submitButton.click();
+  await Promise.any([
+    modal.newToastVisible(/success|accepted|sent|reset|completed|received/i, 60_000),
+    waitForEverestOffline(60_000),
+  ]);
+}
+
 test.describe('charging-stations › Reset command @everest', () => {
   test.describe.configure({ retries: 2 });
 
@@ -33,7 +44,7 @@ test.describe('charging-stations › Reset command @everest', () => {
     const modal = new ModalHarness(page, /reset/i);
     await modal.expectOpen();
     await modal.select(/reset type/i, /^immediate$/i);
-    await modal.submitAndWaitForToast();
+    await submitResetAndConfirm(modal);
   });
 
   test('E2E-071: Reset OnIdle variant against EVerest station', async ({
@@ -47,7 +58,7 @@ test.describe('charging-stations › Reset command @everest', () => {
     const modal = new ModalHarness(page, /reset/i);
     await modal.expectOpen();
     await modal.select(/reset type/i, /^onidle$/i);
-    await modal.submitAndWaitForToast();
+    await submitResetAndConfirm(modal);
   });
 });
 

--- a/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/charging-stations/reset-commands.spec.ts
@@ -28,6 +28,12 @@ async function submitResetAndConfirm(modal: ModalHarness): Promise<void> {
     modal.newToastVisible(/success|accepted|sent|reset|completed|received/i, 60_000),
     waitForEverestOffline(60_000),
   ]);
+  // The reboot trails the ack by a few seconds. Returning before the link
+  // drops lets the next test's online guard sample the pre-reboot window and
+  // walk straight into the outage mid-test. Hold until the drop is observed;
+  // if it never comes the reset simply didn't reboot and there is nothing to
+  // shield the next test from.
+  await waitForEverestOffline(120_000).catch(() => undefined);
 }
 
 test.describe('charging-stations › Reset command @everest', () => {

--- a/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
@@ -79,8 +79,9 @@ test.describe('locations › CRUD', () => {
     // assertion here stays on the pre-fill contract.
     const form = new LocationFormPage(page);
     await form.gotoEdit(seededLocation.id);
-    await expect(form.heading).toContainText(/edit location/i);
-    await expect(form.nameInput).toHaveValue(seededLocation.name);
+    // The prefill lands after the edit query resolves, later than the heading.
+    await expect(form.heading).toContainText(/edit location/i, { timeout: 30_000 });
+    await expect(form.nameInput).toHaveValue(seededLocation.name, { timeout: 30_000 });
   });
 
   test('E2E-024: Create location with empty required fields surfaces validation', async ({

--- a/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
@@ -50,6 +50,7 @@ test.describe('locations › CRUD', () => {
     // numeric id for cleanup.
     const list = new LocationsListPage(page);
     await list.goto();
+    await list.searchInput.fill(name);
     await expect(list.rowByName(name)).toBeVisible({ timeout: 30_000 });
 
     // Cleanup via apiClient: locate by name, delete by id.

--- a/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/locations/crud.spec.ts
@@ -31,7 +31,7 @@ test.describe('locations › CRUD', () => {
   });
 
   test('E2E-021: Create location via UI redirects to detail', async ({ page, apiClient }) => {
-    const name = `e2e-${shortId()}-loc`;
+    const name = `${shortId()}-loc`;
     const form = new LocationFormPage(page);
     await form.gotoNew();
     // United States is the default country and requires State + ZIP per

--- a/apps/operator-ui/tests/e2e/specs/locations/map.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/locations/map.spec.ts
@@ -39,6 +39,7 @@ test.describe('locations › map', () => {
 
     const list = new LocationsListPage(page);
     await list.goto();
+    await list.searchInput.fill(seededLocation.name);
     await expect(list.rowByName(seededLocation.name)).toBeVisible({
       timeout: 15_000,
     });

--- a/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
@@ -4,10 +4,18 @@
 
 import { test, expect } from '../../fixtures';
 import { OverviewPage } from '../../pages/overview.page';
+import { blockGoogleMaps, restoreAllRoutes } from '../../utils/route-overrides';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe('overview › dashboard', () => {
+  // CI has no Maps key, so /overview otherwise fires live requests at
+  // maps.googleapis.com (and renders the SDK's AuthFailure card) on every
+  // test — external network has no business in these assertions. E2E-011
+  // opts back out below because the live SDK is exactly what it tests.
+  test.beforeEach(async ({ page }) => {
+    await blockGoogleMaps(page);
+  });
   test('E2E-010: KPI cards render their headings on /overview', async ({
     page,
     seededLocation,
@@ -54,6 +62,9 @@ test.describe('overview › dashboard', () => {
       'MAPS_E2E_KEY not provisioned; the Google Maps SDK cannot authenticate and the map surface never mounts.',
     );
     void seededLocation;
+
+    // This test wants the real SDK — undo the suite-wide Maps block.
+    await restoreAllRoutes(page);
 
     const overview = new OverviewPage(page);
     await overview.goto();

--- a/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
@@ -21,11 +21,13 @@ test.describe('overview › dashboard', () => {
     const overview = new OverviewPage(page);
     await overview.goto();
 
-    await expect(overview.kpiOnlineHeading).toBeVisible();
-    await expect(overview.kpiActiveTransactionsHeading).toBeVisible();
-    await expect(overview.kpiPluginSuccessHeading).toBeVisible();
-    await expect(overview.kpiChargerActivityHeading).toBeVisible();
-    await expect(overview.locationsCardHeading).toBeVisible();
+    // The KPI headings sit inside query-bound skeletons; under CI load the
+    // Hasura round trips can far outlive the default expect timeout.
+    await expect(overview.kpiOnlineHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiActiveTransactionsHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiPluginSuccessHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiChargerActivityHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.locationsCardHeading).toBeVisible({ timeout: 60_000 });
   });
 
   test('E2E-011: Locations card mounts the Google map surface when MAPS_E2E_KEY is provisioned', async ({
@@ -81,9 +83,9 @@ test.describe('overview › dashboard', () => {
     const overview = new OverviewPage(page);
     await overview.goto();
 
-    await expect(overview.kpiOnlineHeading).toBeVisible();
-    await expect(overview.kpiActiveTransactionsHeading).toBeVisible();
-    await expect(overview.kpiPluginSuccessHeading).toBeVisible();
-    await expect(overview.kpiChargerActivityHeading).toBeVisible();
+    await expect(overview.kpiOnlineHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiActiveTransactionsHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiPluginSuccessHeading).toBeVisible({ timeout: 60_000 });
+    await expect(overview.kpiChargerActivityHeading).toBeVisible({ timeout: 60_000 });
   });
 });

--- a/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/dashboard.spec.ts
@@ -84,8 +84,13 @@ test.describe('overview › dashboard', () => {
     const overview = new OverviewPage(page);
     await overview.goto();
 
-    await expect(overview.kpiActiveTransactionsHeading).toBeVisible();
-    await expect(page.getByText(seededTransaction.transactionId, { exact: false })).toBeVisible({
+    await expect(overview.kpiActiveTransactionsHeading).toBeVisible({ timeout: 60_000 });
+    // The card lists only the 3 newest active transactions, so concurrently
+    // seeded ones can displace ours — look it up via the card's search, which
+    // filters server-side on transactionId.
+    await page.getByRole('combobox').click();
+    await page.keyboard.type(seededTransaction.transactionId);
+    await expect(page.getByRole('option', { name: seededTransaction.transactionId })).toBeVisible({
       timeout: 30_000,
     });
   });

--- a/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
@@ -17,7 +17,9 @@ test.describe('overview › locale', () => {
     await overview.goto();
 
     // Default locale is English: the Locations card heading is rendered in English.
-    await expect(page.getByRole('heading', { name: /^locations$/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /^locations$/i })).toBeVisible({
+      timeout: 30_000,
+    });
 
     // Switch to Brazilian Portuguese via the sidebar language switcher.
     await page.getByRole('button', { name: /^language$/i }).click();

--- a/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/locale.spec.ts
@@ -4,12 +4,17 @@
 
 import { test, expect } from '../../fixtures';
 import { OverviewPage } from '../../pages/overview.page';
+import { blockGoogleMaps } from '../../utils/route-overrides';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.setTimeout(90_000);
 
 test.describe('overview › locale', () => {
+  // Keep the live Maps SDK (no key in CI) out of these navigations.
+  test.beforeEach(async ({ page }) => {
+    await blockGoogleMaps(page);
+  });
   test('E2E-018: language switcher changes UI language and persists across reload', async ({
     page,
   }) => {

--- a/apps/operator-ui/tests/e2e/specs/overview/welcome-modal.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/welcome-modal.spec.ts
@@ -5,10 +5,15 @@
 import { test, expect } from '../../fixtures';
 import { OverviewPage } from '../../pages/overview.page';
 import { clearWelcomeFlagBeforeLoad } from '../../utils/storage';
+import { blockGoogleMaps } from '../../utils/route-overrides';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
 test.describe('overview › welcome modal', () => {
+  // Keep the live Maps SDK (no key in CI) out of these navigations.
+  test.beforeEach(async ({ page }) => {
+    await blockGoogleMaps(page);
+  });
   test('E2E-015: first sign-in shows the welcome modal; dismissal persists across reload', async ({
     page,
   }) => {

--- a/apps/operator-ui/tests/e2e/specs/overview/welcome-modal.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/overview/welcome-modal.spec.ts
@@ -4,7 +4,7 @@
 
 import { test, expect } from '../../fixtures';
 import { OverviewPage } from '../../pages/overview.page';
-import { clearWelcomeFlag } from '../../utils/storage';
+import { clearWelcomeFlagBeforeLoad } from '../../utils/storage';
 
 test.use({ storageState: 'playwright/.auth/admin.json' });
 
@@ -14,15 +14,16 @@ test.describe('overview › welcome modal', () => {
   }) => {
     const overview = new OverviewPage(page);
 
-    // Goto first to obtain origin context, then clear localStorage so the modal
-    // re-appears as if this were the first visit.
-    await page.goto(OverviewPage.path);
-    await clearWelcomeFlag(page);
-    await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
+    // Strip the first-login flag before any app code runs so this navigation
+    // behaves like a genuine first visit. Clearing after goto used to race
+    // the layout effect, which re-writes the flag the moment it shows the
+    // modal — the reload then found the flag and the dialog never rendered.
+    await clearWelcomeFlagBeforeLoad(page);
+    await page.goto(OverviewPage.path, { waitUntil: 'domcontentloaded', timeout: 60_000 });
 
-    await expect(overview.welcomeDialog).toBeVisible({ timeout: 15_000 });
+    await expect(overview.welcomeDialog).toBeVisible({ timeout: 60_000 });
     await overview.welcomeCloseButton.click();
-    await expect(overview.welcomeDialog).toBeHidden();
+    await expect(overview.welcomeDialog).toBeHidden({ timeout: 15_000 });
 
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
     await overview.expectLoaded();

--- a/apps/operator-ui/tests/e2e/specs/partners/register.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/partners/register.spec.ts
@@ -19,11 +19,18 @@ test.describe('partners › register', () => {
     page,
     apiClient,
   }) => {
+    // ZZ is the ISO user-assigned country code, so these rows can never be
+    // confused with real partners, and purgeAllE2eRows sweeps ZZ leftovers.
+    // The party id is random per attempt: a fixed pair used to collide with
+    // the row a failed first attempt left behind, turning every CI retry red.
+    const partyId = Array.from({ length: 3 }, () =>
+      String.fromCharCode(65 + Math.floor(Math.random() * 26)),
+    ).join('');
     const form = new PartnerFormPage(page);
     await form.gotoNew();
     await form.fill({
-      countryCode: 'US',
-      partyId: 'XYZ',
+      countryCode: 'ZZ',
+      partyId,
       versionsUrl: 'https://example.invalid/ocpi/2.2/versions',
       clientToken: 'e2e-client-token',
     });
@@ -36,11 +43,12 @@ test.describe('partners › register', () => {
     // Cleanup: delete the partner row directly.
     await apiClient
       .gql(
-        `mutation Cleanup {
-           delete_TenantPartners(where: { partyId: { _eq: "XYZ" }, countryCode: { _eq: "US" } }) {
+        `mutation Cleanup($partyId: String!) {
+           delete_TenantPartners(where: { partyId: { _eq: $partyId }, countryCode: { _eq: "ZZ" } }) {
              affected_rows
            }
          }`,
+        { partyId },
       )
       .catch(() => undefined);
   });

--- a/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
@@ -17,23 +17,28 @@ test.describe('tariffs › CRUD', () => {
   });
 
   test('E2E-111: Create tariff via UI surfaces success toast', async ({ page, apiClient }) => {
+    // XTS is the ISO currency code reserved for testing, and the price is
+    // unique per attempt — the old fixed USD@0.35 collided with rows a failed
+    // attempt (or another run) left behind, and its cleanup deleted every
+    // matching tariff in the DB, not just ours.
+    const distinctivePrice = Number(`0.${Date.now().toString().slice(-6)}`);
     const form = new TariffFormPage(page);
     await form.gotoNew();
     await form.fill({
-      currency: 'USD',
-      pricePerKwh: 0.35,
+      currency: 'XTS',
+      pricePerKwh: distinctivePrice,
     });
     await form.submit();
 
-    // Cleanup: delete the tariff we just created (best-effort match by
-    // recently-added USD tariff with the per-kWh price we set).
+    // Cleanup: the price is unique, so this can only match our own row.
     await apiClient
       .gql(
-        `mutation Cleanup {
-           delete_Tariffs(where: { currency: { _eq: "USD" }, pricePerKwh: { _eq: 0.35 } }) {
+        `mutation Cleanup($price: numeric!) {
+           delete_Tariffs(where: { currency: { _eq: "XTS" }, pricePerKwh: { _eq: $price } }) {
              affected_rows
            }
          }`,
+        { price: distinctivePrice },
       )
       .catch(() => undefined);
   });
@@ -52,7 +57,7 @@ test.describe('tariffs › CRUD', () => {
        }`,
       {
         obj: {
-          currency: 'USD',
+          currency: 'XTS',
           pricePerKwh: distinctivePrice,
           createdAt: now,
           updatedAt: now,
@@ -73,7 +78,7 @@ test.describe('tariffs › CRUD', () => {
     } finally {
       await apiClient
         .gql(
-          `mutation Cleanup($id: bigint!) {
+          `mutation Cleanup($id: Int!) {
              delete_Tariffs_by_pk(id: $id) { id }
            }`,
           { id: created.id },

--- a/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
@@ -17,11 +17,12 @@ test.describe('tariffs › CRUD', () => {
   });
 
   test('E2E-111: Create tariff via UI surfaces success toast', async ({ page, apiClient }) => {
-    // XTS is the ISO currency code reserved for testing, and the price is
-    // unique per attempt — the old fixed USD@0.35 collided with rows a failed
+    // XTS is the ISO currency code reserved for testing, and the price varies
+    // per attempt — the old fixed USD@0.35 collided with rows a failed
     // attempt (or another run) left behind, and its cleanup deleted every
-    // matching tariff in the DB, not just ours.
-    const distinctivePrice = Number(`0.${Date.now().toString().slice(-6)}`);
+    // matching tariff in the DB, not just ours. Two decimals only: the form's
+    // price input enforces step="0.01", so a finer price blocks the submit.
+    const distinctivePrice = ((Date.now() % 89) + 11) / 100;
     const form = new TariffFormPage(page);
     await form.gotoNew();
     await form.fill({

--- a/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/tariffs/crud.spec.ts
@@ -75,7 +75,13 @@ test.describe('tariffs › CRUD', () => {
       await page.waitForURL(/\/tariffs$/, { timeout: 30_000 });
       const list = new TariffsListPage(page);
       await expect(list.heading).toBeVisible();
-      await expect(page.getByRole('row').filter({ hasText: String(created.id) })).toHaveCount(0);
+      // Match the id cell exactly — a substring match on the whole row also
+      // hits price cells (id 47 vs a 0.47 price from a concurrent test).
+      await expect(
+        page
+          .getByRole('row')
+          .filter({ has: page.getByRole('cell', { name: String(created.id), exact: true }) }),
+      ).toHaveCount(0);
     } finally {
       await apiClient
         .gql(

--- a/apps/operator-ui/tests/e2e/specs/transactions/list.spec.ts
+++ b/apps/operator-ui/tests/e2e/specs/transactions/list.spec.ts
@@ -30,7 +30,7 @@ test.describe('transactions › list', () => {
   }) => {
     // Decoy on a different station so the filter has something to exclude.
     const decoyStation = await seedStation(apiClient, seededLocation.id, {
-      ocppConnectionName: `e2e-${shortId()}-decoy-cp`,
+      ocppConnectionName: `${shortId()}-decoy-cp`,
     });
     const decoyTxn = await seedTransaction(apiClient, decoyStation.ocppConnectionName);
 

--- a/apps/operator-ui/tests/e2e/utils/managed-server.ts
+++ b/apps/operator-ui/tests/e2e/utils/managed-server.ts
@@ -87,13 +87,23 @@ function spawnDetachedServer(): number {
 // return. If a server is already responding, reuse it. Otherwise build a
 // production bundle and spawn `next start`, persisting the PID so
 // teardown can stop it.
+//
+// E2E_SKIP_BUILD: CI builds operator-ui in its own workflow step right before
+// the test step, so rebuilding here doubles ~1.7 min onto the critical path
+// of BOTH e2e lanes. When the flag is set AND a build output exists, reuse
+// it. The BUILD_ID guard keeps the flag safe locally: no artifacts, no skip.
 export async function ensureManagedServer(baseUrl: string): Promise<void> {
   if (await isServerResponding(baseUrl)) {
     console.info('[e2e:managed-server] reusing existing server at', baseUrl);
     return;
   }
-  console.info('[e2e:managed-server] no server responding — building production bundle...');
-  await runNpmScriptToCompletion('build');
+  const buildOutput = resolve(REPO_ROOT, '.next', 'BUILD_ID');
+  if (process.env.E2E_SKIP_BUILD && existsSync(buildOutput)) {
+    console.info('[e2e:managed-server] E2E_SKIP_BUILD set — reusing existing .next build.');
+  } else {
+    console.info('[e2e:managed-server] no server responding — building production bundle...');
+    await runNpmScriptToCompletion('build');
+  }
   console.info('[e2e:managed-server] starting next start...');
   const pid = spawnDetachedServer();
   writeFileSync(PID_FILE, String(pid), 'utf8');

--- a/apps/operator-ui/tests/e2e/utils/managed-server.ts
+++ b/apps/operator-ui/tests/e2e/utils/managed-server.ts
@@ -75,6 +75,12 @@ function spawnDetachedServer(): number {
     detached: true,
     stdio: 'ignore',
     shell: process.platform === 'win32',
+    env: {
+      ...process.env,
+      // Same heap budget as the build: an OOM in `next start` takes down
+      // every worker at once and reads as a mass timeout.
+      NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ''} --max-old-space-size=4096`.trim(),
+    },
   });
   proc.unref();
   if (!proc.pid) {

--- a/apps/operator-ui/tests/e2e/utils/schema-drift.ts
+++ b/apps/operator-ui/tests/e2e/utils/schema-drift.ts
@@ -14,16 +14,31 @@ import type { ApiClient } from '../fixtures/api-client';
 export interface SchemaSnapshot {
   readonly operations: ReadonlyArray<string>;
   readonly columnsByType: Readonly<Record<string, ReadonlyArray<string>>>;
+  // Rendered arg signatures ("id: Int!") for the tracked tables' by-pk and
+  // insert-one operations. Optional so older snapshots keep validating —
+  // the check only runs once the snapshot is regenerated with this field.
+  // Without it a mutation declaring `$id: bigint!` against an `Int!` schema
+  // fails Hasura validation silently (that exact bug leaked every seeded
+  // location for weeks).
+  readonly argTypesByOperation?: Readonly<Record<string, ReadonlyArray<string>>>;
 }
 
 export interface SchemaDriftReport {
   readonly valid: boolean;
   readonly missingOperations: ReadonlyArray<string>;
   readonly missingColumns: ReadonlyArray<{ type: string; column: string }>;
+  readonly changedArgs: ReadonlyArray<{ operation: string; expected: string; actual: string }>;
+}
+
+interface IntrospectionTypeRef {
+  readonly kind: string;
+  readonly name: string | null;
+  readonly ofType?: IntrospectionTypeRef | null;
 }
 
 interface IntrospectionField {
   readonly name: string;
+  readonly args?: ReadonlyArray<{ readonly name: string; readonly type: IntrospectionTypeRef }>;
   readonly type?: {
     readonly name: string | null;
     readonly ofType?: { readonly name: string | null } | null;
@@ -52,6 +67,14 @@ const INTROSPECTION_QUERY = `
         kind
         fields {
           name
+          args {
+            name
+            type {
+              kind
+              name
+              ofType { kind name ofType { kind name ofType { kind name } } }
+            }
+          }
         }
       }
     }
@@ -74,6 +97,21 @@ const TRACKED_TABLES: ReadonlyArray<string> = [
   'TenantPartners',
 ];
 
+function renderTypeRef(ref: IntrospectionTypeRef | null | undefined): string {
+  if (!ref) return 'Unknown';
+  if (ref.kind === 'NON_NULL') return `${renderTypeRef(ref.ofType)}!`;
+  if (ref.kind === 'LIST') return `[${renderTypeRef(ref.ofType)}]`;
+  return ref.name ?? 'Unknown';
+}
+
+// The operations whose argument types we pin — the by-pk mutations are where
+// a wrong variable declaration fails Hasura validation before execution.
+const TRACKED_ARG_OPERATIONS: ReadonlyArray<string> = TRACKED_TABLES.flatMap((t) => [
+  `delete_${t}_by_pk`,
+  `update_${t}_by_pk`,
+  `insert_${t}_one`,
+]);
+
 export async function captureHasuraIntrospection(api: ApiClient): Promise<SchemaSnapshot> {
   const data = await api.gql<{ __schema: IntrospectionSchema }>(INTROSPECTION_QUERY);
   const schema = data.__schema;
@@ -91,9 +129,20 @@ export async function captureHasuraIntrospection(api: ApiClient): Promise<Schema
     columnsByType[tableName] = t.fields.map((f) => f.name).sort();
   }
 
+  const argTypesByOperation: Record<string, string[]> = {};
+  const rootFields = [...(queryType?.fields ?? []), ...(mutationType?.fields ?? [])];
+  for (const opName of TRACKED_ARG_OPERATIONS) {
+    const field = rootFields.find((f) => f.name === opName);
+    if (!field?.args?.length) continue;
+    argTypesByOperation[opName] = field.args
+      .map((a) => `${a.name}: ${renderTypeRef(a.type)}`)
+      .sort();
+  }
+
   return {
     operations: Array.from(operationNames).sort(),
     columnsByType,
+    argTypesByOperation,
   };
 }
 
@@ -112,10 +161,23 @@ export function validateSchemaDrift(
     }
   }
 
+  const changedArgs: { operation: string; expected: string; actual: string }[] = [];
+  if (baseline.argTypesByOperation) {
+    for (const [op, baselineArgs] of Object.entries(baseline.argTypesByOperation)) {
+      const currentArgs = current.argTypesByOperation?.[op];
+      if (!currentArgs) continue; // operation absence is already reported above
+      const expected = baselineArgs.join(', ');
+      const actual = currentArgs.join(', ');
+      if (expected !== actual) changedArgs.push({ operation: op, expected, actual });
+    }
+  }
+
   return {
-    valid: missingOperations.length === 0 && missingColumns.length === 0,
+    valid:
+      missingOperations.length === 0 && missingColumns.length === 0 && changedArgs.length === 0,
     missingOperations,
     missingColumns,
+    changedArgs,
   };
 }
 
@@ -127,6 +189,13 @@ export function formatDriftMessage(report: SchemaDriftReport): string {
   if (report.missingColumns.length > 0) {
     lines.push(
       `Missing columns: ${report.missingColumns.map((m) => `${m.type}.${m.column}`).join(', ')}`,
+    );
+  }
+  if (report.changedArgs.length > 0) {
+    lines.push(
+      `Changed argument types: ${report.changedArgs
+        .map((c) => `${c.operation} (expected ${c.expected}, got ${c.actual})`)
+        .join('; ')}`,
     );
   }
   return lines.join('\n');

--- a/apps/operator-ui/tests/e2e/utils/storage.ts
+++ b/apps/operator-ui/tests/e2e/utils/storage.ts
@@ -17,6 +17,26 @@ export async function clearWelcomeFlag(page: Page): Promise<void> {
   }, FIRST_LOGIN_KEY_PREFIX);
 }
 
+// Removes the first-login flags BEFORE any app code runs on the next
+// navigation. clearWelcomeFlag above runs after goto, which races the layout
+// effect: the effect can re-write the flag (it writes on show) between the
+// clear and the following reload, and then the modal never renders. Init
+// scripts run ahead of the bundle, so this can't lose that race. One-shot via
+// a sessionStorage marker so a later reload in the same context keeps the
+// re-written flag — "dismissal persists across reload" stays testable.
+export async function clearWelcomeFlagBeforeLoad(page: Page): Promise<void> {
+  await page.addInitScript((prefix) => {
+    if (sessionStorage.getItem('e2eWelcomeCleared')) return;
+    sessionStorage.setItem('e2eWelcomeCleared', '1');
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith(prefix)) keys.push(key);
+    }
+    for (const key of keys) localStorage.removeItem(key);
+  }, FIRST_LOGIN_KEY_PREFIX);
+}
+
 export async function setWelcomeFlag(page: Page, userId: string, value: boolean): Promise<void> {
   await page.evaluate(
     ([prefix, id, v]) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,13 @@ export default defineConfig({
     // (they call @playwright/test's test.use(), which only works under the
     // Playwright runner). Run them via `pnpm --filter @citrineos/operator-ui test:e2e`.
     exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'apps/operator-ui/**'],
+    // The testcontainers-backed integration suites annotate their beforeAll
+    // with 90s but leave beforeEach/afterAll on the 5s/10s defaults, which CI
+    // load intermittently blows (truncate cascade, container stop). Raised
+    // globally — passing unit suites never wait on a timeout, this only
+    // bounds failures.
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
     coverage: {
       reporter: ['text', 'json', 'html'],
     },


### PR DESCRIPTION

Note: the tests job is currently red on next itself (AuthorizationMapper 2.1 groupIdToken TypeError, came in with #795) - unrelated to this branch.
