### PR TITLE
fix(server): wire router instance-queue mode to amqp.instanceIdentifier config

### DIFF
--- a/apps/ocpp-server/src/container.ts
+++ b/apps/ocpp-server/src/container.ts
@@ -256,7 +256,15 @@ function registerMessaging(container: AwilixContainer): void {
     ).singleton(),
     routerHandler: asFunction(
       ({ config, channelManager, logger }) =>
-        new RabbitMqReceiver({ config, channelManager, logger }),
+        new RabbitMqReceiver({
+          config,
+          channelManager,
+          logger,
+          // Instance-scoped queue mode (one queue per router process instead of one
+          // per connected station) is opt-in: it only makes sense when the operator
+          // gives each process a stable identity, e.g. the pod name.
+          routerMode: !!config.util.messageBroker.amqp?.instanceIdentifier,
+        }),
     ).singleton(),
   });
 }


### PR DESCRIPTION
## Problem
`RabbitMqReceiver` supports an instance-scoped queue mode for the router (`routerMode` + `config.util.messageBroker.amqp.instanceIdentifier`): one durable queue per router process (`rabbit_queue_router_<id>`) instead of one queue per connected station. This was introduced with the RabbitMQ enhancements in #633 for horizontally-scaled routers with large fleets, where per-station queues mean thousands of queues/consumers.

However, `buildContainer` never passes `routerMode` when constructing `routerHandler` (`apps/ocpp-server/src/container.ts`), so `_isRouterMode` is always `false` and the mode is unreachable — setting `util.messageBroker.amqp.instanceIdentifier` today has no effect on the router.

## Fix
Enable `routerMode` exactly when `instanceIdentifier` is configured:

```ts
routerMode: !!config.util.messageBroker.amqp?.instanceIdentifier,
```

This keeps behavior unchanged for every existing deployment (the field is optional and unset in all shipped configs — per-station queues remain the default, and they behave correctly with multiple router replicas since each station's queue is subscribed by the socket-owning process). Operators who scale the router and want to avoid per-station queue/consumer explosion can now opt in by giving each process a stable identity (e.g. the Kubernetes pod name via the downward API).

Tying the opt-in to `instanceIdentifier` also avoids the fallback identity `router-${Date.now()}` in `receiver.ts`, which would otherwise mint a new orphaned durable queue on every process restart.

## Verification
- `pnpm --filter "@citrineos/ocpp-server..." build` passes.
- Without `instanceIdentifier` set: constructor arg evaluates to `false` → identical wiring to today (verified against a 2-replica router deployment on Kubernetes: per-station queues, one consumer each, REST-initiated calls delivered to the socket-owning replica with zero drops).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


