### PR TITLE
test(core): bind the security event e2e test to ephemeral ports

### DIFF
--- a/packages/core/test/dal/e2e/security-event.e2e.test.ts
+++ b/packages/core/test/dal/e2e/security-event.e2e.test.ts
@@ -26,6 +26,7 @@
 
 import { type ChildProcess, execSync, spawn } from 'child_process';
 import { mkdtempSync, writeFileSync } from 'fs';
+import { type AddressInfo, createServer } from 'net';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Client } from 'pg';
@@ -43,11 +44,6 @@ const SERVER_DIST = fileURLToPath(
   new URL('../../../../../apps/ocpp-server/dist/index.js', import.meta.url),
 );
 
-// ─── Ports used by the server under test ─────────────────────────────────────
-
-const HTTP_PORT = 8080; // Fastify API + /health endpoint
-const WS_PORT = 8081; // OCPP WebSocket (allowUnknownChargingStations: true)
-
 // ─── Shared state across all scenarios ────────────────────────────────────────
 
 let pgContainer: StartedTestContainer;
@@ -56,7 +52,28 @@ let pgPort: number;
 let rabbitPort: number;
 let tempDir: string;
 
+// Assigned in beforeAll. The config's fixed 8080/8081/8085 are deliberately not used - see the
+// comment where these are patched into the config.
+let httpPort: number; // Fastify API + /health endpoint
+let wsPort: number; // OCPP WebSocket (allowUnknownChargingStations: true)
+
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Asks the OS for a port nothing is listening on. There is an unavoidable gap between closing this
+ * probe and the server binding, but that is far narrower a risk than the config's fixed ports,
+ * which a developer running the docker-compose stack already owns.
+ */
+function reserveFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port } = probe.address() as AddressInfo;
+      probe.close(() => resolve(port));
+    });
+  });
+}
 
 function buildTestEnv(extraEnv: Record<string, string> = {}): NodeJS.ProcessEnv {
   return {
@@ -90,7 +107,7 @@ async function waitForHealth(timeoutMs = 45_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(`http://localhost:${HTTP_PORT}/health/ready`);
+      const res = await fetch(`http://localhost:${httpPort}/health/ready`);
       if (res.ok) return;
     } catch {
       // server not up yet
@@ -118,7 +135,7 @@ async function killServer(proc: ChildProcess): Promise<void> {
 
 function connectOcpp(stationId: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(`ws://localhost:${WS_PORT}/${stationId}`, ['ocpp2.0.1']);
+    const ws = new WebSocket(`ws://localhost:${wsPort}/${stationId}`, ['ocpp2.0.1']);
     ws.once('open', () => resolve(ws));
     ws.once('error', reject);
   });
@@ -176,6 +193,20 @@ beforeAll(async () => {
   config.util.messageBroker.amqp!.url = `amqp://guest:guest@localhost:${rabbitPort}`;
   config.util.networkConnection.websocketServers =
     config.util.networkConnection.websocketServers.filter((s) => s.securityProfile === 0);
+
+  // Bind every listener to an ephemeral port instead of the config's fixed 8080/8081/8085.
+  // A developer running the docker-compose stack already owns those, and the server spawned below
+  // then loses the race to bind - silently, because it dies before its logger produces output.
+  // waitForHealth and the OCPP socket would go on to reach *that* server, which happily answers
+  // and persists the SecurityEvent to its own database, leaving this test querying an empty
+  // testcontainer and reporting a phantom persistence failure.
+  [httpPort, wsPort, config.ocpiServer.port] = await Promise.all([
+    reserveFreePort(),
+    reserveFreePort(),
+    reserveFreePort(),
+  ]);
+  config.centralSystem.port = httpPort;
+  config.util.networkConnection.websocketServers[0].port = wsPort;
 
   tempDir = mkdtempSync(join(tmpdir(), 'citrineos-e2e-'));
   writeFileSync(join(tempDir, 'config.json'), JSON.stringify(config, null, 2));


### PR DESCRIPTION
## Problem

`security-event.e2e.test.ts` hardcodes the ports it talks to:

```ts
const HTTP_PORT = 8080; // Fastify API + /health endpoint
const WS_PORT = 8081;   // OCPP WebSocket
```

Those are the ports `docker-compose.yml` publishes, which the README tells contributors to bring up under "Running the Full Stack with Docker". On a machine set up that way, the server this test spawns cannot bind them and exits - silently, before its logger produces any output, so nothing in the test log hints at what happened.

`waitForHealth()` then gets its 200 from the *running* stack, and `connectOcpp()` opens its socket to that same stack. It handles the `SecurityEventNotification` correctly and returns `[3, uuid, {}]`, so the OCPP assertions pass. It also persists the event to its own database, while the test queries the throwaway testcontainer - which is empty.

The result is a failure that reads as `SecurityEventNotification` not persisting, i.e. a product bug, when the product is fine and the harness is talking to the wrong server. It took a while to work out, and I nearly opened an issue for a bug that does not exist.

There is a worse case than the failure. If a contributor's running stack shares the database the test asserts against, these assertions pass while the spawned server is dead - the test goes green having exercised nothing. Nothing in the current code can distinguish the two.

## Change

Reserve ephemeral ports for the three listeners the server binds (`centralSystem`, the `securityProfile: 0` websocket server, and `ocpiServer`) and patch them into the config next to the existing AMQP override, which already establishes this pattern:

```ts
[httpPort, wsPort, config.ocpiServer.port] = await Promise.all([
  reserveFreePort(), reserveFreePort(), reserveFreePort(),
]);
config.centralSystem.port = httpPort;
config.util.networkConnection.websocketServers[0].port = wsPort;
```

The test is then isolated from whatever else is running, rather than requiring contributors to tear their environment down before `pnpm test`.

## Verification

Run with the full docker-compose stack up - the exact condition that broke it:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`[server:Sequelize]` / `[server:Drizzle]` log lines now appear in the output where previously there were none, confirming the spawned server is genuinely the one serving the test.

Full suite on this branch: `73 passed | 1 skipped (74)`, `1750 passed | 4 skipped (1754)`. `prettier --check` and `eslint` clean.

No behaviour change on CI, where the fixed ports were free anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
