### PR TITLE
fix(deploy): docker build fails on EXPOSE with undefined PORT variable

### DIFF
--- a/apps/ocpp-server/deploy.Dockerfile
+++ b/apps/ocpp-server/deploy.Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /usr/local/apps/citrineos
 
 RUN chmod +x /usr/local/apps/citrineos/apps/ocpp-server/entrypoint.sh
 
-EXPOSE ${PORT}
+# REST API, websocket servers (security profiles 0-3)
+EXPOSE 8080 8081 8082 8443 8444
 
 ENTRYPOINT ["/usr/local/apps/citrineos/apps/ocpp-server/entrypoint.sh"]


### PR DESCRIPTION
## Problem
`apps/ocpp-server/deploy.Dockerfile` ends with `EXPOSE ${PORT}`, but `PORT` is never declared as an `ARG` (or given a default). The variable expands to an empty string, so a plain

```
docker build -f apps/ocpp-server/deploy.Dockerfile .
```

always fails with:

```
ERROR: Dockerfile parse error: EXPOSE requires at least one argument
```

## Fix
Replace the undefined variable with the concrete ports the server actually listens on — 8080 (REST API) and 8081/8082/8443/8444 (websocket servers, security profiles 0–3) — matching the port mappings already published in `docker-compose.yml`. `EXPOSE` is documentation metadata, so listing the real set is strictly more useful than a single parameterized port.

## Verification
- `docker build -f apps/ocpp-server/deploy.Dockerfile .` fails on `next` before this change and succeeds with it (also verified with podman/buildah, which fails identically on the unset variable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


