### PR TITLE
fix(core): don't reject an OCPP 1.6 idTag that matches several authorizations

### DIFF
--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -318,13 +318,32 @@ export class TransactionService {
       const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
         idToken: idToken,
       });
-      if (authorizations.length !== 1) {
-        this._logger.error(
-          `Found invalid authorizations ${JSON.stringify(authorizations)} for idToken: ${idToken}`,
-        );
+      if (authorizations.length === 0) {
+        this._logger.error(`No authorization found for idToken: ${idToken}`);
         return response;
       }
-      const authorization = authorizations[0];
+      // An OCPP 1.6 idTag is a bare string with no token type, so the same value can
+      // legitimately be stored under several idTokenTypes (Authorizations has no unique
+      // constraint on idToken, and the 2.0.1/2.1 paths above disambiguate with
+      // idToken.type — 1.6 has nothing to disambiguate with). Resolve deterministically
+      // and fail safe: honour the first non-Accepted match so a Blocked/Expired duplicate
+      // still blocks, rather than rejecting a token whose matches all say Accepted.
+      let authorization = authorizations[0];
+      if (authorizations.length > 1) {
+        const restrictive = authorizations.find(
+          (candidate) =>
+            candidate.status &&
+            OCPP1_6_Mapper.AuthorizationMapper.toStartTransactionResponseStatus(
+              candidate.status,
+            ) !== OCPP1_6.StartTransactionResponseStatus.Accepted,
+        );
+        authorization = restrictive ?? authorization;
+        this._logger.warn(
+          `Found ${authorizations.length} authorizations for idToken ${idToken} ` +
+            `(types: ${authorizations.map((candidate) => candidate.idTokenType).join(', ')}); ` +
+            `using authorization ${authorization.id} (status ${authorization.status}).`,
+        );
+      }
 
       // Check expiration and status
       if (!authorization.status) {


### PR DESCRIPTION
## Problem

`TransactionService.authorizeOcpp16IdToken` rejects a perfectly valid idTag whenever more than one `Authorizations` row shares that token value — even when **every** matching row says `Accepted`.

https://github.com/citrineos/citrineos-core/blob/main/packages/core/src/modules/Transactions/src/module/TransactionService.ts#L316-L327

```ts
const authorizations = await this._authorizeRepository.readAllByQuerystring(tenantId, {
  idToken: idToken,          // no type — OCPP 1.6 has none to give
});
if (authorizations.length !== 1) {
  this._logger.error(`Found invalid authorizations ... for idToken: ${idToken}`);
  return response;           // idTagInfo.status = Invalid
}
```

Two things make this reachable rather than a corrupt-data case:

1. `Authorizations` has **no unique constraint** on `idToken` (only the `id` primary key), so the same value under two `idTokenType`s is a legitimate state.
2. An **OCPP 1.6 `idTag` is a bare string with no token type**, so the lookup cannot disambiguate.

The `length !== 1` guard is sound for the 2.0.1 and 2.1 paths a few lines above, because those query with `idToken.idToken` **and** `idToken.type`:

```ts
readAllByQuerystring(tenantId, { idToken: idToken.idToken, type: idToken.type });
```

The 1.6 path reuses the same guard without the type filter, so the identical database contents work over 2.0.1 and fail over 1.6.

## Impact

Observed on a local deployment with two `Accepted` rows for the same idTag (`ISO14443` and `NoAuthorization`):

- **every** `StartTransaction` answered `{"idTagInfo":{"status":"Invalid"},"transactionId":0}` — 15 for 15
- libocpp correctly honours that per OCPP 1.6 and stops the transaction with reason `DeAuthorized`, ~100 ms after it started
- no session ever reached charging; the charge point behaved correctly throughout

Diagnosing this is unnecessarily hard because a duplicated token and an unknown token produce the same log line (`Found invalid authorizations …`), and the CSMS answers `Invalid` in both cases.

## Fix

- Report the no-match case separately from the multiple-match case.
- On multiple matches, resolve deterministically and **fail safe**: honour the first non-`Accepted` match, so a `Blocked`/`Expired` duplicate still blocks. Only when every match is `Accepted` does the token authorize.
- Log which authorization was used and the types that matched, so the duplicate is visible.

This keeps the security property of the original code (an ambiguous set containing a restrictive entry is not silently upgraded to `Accepted`) while no longer rejecting a token whose matches unanimously say `Accepted`.

## Notes

- Scoped to the 1.6 path only; the 2.0.1 and 2.1 paths are untouched since their type filter already makes the single-match assumption hold.
- An alternative would be a unique constraint on `(tenantId, idToken)`, but that would be a breaking migration for existing deployments and would remove a per-type distinction that 2.x legitimately relies on.
- No behaviour change when exactly one authorization matches.
