### PR TITLE
fix(core): stop the OCPP 2.x concurrent-transaction check reading the flag backwards

### DIFF
--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -136,9 +136,6 @@ export class TransactionService {
       };
       return response;
     } else {
-      // concurrentTransaction is a permission, not a trigger: true means this token MAY hold
-      // several sessions at once, so the check only has to run when it is not set. The 1.6 path
-      // below reads it the same way.
       if (
         authorization.concurrentTransaction !== true &&
         transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started
@@ -425,7 +422,6 @@ export class TransactionService {
     let evseTypeId: number | undefined;
 
     if (typeof evseIdentifier === 'number') {
-      // OCPP 1.6: evseIdentifier is a connector ID — resolve to EVSE type ID
       const connector = await this._locationRepository.readConnectorByStationIdAndOcpp16ConnectorId(
         tenantId,
         ocppConnectionName,
@@ -433,7 +429,6 @@ export class TransactionService {
       );
       evseTypeId = connector?.evse?.evseTypeId;
     } else {
-      // OCPP 2.0.1: evseIdentifier is an EVSEType — use evse.id directly
       evseTypeId = evseIdentifier.id;
     }
 

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -138,8 +138,7 @@ export class TransactionService {
     } else {
       // concurrentTransaction is a permission, not a trigger: true means this token MAY hold
       // several sessions at once, so the check only has to run when it is not set. The 1.6 path
-      // below reads it the same way; the 2.x paths had it inverted, which both rejected a token
-      // deliberately granted concurrency and let every other token run unlimited sessions.
+      // below reads it the same way.
       if (
         authorization.concurrentTransaction !== true &&
         transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -136,8 +136,12 @@ export class TransactionService {
       };
       return response;
     } else {
+      // concurrentTransaction is a permission, not a trigger: true means this token MAY hold
+      // several sessions at once, so the check only has to run when it is not set. The 1.6 path
+      // below reads it the same way; the 2.x paths had it inverted, which both rejected a token
+      // deliberately granted concurrency and let every other token run unlimited sessions.
       if (
-        authorization.concurrentTransaction === true &&
+        authorization.concurrentTransaction !== true &&
         transactionEvent.eventType === OCPP2_0_1.TransactionEventEnumType.Started
       ) {
         const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id!);
@@ -212,7 +216,7 @@ export class TransactionService {
       return response;
     } else {
       if (
-        authorization.concurrentTransaction === true &&
+        authorization.concurrentTransaction !== true &&
         transactionEvent.eventType === OCPP2_1.TransactionEventEnumType.Started
       ) {
         const hasConcurrent = await this._hasConcurrentTransactions(tenantId, authorization.id!);

--- a/packages/core/test/modules/Transactions/module/TransactionService.test.ts
+++ b/packages/core/test/modules/Transactions/module/TransactionService.test.ts
@@ -133,8 +133,9 @@ describe('TransactionService', () => {
     expect(response.idTokenInfo?.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.Invalid);
   });
 
-  it('should not return ConcurrentTx status when there are concurrent transactions and concurrentTx is false', async () => {
+  it('should return ConcurrentTx status when there are concurrent transactions and concurrentTx is false', async () => {
     const authorization = anAuthorization((auth) => {
+      auth.concurrentTransaction = false;
       auth.status = AuthorizationStatusEnum.Accepted;
     });
     authorizationRepository.readAllByQuerystring.mockResolvedValue([authorization]);
@@ -156,10 +157,10 @@ describe('TransactionService', () => {
       messageContext,
     );
 
-    expect(response.idTokenInfo?.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.Accepted);
+    expect(response.idTokenInfo?.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.ConcurrentTx);
   });
 
-  it('should return ConcurrentTx status when there are concurrent transactions and concurrentTx is true', async () => {
+  it('should not return ConcurrentTx status when there are concurrent transactions and concurrentTx is true', async () => {
     const authorization = anAuthorization((auth) => {
       auth.concurrentTransaction = true;
       auth.status = AuthorizationStatusEnum.Accepted;
@@ -183,7 +184,7 @@ describe('TransactionService', () => {
       messageContext,
     );
 
-    expect(response.idTokenInfo?.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.ConcurrentTx);
+    expect(response.idTokenInfo?.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.Accepted);
   });
 
   it('should apply authorizers when status is Accepted and transaction is started', async () => {
@@ -288,6 +289,28 @@ describe('TransactionService', () => {
       expect(response.idTagInfo.status).toBe(OCPP1_6.StartTransactionResponseStatus.ConcurrentTx);
       expect(response.idTagInfo.parentIdTag).toBeUndefined();
       expect(response.idTagInfo.expiryDate).toBeUndefined();
+    });
+
+    it('should allow concurrent transactions when concurrentTransaction is true', async () => {
+      const authorization = anAuthorization((auth) => {
+        auth.concurrentTransaction = true;
+      });
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([authorization]);
+      transactionEventRepository.readAllActiveTransactionsByAuthorizationId.mockResolvedValue([
+        aTransaction(),
+      ]);
+      authorizer.authorize.mockResolvedValue(AuthorizationStatusEnum.Accepted);
+      realTimeAuthorizer.authorize.mockResolvedValue(AuthorizationStatusEnum.Accepted);
+
+      const messageContext = aMessageContext();
+      const connectorId = 1;
+      const response = await transactionService.authorizeOcpp16IdToken(
+        messageContext,
+        faker.string.uuid(),
+        connectorId,
+      );
+
+      expect(response.idTagInfo.status).toBe(OCPP1_6.StartTransactionResponseStatus.Accepted);
     });
   });
 


### PR DESCRIPTION
## The bug

`Authorization.concurrentTransaction` is a **permission**: `true` means this token may hold several sessions at once. `authorizeOcpp16IdToken` reads it that way — it runs the concurrency check when the flag is *not* set. `authorizeOcpp201IdToken` and `authorizeOcpp21IdToken` run the check only when the flag **is** set, which is the exact opposite on both halves:

- A token deliberately granted concurrency is refused with `ConcurrentTx` on its second simultaneous session.
- Every other token — including the `concurrentTransaction = false` default — is never checked at all and can run unlimited simultaneous sessions.

In a mixed 1.6 / 2.0.1 estate the same card therefore behaves oppositely depending on which station it is presented to.

## Why this is a regression, not a design choice

This was already fixed once, in 0c1d1877 (*"Fix inverted concurrentTransaction logic in authorization"*, #185), which set both protocol paths to `!== true`. The restructure in ad2aa677 reverted it: it flipped the 2.0.1 condition back to `=== true`, stripped the guard out of the 1.6 path entirely, inverted the two unit tests to assert the reverted behaviour, and deleted the 1.6 test that covered it.

The 1.6 guard has since been restored. The 2.x paths have not, and the tests still encode the inverted semantics — which is why nothing caught it.

## The change

- `!== true` on the 2.0.1 and 2.1 paths, matching 1.6.
- The two 2.0.1 unit tests corrected back to the semantics 0c1d1877 established.
- The 1.6 test deleted by ad2aa677 reinstated, so both protocol paths are now pinned to the same rule.

## Verification

```
npx vitest run packages/core/test/modules/Transactions/module/TransactionService.test.ts
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

Both corrected tests fail on `next` for the right reason before the source change (`expected 'Accepted' to be 'ConcurrentTx'` and `expected 'ConcurrentTx' to be 'Accepted'`).

Full `packages/core` suite: 1133 passed. The 6 failing files are testcontainers integration/e2e tests that need a Docker runtime, unrelated to this change.
