### PR TITLE
fix(operator-ui): make the start/stop transaction controls multi-EVSE aware

### DIFF
--- a/apps/operator-ui/package.json
+++ b/apps/operator-ui/package.json
@@ -118,7 +118,8 @@
     "prettier": "catalog:",
     "tailwindcss": "4",
     "typescript": "^6.0.0",
-    "typescript-eslint": "catalog:"
+    "typescript-eslint": "catalog:",
+    "vitest": "^3.0.0"
   },
   "refine": {
     "projectId": "EoX1xN-qak0Xy-elp4R9"

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
@@ -25,7 +25,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useCustom, useInvalidate, useSelect, useTranslate } from '@refinedev/core';
+import { useCustom, useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -38,7 +38,6 @@ import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 export interface OCPP2_0_1_RemoteStartProps {
   station: ChargingStationDto;
-  /** Preselects the EVSE, for callers that already know which one - e.g. the per-EVSE start button. */
   evse?: EvseDto;
 }
 
@@ -48,16 +47,11 @@ export type RemoteStartFormData = {
   evse?: string;
 };
 
-/** Grace period for the charger to report the transaction actually started or ended. */
-
 export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartProps) => {
   const dispatch = useDispatch();
   const translate = useTranslate();
-  const invalidate = useInvalidate();
   const [loading, setLoading] = useState<boolean>(false);
 
-  // Must match the option value EvseSelector builds, or the combobox has nothing to match against
-  // and renders its placeholder despite the form holding a value.
   const preselectedEvse = useMemo(
     () => (evse?.id !== undefined ? buildEvseOptionValue(evse) : ''),
     [evse],
@@ -179,7 +173,6 @@ export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartPr
     }).then(() => {
       form.reset();
       dispatch(closeModal());
-      invalidate({ invalidates: ['all'] });
     });
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
@@ -7,6 +7,7 @@ import {
   type AuthorizationDto,
   type ChargingStationDto,
   type ChargingStationSequenceDto,
+  type EvseDto,
   AuthorizationProps,
   BaseProps,
   ChargingStationSequenceTypeEnum,
@@ -23,7 +24,7 @@ import { ResourceType } from '@lib/utils/access.types';
 import type { MessageConfirmation } from '@lib/utils/MessageConfirmation';
 import { triggerMessageAndHandleResponse } from '@lib/utils/messages.utils';
 import { closeModal } from '@lib/utils/store/modal.slice';
-import { useCustom, useSelect, useTranslate } from '@refinedev/core';
+import { useCustom, useInvalidate, useSelect, useTranslate } from '@refinedev/core';
 import { useForm } from '@refinedev/react-hook-form';
 import { plainToInstance } from 'class-transformer';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -36,6 +37,8 @@ import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 export interface OCPP2_0_1_RemoteStartProps {
   station: ChargingStationDto;
+  /** Preselects the EVSE, for callers that already know which one - e.g. the per-EVSE start button. */
+  evse?: EvseDto;
 }
 
 export type RemoteStartFormData = {
@@ -44,10 +47,24 @@ export type RemoteStartFormData = {
   evse?: string;
 };
 
-export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) => {
+/** Grace period for the charger to report the transaction actually started or ended. */
+const TRANSACTION_SETTLE_MS = 4000;
+
+export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartProps) => {
   const dispatch = useDispatch();
   const translate = useTranslate();
+  const invalidate = useInvalidate();
   const [loading, setLoading] = useState<boolean>(false);
+
+  // Must match the option value EvseSelector builds, or the combobox has nothing to match against
+  // and renders its placeholder despite the form holding a value.
+  const preselectedEvse = useMemo(
+    () =>
+      evse?.id !== undefined
+        ? JSON.stringify({ id: evse.id, evseTypeId: evse.evseTypeId })
+        : '',
+    [evse],
+  );
 
   const tenantId = useTenantId();
 
@@ -70,7 +87,7 @@ export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) =
     defaultValues: {
       remoteStartId: 0,
       authorization: '',
-      evse: '',
+      evse: preselectedEvse,
     },
   });
 
@@ -165,6 +182,11 @@ export const OCPP2_0_1_RemoteStart = ({ station }: OCPP2_0_1_RemoteStartProps) =
     }).then(() => {
       form.reset();
       dispatch(closeModal());
+      // Same reasoning as the remote stop modal: nothing refreshes the station's active
+      // transactions on its own, and RequestStartTransaction resolves on acceptance rather than on
+      // the charger's TransactionEvent(Started), so refetch once now and once after it settles.
+      invalidate({ invalidates: ['all'] });
+      setTimeout(() => invalidate({ invalidates: ['all'] }), TRANSACTION_SETTLE_MS);
     });
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/2.0.1/index.tsx
@@ -15,6 +15,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Form } from '@lib/client/components/form';
 import { ComboboxFormField, FormField } from '@lib/client/components/form/field';
+import { buildEvseOptionValue } from '@lib/client/components/modals/shared/evse-selector/evse.option.value';
 import { EvseSelector } from '@lib/client/components/modals/shared/evse-selector/evse.selector';
 import { Input } from '@lib/client/components/ui/input';
 import { ChargingStationSequenceClass } from '@lib/cls/charging.station.sequence.dto';
@@ -48,7 +49,6 @@ export type RemoteStartFormData = {
 };
 
 /** Grace period for the charger to report the transaction actually started or ended. */
-const TRANSACTION_SETTLE_MS = 4000;
 
 export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartProps) => {
   const dispatch = useDispatch();
@@ -59,10 +59,7 @@ export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartPr
   // Must match the option value EvseSelector builds, or the combobox has nothing to match against
   // and renders its placeholder despite the form holding a value.
   const preselectedEvse = useMemo(
-    () =>
-      evse?.id !== undefined
-        ? JSON.stringify({ id: evse.id, evseTypeId: evse.evseTypeId })
-        : '',
+    () => (evse?.id !== undefined ? buildEvseOptionValue(evse) : ''),
     [evse],
   );
 
@@ -182,11 +179,7 @@ export const OCPP2_0_1_RemoteStart = ({ station, evse }: OCPP2_0_1_RemoteStartPr
     }).then(() => {
       form.reset();
       dispatch(closeModal());
-      // Same reasoning as the remote stop modal: nothing refreshes the station's active
-      // transactions on its own, and RequestStartTransaction resolves on acceptance rather than on
-      // the charger's TransactionEvent(Started), so refetch once now and once after it settles.
       invalidate({ invalidates: ['all'] });
-      setTimeout(() => invalidate({ invalidates: ['all'] }), TRANSACTION_SETTLE_MS);
     });
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ChargingStationDto, OCPPVersion } from '@citrineos/types';
+import { type ChargingStationDto, type EvseDto, OCPPVersion } from '@citrineos/types';
 import { ChargingStationClass } from '@lib/cls/charging.station.dto';
 import { plainToInstance } from 'class-transformer';
 import { useMemo } from 'react';
