### PR TITLE
fix(core): close the OCPP 1.6 authorization bypass for a statusless token

### DIFF
--- a/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.ts
@@ -89,7 +89,7 @@ export class AuthorizeRequestOcpp16Handler extends AbstractHandler {
       const authorization = authorizations[0];
 
       if (!authorization.status) {
-        response.idTagInfo.status = OCPP1_6.AuthorizeResponseStatus.Accepted;
+        this._logger.error(`Authorization for idToken ${request.idTag} has no status; rejecting.`);
       } else if (authorization.status === AuthorizationStatusEnum.Accepted) {
         const cacheExpiryDateTime = authorization.cacheExpiryDateTime;
         const groupAuthorizationId = authorization.groupAuthorizationId;

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -328,7 +328,9 @@ export class TransactionService {
 
       // Check expiration and status
       if (!authorization.status) {
-        response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.Accepted;
+        this._logger.error(
+          `Authorization ${authorization.id} for idToken ${idToken} has no status; rejecting.`,
+        );
         return response;
       }
 

--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -424,7 +424,6 @@ export class TransactionService {
     let evseTypeId: number | undefined;
 
     if (typeof evseIdentifier === 'number') {
-      // OCPP 1.6: evseIdentifier is a connector ID — resolve to EVSE type ID
       const connector = await this._locationRepository.readConnectorByStationIdAndOcpp16ConnectorId(
         tenantId,
         ocppConnectionName,
@@ -432,7 +431,6 @@ export class TransactionService {
       );
       evseTypeId = connector?.evse?.evseTypeId;
     } else {
-      // OCPP 2.0.1: evseIdentifier is an EVSEType — use evse.id directly
       evseTypeId = evseIdentifier.id;
     }
 

--- a/packages/core/test/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.test.ts
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest';
+import { type IAuthorizer, type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  AuthorizationStatusEnum,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP1_6,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type { IAuthorizationRepository } from '@dal/interfaces/repositories.js';
+import { AuthorizeRequestOcpp16Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.Authorize,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP1_6,
+  } as unknown as IMessage<T>;
+}
+
+function makeHandler(authorizations: unknown[]) {
+  const { logger } = createTestContainer();
+  const ocppSender = makeMockOcppSender();
+
+  const authorizationRepository = {
+    readAllByQuerystring: vi.fn().mockResolvedValue(authorizations),
+    readOnlyOneByQuerystring: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const authorizer = {
+    authorize: vi.fn().mockResolvedValue(AuthorizationStatusEnum.Accepted),
+  } as unknown as IAuthorizer;
+
+  const handler = new AuthorizeRequestOcpp16Handler({
+    logger,
+    ocppSender,
+    authorizers: [authorizer],
+    authorizationRepository: authorizationRepository as unknown as IAuthorizationRepository,
+  } as never);
+
+  return { handler, ocppSender, authorizationRepository, authorizer };
+}
+
+/** Pulls the AuthorizeResponse out of the single sendCallResultWithMessage call. */
+function sentResponse(
+  ocppSender: ReturnType<typeof makeMockOcppSender>,
+): OCPP1_6.AuthorizeResponse {
+  expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalledOnce();
+  return ocppSender.sendCallResultWithMessage.mock.calls[0][1] as OCPP1_6.AuthorizeResponse;
+}
+
+const request: OCPP1_6.AuthorizeRequest = { idTag: 'TAG001' };
+
+describe('AuthorizeRequestOcpp16Handler', () => {
+  it('accepts an idTag whose authorization is Accepted', async () => {
+    const { handler, ocppSender } = makeHandler([
+      { idToken: 'TAG001', status: AuthorizationStatusEnum.Accepted },
+    ]);
+
+    await handler.handle(makeMessage(request));
+
+    expect(sentResponse(ocppSender).idTagInfo.status).toBe(
+      OCPP1_6.AuthorizeResponseStatus.Accepted,
+    );
+  });
+
+  it('does not accept an idTag whose authorization has no status', async () => {
+    const { handler, ocppSender } = makeHandler([{ idToken: 'TAG001', status: undefined }]);
+
+    await handler.handle(makeMessage(request));
+
+    expect(sentResponse(ocppSender).idTagInfo.status).toBe(OCPP1_6.AuthorizeResponseStatus.Invalid);
+  });
+
+  it('does not consult the authorizers for an authorization that has no status', async () => {
+    const { handler, authorizer } = makeHandler([{ idToken: 'TAG001', status: null }]);
+
+    await handler.handle(makeMessage(request));
+
+    expect(authorizer.authorize).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/test/modules/Transactions/module/TransactionService.test.ts
+++ b/packages/core/test/modules/Transactions/module/TransactionService.test.ts
@@ -270,6 +270,48 @@ describe('TransactionService', () => {
       expect(response.idTagInfo.expiryDate).toBeUndefined();
     });
 
+    it('should not accept an authorization that has no status', async () => {
+      const authorization = anAuthorization((auth) => {
+        auth.status = undefined as unknown as AuthorizationStatusEnum;
+      });
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([authorization]);
+      transactionEventRepository.readAllActiveTransactionsByAuthorizationId.mockResolvedValue([]);
+      authorizer.authorize.mockResolvedValue(AuthorizationStatusEnum.Accepted);
+      realTimeAuthorizer.authorize.mockResolvedValue(AuthorizationStatusEnum.Accepted);
+
+      const messageContext = aMessageContext();
+      const connectorId = 1;
+      const response = await transactionService.authorizeOcpp16IdToken(
+        messageContext,
+        faker.string.uuid(),
+        connectorId,
+      );
+
+      expect(response.idTagInfo.status).toBe(OCPP1_6.StartTransactionResponseStatus.Invalid);
+    });
+
+    it('should not consult the authorizers for an authorization that has no status', async () => {
+      const authorization = anAuthorization((auth) => {
+        auth.status = undefined as unknown as AuthorizationStatusEnum;
+      });
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([authorization]);
+      transactionEventRepository.readAllActiveTransactionsByAuthorizationId.mockResolvedValue([]);
+      // A permissive real-time authorizer must not be able to rescue a statusless token, and the
+      // rejection has to happen before we spend a network round trip asking it.
+      realTimeAuthorizer.authorize.mockResolvedValue(AuthorizationStatusEnum.Accepted);
+
+      const messageContext = aMessageContext();
+      const connectorId = 1;
+      const response = await transactionService.authorizeOcpp16IdToken(
+        messageContext,
+        faker.string.uuid(),
+        connectorId,
+      );
+
+      expect(response.idTagInfo.status).toBe(OCPP1_6.StartTransactionResponseStatus.Invalid);
+      expect(realTimeAuthorizer.authorize).not.toHaveBeenCalled();
+    });
+
     it('should return ConcurrentTx status when an active transaction exists', async () => {
       const authorization = anAuthorization();
       authorizationRepository.readAllByQuerystring.mockResolvedValue([authorization]);


### PR DESCRIPTION
## The bug

An `Authorization` row whose `status` is null is treated as an implicit **allow** on both OCPP 1.6 entry points:

- `TransactionService.authorizeOcpp16IdToken` returns `Accepted` immediately, skipping the `cacheExpiryDateTime` check, the concurrent-transaction check, and every authorizer — including `RealTimeAuthorizer`, which is the operator's only veto over a token at authorize time.
- `AuthorizeRequestOcpp16Handler` does the same for the standalone `Authorize` call.

```ts
// TransactionService.authorizeOcpp16IdToken
if (!authorization.status) {
  response.idTagInfo.status = OCPP1_6.StartTransactionResponseStatus.Accepted;
  return response;                    // no expiry, no concurrency, no authorizers
}
```

## Is a null status actually reachable?

Yes. `Authorizations.status` has no `NOT NULL`, and both the Sequelize and Drizzle models declare it optional. Rows reach that state through any write path that sets only the fields it was given — an OCPP 1.6 `idTag` is a bare string that carries no status of its own.

It fails open on the one protocol where an `idTag` has nothing else authenticating it.

## Precedent

ac4f60e9 (*"fixing authorization loophole for unknown tokens"*) removed exactly this branch from `authorizeOcpp201IdToken`. The two 1.6 copies were left behind; the 2.0.1 `Authorize` handler has never had one. This closes the same hole on 1.6.

## The change

Reject instead of accepting, and log which authorization was rejected so a misconfigured row is findable rather than silently permissive.

Adds `packages/core/test/handlers/requests/1.6/AuthorizeRequestOcpp16Handler.test.ts` — the handler had no test file.

## Verification

```
npx vitest run packages/core/test/handlers/requests/1.6 \
               packages/core/test/modules/Transactions/module/TransactionService.test.ts
 Test Files  4 passed (4)
      Tests  24 passed (24)
```

The three new tests fail on `next` before the source change, each with `expected 'Accepted' to be 'Invalid'`.
