### PR TITLE
fix(core): resolve OCPP 2.0.1 connector status through its EVSE

### DIFF
--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -76,13 +76,21 @@ export class StatusNotificationService {
       const matchingEvse = chargingStation.evses?.find(
         (evse) => evse.evseTypeId === statusNotificationRequest.evseId,
       );
+      // The request's connectorId is scoped to the EVSE, so it is matched against
+      // evseTypeConnectorId - the same key the transaction path uses
+      // (TransactionEvent.createOrUpdateTransactionByTransactionEventRequest).
+      // Matching it against Connector.connectorId, which is the station-wide 1.6
+      // numbering, makes every EVSE's "connector 1" resolve to the same row.
       const matchingConnector = (matchingEvse?.connectors as Connector[] | undefined)?.find(
-        (c) => c.connectorId === statusNotificationRequest.connectorId,
+        (c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId,
       );
 
       const connector = {
         tenantId,
-        connectorId: statusNotificationRequest.connectorId,
+        // createOrUpdateConnector upserts on (ocppConnectionName, connectorId), so this has to be
+        // the matched row's station-wide number. Writing the EVSE-scoped one collapses a
+        // multi-EVSE station onto a single Connector row, last notification wins.
+        connectorId: matchingConnector?.connectorId ?? statusNotificationRequest.connectorId,
         ocppConnectionName: ocppConnectionName,
         evseId: matchingConnector?.evseId ?? matchingEvse?.id,
         evseTypeConnectorId: matchingConnector?.evseTypeConnectorId,

--- a/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
+++ b/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
@@ -10,6 +10,7 @@ import { StatusNotificationService } from '@modules/Transactions/src/module/Stat
 import {
   aChargingStation,
   aComponent,
+  aConnector,
   aEvse,
   anEvse,
   aVariable,
@@ -195,6 +196,101 @@ describe('StatusNotificationService', () => {
       );
 
       expect(deviceModelRepository.createOrUpdateDeviceModelByStationId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Test process OCPP 2.0.1 StatusNotification on a multi-EVSE Charging Station', () => {
+    // In OCPP 2.0.1 the connectorId is scoped to the EVSE, so a station with two single-connector
+    // EVSEs reports connectorId 1 twice - once for each EVSE. Connector.connectorId is the
+    // station-wide OCPP 1.6 numbering and is what createOrUpdateConnector upserts on, so the
+    // incoming connectorId has to be resolved through the matching EVSE rather than used directly.
+    const aTwoEvseChargingStation = () =>
+      aChargingStation((cs) => {
+        cs.evses = [
+          aEvse((evse) => {
+            evse.id = 1;
+            evse.evseTypeId = 1;
+            evse.connectors = [
+              aConnector((c) => {
+                c.id = 10;
+                c.evseId = 1;
+                c.connectorId = 1;
+                c.evseTypeConnectorId = 1;
+              }),
+            ];
+          }),
+          aEvse((evse) => {
+            evse.id = 2;
+            evse.evseTypeId = 2;
+            evse.connectors = [
+              aConnector((c) => {
+                c.id = 20;
+                c.evseId = 2;
+                c.connectorId = 2;
+                c.evseTypeConnectorId = 1;
+              }),
+            ];
+          }),
+        ];
+      });
+
+    beforeEach(() => {
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aTwoEvseChargingStation(),
+      );
+      componentRepository.readAllByQuery.mockResolvedValue([]);
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+    });
+
+    it('should update the second EVSEs own connector when it reports its connector 1', async () => {
+      await statusNotificationService.processStatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aStatusNotificationRequest((request) => {
+          request.evseId = 2;
+          request.connectorId = 1;
+        }),
+      );
+
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ evseId: 2, connectorId: 2, evseTypeConnectorId: 1 }),
+      );
+    });
+
+    it('should update the first EVSEs own connector when it reports its connector 1', async () => {
+      await statusNotificationService.processStatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aStatusNotificationRequest((request) => {
+          request.evseId = 1;
+          request.connectorId = 1;
+        }),
+      );
+
+      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ evseId: 1, connectorId: 1, evseTypeConnectorId: 1 }),
+      );
+    });
+
+    it('should give each EVSE a distinct connector when both report their connector 1', async () => {
+      for (const evseId of [1, 2]) {
+        await statusNotificationService.processStatusNotification(
+          DEFAULT_TENANT_ID,
+          MOCK_STATION_ID,
+          aStatusNotificationRequest((request) => {
+            request.evseId = evseId;
+            request.connectorId = 1;
+          }),
+        );
+      }
+
+      const targeted = locationRepository.createOrUpdateConnector.mock.calls.map(
+        ([, connector]) => connector.connectorId,
+      );
+
+      expect(targeted).toEqual([1, 2]);
     });
   });
 


