### PR TITLE
fix(base): ignore non-energy meter units instead of throwing

### DIFF
--- a/packages/base/src/util/MeterValueUtils.ts
+++ b/packages/base/src/util/MeterValueUtils.ts
@@ -212,33 +212,36 @@ export class MeterValueUtils {
         return null;
       }
 
-      let sum = 0;
-      for (const value of phaseNeutralValues) {
-        const normalizedValue = this.normalizeToKwh(value);
-        if (normalizedValue !== null) {
-          sum += normalizedValue;
-        }
-      }
-
-      return sum;
+      return this.sumNormalized(phaseNeutralValues);
     }
 
     // Sum all the normalized phase values
+    return this.sumNormalized(phaseValues);
+  }
+
+  /**
+   * Sum a set of same-measurand sampled values in kWh, skipping any whose unit is not an energy
+   * unit. Returns null when none of them normalized, so that a phase set reported entirely in
+   * the wrong unit is treated as "no reading" rather than as a genuine 0 kWh.
+   */
+  private static sumNormalized(sampledValues: SampledValue[]): number | null {
     let sum = 0;
-    for (const value of phaseValues) {
+    let normalizedAny = false;
+    for (const value of sampledValues) {
       const normalizedValue = this.normalizeToKwh(value);
       if (normalizedValue !== null) {
         sum += normalizedValue;
+        normalizedAny = true;
       }
     }
 
-    return sum;
+    return normalizedAny ? sum : null;
   }
 
   /**
    * Convert a sampled value to kWh, applying unit multipliers.
    * @param value A SampledValueType entry.
-   * @returns The converted value in kWh, or null if unit is missing.
+   * @returns The converted value in kWh, or null when the unit is not an energy unit.
    */
   private static normalizeToKwh(value: SampledValue): number | null {
     let powerOfTen = value.unitOfMeasure?.multiplier ?? 0;
@@ -256,7 +259,11 @@ export class MeterValueUtils {
         powerOfTen -= 3;
         break;
       default:
-        throw new Error(`Unknown unit for energy measurement: ${unit}`);
+        // Not an energy unit, so this is not a reading we can total. A charging station that
+        // reports e.g. Amps under an energy measurand (or omits the measurand on a current
+        // sample, which defaults it to Energy.Active.Import.Register) is out of spec, but
+        // throwing here would abort handling of the whole message.
+        return null;
     }
 
     return value.value * 10 ** powerOfTen;

--- a/packages/base/test/util/MeterValueUtils.test.ts
+++ b/packages/base/test/util/MeterValueUtils.test.ts
@@ -205,6 +205,67 @@ describe('MeterValueUtils', () => {
         ];
         expect(MeterValueUtils.getTotalKwh(meterValues, 0)).toBe(100); // 200kWh - 100kWh = 100kWh
       });
+
+      describe('Unrecognised units', () => {
+        // A charging station is not obliged to be well-formed. Throwing from deep inside the
+        // total takes out the whole MeterValues/TransactionEvent handler for that message.
+
+        it('ignores a reading whose unit is not an energy unit', () => {
+          const meterValues = [
+            makeMeterValue('2025-05-29T12:01:00Z', 'Energy.Active.Import.Register', 100, 'kWh'),
+            makeMeterValue('2025-05-29T12:02:00Z', 'Energy.Active.Import.Register', 16, 'A'),
+            makeMeterValue('2025-05-29T12:03:00Z', 'Energy.Active.Import.Register', 150, 'kWh'),
+          ];
+          expect(() => MeterValueUtils.getTotalKwh(meterValues, 0)).not.toThrow();
+          expect(MeterValueUtils.getTotalKwh(meterValues, 0)).toBe(50); // 150 - 100, ignoring the Amps
+        });
+
+        it('ignores a value with no measurand reported in Amps', () => {
+          // Measurand defaults to Energy.Active.Import.Register, so a charger that omits the
+          // measurand on a current sample sends what looks like an energy register in Amps.
+          const meterValues: MeterValueDto[] = [
+            {
+              timestamp: '2025-05-29T12:01:00Z',
+              sampledValue: [{ value: 16, unitOfMeasure: { unit: 'A', multiplier: 0 } }],
+            },
+          ];
+          expect(() => MeterValueUtils.getTotalKwh(meterValues, 0)).not.toThrow();
+          expect(MeterValueUtils.getTotalKwh(meterValues, 0)).toBe(0);
+        });
+
+        it('ignores an unrecognised unit when computing meterStart', () => {
+          const meterValues = [
+            makeMeterValue('2025-05-29T12:01:00Z', 'Energy.Active.Import.Register', 16, 'A'),
+            makeMeterValue('2025-05-29T12:02:00Z', 'Energy.Active.Import.Register', 5000, 'Wh'),
+          ];
+          expect(() => MeterValueUtils.getMeterStart(meterValues)).not.toThrow();
+          expect(MeterValueUtils.getMeterStart(meterValues)).toBe(5);
+        });
+
+        it('ignores an unrecognised unit among phased values', () => {
+          const meterValues: MeterValueDto[] = [
+            {
+              timestamp: '2025-05-29T12:01:00Z',
+              sampledValue: [
+                {
+                  measurand: 'Energy.Active.Import.Register',
+                  phase: 'L1',
+                  value: 10,
+                  unitOfMeasure: { unit: 'kWh', multiplier: 0 },
+                },
+                {
+                  measurand: 'Energy.Active.Import.Register',
+                  phase: 'L2',
+                  value: 99,
+                  unitOfMeasure: { unit: 'A', multiplier: 0 },
+                },
+              ],
+            },
+          ];
+          expect(() => MeterValueUtils.getTotalKwh(meterValues, 0, 4)).not.toThrow();
+          expect(MeterValueUtils.getTotalKwh(meterValues, 0, 4)).toBe(6); // 10 - 4, ignoring L2
+        });
+      });
     });
 
     it('returns 0 for empty meter values', () => {


### PR DESCRIPTION
## Problem

`MeterValueUtils.normalizeToKwh` threw on any unit it did not recognise:

```ts
default:
  throw new Error(`Unknown unit for energy measurement: ${unit}`);
```

It is reached from `getTotalKwh` and `getMeterStart`, which run inside `MeterValuesRequestOcpp2Handler` and `TransactionEventRequestOcpp2Handler` (and, via `updateTransactionByMeterValues`, the 1.6 path). One malformed sampled value therefore aborts handling of the **entire message**: no meter values stored, no total recalculated, and the charger receives a `CallError` rather than a result.

This is easy for a charging station to trigger without meaning to. Per spec a sampled value with **no** `measurand` defaults to `Energy.Active.Import.Register` — and `findMeasurandValue` implements exactly that. So a charger that omits the measurand on a current sample sends something the CSMS reads as an energy register denominated in Amps:

```
MeterValueUtils.getTotalKwh([{ value: 16, unitOfMeasure: { unit: 'A' } }], 12.5)
-> Error: Unknown unit for energy measurement: A
```

Reproduced against the built package.

This is a different defect from #852, which corrects the *measurand* mapping; this is the *unit* switch.

## Fix

Return `null` instead of throwing. Both callers — `findMeasurandValue` and `sumPhasedValues` — already treat `null` as "no reading here", so the unusable sample is skipped and any well-formed readings in the same batch still count.

`sumPhasedValues` needed a matching change. It summed into a zero-initialised accumulator and returned it unconditionally:

```ts
let sum = 0;
for (const value of phaseValues) {
  const normalizedValue = this.normalizeToKwh(value);
  if (normalizedValue !== null) sum += normalizedValue;
}
return sum;
```

A phase set reported entirely in the wrong unit used to throw; without this change it would now yield a genuine-looking **0 kWh register reading**, and a 0 register against a non-zero `meterStart` produces a large negative total. Extracted `sumNormalized`, which returns `null` when nothing normalized. Both phase branches now share it.

## Tests

Four new cases under `getTotalKwh > Unit normalization > Unrecognised units`:

- a non-energy unit mid-batch is ignored and the surrounding readings still total correctly;
- a measurand-less value in Amps is ignored;
- `getMeterStart` skips it too;
- an unrecognised unit among phased values is skipped without poisoning the sum.

All four fail on `next` with `Error: Unknown unit for energy measurement: A`.

## Verification

`pnpm build` then `npx vitest run`:

- **before:** 1748 passed, 2 failed, 4 skipped
- **after:** 1752 passed (+4 new), 2 failed, 4 skipped

The 2 failures are `packages/core/test/dal/e2e/security-event.e2e.test.ts`, which fail identically on unmodified `next` — pre-existing and unrelated.