### PR TITLE
fix(handlers): correlate NotifyCustomerInformation and NotifyDisplayMessages by requestId against the payload column

### DIFF
--- a/packages/core/src/handlers/requests/2/NotifyCustomerInformationRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/NotifyCustomerInformationRequestOcpp2Handler.ts
@@ -57,7 +57,7 @@ export class NotifyCustomerInformationRequestOcpp2Handler extends AbstractHandle
           tenantId: message.context.tenantId,
           ocppConnectionName: message.context.ocppConnectionName,
           action: OCPP_CallAction.CustomerInformation,
-          message: {
+          payload: {
             requestId: requestId,
           },
         },

--- a/packages/core/src/handlers/requests/2/NotifyDisplayMessagesRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/NotifyDisplayMessagesRequestOcpp2Handler.ts
@@ -65,7 +65,7 @@ export class NotifyDisplayMessagesRequestOcpp2Handler extends AbstractHandler {
           tenantId: message.context.tenantId,
           ocppConnectionName: message.context.ocppConnectionName,
           action: OCPP_CallAction.GetDisplayMessages,
-          message: {
+          payload: {
             requestId: requestId,
           },
         },

--- a/packages/core/test/handlers/requests/2/NotifyCustomerInformationRequestOcpp2Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/NotifyCustomerInformationRequestOcpp2Handler.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type OcppRequest,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP_CallAction,
+} from '@citrineos/types';
+import { DEFAULT_TENANT_ID, Message, type OCPP2_request_types } from '@citrineos/base';
+import { NotifyCustomerInformationRequestOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+const STATION_ID = 'station-001';
+const REQUEST_ID = 9940;
+
+function aNotifyCustomerInformationMessage<T extends OcppRequest>(payload: T): Message<T> {
+  return new Message(
+    MessageOrigin.ChargingStation,
+    EventGroup.Reporting,
+    OCPP_CallAction.NotifyCustomerInformation,
+    MessageState.Request,
+    {
+      correlationId: 'corr-001',
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION_ID,
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    'ocpp2.0.1',
+  );
+}
+
+function aNotifyCustomerInformationRequest(): OCPP2_request_types.NotifyCustomerInformationRequest {
+  return {
+    data: 'customer data',
+    seqNo: 0,
+    generatedAt: new Date().toISOString(),
+    requestId: REQUEST_ID,
+  };
+}
+
+describe('NotifyCustomerInformationRequestOcpp2Handler', () => {
+  const { logger } = createTestContainer();
+  let handler: NotifyCustomerInformationRequestOcpp2Handler;
+  let ocppMessageRepository: { readAllByQuery: ReturnType<typeof vi.fn> };
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    ocppMessageRepository = { readAllByQuery: vi.fn() };
+    ocppSender = makeMockOcppSender();
+
+    handler = new NotifyCustomerInformationRequestOcpp2Handler({
+      logger,
+      ocppSender,
+      ocppMessageRepository,
+    });
+  });
+
+  it('correlates the requestId against the stored payload and acknowledges', async () => {
+    ocppMessageRepository.readAllByQuery.mockResolvedValue([{ id: 1 }]);
+
+    await handler.handle(aNotifyCustomerInformationMessage(aNotifyCustomerInformationRequest()));
+
+    expect(ocppMessageRepository.readAllByQuery).toHaveBeenCalledWith(DEFAULT_TENANT_ID, {
+      where: {
+        tenantId: DEFAULT_TENANT_ID,
+        ocppConnectionName: STATION_ID,
+        action: OCPP_CallAction.CustomerInformation,
+        payload: { requestId: REQUEST_ID },
+      },
+      limit: 1,
+    });
+    expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalled();
+    expect(ocppSender.sendCallErrorWithMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects with a CallError when no CustomerInformationRequest matches the requestId', async () => {
+    ocppMessageRepository.readAllByQuery.mockResolvedValue([]);
+
+    await handler.handle(aNotifyCustomerInformationMessage(aNotifyCustomerInformationRequest()));
+
+    expect(ocppSender.sendCallErrorWithMessage).toHaveBeenCalled();
+    expect(ocppSender.sendCallResultWithMessage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/handlers/requests/2/NotifyDisplayMessagesRequestOcpp2Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/NotifyDisplayMessagesRequestOcpp2Handler.test.ts
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type OcppRequest,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP_CallAction,
+} from '@citrineos/types';
+import { DEFAULT_TENANT_ID, Message, type OCPP2_request_types } from '@citrineos/base';
+import { NotifyDisplayMessagesRequestOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+const STATION_ID = 'station-001';
+const REQUEST_ID = 42;
+
+function aNotifyDisplayMessagesMessage<T extends OcppRequest>(payload: T): Message<T> {
+  return new Message(
+    MessageOrigin.ChargingStation,
+    EventGroup.Configuration,
+    OCPP_CallAction.NotifyDisplayMessages,
+    MessageState.Request,
+    {
+      correlationId: 'corr-001',
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION_ID,
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    'ocpp2.0.1',
+  );
+}
+
+function aNotifyDisplayMessagesRequest(): OCPP2_request_types.NotifyDisplayMessagesRequest {
+  return {
+    requestId: REQUEST_ID,
+    messageInfo: [],
+  };
+}
+
+describe('NotifyDisplayMessagesRequestOcpp2Handler', () => {
+  const { logger } = createTestContainer();
+  let handler: NotifyDisplayMessagesRequestOcpp2Handler;
+  let ocppMessageRepository: { readAllByQuery: ReturnType<typeof vi.fn> };
+  let deviceModelRepository: { findOrCreateEvseAndComponent: ReturnType<typeof vi.fn> };
+  let messageInfoRepository: {
+    createOrUpdateByMessageInfoTypeAndStationId: ReturnType<typeof vi.fn>;
+  };
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    ocppMessageRepository = { readAllByQuery: vi.fn() };
+    deviceModelRepository = { findOrCreateEvseAndComponent: vi.fn() };
+    messageInfoRepository = { createOrUpdateByMessageInfoTypeAndStationId: vi.fn() };
+    ocppSender = makeMockOcppSender();
+
+    handler = new NotifyDisplayMessagesRequestOcpp2Handler({
+      logger,
+      ocppSender,
+      ocppMessageRepository,
+      deviceModelRepository,
+      messageInfoRepository,
+    });
+  });
+
+  it('correlates the requestId against the stored payload and acknowledges', async () => {
+    ocppMessageRepository.readAllByQuery.mockResolvedValue([{ id: 1 }]);
+
+    await handler.handle(aNotifyDisplayMessagesMessage(aNotifyDisplayMessagesRequest()));
+
+    expect(ocppMessageRepository.readAllByQuery).toHaveBeenCalledWith(DEFAULT_TENANT_ID, {
+      where: {
+        tenantId: DEFAULT_TENANT_ID,
+        ocppConnectionName: STATION_ID,
+        action: OCPP_CallAction.GetDisplayMessages,
+        payload: { requestId: REQUEST_ID },
+      },
+      limit: 1,
+    });
+    expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalled();
+    expect(ocppSender.sendCallErrorWithMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects with a CallError when no GetDisplayMessagesRequest matches the requestId', async () => {
+    ocppMessageRepository.readAllByQuery.mockResolvedValue([]);
+
+    await handler.handle(aNotifyDisplayMessagesMessage(aNotifyDisplayMessagesRequest()));
+
+    expect(ocppSender.sendCallErrorWithMessage).toHaveBeenCalled();
+    expect(ocppSender.sendCallResultWithMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

Every `NotifyCustomerInformation` and `NotifyDisplayMessages` sent by a charging station is rejected with `CALLERROR PropertyConstraintViolation` ("RequestId was not provided in a ...Request."), even when the station echoes the exact `requestId` the CSMS sent.

Both handlers validate the notification by looking up the originating request in `OCPPMessages`:

```ts
where: {
  ...
  action: OCPP_CallAction.CustomerInformation,
  message: { requestId: requestId },
}
```

The OCPP message model refactor (#816) replaced the `message` column with `payload` (parsed OCPP payload, JSONB) and `raw` (wire frame, TEXT), but these two queries were carried over unchanged. They now reference a column that no longer exists, so the lookup fails and the handler always errors — the notification data is lost.

This replaces #808, which fixed the same correlation failure in the pre-refactor code (there the column existed but held the raw RPC frame array, so the object match never matched). The refactor moved the logic from `Reporting`/`Configuration` module files into the per-message handler classes, which is why that PR no longer applied. With `payload` now storing the parsed payload object, the fix reduces to matching against the right column.

## Fix

Query `payload: { requestId }` instead of `message: { requestId }` in:

- `packages/core/src/handlers/requests/2/NotifyCustomerInformationRequestOcpp2Handler.ts`
- `packages/core/src/handlers/requests/2/NotifyDisplayMessagesRequestOcpp2Handler.ts`

## Tests

- Added unit tests for both handlers covering the accept path (asserting the repository is queried by `payload.requestId`) and the reject path (no matching request → CallError). `vitest run` on the two files: 4/4 pass.
- `tsc --noEmit` over `packages/core`: identical pre-existing error count before and after the change; no new errors.
- The original defect was observed end-to-end against a real OCPP 2.0.1 station: all `CustomerInformation` variants were `Accepted` by the charger, and every resulting `NotifyCustomerInformation` was rejected by the CSMS. With the correlation fixed (equivalent change on our fork), the station receives a proper `NotifyCustomerInformationResponse` CallResult.