### PR DESCRIPTION
## Problem

In OCPP 2.0.1 a `connectorId` is scoped to its EVSE. A Charging Station with two single-connector EVSEs therefore reports `connectorId: 1` **twice** - once for each EVSE:

```
evseId 1, connectorId 1, Available
evseId 2, connectorId 1, Available
```

`Connector.connectorId` holds the station-wide OCPP 1.6 numbering (per the operator UI's own field description: *"The serial integers starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station"*), and `LocationRepository.createOrUpdateConnector` upserts on `(ocppConnectionName, connectorId)`. `processStatusNotification` writes the incoming EVSE-scoped value straight into that column, so both notifications resolve to the same `Connector` row.

The result on any multi-EVSE 2.0.1 station:

- one `Connector` row absorbs every EVSE's status, its `evseId` flipping to whichever notification arrived last;
- every other EVSE ends up owning no connectors at all, so the UI renders them empty;
- those EVSEs' connectors never receive a status and sit at `Unknown` indefinitely.

The transaction path does not share the defect - `TransactionEvent.createOrUpdateTransactionByTransactionEventRequest` already resolves the connector by `(ocppConnectionName, evseId, evseTypeConnectorId)`. So the two paths currently disagree about what identifies a connector, and because that lookup is a `readOrCreate`, a session on an EVSE whose connector was reassigned silently creates an extra `Connector` row.

<img width="1533" height="604" alt="image" src="https://github.com/user-attachments/assets/52f07030-7a74-4037-80b2-6c84d9438506" />

## Fix

Resolve the incoming connectorId against the matching EVSE's `evseTypeConnectorId` - the same key the transaction path uses - and upsert on the matched row's own station-wide `connectorId`:

```ts
const matchingConnector = (matchingEvse?.connectors as Connector[] | undefined)?.find(
  (c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId,
);

const connector = {
  tenantId,
  connectorId: matchingConnector?.connectorId ?? statusNotificationRequest.connectorId,
  ...
```

Stations whose connectors are not commissioned fall back to the previous behaviour via the `??`, so the ad-hoc path is unchanged.

<img width="1521" height="465" alt="image" src="https://github.com/user-attachments/assets/94d386e1-e76d-467e-8b90-b1a6217be4ce" />

## Tests

Three cases added under a new `multi-EVSE Charging Station` describe block. Two of them fail on `main` for the right reason:

```
× should update the second EVSEs own connector when it reports its connector 1
× should give each EVSE a distinct connector when both report their connector 1
  → expected [ 1, 1 ] to deeply equal [ 1, 2 ]

Tests  2 failed | 15 passed (17)   # before
Tests  17 passed (17)              # after
```

`[1, 1]` is the collision stated directly: both EVSEs' notifications targeting connector row 1.

## How this was found

Against an EVerest simulator presenting two EVSEs per charge point across three charge points. Before the fix, each station's two notifications - arriving ~5 ms apart - landed on one row, leaving the first EVSE with no connectors and the second holding both. After it, all six connectors keep their own EVSE across restarts and each reports its own status.

## Scope

`processOcpp16StatusNotification` is untouched; OCPP 1.6 has no EVSE-scoped connector numbering and does not have this problem.