### PR TITLE
fix(core): attach OCPP 2.x MeterValues to their transaction

### DIFF
--- a/packages/core/src/handlers/requests/2/MeterValuesRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/MeterValuesRequestOcpp2Handler.ts
@@ -103,8 +103,6 @@ export class MeterValuesRequestOcpp2Handler extends AbstractHandler {
 
       if (activeTransaction) {
         await this._transactionService.recalculateTotalKwh(activeTransaction, meterValuesCreated);
-        // Only the CostUpdated call is optional; attaching the reading to its transaction
-        // and keeping totalKwh current are not.
         if (this._sendCostUpdatedOnMeterValue) {
           await this._costNotifier.calculateCostAndNotify(
             activeTransaction,

--- a/packages/core/src/handlers/requests/2/MeterValuesRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/MeterValuesRequestOcpp2Handler.ts
@@ -5,6 +5,7 @@ import {
   AbstractHandler,
   type AbstractHandlerDependencies,
   AsRequestHandler,
+  type BootstrapConfig,
   type IMessage,
   type IOcppSender,
   OcppError,
@@ -14,6 +15,7 @@ import {
   type HandlerProperties,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
+  type SystemConfig,
   OCPP2_request_types,
   OCPP2_response_types,
 } from '@citrineos/types';
@@ -35,11 +37,13 @@ export class MeterValuesRequestOcpp2Handler extends AbstractHandler {
   constructor({
     logger,
     ocppSender,
+    config,
     costNotifier,
     signedMeterValuesUtil,
     transactionEventRepository,
     transactionService,
   }: AbstractHandlerDependencies & {
+    config: BootstrapConfig & SystemConfig;
     costNotifier: CostNotifier;
     ocppSender: IOcppSender;
     signedMeterValuesUtil: SignedMeterValuesUtil;
@@ -53,6 +57,8 @@ export class MeterValuesRequestOcpp2Handler extends AbstractHandler {
     this._signedMeterValuesUtil = signedMeterValuesUtil;
     this._transactionEventRepository = transactionEventRepository;
     this._transactionService = transactionService;
+
+    this._sendCostUpdatedOnMeterValue = config.modules.transactions.sendCostUpdatedOnMeterValue;
   }
 
   async handle(
@@ -72,7 +78,7 @@ export class MeterValuesRequestOcpp2Handler extends AbstractHandler {
     const evseId = message.payload.evseId;
 
     // When evseId is 0, the MeterValuesRequest message SHALL be associated with the entire Charging Station.
-    if (this._sendCostUpdatedOnMeterValue && evseId !== 0) {
+    if (evseId !== 0) {
       const activeTransaction: Transaction | undefined =
         await this._transactionEventRepository.getActiveTransactionByStationIdAndEvseId(
           tenantId,
@@ -97,11 +103,15 @@ export class MeterValuesRequestOcpp2Handler extends AbstractHandler {
 
       if (activeTransaction) {
         await this._transactionService.recalculateTotalKwh(activeTransaction, meterValuesCreated);
-        await this._costNotifier.calculateCostAndNotify(
-          activeTransaction,
-          message.context.tenantId,
-          message.protocol,
-        );
+        // Only the CostUpdated call is optional; attaching the reading to its transaction
+        // and keeping totalKwh current are not.
+        if (this._sendCostUpdatedOnMeterValue) {
+          await this._costNotifier.calculateCostAndNotify(
+            activeTransaction,
+            message.context.tenantId,
+            message.protocol,
+          );
+        }
       }
     } else {
       await this._transactionService.createMeterValues(tenantId, meterValues);

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -278,8 +278,6 @@ export class TransactionService {
   ): Promise<MeterValue[]> {
     return Promise.all(
       meterValues.map(async (meterValue) => {
-        // A reading belongs to whichever transaction was running on the EVSE, whatever its
-        // reading context.
         if (transactionDbId) {
           return await this._transactionEventRepository.createMeterValue(
             tenantId,
@@ -417,7 +415,6 @@ export class TransactionService {
     let evseTypeId: number | undefined;
 
     if (typeof evseIdentifier === 'number') {
-      // OCPP 1.6: evseIdentifier is a connector ID — resolve to EVSE type ID
       const connector = await this._locationRepository.readConnectorByStationIdAndOcpp16ConnectorId(
         tenantId,
         ocppConnectionName,
@@ -425,7 +422,6 @@ export class TransactionService {
       );
       evseTypeId = connector?.evse?.evseTypeId;
     } else {
-      // OCPP 2.0.1: evseIdentifier is an EVSEType — use evse.id directly
       evseTypeId = evseIdentifier.id;
     }
 

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -278,10 +278,11 @@ export class TransactionService {
   ): Promise<MeterValue[]> {
     return Promise.all(
       meterValues.map(async (meterValue) => {
-        const hasPeriodic: boolean = meterValue.sampledValue?.some(
-          (s) => s.context === OCPP2_0_1.ReadingContextEnumType.Sample_Periodic,
-        );
-        if (transactionDbId && hasPeriodic) {
+        // A reading belongs to whichever transaction was running on the EVSE, whatever its
+        // reading context. Requiring Sample.Periodic here orphaned every other context —
+        // Sample.Clock, Transaction.Begin/End, Trigger — which is most of what a 1.6-era
+        // charger reports outside a TransactionEvent.
+        if (transactionDbId) {
           return await this._transactionEventRepository.createMeterValue(
             tenantId,
             meterValue,

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -279,9 +279,7 @@ export class TransactionService {
     return Promise.all(
       meterValues.map(async (meterValue) => {
         // A reading belongs to whichever transaction was running on the EVSE, whatever its
-        // reading context. Requiring Sample.Periodic here orphaned every other context —
-        // Sample.Clock, Transaction.Begin/End, Trigger — which is most of what a 1.6-era
-        // charger reports outside a TransactionEvent.
+        // reading context.
         if (transactionDbId) {
           return await this._transactionEventRepository.createMeterValue(
             tenantId,

--- a/packages/core/test/handlers/requests/2/MeterValuesRequestOcpp2Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/MeterValuesRequestOcpp2Handler.test.ts
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest';
+import { type BootstrapConfig, type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  type SystemConfig,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type { ITransactionEventRepository } from '@dal/interfaces/repositories.js';
+import { MeterValuesRequestOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+function makeConfig(sendCostUpdatedOnMeterValue: boolean): BootstrapConfig & SystemConfig {
+  return {
+    modules: {
+      transactions: {
+        requests: [],
+        responses: [],
+        sendCostUpdatedOnMeterValue,
+      },
+    },
+  } as unknown as BootstrapConfig & SystemConfig;
+}
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Transactions,
+    action: OCPP_CallAction.MeterValues,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<T>;
+}
+
+const ACTIVE_TRANSACTION = {
+  id: 42,
+  transactionId: 'txn-001',
+  tariffId: 7,
+  isActive: true,
+  totalKwh: 12.5,
+};
+
+function makeRequest(evseId: number): OCPP2_0_1.MeterValuesRequest {
+  return {
+    evseId,
+    meterValue: [
+      {
+        timestamp: new Date().toISOString(),
+        sampledValue: [
+          {
+            value: 112.5,
+            context: OCPP2_0_1.ReadingContextEnumType.Sample_Periodic,
+            measurand: OCPP2_0_1.MeasurandEnumType.Energy_Active_Import_Register,
+            unitOfMeasure: { unit: 'kWh', multiplier: 0 },
+          },
+        ],
+      },
+    ],
+  } as OCPP2_0_1.MeterValuesRequest;
+}
+
+function makeHandler(
+  overrides: {
+    sendCostUpdatedOnMeterValue?: boolean;
+    activeTransaction?: unknown;
+  } = {},
+) {
+  const { logger } = createTestContainer();
+  const ocppSender = makeMockOcppSender();
+
+  const transactionEventRepository = {
+    getActiveTransactionByStationIdAndEvseId: vi
+      .fn()
+      .mockResolvedValue(
+        'activeTransaction' in overrides ? overrides.activeTransaction : ACTIVE_TRANSACTION,
+      ),
+  };
+
+  const transactionService = {
+    createMeterValues: vi.fn().mockResolvedValue([]),
+    recalculateTotalKwh: vi.fn().mockResolvedValue(12.5),
+  };
+
+  const costNotifier = { calculateCostAndNotify: vi.fn().mockResolvedValue(undefined) };
+  const signedMeterValuesUtil = { validateMeterValues: vi.fn().mockResolvedValue(true) };
+
+  const handler = new MeterValuesRequestOcpp2Handler({
+    logger,
+    ocppSender,
+    config: makeConfig(overrides.sendCostUpdatedOnMeterValue ?? false),
+    costNotifier: costNotifier as any,
+    signedMeterValuesUtil: signedMeterValuesUtil as any,
+    transactionEventRepository:
+      transactionEventRepository as unknown as ITransactionEventRepository,
+    transactionService: transactionService as any,
+  });
+
+  return { handler, ocppSender, transactionEventRepository, transactionService, costNotifier };
+}
+
+describe('MeterValuesRequestOcpp2Handler', () => {
+  describe('transaction association', () => {
+    // Attaching a meter value to its transaction is what makes it billable and what the
+    // operator UI reads; it must not depend on whether cost notifications are switched on.
+    it('links meter values to the active transaction on the EVSE', async () => {
+      const { handler, transactionService } = makeHandler();
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(transactionService.createMeterValues).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.any(Array),
+        ACTIVE_TRANSACTION.id,
+        ACTIVE_TRANSACTION.transactionId,
+        ACTIVE_TRANSACTION.tariffId,
+      );
+    });
+
+    it('links meter values when cost updates are driven by the interval instead', async () => {
+      const { handler, transactionService } = makeHandler({ sendCostUpdatedOnMeterValue: false });
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(transactionService.createMeterValues).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.any(Array),
+        ACTIVE_TRANSACTION.id,
+        ACTIVE_TRANSACTION.transactionId,
+        ACTIVE_TRANSACTION.tariffId,
+      );
+    });
+
+    it('recalculates totalKwh from the newly stored meter values', async () => {
+      const { handler, transactionService } = makeHandler();
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(transactionService.recalculateTotalKwh).toHaveBeenCalledOnce();
+    });
+
+    it('stores meter values unlinked when evseId is 0', async () => {
+      // evseId 0 addresses the whole Charging Station, so there is no transaction to attach to.
+      const { handler, transactionService, transactionEventRepository } = makeHandler();
+
+      await handler.handle(makeMessage(makeRequest(0)));
+
+      expect(
+        transactionEventRepository.getActiveTransactionByStationIdAndEvseId,
+      ).not.toHaveBeenCalled();
+      expect(transactionService.createMeterValues).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.any(Array),
+      );
+      expect(transactionService.recalculateTotalKwh).not.toHaveBeenCalled();
+    });
+
+    it('stores meter values unlinked when the EVSE has no active transaction', async () => {
+      const { handler, transactionService } = makeHandler({ activeTransaction: undefined });
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(transactionService.createMeterValues).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.any(Array),
+        undefined,
+        undefined,
+        undefined,
+      );
+      expect(transactionService.recalculateTotalKwh).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cost notification', () => {
+    it('notifies cost when sendCostUpdatedOnMeterValue is enabled', async () => {
+      const { handler, costNotifier } = makeHandler({ sendCostUpdatedOnMeterValue: true });
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(costNotifier.calculateCostAndNotify).toHaveBeenCalledOnce();
+    });
+
+    it('does not notify cost when sendCostUpdatedOnMeterValue is disabled', async () => {
+      const { handler, costNotifier } = makeHandler({ sendCostUpdatedOnMeterValue: false });
+
+      await handler.handle(makeMessage(makeRequest(1)));
+
+      expect(costNotifier.calculateCostAndNotify).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`MeterValuesRequestOcpp2Handler` declares `_sendCostUpdatedOnMeterValue` (`:33`) but **never assigns it** — the constructor does not take `config` at all. Compare `TransactionEventRequestOcpp2Handler:97`, which reads the same setting. Because the field's declared type includes `undefined`, `strictPropertyInitialization` is satisfied and the compiler stays quiet.

So the guard at `:75`

```ts
if (this._sendCostUpdatedOnMeterValue && evseId !== 0) {
```

is permanently false, and **every** OCPP 2.0.1/2.1 `MeterValuesRequest` falls through to `:107`:

```ts
await this._transactionService.createMeterValues(tenantId, meterValues);
```

with no `transactionDatabaseId`, `transactionId` or `tariffId`. The consequences:

- meter values are persisted **orphaned** — never linked to the transaction that produced them;
- `recalculateTotalKwh` never runs from the `MeterValues` path, so `Transaction.totalKwh` only ever moves when readings arrive embedded in a `TransactionEvent`;
- `calculateCostAndNotify` never fires.

This is the default behaviour: both shipped configs (`apps/ocpp-server/src/config/envs/{local,docker}.ts:155/157`) set `costUpdatedInterval`, and the schema refinement at `packages/types/src/config/types.ts:529` forbids setting both.

### Second layer

Assigning the field alone is not sufficient. `TransactionService.createMeterValues:285-298` only threads the transaction ids through when the batch contains a `Sample.Periodic` reading:

```ts
const hasPeriodic = meterValue.sampledValue?.some((s) => s.context === Sample_Periodic);
if (transactionDbId && hasPeriodic) { /* linked */ } else { /* orphaned */ }
```

`Sample.Clock`, `Transaction.Begin`, `Transaction.End` and `Trigger` batches are all silently orphaned. `createMeterValues` has exactly one caller — this handler — so the context test serves no purpose beyond dropping the link.

## Fix

1. Take `config` in the constructor and assign `_sendCostUpdatedOnMeterValue`.
2. Gate only the `CostUpdated` call on that setting. Associating a reading with its transaction and keeping `totalKwh` current are not optional behaviours, and gating them on a cost-notification flag conflates two unrelated concerns. They now happen whenever the request names a real EVSE (`evseId !== 0`) that has an active transaction.
3. Drop the `hasPeriodic` condition in `TransactionService.createMeterValues`.

`config` is already resolvable in this Awilix scope — `TransactionEventRequestOcpp2Handler` sits in the same `TRANSACTIONS_HANDLERS` list and takes it.

## Tests

New `packages/core/test/handlers/requests/2/MeterValuesRequestOcpp2Handler.test.ts`, 7 cases:

- meter values are linked to the EVSE's active transaction (also with `sendCostUpdatedOnMeterValue: false`, the shipped default);
- `totalKwh` is recalculated;
- readings are stored unlinked for `evseId: 0` and when the EVSE has no active transaction;
- `CostUpdated` fires when the setting is on and not when it is off.

5 of the 7 fail on `next` — including *notifies cost when sendCostUpdatedOnMeterValue is enabled*, which demonstrates the setting is inert today.

## Verification

`pnpm build` then `npx vitest run`:

- **before:** 1748 passed, 2 failed, 4 skipped
- **after:** 1755 passed (+7 new), 2 failed, 4 skipped

The 2 failures are `packages/core/test/dal/e2e/security-event.e2e.test.ts`, which fail identically on unmodified `next` — pre-existing and unrelated. `eslint` reports 0 errors; the 2 remaining warnings are in `OcppRouter/DataApi.ts` and `Reporting/2/MessageApi.ts`, untouched here.