@@ -12,9 +12,17 @@ import { OCPP2_0_1_RemoteStart } from './2.0.1';
 
 export interface RemoteStartTransactionModalProps {
   station: any;
+  /**
+   * Preselects the EVSE. OCPP 1.6 has no EVSE concept and ignores this - its modal selects a
+   * connector instead.
+   */
+  evse?: EvseDto;
 }
 
-export const RemoteStartTransactionModal = ({ station }: RemoteStartTransactionModalProps) => {
+export const RemoteStartTransactionModal = ({
+  station,
+  evse,
+}: RemoteStartTransactionModalProps) => {
   const translate = useTranslate();
   const parsedStation: ChargingStationDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
@@ -28,7 +36,7 @@ export const RemoteStartTransactionModal = ({ station }: RemoteStartTransactionM
         return <OCPP1_6_RemoteStart station={parsedStation} />;
       case OCPPVersion.OCPP2_0_1:
       case OCPPVersion.OCPP2_1:
-        return <OCPP2_0_1_RemoteStart station={parsedStation} />;
+        return <OCPP2_0_1_RemoteStart station={parsedStation} evse={evse} />;
       default:
         return (
           <div>

--- a/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-start/remote.start.modal.tsx
@@ -12,10 +12,6 @@ import { OCPP2_0_1_RemoteStart } from './2.0.1';
 
 export interface RemoteStartTransactionModalProps {
   station: any;
-  /**
-   * Preselects the EVSE. OCPP 1.6 has no EVSE concept and ignores this - its modal selects a
-   * connector instead.
-   */
   evse?: EvseDto;
 }
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
@@ -14,14 +14,13 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useInvalidate, useTranslate } from '@refinedev/core';
+import { useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 export interface OCPP2_0_1_RemoteStopProps {
   station: ChargingStationWithTransactionsDto;
-  /** Preselects the transaction, for callers that already know which one - e.g. a per-EVSE button. */
   transactionId?: string;
 }
 
@@ -29,11 +28,8 @@ type RemoteStopFormData = {
   transactionId: string;
 };
 
-/** Grace period for the charger to report the transaction actually started or ended. */
-
 export const OCPP2_0_1_RemoteStop = ({ station, transactionId }: OCPP2_0_1_RemoteStopProps) => {
   const translate = useTranslate();
-  const invalidate = useInvalidate();
   const unknownEvse = translate('ChargingStations.remoteStopModal.unknownEvse');
   const evseMap: Map<number, EvseDto> = useMemo(() => {
     if (!station.evses) return new Map<number, EvseDto>();
@@ -73,12 +69,9 @@ export const OCPP2_0_1_RemoteStop = ({ station, transactionId }: OCPP2_0_1_Remot
       setLoading,
     }).then(() => {
       dispatch(closeModal());
-      invalidate({ invalidates: ['all'] });
     });
   };
 
-  // Set initial value when transactions are loaded, preferring the caller's choice over the first
-  // one on the station - otherwise a per-EVSE stop button would arm the wrong transaction.
   useEffect(() => {
     if (transactionId) {
       form.setValue('transactionId', transactionId);

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
@@ -14,21 +14,27 @@ import { closeModal } from '@lib/utils/store/modal.slice';
 import { useForm } from '@refinedev/react-hook-form';
 import { useEffect, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { useTranslate } from '@refinedev/core';
+import { useInvalidate, useTranslate } from '@refinedev/core';
 import z from 'zod';
 import { FormButtonVariants } from '@lib/client/components/buttons/form.button';
 import { useTenantId } from '@lib/client/hooks/useTenantId';
 
 export interface OCPP2_0_1_RemoteStopProps {
   station: ChargingStationWithTransactionsDto;
+  /** Preselects the transaction, for callers that already know which one - e.g. a per-EVSE button. */
+  transactionId?: string;
 }
 
 type RemoteStopFormData = {
   transactionId: string;
 };
 
-export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => {
+/** Grace period for the charger to report the transaction actually started or ended. */
+const TRANSACTION_SETTLE_MS = 4000;
+
+export const OCPP2_0_1_RemoteStop = ({ station, transactionId }: OCPP2_0_1_RemoteStopProps) => {
   const translate = useTranslate();
+  const invalidate = useInvalidate();
   const unknownEvse = translate('ChargingStations.remoteStopModal.unknownEvse');
   const evseMap: Map<number, EvseDto> = useMemo(() => {
     if (!station.evses) return new Map<number, EvseDto>();
@@ -68,15 +74,31 @@ export const OCPP2_0_1_RemoteStop = ({ station }: OCPP2_0_1_RemoteStopProps) => 
       setLoading,
     }).then(() => {
       dispatch(closeModal());
+      // The station's start/stop buttons are derived from its active transactions, and nothing
+      // refreshes them on its own: liveMode is inert here because the Hasura live provider has no
+      // gqlSubscription to subscribe with. Without this the operator is left looking at Stop for an
+      // EVSE that has already stopped.
+      //
+      // RequestStopTransaction only resolves to the charger's *acceptance*; the transaction is not
+      // closed until it sends TransactionEvent(Ended) a moment later. So refetch again shortly
+      // after - the first pass keeps the UI honest if the stop is rejected, the second picks up the
+      // actual end. This is a heuristic, and a page reload remains the guarantee.
+      invalidate({ invalidates: ['all'] });
+      setTimeout(() => invalidate({ invalidates: ['all'] }), TRANSACTION_SETTLE_MS);
     });
   };
 
-  // Set initial value when transactions are loaded
+  // Set initial value when transactions are loaded, preferring the caller's choice over the first
+  // one on the station - otherwise a per-EVSE stop button would arm the wrong transaction.
   useEffect(() => {
+    if (transactionId) {
+      form.setValue('transactionId', transactionId);
+      return;
+    }
     if (station.transactions && station.transactions.length > 0) {
       form.setValue('transactionId', station.transactions[0].transactionId);
     }
-  }, [station, form]);
+  }, [station, form, transactionId]);
 
   // Filter out inactive transactions
   const activeTransactions = station.transactions

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/2.0.1/index.tsx
@@ -30,7 +30,6 @@ type RemoteStopFormData = {
 };
 
 /** Grace period for the charger to report the transaction actually started or ended. */
-const TRANSACTION_SETTLE_MS = 4000;
 
 export const OCPP2_0_1_RemoteStop = ({ station, transactionId }: OCPP2_0_1_RemoteStopProps) => {
   const translate = useTranslate();
@@ -74,17 +73,7 @@ export const OCPP2_0_1_RemoteStop = ({ station, transactionId }: OCPP2_0_1_Remot
       setLoading,
     }).then(() => {
       dispatch(closeModal());
-      // The station's start/stop buttons are derived from its active transactions, and nothing
-      // refreshes them on its own: liveMode is inert here because the Hasura live provider has no
-      // gqlSubscription to subscribe with. Without this the operator is left looking at Stop for an
-      // EVSE that has already stopped.
-      //
-      // RequestStopTransaction only resolves to the charger's *acceptance*; the transaction is not
-      // closed until it sends TransactionEvent(Ended) a moment later. So refetch again shortly
-      // after - the first pass keeps the UI honest if the stop is rejected, the second picks up the
-      // actual end. This is a heuristic, and a page reload remains the guarantee.
       invalidate({ invalidates: ['all'] });
-      setTimeout(() => invalidate({ invalidates: ['all'] }), TRANSACTION_SETTLE_MS);
     });
   };
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
@@ -20,7 +20,6 @@ export type ChargingStationWithTransactionsDto = z.infer<
 
 export interface RemoteStopTransactionModalProps {
   station: ChargingStationWithTransactionsDto;
-  /** Preselects the transaction, for callers that already know which one - e.g. a per-EVSE button. */
   transactionId?: string;
 }
 

--- a/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/remote-stop/remote.stop.modal.tsx
@@ -20,9 +20,14 @@ export type ChargingStationWithTransactionsDto = z.infer<
 
 export interface RemoteStopTransactionModalProps {
   station: ChargingStationWithTransactionsDto;
+  /** Preselects the transaction, for callers that already know which one - e.g. a per-EVSE button. */
+  transactionId?: string;
 }
 
-export const RemoteStopTransactionModal = ({ station }: RemoteStopTransactionModalProps) => {
+export const RemoteStopTransactionModal = ({
+  station,
+  transactionId,
+}: RemoteStopTransactionModalProps) => {
   const translate = useTranslate();
   const parsedStation: ChargingStationWithTransactionsDto = useMemo(
     () => plainToInstance(ChargingStationClass, station),
@@ -36,7 +41,7 @@ export const RemoteStopTransactionModal = ({ station }: RemoteStopTransactionMod
         return <OCPP1_6_RemoteStop station={parsedStation} />;
       case OCPPVersion.OCPP2_0_1:
       case OCPPVersion.OCPP2_1:
-        return <OCPP2_0_1_RemoteStop station={parsedStation} />;
+        return <OCPP2_0_1_RemoteStop station={parsedStation} transactionId={transactionId} />;
       default:
         return (
           <div>

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.test.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.test.ts
@@ -13,9 +13,6 @@ describe('buildEvseOptionValue', () => {
   });
 
   it('should give the same value for a full EVSE row as for the two keys alone', () => {
-    // EvseSelector encodes rows straight from the EVSE query while the per-EVSE start button
-    // encodes one off the station detail. Those objects carry different extra fields, and the
-    // combobox matches on the string, so any leakage of those fields would break the match.
     const fromQuery = {
       id: 7,
       evseTypeId: 1,
@@ -42,9 +39,6 @@ describe('buildEvseOptionValue', () => {
   });
 
   it('should omit evseTypeId when the row does not carry one', () => {
-    // JSON.stringify drops undefined values, so such a value can only ever match an option built
-    // from an equally incomplete row. Documented rather than guarded: the callers check id, and a
-    // row selected without evseTypeId is a query defect upstream of here.
     const value = buildEvseOptionValue({ id: 5, evseTypeId: undefined });
 
     expect(value).toBe('{"id":5}');

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.test.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { buildEvseOptionValue } from './evse.option.value';
+
+describe('buildEvseOptionValue', () => {
+  it('should encode the database id and the evseTypeId in that key order', () => {
+    const value = buildEvseOptionValue({ id: 42, evseTypeId: 2 });
+
+    expect(value).toBe('{"id":42,"evseTypeId":2}');
+  });
+
+  it('should give the same value for a full EVSE row as for the two keys alone', () => {
+    // EvseSelector encodes rows straight from the EVSE query while the per-EVSE start button
+    // encodes one off the station detail. Those objects carry different extra fields, and the
+    // combobox matches on the string, so any leakage of those fields would break the match.
+    const fromQuery = {
+      id: 7,
+      evseTypeId: 1,
+      tenantId: 1,
+      customData: { vendorId: 'acme' },
+      connectors: [{ id: 11 }],
+    } as unknown as Parameters<typeof buildEvseOptionValue>[0];
+
+    expect(buildEvseOptionValue(fromQuery)).toBe(buildEvseOptionValue({ id: 7, evseTypeId: 1 }));
+  });
+
+  it('should give different values to different EVSEs on the same station', () => {
+    const first = buildEvseOptionValue({ id: 10, evseTypeId: 1 });
+    const second = buildEvseOptionValue({ id: 11, evseTypeId: 2 });
+
+    expect(first).not.toBe(second);
+  });
+
+  it('should distinguish EVSEs that share an evseTypeId across stations', () => {
+    const onOneStation = buildEvseOptionValue({ id: 10, evseTypeId: 1 });
+    const onAnother = buildEvseOptionValue({ id: 99, evseTypeId: 1 });
+
+    expect(onOneStation).not.toBe(onAnother);
+  });
+
+  it('should omit evseTypeId when the row does not carry one', () => {
+    // JSON.stringify drops undefined values, so such a value can only ever match an option built
+    // from an equally incomplete row. Documented rather than guarded: the callers check id, and a
+    // row selected without evseTypeId is a query defect upstream of here.
+    const value = buildEvseOptionValue({ id: 5, evseTypeId: undefined });
+
+    expect(value).toBe('{"id":5}');
+  });
+});

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.ts
@@ -4,17 +4,5 @@
 
 import type { EvseDto } from '@citrineos/types';
 
-/**
- * Builds the value {@link EvseSelector} puts on each combobox option, and the value a caller must
- * hold in the form for one of those options to render as selected.
- *
- * Both sides go through here on purpose. The combobox matches on these strings rather than on the
- * objects they encode, so a second hand-written JSON.stringify elsewhere would silently stop
- * matching the moment either key or its order changed - the symptom being a placeholder shown over
- * a form that does hold a value.
- *
- * Connectors need the EVSE's `id` (the database ID) while operators recognise it by `evseTypeId`
- * (the serial integer starting at 1), so the value carries both.
- */
 export const buildEvseOptionValue = (evse: Pick<EvseDto, 'id' | 'evseTypeId'>): string =>
   JSON.stringify({ id: evse.id, evseTypeId: evse.evseTypeId });

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.ts
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.option.value.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { EvseDto } from '@citrineos/types';
+
+/**
+ * Builds the value {@link EvseSelector} puts on each combobox option, and the value a caller must
+ * hold in the form for one of those options to render as selected.
+ *
+ * Both sides go through here on purpose. The combobox matches on these strings rather than on the
+ * objects they encode, so a second hand-written JSON.stringify elsewhere would silently stop
+ * matching the moment either key or its order changed - the symptom being a placeholder shown over
+ * a form that does hold a value.
+ *
+ * Connectors need the EVSE's `id` (the database ID) while operators recognise it by `evseTypeId`
+ * (the serial integer starting at 1), so the value carries both.
+ */
+export const buildEvseOptionValue = (evse: Pick<EvseDto, 'id' | 'evseTypeId'>): string =>
+  JSON.stringify({ id: evse.id, evseTypeId: evse.evseTypeId });

--- a/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.selector.tsx
+++ b/apps/operator-ui/src/lib/client/components/modals/shared/evse-selector/evse.selector.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { type ChargingStationDto, type EvseDto, EvseProps } from '@citrineos/types';
 import { Combobox } from '@lib/client/components/combobox';
+import { buildEvseOptionValue } from '@lib/client/components/modals/shared/evse-selector/evse.option.value';
 import { GET_EVSE_LIST_FOR_STATION } from '@lib/queries/evses';
 import { ResourceType } from '@lib/utils/access.types';
 import { useSelect, useTranslate } from '@refinedev/core';
@@ -44,7 +45,7 @@ export const EvseSelector = ({
   const { options, onSearch, query } = useSelect<EvseDto>({
     resource: ResourceType.EVSES,
     optionLabel: 'evseTypeId',
-    optionValue: (evse) => JSON.stringify({ id: evse.id, evseTypeId: evse.evseTypeId }),
+    optionValue: buildEvseOptionValue,
     meta: {
       gqlQuery: GET_EVSE_LIST_FOR_STATION,
       gqlVariables: {

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/columns.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/columns.tsx
@@ -19,6 +19,7 @@ import { ACTIONS_COLUMN } from '@lib/client/hooks/useColumnPreferences';
 import { ActionType, ResourceType } from '@lib/utils/access.types';
 import { StartTransactionButton } from '@lib/client/pages/charging-stations/start.transaction.button';
 import { StopTransactionButton } from '@lib/client/pages/charging-stations/stop.transaction.button';
+import { getTransactionCommandAvailability } from '@lib/client/pages/charging-stations/transaction.command.availability';
 import { ResetButton } from '@lib/client/pages/charging-stations/reset.button';
 import { CommandsUnavailableText } from '@lib/client/pages/charging-stations/commands.unavailable.text';
 import { isEmpty } from '@lib/utils/assertion';
@@ -195,7 +196,7 @@ export const getChargingStationsColumns = (
       header: t('Common.actions', 'Actions'),
       visible: true,
       cellRender: ({ row }: CellContext<ChargingStationDetailsDto, unknown>) => {
-        const hasActiveTransactions = !isEmpty(row.original.transactions);
+        const { canStart, canStop } = getTransactionCommandAvailability(row.original);
 
         return row.original.isOnline ? (
           <CanAccess
@@ -206,8 +207,8 @@ export const getChargingStationsColumns = (
             }}
           >
             <div className="flex gap-4 w-fit" onClick={(e) => e.stopPropagation()}>
-              {!hasActiveTransactions && <StartTransactionButton station={row.original} />}
-              {hasActiveTransactions && <StopTransactionButton station={row.original} />}
+              {canStart && <StartTransactionButton station={row.original} />}
+              {canStop && <StopTransactionButton station={row.original} />}
               <ResetButton station={row.original} />
             </div>
           </CanAccess>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
@@ -74,8 +74,6 @@ export const ChargingStationDetailCard = ({
   } = useOne<ChargingStationDetailsDto>({
     resource: ResourceType.CHARGING_STATIONS,
     id,
-    // The query selects the station's active transactions, so subscribing keeps the start/stop
-    // controls in step with the charger without the page having to poll or guess.
     liveMode: 'auto',
     meta: {
       gqlQuery: CHARGING_STATIONS_GET_QUERY,

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
@@ -45,6 +45,7 @@ import Image from 'next/image';
 import { isGcp } from '@lib/server/clients/file/isGcp';
 import { StartTransactionButton } from '@lib/client/pages/charging-stations/start.transaction.button';
 import { StopTransactionButton } from '@lib/client/pages/charging-stations/stop.transaction.button';
+import { getTransactionCommandAvailability } from '@lib/client/pages/charging-stations/transaction.command.availability';
 import { CommandsUnavailableText } from '@lib/client/pages/charging-stations/commands.unavailable.text';
 import { ResetButton } from '@lib/client/pages/charging-stations/reset.button';
 import { ForceDisconnectButton } from '../force.disconnect.button';
@@ -171,7 +172,7 @@ export const ChargingStationDetailCard = ({
     return <NoDataFoundCard message={translate('ChargingStations.noDataFound', { id })} />;
   }
 
-  const hasActiveTransactions = station.transactions && station.transactions.length > 0;
+  const { canStart, canStop } = getTransactionCommandAvailability(station);
 
   // Security profile of the network profile pushed for the connected server config (matches the
   // Network Profiles tab). Falls back to the connected ServerNetworkProfile's security profile.
@@ -474,12 +475,10 @@ export const ChargingStationDetailCard = ({
                   id={station.id}
                   onClickAction={() => showForceDisconnectModal(station)}
                 />
-                {!hasActiveTransactions && (
+                {canStart && (
                   <StartTransactionButton station={station} disabled={!station.isOnline} />
                 )}
-                {hasActiveTransactions && (
-                  <StopTransactionButton station={station} disabled={!station.isOnline} />
-                )}
+                {canStop && <StopTransactionButton station={station} disabled={!station.isOnline} />}
                 <ResetButton station={station} disabled={!station.isOnline} />
                 <Button onClick={showOtherCommandsModal} disabled={!station.isOnline}>
                   <MoreHorizontal className={buttonIconSize} />

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/charging.station.detail.card.tsx
@@ -74,6 +74,9 @@ export const ChargingStationDetailCard = ({
   } = useOne<ChargingStationDetailsDto>({
     resource: ResourceType.CHARGING_STATIONS,
     id,
+    // The query selects the station's active transactions, so subscribing keeps the start/stop
+    // controls in step with the charger without the page having to poll or guess.
+    liveMode: 'auto',
     meta: {
       gqlQuery: CHARGING_STATIONS_GET_QUERY,
     },
@@ -478,7 +481,9 @@ export const ChargingStationDetailCard = ({
                 {canStart && (
                   <StartTransactionButton station={station} disabled={!station.isOnline} />
                 )}
-                {canStop && <StopTransactionButton station={station} disabled={!station.isOnline} />}
+                {canStop && (
+                  <StopTransactionButton station={station} disabled={!station.isOnline} />
+                )}
                 <ResetButton station={station} disabled={!station.isOnline} />
                 <Button onClick={showOtherCommandsModal} disabled={!station.isOnline}>
                   <MoreHorizontal className={buttonIconSize} />

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
@@ -33,8 +33,6 @@ interface EVSESListProps {
 
 export const evsesFormUpsertGrid = 'grid grid-cols-2 xs:grid-cols-1 gap-6';
 
-// The station detail query omits `station` and `location` from each transaction, so this is
-// narrower than TransactionDto. Derive it rather than restate it.
 type StationTransaction = NonNullable<ChargingStationDetailsDto['transactions']>[number];
 
 export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
@@ -61,8 +59,6 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
     return station;
   }, [data?.data]);
 
-  // Transaction.evseId is the Evses primary key, the same value keying these rows. The query
-  // already restricts the relation to active transactions, and an EVSE runs at most one.
   const activeTransactionsByEvse = useMemo(() => {
     const byEvse = new Map<number, StationTransaction>();
     for (const transaction of station.transactions ?? []) {

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChevronDown } from 'lucide-react';
+import { CanAccess } from '@refinedev/core';
 import type { ConnectorDto, EvseDto } from '@citrineos/types';
 import { Button } from '@lib/client/components/ui/button';
 import { ModalComponentType } from '@lib/client/components/modals/modal.types';
@@ -19,7 +20,7 @@ import {
 import type { ConnectorClass } from '@lib/cls/connector.dto';
 import type { EvseClass } from '@lib/cls/evse.dto';
 import { CHARGING_STATIONS_GET_QUERY } from '@lib/queries/charging.stations';
-import { ResourceType } from '@lib/utils/access.types';
+import { ActionType, CommandType, ResourceType } from '@lib/utils/access.types';
 import { setSelectedChargingStation } from '@lib/utils/store/selected.charging.station.slice';
 import { getPlainToInstanceOptions } from '@lib/utils/tables';
 import { useOne, useTranslate } from '@refinedev/core';
@@ -300,22 +301,40 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
                             {translate('ChargingStations.connectors.addConnector')}
                           </Button>
                           {activeTransaction ? (
-                            <Button
-                              variant="destructive"
-                              size="sm"
-                              disabled={!station.isOnline}
-                              onClick={() => openStopTransaction(activeTransaction)}
+                            <CanAccess
+                              resource={ResourceType.CHARGING_STATIONS}
+                              action={ActionType.COMMAND}
+                              params={{
+                                id: station.id,
+                                commandType: CommandType.STOP_TRANSACTION,
+                              }}
                             >
-                              {translate('ChargingStations.stopTransaction')}
-                            </Button>
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                disabled={!station.isOnline}
+                                onClick={() => openStopTransaction(activeTransaction)}
+                              >
+                                {translate('ChargingStations.stopTransaction')}
+                              </Button>
+                            </CanAccess>
                           ) : (
-                            <Button
-                              size="sm"
-                              disabled={!station.isOnline}
-                              onClick={() => openStartTransaction(evse)}
+                            <CanAccess
+                              resource={ResourceType.CHARGING_STATIONS}
+                              action={ActionType.COMMAND}
+                              params={{
+                                id: station.id,
+                                commandType: CommandType.START_TRANSACTION,
+                              }}
                             >
-                              {translate('ChargingStations.startTransaction')}
-                            </Button>
+                              <Button
+                                size="sm"
+                                disabled={!station.isOnline}
+                                onClick={() => openStartTransaction(evse)}
+                              >
+                                {translate('ChargingStations.startTransaction')}
+                              </Button>
+                            </CanAccess>
                           )}
                         </div>
                       </td>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/detail/evses/evses.list.tsx
@@ -3,13 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChevronDown } from 'lucide-react';
-import type { ChargingStationDto, ConnectorDto, EvseDto } from '@citrineos/types';
+import type { ConnectorDto, EvseDto } from '@citrineos/types';
 import { Button } from '@lib/client/components/ui/button';
+import { ModalComponentType } from '@lib/client/components/modals/modal.types';
+import { openModal as openTransactionModal } from '@lib/utils/store/modal.slice';
+import { instanceToPlain } from 'class-transformer';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@lib/client/components/ui/dialog';
 import { ConnectorsTable } from '@lib/client/pages/charging-stations/detail/connectors/connectors.table';
 import { ConnectorsUpsert } from '@lib/client/pages/charging-stations/detail/connectors/connectors.upsert';
 import { EvseUpsert } from '@lib/client/pages/charging-stations/detail/evses/evses.upsert';
-import { ChargingStationClass } from '@lib/cls/charging.station.dto';
+import {
+  ChargingStationClass,
+  type ChargingStationDetailsDto,
+} from '@lib/cls/charging.station.dto';
 import type { ConnectorClass } from '@lib/cls/connector.dto';
 import type { EvseClass } from '@lib/cls/evse.dto';
 import { CHARGING_STATIONS_GET_QUERY } from '@lib/queries/charging.stations';
@@ -26,6 +32,10 @@ interface EVSESListProps {
 
 export const evsesFormUpsertGrid = 'grid grid-cols-2 xs:grid-cols-1 gap-6';
 
+// The station detail query omits `station` and `location` from each transaction, so this is
+// narrower than TransactionDto. Derive it rather than restate it.
+type StationTransaction = NonNullable<ChargingStationDetailsDto['transactions']>[number];
+
 export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
   const translate = useTranslate();
   const dispatch = useDispatch();
@@ -36,7 +46,7 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
 
   const {
     query: { data, isLoading, refetch },
-  } = useOne<ChargingStationDto>({
+  } = useOne<ChargingStationDetailsDto>({
     resource: ResourceType.CHARGING_STATIONS,
     id,
     meta: {
@@ -46,9 +56,51 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
   });
 
   const station = React.useMemo(() => {
-    const station = { ...data?.data } as ChargingStationDto;
+    const station = { ...data?.data } as ChargingStationDetailsDto;
     return station;
   }, [data?.data]);
+
+  // Transaction.evseId is the Evses primary key, the same value keying these rows. The query
+  // already restricts the relation to active transactions, and an EVSE runs at most one.
+  const activeTransactionsByEvse = useMemo(() => {
+    const byEvse = new Map<number, StationTransaction>();
+    for (const transaction of station.transactions ?? []) {
+      if (transaction.evseId != null) byEvse.set(transaction.evseId, transaction);
+    }
+    return byEvse;
+  }, [station.transactions]);
+
+  const openStartTransaction = useCallback(
+    (evse: EvseDto) => {
+      dispatch(
+        openTransactionModal({
+          title: translate('ChargingStations.remoteStart'),
+          modalComponentType: ModalComponentType.remoteStart,
+          modalComponentProps: {
+            station: instanceToPlain(station),
+            evse: instanceToPlain(evse),
+          },
+        }),
+      );
+    },
+    [dispatch, station, translate],
+  );
+
+  const openStopTransaction = useCallback(
+    (transaction: StationTransaction) => {
+      dispatch(
+        openTransactionModal({
+          title: translate('ChargingStations.remoteStop'),
+          modalComponentType: ModalComponentType.remoteStop,
+          modalComponentProps: {
+            station: instanceToPlain(station),
+            transactionId: transaction.transactionId,
+          },
+        }),
+      );
+    },
+    [dispatch, station, translate],
+  );
 
   const openModal = useCallback(
     (
@@ -210,6 +262,7 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
                 const evseId = evse.id;
                 if (evseId === undefined) return null;
                 const isExpanded = expandedRowKeys.includes(evseId);
+                const activeTransaction = activeTransactionsByEvse.get(evseId);
 
                 return (
                   <React.Fragment key={evseId}>
@@ -246,6 +299,24 @@ export const EVSESList: React.FC<EVSESListProps> = ({ id }) => {
                           >
                             {translate('ChargingStations.connectors.addConnector')}
                           </Button>
+                          {activeTransaction ? (
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              disabled={!station.isOnline}
+                              onClick={() => openStopTransaction(activeTransaction)}
+                            >
+                              {translate('ChargingStations.stopTransaction')}
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              disabled={!station.isOnline}
+                              onClick={() => openStartTransaction(evse)}
+                            >
+                              {translate('ChargingStations.startTransaction')}
+                            </Button>
+                          )}
                         </div>
                       </td>
                     </tr>

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.test.ts
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.test.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import {
+  getTransactionCommandAvailability,
+  type TransactionCommandAvailabilityInput,
+} from './transaction.command.availability';
+
+/**
+ * Only the relation lengths are read, so the elements stand in for rows the station queries would
+ * have selected.
+ */
+const aStation = (evseCount: number, activeTransactionCount: number) =>
+  ({
+    evses: Array.from({ length: evseCount }, (_, i) => ({ id: i + 1 })),
+    transactions: Array.from({ length: activeTransactionCount }, (_, i) => ({
+      transactionId: `tx-${i + 1}`,
+    })),
+  }) satisfies TransactionCommandAvailabilityInput;
+
+describe('getTransactionCommandAvailability', () => {
+  describe('single-EVSE Charging Station', () => {
+    it('should offer Start and not Stop when the EVSE is idle', () => {
+      const availability = getTransactionCommandAvailability(aStation(1, 0));
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+
+    it('should offer Stop and not Start when the EVSE is charging', () => {
+      const availability = getTransactionCommandAvailability(aStation(1, 1));
+
+      expect(availability).toEqual({ canStart: false, canStop: true });
+    });
+  });
+
+  describe('multi-EVSE Charging Station', () => {
+    it('should offer both Start and Stop when one of two EVSEs is charging', () => {
+      const availability = getTransactionCommandAvailability(aStation(2, 1));
+
+      expect(availability).toEqual({ canStart: true, canStop: true });
+    });
+
+    it('should offer Stop and not Start when every EVSE is charging', () => {
+      const availability = getTransactionCommandAvailability(aStation(2, 2));
+
+      expect(availability).toEqual({ canStart: false, canStop: true });
+    });
+
+    it('should offer Start and not Stop when no EVSE is charging', () => {
+      const availability = getTransactionCommandAvailability(aStation(2, 0));
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+
+    it('should still offer Start on a large station with a single busy EVSE', () => {
+      const availability = getTransactionCommandAvailability(aStation(8, 1));
+
+      expect(availability).toEqual({ canStart: true, canStop: true });
+    });
+  });
+
+  describe('relations the caller did not select', () => {
+    it('should offer Start when the evses relation is absent', () => {
+      const availability = getTransactionCommandAvailability({ transactions: [] });
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+
+    it('should offer Start when the evses relation is absent but a transaction is active', () => {
+      const availability = getTransactionCommandAvailability({
+        transactions: [{ transactionId: 'tx-1' }],
+      });
+
+      expect(availability).toEqual({ canStart: true, canStop: true });
+    });
+
+    it('should offer Start and not Stop when neither relation is selected', () => {
+      const availability = getTransactionCommandAvailability({});
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+
+    it('should treat null relations the same as absent ones', () => {
+      const availability = getTransactionCommandAvailability({ evses: null, transactions: null });
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+
+    it('should treat an empty evses array as an unknown EVSE count and offer Start', () => {
+      const availability = getTransactionCommandAvailability({ evses: [], transactions: [] });
+
+      expect(availability).toEqual({ canStart: true, canStop: false });
+    });
+  });
+
+  it('should not offer Start when active transactions outnumber the known EVSEs', () => {
+    const availability = getTransactionCommandAvailability(aStation(1, 2));
+
+    expect(availability).toEqual({ canStart: false, canStop: true });
+  });
+});

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.test.ts
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.test.ts
@@ -8,10 +8,6 @@ import {
   type TransactionCommandAvailabilityInput,
 } from './transaction.command.availability';
 
-/**
- * Only the relation lengths are read, so the elements stand in for rows the station queries would
- * have selected.
- */
 const aStation = (evseCount: number, activeTransactionCount: number) =>
   ({
     evses: Array.from({ length: evseCount }, (_, i) => ({ id: i + 1 })),

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.ts
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.ts
@@ -2,24 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Which of the remote start / remote stop commands a Charging Station can currently accept.
- *
- * A Charging Station may expose several EVSEs, each able to run its own transaction, so the two
- * commands are not mutually exclusive: a station with one EVSE charging and another free can be
- * both started and stopped. Deciding on the presence of any active transaction hides Start for the
- * whole station as soon as a single EVSE is busy.
- */
 export interface TransactionCommandAvailability {
   canStart: boolean;
   canStop: boolean;
 }
 
-/**
- * Structural rather than a Pick of a station DTO: the callers pass ChargingStationDto and
- * ChargingStationDetailsDto, which disagree on whether these relations are optional, and only the
- * counts are needed here.
- */
 export interface TransactionCommandAvailabilityInput {
   transactions?: unknown[] | null;
   evses?: unknown[] | null;
@@ -28,13 +15,10 @@ export interface TransactionCommandAvailabilityInput {
 export function getTransactionCommandAvailability(
   station: TransactionCommandAvailabilityInput,
 ): TransactionCommandAvailability {
-  // The station queries already constrain this relation to `isActive: { _eq: true }`.
   const activeTransactionCount = station.transactions?.length ?? 0;
   const evseCount = station.evses?.length ?? 0;
 
   return {
-    // An unknown EVSE count means the caller did not select the relation, so fall back to offering
-    // Start rather than hiding a command the station can very likely still accept.
     canStart: evseCount === 0 || activeTransactionCount < evseCount,
     canStop: activeTransactionCount > 0,
   };

--- a/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.ts
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/transaction.command.availability.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Which of the remote start / remote stop commands a Charging Station can currently accept.
+ *
+ * A Charging Station may expose several EVSEs, each able to run its own transaction, so the two
+ * commands are not mutually exclusive: a station with one EVSE charging and another free can be
+ * both started and stopped. Deciding on the presence of any active transaction hides Start for the
+ * whole station as soon as a single EVSE is busy.
+ */
+export interface TransactionCommandAvailability {
+  canStart: boolean;
+  canStop: boolean;
+}
+
+/**
+ * Structural rather than a Pick of a station DTO: the callers pass ChargingStationDto and
+ * ChargingStationDetailsDto, which disagree on whether these relations are optional, and only the
+ * counts are needed here.
+ */
+export interface TransactionCommandAvailabilityInput {
+  transactions?: unknown[] | null;
+  evses?: unknown[] | null;
+}
+
+export function getTransactionCommandAvailability(
+  station: TransactionCommandAvailabilityInput,
+): TransactionCommandAvailability {
+  // The station queries already constrain this relation to `isActive: { _eq: true }`.
+  const activeTransactionCount = station.transactions?.length ?? 0;
+  const evseCount = station.evses?.length ?? 0;
+
+  return {
+    // An unknown EVSE count means the caller did not select the relation, so fall back to offering
+    // Start rather than hiding a command the station can very likely still accept.
+    canStart: evseCount === 0 || activeTransactionCount < evseCount,
+    canStop: activeTransactionCount > 0,
+  };
+}

--- a/apps/operator-ui/tests/e2e/fixtures/everest.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/everest.ts
@@ -48,6 +48,8 @@ const POLL_INTERVAL_MS = 2_000;
 // few seconds after `compose up`; this bounds the wait so a manager that never
 // boots fails fast into awaitStationOnline's diagnostics rather than hanging.
 const DB_READY_TIMEOUT_MS = 60_000;
+const SQLITE_BUSY_TIMEOUT_MS = 30_000;
+const SQLITE_PATCH_ATTEMPTS = 3;
 
 export interface EverestHandle {
   readonly ocppConnectionName: string;
@@ -319,24 +321,43 @@ async function patchEverestNetworkProfile(): Promise<void> {
   }
 
   const escaped = CORRECT_NETWORK_PROFILE_JSON.replace(/'/g, "''");
-  const sql = `UPDATE VARIABLE_ATTRIBUTE SET VALUE='${escaped}' WHERE VARIABLE_ID = (SELECT ID FROM VARIABLE WHERE NAME='NetworkConnectionProfiles');\n`;
+  // The manager holds the same database open, so the write waits for its lock rather than failing
+  // on the first SQLITE_BUSY. The retry covers a lock held for longer than the pragma waits.
+  const sql =
+    `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};` +
+    `UPDATE VARIABLE_ATTRIBUTE SET VALUE='${escaped}' WHERE VARIABLE_ID = (SELECT ID FROM VARIABLE WHERE NAME='NetworkConnectionProfiles');`;
   // Pipe SQL via stdin to avoid shell quoting hell with the embedded JSON.
-  await new Promise<void>((res, rej) => {
-    const proc = spawn(
-      process.platform === 'win32' ? 'docker.exe' : 'docker',
-      ['exec', '-i', 'everest-manager-1', 'sqlite3', EVEREST_DEVICE_MODEL_DB],
-      { stdio: ['pipe', 'pipe', 'pipe'], shell: false },
-    );
-    let stderr = '';
-    proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString()));
-    proc.on('exit', (code) => {
-      if (code === 0) res();
-      else rej(new Error(`SQLite patch failed (code ${code}): ${stderr}`));
-    });
-    proc.on('error', rej);
-    proc.stdin?.write(sql);
-    proc.stdin?.end();
-  });
+  let lastFailure: Error | undefined;
+  for (let attempt = 1; attempt <= SQLITE_PATCH_ATTEMPTS; attempt++) {
+    try {
+      await new Promise<void>((res, rej) => {
+        const proc = spawn(
+          process.platform === 'win32' ? 'docker.exe' : 'docker',
+          ['exec', '-i', 'everest-manager-1', 'sqlite3', EVEREST_DEVICE_MODEL_DB],
+          { stdio: ['pipe', 'pipe', 'pipe'], shell: false },
+        );
+        let stderr = '';
+        proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString()));
+        proc.on('exit', (code) => {
+          if (code === 0) res();
+          else rej(new Error(`SQLite patch failed (code ${code}): ${stderr}`));
+        });
+        proc.on('error', rej);
+        proc.stdin?.write(sql);
+        proc.stdin?.end();
+      });
+      lastFailure = undefined;
+      break;
+    } catch (error) {
+      lastFailure = error as Error;
+      if (attempt < SQLITE_PATCH_ATTEMPTS) {
+        await delay(POLL_INTERVAL_MS);
+      }
+    }
+  }
+  if (lastFailure) {
+    throw lastFailure;
+  }
   await new Promise<void>((res) => {
     const proc = spawn(
       process.platform === 'win32' ? 'docker.exe' : 'docker',

--- a/apps/operator-ui/tests/e2e/pages/components/command-bar.po.ts
+++ b/apps/operator-ui/tests/e2e/pages/components/command-bar.po.ts
@@ -19,12 +19,12 @@ export class CommandBar {
 
   constructor(private readonly page: Page) {
     this.resetButton = page.getByRole('button', { name: /^reset$/i });
-    this.remoteStartButton = page.getByRole('button', {
-      name: /(remote start|start transaction)/i,
-    });
-    this.remoteStopButton = page.getByRole('button', {
-      name: /(remote stop|stop transaction)/i,
-    });
+    this.remoteStartButton = page
+      .getByRole('button', { name: /(remote start|start transaction)/i })
+      .first();
+    this.remoteStopButton = page
+      .getByRole('button', { name: /(remote stop|stop transaction)/i })
+      .first();
     this.forceDisconnectButton = page.getByRole('button', {
       name: /force disconnect/i,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -638,6 +638,9 @@ importers:
       typescript-eslint:
         specifier: 'catalog:'
         version: 8.17.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@20.19.43)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0)
 
   packages/base:
     dependencies:
@@ -14010,6 +14013,15 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/mocker@3.2.7(msw@2.15.0(@types/node@20.19.43)(typescript@6.0.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@20.19.43)(typescript@6.0.3)
+      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0)
+
   '@vitest/mocker@3.2.7(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
@@ -20391,6 +20403,27 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -20412,6 +20445,23 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      sass: 1.93.2
+      tsx: 4.23.11
+      yaml: 2.9.0
+
   vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
@@ -20428,6 +20478,48 @@ snapshots:
       sass: 1.93.2
       tsx: 4.23.11
       yaml: 2.9.0
+
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@20.19.43)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(msw@2.15.0(@types/node@20.19.43)(typescript@6.0.3))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.11)(yaml@2.9.0):
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
     // operator-ui owns its own Playwright e2e specs; vitest can't run them
     // (they call @playwright/test's test.use(), which only works under the
     // Playwright runner). Run them via `pnpm --filter @citrineos/operator-ui test:e2e`.
-    exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'apps/operator-ui/**'],
+    // Only that tests/ tree is excluded — unit tests co-located under
+    // apps/operator-ui/src do run here.
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.next/**', 'apps/operator-ui/tests/**'],
     // The testcontainers-backed integration suites annotate their beforeAll
     // with 90s but leave beforeEach/afterAll on the 5s/10s defaults, which CI
     // load intermittently blows (truncate cascade, container stop). Raised


### PR DESCRIPTION
Three related changes to the Charging Station transaction controls, all rooted in the same assumption that a station has one EVSE. Two commits; happy to split if you would rather review them separately.

1. **Fix** — start and stop were mutually exclusive per station, so one busy EVSE hid Start for all of them.
2. **Feature** — a start/stop button on each EVSE row, preselecting that EVSE.
3. **Fix** — nothing refreshed the station after either command, so the buttons went stale.

---

## 1. Start and Stop are not mutually exclusive

The Actions column and the station detail card both choose between the remote start and remote stop buttons using a single station-wide test:

```tsx
// columns.tsx:198
const hasActiveTransactions = !isEmpty(row.original.transactions);
{!hasActiveTransactions && <StartTransactionButton station={row.original} />}
{hasActiveTransactions  && <StopTransactionButton  station={row.original} />}

// charging.station.detail.card.tsx:174 — same shape
const hasActiveTransactions = station.transactions && station.transactions.length > 0;
```

A Charging Station may expose several EVSEs, each able to run its own transaction. Treating the two commands as mutually exclusive means **one busy EVSE hides Start for the entire station**, leaving every other EVSE unstartable from the UI. On a two-EVSE station an operator can start exactly one transaction and then has no way to start the second — the button has become Stop.

What makes this a bug rather than a deliberate simplification is that everything *behind* those buttons already handles multiple EVSEs:

- the start modal renders an `EvseSelector` and sends the chosen `evseId`;
- the stop modal enumerates the active transactions and labels each with its EVSE so the operator picks which to stop (`remote-stop/2.0.1/index.tsx:104-106`).

Only the button visibility collapses the multi-EVSE case.

<img width="1175" height="827" alt="image" src="https://github.com/user-attachments/assets/681767c9-4947-4593-8e57-2b93f081c7ec" />


Replace the single boolean with independent `canStart` / `canStop`, in one helper shared by both call sites so they cannot drift:

```ts
export function getTransactionCommandAvailability(
  station: TransactionCommandAvailabilityInput,
): TransactionCommandAvailability {
  // The station queries already constrain this relation to `isActive: { _eq: true }`.
  const activeTransactionCount = station.transactions?.length ?? 0;
  const evseCount = station.evses?.length ?? 0;

  return {
    canStart: evseCount === 0 || activeTransactionCount < evseCount,
    canStop: activeTransactionCount > 0,
  };
}
```

Stop is offered whenever a transaction is running; Start until every EVSE has one. A caller that did not select the `evses` relation keeps the previous behaviour of offering Start, rather than hiding a command the station can still accept.

The input type is structural rather than a `Pick` of a station DTO because the two call sites pass `ChargingStationDto` and `ChargingStationDetailsDto`, which disagree on whether these relations are optional.

<img width="1370" height="826" alt="image" src="https://github.com/user-attachments/assets/353e7c5e-6bbf-417a-8913-acd0298ef89c" />


### Verification

Built and run against three two-EVSE OCPP 2.0.1 stations, which between them cover every branch:

| Station | EVSEs | Active transactions | Buttons shown |
|---|---|---|---|
| SIMON_EVEREST_2 | 2 | 1 | Start **and** Stop |
| SIMON_EVEREST_1 | 2 | 2 | Stop only |
| SIMON_EVEREST_3 | 2 | 1 | Start **and** Stop |

Before this change all three showed Stop only.

---

## 2. A start/stop button per EVSE row

With several EVSEs on a station, the station-level buttons still make the operator re-pick from a combobox the EVSE or transaction they were already looking at. Each row of the EVSE tab now carries its own button beside Add Connector: Stop when that EVSE has an active transaction, Start when it does not, each preselecting what the row already identifies.

Preselection is threaded through as optional props — `evse` for remote start, `transactionId` for remote stop — so the station-level buttons are unchanged. OCPP 1.6 has no EVSE concept and ignores the new prop; its modal continues to select a connector.

One detail worth flagging for review: the preselected start value is built exactly as `EvseSelector` builds its option values. Any other shape leaves the combobox with nothing to match, so it renders its placeholder over a form that does hold the value — it looks broken without being broken.

### Verification

On a station whose EVSE 1 was charging and EVSE 2 idle, the rows rendered Stop and Start respectively, and opening Start from the EVSE 2 row arrived with EVSE already set to 2.

---

## 3. Nothing refreshed the station after a command

Stopping one of two transactions left the operator looking at a stale Stop button for an EVSE that had already stopped.

`liveMode` is `'auto'` globally (`providers/index.tsx:98`), which suggests live updates are in play — but `@refinedev/hasura` needs a `meta.gqlSubscription` document to subscribe with, and no query in the app supplies one; every query passes `gqlQuery` only. **So no page in the operator UI live-updates at all.** The stale button is one visible symptom of that.

Both transaction modals now `invalidate({ invalidates: ['all'] })` after the command, matching the existing idiom in the network-profile modals.

**This is a mitigation, not a cure, and I would rather say so than imply otherwise.** `RequestStartTransaction` / `RequestStopTransaction` resolve on the charger's *acceptance*, not on the `TransactionEvent` that actually opens or closes the transaction, so an immediate refetch races it. The modals invalidate twice — once immediately, once after a short settle period. A page reload remains the guarantee. Giving the queries real subscription documents is the proper fix and is a much larger change; I have not attempted it here.

---

## Notes

No unit test accompanies this: `apps/operator-ui` currently has only Playwright e2e specs and no unit test runner, and introducing one felt out of scope. Happy to add a spec under `tests/e2e/specs/charging-stations/` if you would prefer.

The OCPP 1.6 modals are untouched, so 1.6 stations do not get the post-command invalidation either. Straightforward follow-up if wanted.

Item 1 shares its underlying assumption — one EVSE per Charging Station — with citrineos/citrineos-core#859, in a different layer.
