### PR TITLE
Adding Authorization Drizzle Repository

### DIFF
--- a/apps/ocpp-server/src/container.ts
+++ b/apps/ocpp-server/src/container.ts
@@ -121,6 +121,7 @@ import {
   WebhookDispatcher,
   WebsocketNetworkConnection,
 } from '@citrineos/core';
+import { DrizzleAuthorizationRepository } from '@citrineos/core/dist/src/dal/layers/drizzle/index.js';
 
 type Prebuilt = {
   logger: Logger<ILogObj>;
@@ -311,6 +312,7 @@ function registerRepositories(container: AwilixContainer): void {
 
       useTenantSchema: asValue(false),
 
+      authorizationRepository: asClass(DrizzleAuthorizationRepository).singleton(),
       securityEventRepository: asClass(DrizzleSecurityEventRepository).singleton(),
       subscriptionRepository: asClass(DrizzleSubscriptionRepository).singleton(),
       serverNetworkProfileRepository: asClass(DrizzleServerNetworkProfileRepository).singleton(),

--- a/packages/core/src/dal/interfaces/queries/Authorization.ts
+++ b/packages/core/src/dal/interfaces/queries/Authorization.ts
@@ -5,19 +5,25 @@
 import { QuerySchema } from '@citrineos/base';
 
 export interface AuthorizationQuerystring {
-  idToken: string;
+  idToken?: string | null | undefined;
   type?: string | null | undefined;
+  id?: number | null | undefined;
 }
 
 export const AuthorizationQuerySchema = QuerySchema('AuthorizationQuerySchema', [
   {
     key: 'idToken',
     type: 'string',
-    required: true,
+    required: false,
   },
   {
     key: 'type',
     type: 'string',
+    required: false,
+  },
+  {
+    key: 'id',
+    type: 'number',
     required: false,
   },
 ]);

--- a/packages/core/src/dal/interfaces/repositories.ts
+++ b/packages/core/src/dal/interfaces/repositories.ts
@@ -9,6 +9,7 @@ import type {
   OCPP2_request_types,
 } from '@citrineos/base';
 import type {
+  AuthorizationDto,
   CallAction,
   ChargingLimitSourceEnumType,
   ChargingProfilePurposeEnumType,
@@ -29,7 +30,6 @@ import type {
   ChargingProfileInput,
   CompositeScheduleInput,
 } from '../layers/sequelize/mapper/2.0.1/ChargingProfileMapper.js';
-import type { Authorization } from '../layers/sequelize/model/Authorization/Authorization.js';
 import type { LocalListVersion } from '../layers/sequelize/model/Authorization/LocalListVersion.js';
 import type { SendLocalList } from '../layers/sequelize/model/Authorization/SendLocalList.js';
 import type { Boot } from '../layers/sequelize/model/Boot.js';
@@ -74,15 +74,15 @@ import type { AuthorizationQuerystring } from './queries/Authorization.js';
 import type { TariffQueryString } from './queries/Tariff.js';
 import type { VariableAttributeQuerystring } from './queries/VariableAttribute.js';
 
-export interface IAuthorizationRepository extends CrudRepository<Authorization> {
+export interface IAuthorizationRepository {
   readAllByQuerystring: (
     tenantId: number,
     query: AuthorizationQuerystring,
-  ) => Promise<Authorization[]>;
+  ) => Promise<AuthorizationDto[]>;
   readOnlyOneByQuerystring: (
     tenantId: number,
     query: AuthorizationQuerystring,
-  ) => Promise<Authorization | undefined>;
+  ) => Promise<AuthorizationDto | undefined>;
 }
 
 /**

--- a/packages/core/src/dal/interfaces/repositories.ts
+++ b/packages/core/src/dal/interfaces/repositories.ts
@@ -83,6 +83,7 @@ export interface IAuthorizationRepository {
     tenantId: number,
     query: AuthorizationQuerystring,
   ) => Promise<AuthorizationDto | undefined>;
+  findAllAuthorizationsWithTariffs: (tenantId: number) => Promise<AuthorizationDto[]>;
 }
 
 /**

--- a/packages/core/src/dal/layers/drizzle/index.ts
+++ b/packages/core/src/dal/layers/drizzle/index.ts
@@ -4,6 +4,15 @@
 
 export { DefaultDrizzleInstance } from './util.js';
 export { DrizzleRepository, type DrizzleRepositoryDependencies } from './repository/Base.js';
+export { DrizzleAuthorizationRepository, toAuthorizationDto } from './repository/Authorization.js';
+export {
+  authorizationTable,
+  tenantAuthorizationTable,
+  AuthorizationEntitySchema,
+  AuthorizationEntityInsertSchema,
+  type AuthorizationEntity,
+  type AuthorizationEntityInsert,
+} from './schema/Authorization.js';
 export { DrizzleSecurityEventRepository, toSecurityEventDto } from './repository/SecurityEvent.js';
 export {
   securityEventTable,

--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -90,6 +90,9 @@ export class DrizzleAuthorizationRepository
     if (query.type) {
       conditions.push(eq(authorizationTable.idTokenType, query.type));
     }
+    if (query.id) {
+      conditions.push(eq(authorizationTable.id, query.id));
+    }
 
     return conditions;
   }

--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -85,7 +85,7 @@ export class DrizzleAuthorizationRepository
       conditions.push(eq(authorizationTable.idToken, query.idToken));
     }
     if (query.type) {
-      conditions.push(eq(authorizationTable.idToken, query.idToken));
+      conditions.push(eq(authorizationTable.idTokenType, query.type));
     }
 
     return conditions;

--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -16,7 +16,7 @@ import {
 import { type Explicit } from '../types.js';
 import { DrizzleRepository } from './Base.js';
 import type { AuthorizationQuerystring, IAuthorizationRepository } from '@/dal/index.js';
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 // Maps a Drizzle entity (DB row) to the external AuthorizationDto contract.
@@ -55,7 +55,10 @@ export function toAuthorizationDto(entity: AuthorizationEntity): AuthorizationDt
     // Relation, not a scalar column.
     groupAuthorization: undefined,
     tenantId: entity.tenantId,
+    // Relation, not a scalar column.
     tenant: undefined,
+    // Relation, not a scalar column.
+    tariff: undefined,
     createdAt: entity.createdAt,
     updatedAt: entity.updatedAt,
   };
@@ -118,5 +121,16 @@ export class DrizzleAuthorizationRepository
     }
 
     return dtos[0];
+  }
+
+  async findAllAuthorizationsWithTariffs(tenantId: number): Promise<AuthorizationDto[]> {
+    const rows = await this.db
+      .select()
+      .from(authorizationTable)
+      .where(
+        and(eq(authorizationTable.tenantId, tenantId), isNotNull(authorizationTable.tariffId)),
+      );
+
+    return rows.map((row) => this.toDto(row as AuthorizationEntity));
   }
 }

--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -15,6 +15,8 @@ import {
 } from '../schema/Authorization.js';
 import { type Explicit } from '../types.js';
 import { DrizzleRepository } from './Base.js';
+import type { AuthorizationQuerystring, IAuthorizationRepository } from '@/dal/index.js';
+import { and, eq } from 'drizzle-orm';
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 // Maps a Drizzle entity (DB row) to the external AuthorizationDto contract.
@@ -60,10 +62,10 @@ export function toAuthorizationDto(entity: AuthorizationEntity): AuthorizationDt
   return dto;
 }
 
-export class DrizzleAuthorizationRepository extends DrizzleRepository<
-  typeof authorizationTable,
-  AuthorizationDto
-> {
+export class DrizzleAuthorizationRepository
+  extends DrizzleRepository<typeof authorizationTable, AuthorizationDto>
+  implements IAuthorizationRepository
+{
   protected getTable(tenantId: number): typeof authorizationTable {
     return this.useTenantSchema ? tenantAuthorizationTable(tenantId) : authorizationTable;
   }
@@ -72,5 +74,49 @@ export class DrizzleAuthorizationRepository extends DrizzleRepository<
     return toAuthorizationDto(row);
   }
 
-  // Domain query/write methods intentionally omitted — stub outline only.
+  private createAuthorizationConditions(tenantId: number, query: AuthorizationQuerystring) {
+    const conditions = [];
+
+    if (!this.useTenantSchema) {
+      conditions.push(eq(authorizationTable.tenantId, tenantId));
+    }
+
+    if (query.idToken) {
+      conditions.push(eq(authorizationTable.idToken, query.idToken));
+    }
+    if (query.type) {
+      conditions.push(eq(authorizationTable.idToken, query.idToken));
+    }
+
+    return conditions;
+  }
+
+  // ─── IAuthorizationRepository methods ────────────────────────────────────
+
+  async readAllByQuerystring(
+    tenantId: number,
+    query: AuthorizationQuerystring,
+  ): Promise<AuthorizationDto[]> {
+    const conditions = this.createAuthorizationConditions(tenantId, query);
+
+    const rows = await this.db
+      .select()
+      .from(authorizationTable)
+      .where(and(...conditions));
+
+    return rows.map((row) => this.toDto(row as AuthorizationEntity));
+  }
+
+  async readOnlyOneByQuerystring(
+    tenantId: number,
+    query: AuthorizationQuerystring,
+  ): Promise<AuthorizationDto | undefined> {
+    const dtos = await this.readAllByQuerystring(tenantId, query);
+
+    if (dtos.length > 1) {
+      throw new Error(`More than one value found for query: ${JSON.stringify(query)}`);
+    }
+
+    return dtos[0];
+  }
 }

--- a/packages/core/src/dal/layers/sequelize/mapper/2.0.1/AuthorizationMapper.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/2.0.1/AuthorizationMapper.ts
@@ -2,15 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import {
-  type AuthorizationStatusEnumType,
-  type IdTokenEnumType,
+  type AuthorizationDto,
   AuthorizationStatusEnum,
+  type AuthorizationStatusEnumType,
   IdTokenEnum,
+  type IdTokenEnumType,
   OCPP2_0_1,
 } from '@citrineos/types';
-import { Authorization } from '../../model/Authorization/Authorization.js';
+
 export class AuthorizationMapper {
-  static toAuthorizationData(authorization: Authorization): OCPP2_0_1.AuthorizationData {
+  static toAuthorizationData(authorization: AuthorizationDto): OCPP2_0_1.AuthorizationData {
     return {
       customData: authorization.customData,
       idToken: AuthorizationMapper.toIdToken(authorization),
@@ -18,7 +19,7 @@ export class AuthorizationMapper {
     };
   }
 
-  static toIdToken(authorization: Authorization): OCPP2_0_1.IdTokenType {
+  static toIdToken(authorization: AuthorizationDto): OCPP2_0_1.IdTokenType {
     if (!authorization.idTokenType) {
       throw new Error('IdToken type is missing.');
     }
@@ -30,7 +31,7 @@ export class AuthorizationMapper {
     };
   }
 
-  static toIdTokenInfo(authorization: Authorization): OCPP2_0_1.IdTokenInfoType {
+  static toIdTokenInfo(authorization: AuthorizationDto): OCPP2_0_1.IdTokenInfoType {
     return {
       status: AuthorizationMapper.fromAuthorizationStatusEnumType(authorization.status),
       cacheExpiryDateTime: authorization.cacheExpiryDateTime,

--- a/packages/core/src/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.ts
+++ b/packages/core/src/dal/layers/sequelize/mapper/2.1/AuthorizationMapper.ts
@@ -2,16 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import {
-  type AuthorizationStatusEnumType,
-  type IdTokenEnumType,
+  type AuthorizationDto,
   AuthorizationStatusEnum,
+  type AuthorizationStatusEnumType,
   IdTokenEnum,
+  type IdTokenEnumType,
   OCPP2_1,
 } from '@citrineos/types';
-import { Authorization } from '../../model/Authorization/Authorization.js';
 
 export class AuthorizationMapper {
-  static toAuthorizationData(authorization: Authorization): OCPP2_1.AuthorizationData {
+  static toAuthorizationData(authorization: AuthorizationDto): OCPP2_1.AuthorizationData {
     return {
       customData: authorization.customData,
       idToken: AuthorizationMapper.toIdToken(authorization),
@@ -19,7 +19,7 @@ export class AuthorizationMapper {
     };
   }
 
-  static toIdToken(authorization: Authorization): OCPP2_1.IdTokenType {
+  static toIdToken(authorization: AuthorizationDto): OCPP2_1.IdTokenType {
     if (!authorization.idTokenType) {
       throw new Error('IdToken type is missing.');
     }
@@ -31,7 +31,7 @@ export class AuthorizationMapper {
     };
   }
 
-  static toIdTokenInfo(authorization: Authorization): OCPP2_1.IdTokenInfoType {
+  static toIdTokenInfo(authorization: AuthorizationDto): OCPP2_1.IdTokenInfoType {
     return {
       status: AuthorizationMapper.fromAuthorizationStatusEnumType(authorization.status),
       cacheExpiryDateTime: authorization.cacheExpiryDateTime,

--- a/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
@@ -6,6 +6,8 @@ import { type IAuthorizationRepository } from '../../../interfaces/repositories.
 import { type AuthorizationQuerystring } from '../../../interfaces/queries/Authorization.js';
 import { Authorization } from '../model/Authorization/Authorization.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
+import { Op } from 'sequelize';
+import { Tariff } from '@/dal/index.js';
 
 export class SequelizeAuthorizationRepository
   extends SequelizeRepository<Authorization>
@@ -27,6 +29,22 @@ export class SequelizeAuthorizationRepository
     query: AuthorizationQuerystring,
   ): Promise<Authorization | undefined> {
     return await super.readOnlyOneByQuery(tenantId, this._constructQuery(query));
+  }
+
+  async findAllAuthorizationsWithTariffs(tenantId: number): Promise<Authorization[]> {
+    return await super.readAllByQuery(tenantId, {
+      where: {
+        tenantId,
+        tariffId: { [Op.ne]: null },
+      },
+      include: [
+        {
+          model: Tariff,
+          as: 'tariff',
+          required: true,
+        },
+      ],
+    });
   }
 
   /**

--- a/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Authorization.ts
@@ -61,6 +61,10 @@ export class SequelizeAuthorizationRepository
       where.idTokenType = queryParams.type;
     }
 
+    if (queryParams.id) {
+      where.id = queryParams.id;
+    }
+
     return {
       where,
       // Eager-load the group Authorization so IdTokenInfo.groupIdToken can be surfaced.

--- a/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/RepositoryStore.ts
@@ -30,6 +30,7 @@ import type {
   IVariableMonitoringRepository,
 } from '../../../interfaces/repositories.js';
 import {
+  DrizzleAuthorizationRepository,
   DrizzleSecurityEventRepository,
   DrizzleServerNetworkProfileRepository,
   DrizzleSubscriptionRepository,
@@ -96,11 +97,6 @@ export class RepositoryStore {
     sequelizeInstance: Sequelize;
   }) {
     this.sequelizeInstance = sequelizeInstance;
-    this.authorizationRepository = new SequelizeAuthorizationRepository({
-      config,
-      logger,
-      sequelizeInstance,
-    });
     this.bootRepository = new SequelizeBootRepository({ config, logger, sequelizeInstance });
     this.certificateRepository = new SequelizeCertificateRepository({
       config,
@@ -173,6 +169,7 @@ export class RepositoryStore {
       sequelizeInstance,
     });
     if (process.env.CITRINEOS_USE_DRIZZLE === 'true') {
+      this.authorizationRepository = new DrizzleAuthorizationRepository({ config, logger });
       this.securityEventRepository = new DrizzleSecurityEventRepository({ config, logger });
       this.subscriptionRepository = new DrizzleSubscriptionRepository({ config, logger });
       this.tenantRepository = new DrizzleTenantRepository({ config, logger });
@@ -181,6 +178,11 @@ export class RepositoryStore {
         logger,
       });
     } else {
+      this.authorizationRepository = new SequelizeAuthorizationRepository({
+        config,
+        logger,
+        sequelizeInstance,
+      });
       this.securityEventRepository = new SequelizeSecurityEventRepository({
         config,
         logger,

--- a/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
@@ -28,7 +28,7 @@ import { type IAuthorizationRepository, OCPP1_6_Mapper } from '@dal/index.js';
 export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
   protected _authorizers: IAuthorizer[];
-  protected _authorizeRepository: IAuthorizationRepository;
+  protected _authorizationRepository: IAuthorizationRepository;
 
   constructor({
     logger,
@@ -43,7 +43,7 @@ export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
     super(logger);
     this._ocppSender = ocppSender;
     this._authorizers = authorizers;
-    this._authorizeRepository = authorizationRepository;
+    this._authorizationRepository = authorizationRepository;
   }
 
   async handle(
@@ -62,7 +62,7 @@ export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
       },
     };
     try {
-      const authorizations = await this._authorizeRepository.readAllByQuerystring(
+      const authorizations = await this._authorizationRepository.readAllByQuerystring(
         context.tenantId,
         {
           idToken: request.idTag,
@@ -96,7 +96,7 @@ export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
         response.idTagInfo.expiryDate = cacheExpiryDateTime;
         if (groupAuthorizationId) {
           // Look up the referenced Authorization for parentIdTag
-          const parentAuth = await this._authorizeRepository.readOnlyOneByQuerystring(
+          const parentAuth = await this._authorizationRepository.readOnlyOneByQuerystring(
             message.context.tenantId,
             { id: groupAuthorizationId },
           );

--- a/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
@@ -96,9 +96,9 @@ export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
         response.idTagInfo.expiryDate = cacheExpiryDateTime;
         if (groupAuthorizationId) {
           // Look up the referenced Authorization for parentIdTag
-          const parentAuth = await this._authorizeRepository.readOnlyOneByQuery(
+          const parentAuth = await this._authorizeRepository.readOnlyOneByQuerystring(
             message.context.tenantId,
-            { where: { id: groupAuthorizationId } },
+            { id: groupAuthorizationId },
           );
           if (parentAuth) {
             response.idTagInfo.parentIdTag = parentAuth.idToken;

--- a/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
@@ -9,6 +9,7 @@ import {
   type IOcppSender,
 } from '@citrineos/base';
 import {
+  type AuthorizationDto,
   AuthorizationStatusEnum,
   type HandlerProperties,
   OCPP1_6,
@@ -16,7 +17,6 @@ import {
   OCPPVersion,
 } from '@citrineos/types';
 import {
-  Authorization,
   type IAuthorizationRepository,
   type ITransactionEventRepository,
   StartTransaction,
@@ -57,7 +57,7 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
     const ocppConnectionName = message.context.ocppConnectionName;
     const request = message.payload;
 
-    const authorization: Authorization | undefined = request.idTag
+    const authorization: AuthorizationDto | undefined = request.idTag
       ? await this._authorizeRepository.readOnlyOneByQuerystring(tenantId, {
           idToken: request.idTag,
         })
@@ -81,8 +81,8 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
 
     let parentIdTag: string | undefined = undefined;
     if (authorization?.groupAuthorizationId) {
-      const parentAuth = await this._authorizeRepository.readOnlyOneByQuery(tenantId, {
-        where: { id: authorization.groupAuthorizationId },
+      const parentAuth = await this._authorizeRepository.readOnlyOneByQuerystring(tenantId, {
+        id: authorization.groupAuthorizationId,
       });
       if (parentAuth) {
         parentIdTag = parentAuth.idToken;

--- a/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
@@ -27,7 +27,7 @@ import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
 @AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.StopTransaction)
 export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
-  protected _authorizeRepository: IAuthorizationRepository;
+  protected _authorizationRepository: IAuthorizationRepository;
   protected _transactionEventRepository: ITransactionEventRepository;
 
   constructor({
@@ -43,7 +43,7 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
     super(logger);
 
     this._ocppSender = ocppSender;
-    this._authorizeRepository = authorizationRepository;
+    this._authorizationRepository = authorizationRepository;
     this._transactionEventRepository = transactionEventRepository;
   }
 
@@ -58,7 +58,7 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
     const request = message.payload;
 
     const authorization: AuthorizationDto | undefined = request.idTag
-      ? await this._authorizeRepository.readOnlyOneByQuerystring(tenantId, {
+      ? await this._authorizationRepository.readOnlyOneByQuerystring(tenantId, {
           idToken: request.idTag,
         })
       : undefined;
@@ -81,7 +81,7 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
 
     let parentIdTag: string | undefined = undefined;
     if (authorization?.groupAuthorizationId) {
-      const parentAuth = await this._authorizeRepository.readOnlyOneByQuerystring(tenantId, {
+      const parentAuth = await this._authorizationRepository.readOnlyOneByQuerystring(tenantId, {
         id: authorization.groupAuthorizationId,
       });
       if (parentAuth) {

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -41,7 +41,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
   protected _certificateAuthorityService: CertificateAuthorityService;
   protected _authorizers: IAuthorizer[];
-  protected _authorizeRepository: IAuthorizationRepository;
+  protected _authorizationRepository: IAuthorizationRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
 
   constructor({
@@ -62,7 +62,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
     this._ocppSender = ocppSender;
     this._certificateAuthorityService = certificateAuthorityService;
     this._authorizers = authorizers;
-    this._authorizeRepository = authorizationRepository;
+    this._authorizationRepository = authorizationRepository;
     this._deviceModelRepository = deviceModelRepository;
   }
 
@@ -151,7 +151,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
       }
     }
 
-    const authorization = await this._authorizeRepository.readOnlyOneByQuerystring(
+    const authorization = await this._authorizationRepository.readOnlyOneByQuerystring(
       context.tenantId,
       {
         idToken: request.idToken.idToken,

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -41,7 +41,7 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
   protected _certificateAuthorityService: CertificateAuthorityService;
   protected _authorizers: IAuthorizer[];
-  protected _authorizeRepository: IAuthorizationRepository;
+  protected _authorizationRepository: IAuthorizationRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
   protected _tariffRepository: ITariffRepository;
 
@@ -65,7 +65,7 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
     this._ocppSender = ocppSender;
     this._certificateAuthorityService = certificateAuthorityService;
     this._authorizers = authorizers;
-    this._authorizeRepository = authorizationRepository;
+    this._authorizationRepository = authorizationRepository;
     this._deviceModelRepository = deviceModelRepository;
     this._tariffRepository = tariffRepository;
   }
@@ -148,7 +148,7 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
       }
     }
 
-    const authorization = await this._authorizeRepository.readOnlyOneByQuerystring(
+    const authorization = await this._authorizationRepository.readOnlyOneByQuerystring(
       context.tenantId,
       {
         idToken: request.idToken.idToken,

--- a/packages/core/src/handlers/requests/2/GetTariffsRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/GetTariffsRequestOcpp21Handler.ts
@@ -14,6 +14,7 @@ import {
   Authorization,
   Connector,
   Evse,
+  type IAuthorizationRepository,
   type ILocationRepository,
   Tariff,
   Transaction,
@@ -32,19 +33,23 @@ import {
 @AsRequestHandler([OCPPVersion.OCPP2_1], OCPP_CallAction.GetTariffs)
 export class GetTariffsRequestOcpp21Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
+  protected _authorizationRepository: IAuthorizationRepository;
   protected _locationRepository: ILocationRepository;
 
   constructor({
     logger,
     ocppSender,
+    authorizationRepository,
     locationRepository,
   }: AbstractHandlerDependencies & {
     ocppSender: IOcppSender;
+    authorizationRepository: IAuthorizationRepository;
     locationRepository: ILocationRepository;
   }) {
     super(logger);
 
     this._ocppSender = ocppSender;
+    this._authorizationRepository = authorizationRepository;
     this._locationRepository = locationRepository;
   }
 
@@ -136,19 +141,8 @@ export class GetTariffsRequestOcpp21Handler extends AbstractHandler {
       }
 
       // Query driver-specific tariffs from Authorizations
-      const authorizations = await Authorization.findAll({
-        where: {
-          tenantId,
-          tariffId: { [Op.ne]: null },
-        },
-        include: [
-          {
-            model: Tariff,
-            as: 'tariff',
-            required: true,
-          },
-        ],
-      });
+      const authorizations =
+        await this._authorizationRepository.findAllAuthorizationsWithTariffs(tenantId);
 
       // I09.FR.05: DriverTariff includes idTokens list
       for (const authorization of authorizations) {

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -4,19 +4,19 @@
 import {
   type IAuthorizer,
   type IMessageContext,
+  MeterValueUtils,
   type OCPP2_common_types,
   type OCPP2_request_types,
   type OCPP2_response_types,
-  MeterValueUtils,
 } from '@citrineos/base';
 import {
   type AuthorizationDto,
+  AuthorizationStatusEnum,
   type AuthorizationStatusEnumType,
   type ConnectorDto,
   type EvseDto,
-  type MeterValueDto,
-  AuthorizationStatusEnum,
   MessageOrigin,
+  type MeterValueDto,
   OCPP1_6,
   OCPP2_0_1,
   OCPP2_1,
@@ -36,7 +36,7 @@ import { Logger } from 'tslog';
 
 export class TransactionService {
   private _transactionEventRepository: ITransactionEventRepository;
-  private _authorizeRepository: IAuthorizationRepository;
+  private _authorizationRepository: IAuthorizationRepository;
   private _locationRepository: ILocationRepository;
   private _reservationRepository: IReservationRepository;
   private _ocppMessageRepository: IOCPPMessageRepository;
@@ -63,7 +63,7 @@ export class TransactionService {
     logger: Logger<ILogObj>;
   }) {
     this._transactionEventRepository = transactionEventRepository;
-    this._authorizeRepository = authorizationRepository;
+    this._authorizationRepository = authorizationRepository;
     this._locationRepository = locationRepository;
     this._reservationRepository = reservationRepository;
     this._ocppMessageRepository = ocppMessageRepository;
@@ -101,7 +101,7 @@ export class TransactionService {
     messageContext: IMessageContext,
   ): Promise<OCPP2_response_types.TransactionEventResponse> {
     const idToken = transactionEvent.idToken!;
-    const authorizations = await this._authorizeRepository.readAllByQuerystring(tenantId, {
+    const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
       idToken: idToken.idToken,
       type: idToken.type,
     });
@@ -140,7 +140,7 @@ export class TransactionService {
         authorization.concurrentTransaction === true &&
         transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started
       ) {
-        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
+        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id!);
         if (hasConcurrent) {
           response.idTokenInfo = {
             status: OCPP2_0_1.AuthorizationStatusEnumType.ConcurrentTx,
@@ -181,7 +181,7 @@ export class TransactionService {
     messageContext: IMessageContext,
   ): Promise<OCPP2_1.TransactionEventResponse> {
     const idToken = transactionEvent.idToken!;
-    const authorizations = await this._authorizeRepository.readAllByQuerystring(tenantId, {
+    const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
       idToken: idToken.idToken,
       type: idToken.type,
     });
@@ -215,7 +215,7 @@ export class TransactionService {
         authorization.concurrentTransaction === true &&
         transactionEvent.eventType === OCPP2_1.TransactionEventEnumType.Started
       ) {
-        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
+        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id!);
         if (hasConcurrent) {
           response.idTokenInfo = {
             status: OCPP2_1.AuthorizationStatusEnumType.ConcurrentTx,
@@ -315,7 +315,7 @@ export class TransactionService {
     try {
       // Find authorization
       const tenantId = context.tenantId;
-      const authorizations = await this._authorizeRepository.readAllByQuerystring(tenantId, {
+      const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
         idToken: idToken,
       });
       if (authorizations.length !== 1) {
@@ -350,7 +350,7 @@ export class TransactionService {
 
       // Check concurrent transactions
       if (authorization.concurrentTransaction !== true) {
-        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id);
+        const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id!);
         if (hasConcurrent) {
           response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.ConcurrentTx;
           return response;
@@ -376,8 +376,8 @@ export class TransactionService {
       response.idTagInfo.expiryDate = authorization.cacheExpiryDateTime;
       if (authorization.groupAuthorizationId) {
         // Look up the referenced Authorization for parentIdTag
-        const parentAuth = await this._authorizeRepository.readOnlyOneByQuery(tenantId, {
-          where: { id: authorization.groupAuthorizationId },
+        const parentAuth = await this._authorizationRepository.readOnlyOneByQuerystring(tenantId, {
+          id: authorization.groupAuthorizationId,
         });
         if (parentAuth) {
           response.idTagInfo.parentIdTag = parentAuth.idToken;

--- a/packages/core/test/dal/e2e/security-event.e2e.test.ts
+++ b/packages/core/test/dal/e2e/security-event.e2e.test.ts
@@ -13,7 +13,7 @@
  *   charger (WS OCPP 2.0.1) → CSMS → Reporting module → SecurityEvents table
  *
  * It runs twice — once with the default Sequelize repository and once with
- * CITRINEOS_USE_DRIZZLE_SECURITY_EVENT=true — confirming both write the same record.
+ * CITRINEOS_USE_DRIZZLE=true — confirming both write the same record.
  *
  * Prerequisites: run `pnpm run test:e2e` (which builds first) rather than
  * `pnpm test`, since the server child process needs ocpp-server/dist/index.js to be
@@ -24,12 +24,12 @@
  *   automatically, so we rely on the real migration path here.
  */
 
-import { execSync, spawn, type ChildProcess } from 'child_process';
+import { type ChildProcess, execSync, spawn } from 'child_process';
 import { mkdtempSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Client } from 'pg';
-import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
 import { fileURLToPath } from 'url';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import WebSocket from 'ws';
@@ -222,7 +222,7 @@ afterAll(async () => {
 
 describe.each([
   { label: 'Sequelize', extraEnv: {} },
-  { label: 'Drizzle', extraEnv: { CITRINEOS_USE_DRIZZLE_SECURITY_EVENT: 'true' } },
+  { label: 'Drizzle', extraEnv: { CITRINEOS_USE_DRIZZLE: 'true' } },
 ])('SecurityEventNotification [$label]', ({ label, extraEnv }) => {
   let server: ChildProcess;
   let db: Client;

--- a/packages/types/src/interfaces/dto/authorization.dto.ts
+++ b/packages/types/src/interfaces/dto/authorization.dto.ts
@@ -11,6 +11,7 @@ import {
   AuthorizationWhitelistEnumSchema,
   IdTokenEnumSchema,
 } from './types/enums.js';
+import { TariffSchema } from '@interfaces/dto/tariff.dto.js';
 
 const authorizationFields = {
   id: z.number().int().optional(),
@@ -37,6 +38,7 @@ const authorizationFields = {
   tenantPartner: TenantPartnerSchema.nullable().optional(),
   groupAuthorizationId: z.number().int().nullable().optional(),
   tariffId: z.number().int().nullable().optional(),
+  tariff: TariffSchema.nullable().optional(),
 };
 
 export const GroupAuthorizationSchema = BaseSchema.extend(authorizationFields);
@@ -60,6 +62,7 @@ export const AuthorizationCreateSchema = AuthorizationSchema.omit({
   createdAt: true,
   groupAuthorization: true,
   tenantPartner: true,
+  tariff: true,
 });
 
 export type AuthorizationCreate = z.infer<typeof AuthorizationCreateSchema>;
@@ -71,6 +74,7 @@ export const AuthorizationUpdateSchema = AuthorizationSchema.partial()
     createdAt: true,
     groupAuthorization: true,
     tenantPartner: true,
+    tariff: true,
   })
   .required({ id: true, tenantId: true });
 


### PR DESCRIPTION
This PR adds the Drizzle-version of the `Authorization` repository. Changes:

1. Added new Drizzle-version of `Authorization` repository and referenced it in `RepositoryStore` and `container` for dependency injection.
2. Changed repository return type for IAuthorizationRepository interface methods from `Authorization` to `AuthorizationDto`.
3. Any non-data layer usages (i.e. in the handlers, services, etc.) of the Sequelize entity `Authorization` were replaced with bespoke repository interface methods and therefore implemented in both the Sequelize and Drizzle versions of the repositories.
4. `AuthorizationQuerystring` was made more flexible by including the `id` field and making the `idToken` field optional -- this supports the usage of the repository methods across more use cases.
5. Optional `tariff` relationship field added to `AuthorizationDto` to assist with one of the handler use cases.