### PR TITLE
fix(core): correct the inverted EVSE restriction checks in the OCPP 2.x Authorize handlers

### DIFF
--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -228,7 +228,6 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
                 if (evseIdDisallowed) {
                   evseIds.delete(evseIdAttribute.component?.evse?.id as number);
                 } else if (!hasConnectorTypeRestriction) {
-                  // With no connector-type filter, this list alone decides the permitted set.
                   evseIds.add(evseIdAttribute.component?.evse?.id as number);
                 }
               }

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -180,8 +180,6 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
           // Authorization restrictions MUST provide these variable attributes as defined in Physical Component
           // list of Part 2 - Appendices of OCPP 2.0.1
           let evseIds: Set<number> | undefined = undefined;
-          // One flag for both checks below: an empty allowedConnectorTypes array is truthy but
-          // is not a restriction, and reading it as one left the permitted set empty.
           const allowedConnectorTypes = authorization.allowedConnectorTypes ?? [];
           const hasConnectorTypeRestriction = allowedConnectorTypes.length > 0;
           if (hasConnectorTypeRestriction) {
@@ -195,8 +193,6 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
                 type: AttributeEnum.Actual,
               });
             for (const connectorType of connectorTypes) {
-              // indexOf(...) > 0 dropped the type at index 0, so a single-entry allow list
-              // matched nothing and every driver was refused with NotAllowedTypeEVSE.
               if (allowedConnectorTypes.includes(connectorType.value as string)) {
                 evseIds.add(connectorType.component?.evse?.id as number);
               }
@@ -225,9 +221,6 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
                   type: AttributeEnum.Actual,
                 });
               for (const evseIdAttribute of evseIdAttributes) {
-                // `some(startsWith(disallowedPrefix))` answers "is this EVSE disallowed", but the
-                // result was named and used as though it meant "allowed": the branches below
-                // admitted exactly the disallowed EVSEs and discarded the permitted ones.
                 const evseIdDisallowed: boolean = authorization.disallowedEvseIdPrefixes.some(
                   (disallowedEvseId: string) =>
                     (evseIdAttribute.value as string).startsWith(disallowedEvseId),

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -180,10 +180,11 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
           // Authorization restrictions MUST provide these variable attributes as defined in Physical Component
           // list of Part 2 - Appendices of OCPP 2.0.1
           let evseIds: Set<number> | undefined = undefined;
-          if (
-            authorization.allowedConnectorTypes &&
-            authorization.allowedConnectorTypes.length > 0
-          ) {
+          // One flag for both checks below: an empty allowedConnectorTypes array is truthy but
+          // is not a restriction, and reading it as one left the permitted set empty.
+          const allowedConnectorTypes = authorization.allowedConnectorTypes ?? [];
+          const hasConnectorTypeRestriction = allowedConnectorTypes.length > 0;
+          if (hasConnectorTypeRestriction) {
             evseIds = new Set();
             const connectorTypes: VariableAttribute[] =
               await this._deviceModelRepository.readAllByQuerystring(context.tenantId, {
@@ -194,8 +195,10 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
                 type: AttributeEnum.Actual,
               });
             for (const connectorType of connectorTypes) {
-              if (authorization.allowedConnectorTypes.indexOf(connectorType.value as string) > 0) {
-                evseIds.add(connectorType.evse?.id as number);
+              // indexOf(...) > 0 dropped the type at index 0, so a single-entry allow list
+              // matched nothing and every driver was refused with NotAllowedTypeEVSE.
+              if (allowedConnectorTypes.includes(connectorType.value as string)) {
+                evseIds.add(connectorType.component?.evse?.id as number);
               }
             }
           }
@@ -222,14 +225,18 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
                   type: AttributeEnum.Actual,
                 });
               for (const evseIdAttribute of evseIdAttributes) {
-                const evseIdAllowed: boolean = authorization.disallowedEvseIdPrefixes.some(
+                // `some(startsWith(disallowedPrefix))` answers "is this EVSE disallowed", but the
+                // result was named and used as though it meant "allowed": the branches below
+                // admitted exactly the disallowed EVSEs and discarded the permitted ones.
+                const evseIdDisallowed: boolean = authorization.disallowedEvseIdPrefixes.some(
                   (disallowedEvseId: string) =>
                     (evseIdAttribute.value as string).startsWith(disallowedEvseId),
                 );
-                if (evseIdAllowed && !authorization.allowedConnectorTypes) {
-                  evseIds.add(evseIdAttribute.evse?.id as number);
-                } else if (!evseIdAllowed && authorization.allowedConnectorTypes) {
-                  evseIds.delete(evseIdAttribute.evse?.id as number);
+                if (evseIdDisallowed) {
+                  evseIds.delete(evseIdAttribute.component?.evse?.id as number);
+                } else if (!hasConnectorTypeRestriction) {
+                  // With no connector-type filter, this list alone decides the permitted set.
+                  evseIds.add(evseIdAttribute.component?.evse?.id as number);
                 }
               }
             }

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -220,7 +220,6 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
                 if (evseIdDisallowed) {
                   evseIds.delete(evseIdAttribute.component?.evse?.id as number);
                 } else if (!hasConnectorTypeRestriction) {
-                  // With no connector-type filter, this list alone decides the permitted set.
                   evseIds.add(evseIdAttribute.component?.evse?.id as number);
                 }
               }

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -172,8 +172,6 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
           } as OCPP2_response_types.AuthorizeResponse;
         } else {
           let evseIds: Set<number> | undefined = undefined;
-          // One flag for both checks below: an empty allowedConnectorTypes array is truthy but
-          // is not a restriction, and reading it as one left the permitted set empty.
           const allowedConnectorTypes = authorization.allowedConnectorTypes ?? [];
           const hasConnectorTypeRestriction = allowedConnectorTypes.length > 0;
           if (hasConnectorTypeRestriction) {
@@ -187,8 +185,6 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
                 type: AttributeEnum.Actual,
               });
             for (const connectorType of connectorTypes) {
-              // indexOf(...) > 0 dropped the type at index 0, so a single-entry allow list
-              // matched nothing and every driver was refused with NotAllowedTypeEVSE.
               if (allowedConnectorTypes.includes(connectorType.value as string)) {
                 evseIds.add(connectorType.component?.evse?.id as number);
               }
@@ -217,9 +213,6 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
                   type: AttributeEnum.Actual,
                 });
               for (const evseIdAttribute of evseIdAttributes) {
-                // `some(startsWith(disallowedPrefix))` answers "is this EVSE disallowed", but the
-                // result was named and used as though it meant "allowed": the branches below
-                // admitted exactly the disallowed EVSEs and discarded the permitted ones.
                 const evseIdDisallowed: boolean = authorization.disallowedEvseIdPrefixes.some(
                   (disallowedEvseId: string) =>
                     (evseIdAttribute.value as string).startsWith(disallowedEvseId),

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -172,10 +172,11 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
           } as OCPP2_response_types.AuthorizeResponse;
         } else {
           let evseIds: Set<number> | undefined = undefined;
-          if (
-            authorization.allowedConnectorTypes &&
-            authorization.allowedConnectorTypes.length > 0
-          ) {
+          // One flag for both checks below: an empty allowedConnectorTypes array is truthy but
+          // is not a restriction, and reading it as one left the permitted set empty.
+          const allowedConnectorTypes = authorization.allowedConnectorTypes ?? [];
+          const hasConnectorTypeRestriction = allowedConnectorTypes.length > 0;
+          if (hasConnectorTypeRestriction) {
             evseIds = new Set();
             const connectorTypes: VariableAttribute[] =
               await this._deviceModelRepository.readAllByQuerystring(context.tenantId, {
@@ -186,8 +187,10 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
                 type: AttributeEnum.Actual,
               });
             for (const connectorType of connectorTypes) {
-              if (authorization.allowedConnectorTypes.indexOf(connectorType.value as string) > 0) {
-                evseIds.add(connectorType.evse?.id as number);
+              // indexOf(...) > 0 dropped the type at index 0, so a single-entry allow list
+              // matched nothing and every driver was refused with NotAllowedTypeEVSE.
+              if (allowedConnectorTypes.includes(connectorType.value as string)) {
+                evseIds.add(connectorType.component?.evse?.id as number);
               }
             }
           }
@@ -214,14 +217,18 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
                   type: AttributeEnum.Actual,
                 });
               for (const evseIdAttribute of evseIdAttributes) {
-                const evseIdAllowed: boolean = authorization.disallowedEvseIdPrefixes.some(
+                // `some(startsWith(disallowedPrefix))` answers "is this EVSE disallowed", but the
+                // result was named and used as though it meant "allowed": the branches below
+                // admitted exactly the disallowed EVSEs and discarded the permitted ones.
+                const evseIdDisallowed: boolean = authorization.disallowedEvseIdPrefixes.some(
                   (disallowedEvseId: string) =>
                     (evseIdAttribute.value as string).startsWith(disallowedEvseId),
                 );
-                if (evseIdAllowed && !authorization.allowedConnectorTypes) {
-                  evseIds.add(evseIdAttribute.evse?.id as number);
-                } else if (!evseIdAllowed && authorization.allowedConnectorTypes) {
-                  evseIds.delete(evseIdAttribute.evse?.id as number);
+                if (evseIdDisallowed) {
+                  evseIds.delete(evseIdAttribute.component?.evse?.id as number);
+                } else if (!hasConnectorTypeRestriction) {
+                  // With no connector-type filter, this list alone decides the permitted set.
+                  evseIds.add(evseIdAttribute.component?.evse?.id as number);
                 }
               }
             }

--- a/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201Handler.test.ts
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest';
+import { type IAuthorizer, type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  AuthorizationStatusEnum,
+  EventGroup,
+  IdTokenEnum,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type {
+  IAuthorizationRepository,
+  IDeviceModelRepository,
+} from '@dal/interfaces/repositories.js';
+import { AuthorizeRequestOcpp201Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+import type { CertificateAuthorityService } from '@/util/index.js';
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.Authorize,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<T>;
+}
+
+/**
+ * A VariableAttribute row as the device model returns it for the Connector.ConnectorType and
+ * EVSE.EvseId lookups the restriction checks are driven from.
+ */
+function anAttribute(evseId: number, value: string) {
+  // constructQuery eager-loads EvseType through the Component include, so that is where the
+  // handler has to read the EVSE from - the attribute's own evse association is not populated.
+  return { value, component: { evse: { id: evseId } } };
+}
+
+function makeHandler(options: {
+  authorization: Record<string, unknown>;
+  connectorTypes?: ReturnType<typeof anAttribute>[];
+  evseIds?: ReturnType<typeof anAttribute>[];
+}) {
+  const { logger } = createTestContainer();
+  const ocppSender = makeMockOcppSender();
+
+  const authorizationRepository = {
+    readOnlyOneByQuerystring: vi.fn().mockResolvedValue(options.authorization),
+  };
+
+  // The handler distinguishes the two device-model lookups by variable_name.
+  const deviceModelRepository = {
+    readAllByQuerystring: vi.fn().mockImplementation(async (_tenantId, query) => {
+      if (query.variable_name === 'ConnectorType') return options.connectorTypes ?? [];
+      if (query.variable_name === 'EvseId') return options.evseIds ?? [];
+      return [];
+    }),
+  };
+
+  const handler = new AuthorizeRequestOcpp201Handler({
+    logger,
+    ocppSender,
+    certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+    authorizers: [] as IAuthorizer[],
+    authorizationRepository: authorizationRepository as unknown as IAuthorizationRepository,
+    deviceModelRepository: deviceModelRepository as unknown as IDeviceModelRepository,
+  } as never);
+
+  return { handler, ocppSender };
+}
+
+function sentResponse(
+  ocppSender: ReturnType<typeof makeMockOcppSender>,
+): OCPP2_0_1.AuthorizeResponse {
+  expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalledOnce();
+  return ocppSender.sendCallResultWithMessage.mock.calls[0][1] as OCPP2_0_1.AuthorizeResponse;
+}
+
+const request: OCPP2_0_1.AuthorizeRequest = {
+  idToken: { idToken: 'TAG001', type: IdTokenEnum.Central },
+};
+
+const acceptedAuthorization = {
+  idToken: 'TAG001',
+  idTokenType: IdTokenEnum.Central,
+  status: AuthorizationStatusEnum.Accepted,
+};
+
+describe('AuthorizeRequestOcpp201Handler EVSE restrictions', () => {
+  describe('allowedConnectorTypes', () => {
+    it('allows an EVSE whose connector type is the only allowed type', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: { ...acceptedAuthorization, allowedConnectorTypes: ['cCCS2'] },
+        connectorTypes: [anAttribute(1, 'cCCS2')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      const response = sentResponse(ocppSender);
+      expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+      expect(response.idTokenInfo.evseId).toEqual([1]);
+    });
+
+    it('allows an EVSE whose connector type is the first of several allowed types', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: {
+          ...acceptedAuthorization,
+          allowedConnectorTypes: ['cCCS2', 'cMCS'],
+        },
+        connectorTypes: [anAttribute(1, 'cCCS2')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      expect(sentResponse(ocppSender).idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+    });
+
+    it('refuses with NotAllowedTypeEVSE when no EVSE has an allowed connector type', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: { ...acceptedAuthorization, allowedConnectorTypes: ['cMCS'] },
+        connectorTypes: [anAttribute(1, 'cCCS2')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      expect(sentResponse(ocppSender).idTokenInfo.status).toBe(
+        AuthorizationStatusEnum.NotAllowedTypeEVSE,
+      );
+    });
+
+    it('restricts the response to only the EVSEs with an allowed connector type', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: { ...acceptedAuthorization, allowedConnectorTypes: ['cMCS'] },
+        connectorTypes: [anAttribute(1, 'cCCS2'), anAttribute(2, 'cMCS')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      const response = sentResponse(ocppSender);
+      expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+      expect(response.idTokenInfo.evseId).toEqual([2]);
+    });
+  });
+
+  describe('disallowedEvseIdPrefixes', () => {
+    it('allows the EVSEs that do not carry a disallowed prefix', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: { ...acceptedAuthorization, disallowedEvseIdPrefixes: ['UK*DEP*'] },
+        evseIds: [anAttribute(1, 'UK*DEP*E001'), anAttribute(2, 'UK*VLT*E002')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      const response = sentResponse(ocppSender);
+      expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+      expect(response.idTokenInfo.evseId).toEqual([2]);
+    });
+
+    it('refuses with NotAtThisLocation when every EVSE carries a disallowed prefix', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: { ...acceptedAuthorization, disallowedEvseIdPrefixes: ['UK*DEP*'] },
+        evseIds: [anAttribute(1, 'UK*DEP*E001')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      expect(sentResponse(ocppSender).idTokenInfo.status).toBe(
+        AuthorizationStatusEnum.NotAtThisLocation,
+      );
+    });
+
+    it('removes a disallowed EVSE from the set the connector-type check allowed', async () => {
+      const { handler, ocppSender } = makeHandler({
+        authorization: {
+          ...acceptedAuthorization,
+          allowedConnectorTypes: ['cMCS'],
+          disallowedEvseIdPrefixes: ['UK*DEP*'],
+        },
+        connectorTypes: [anAttribute(1, 'cMCS'), anAttribute(2, 'cMCS')],
+        evseIds: [anAttribute(1, 'UK*DEP*E001'), anAttribute(2, 'UK*VLT*E002')],
+      });
+
+      await handler.handle(makeMessage(request));
+
+      const response = sentResponse(ocppSender);
+      expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+      expect(response.idTokenInfo.evseId).toEqual([2]);
+    });
+  });
+
+  it('places no evseId restriction on an authorization that carries neither list', async () => {
+    const { handler, ocppSender } = makeHandler({
+      authorization: acceptedAuthorization,
+      connectorTypes: [anAttribute(1, 'cCCS2')],
+      evseIds: [anAttribute(1, 'UK*VLT*E001')],
+    });
+
+    await handler.handle(makeMessage(request));
+
+    const response = sentResponse(ocppSender);
+    expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Accepted);
+    expect(response.idTokenInfo.evseId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The bug

Both restrictions an `Authorization` can carry resolve to the opposite of what they say. Present identically in `AuthorizeRequestOcpp201Handler` and `AuthorizeRequestOcpp21Handler`.

### `allowedConnectorTypes` — off-by-one

```ts
if (authorization.allowedConnectorTypes.indexOf(connectorType.value as string) > 0) {
  evseIds.add(connectorType.evse?.id as number);
}
```

`indexOf` returns `0` for the first entry, and `0 > 0` is false. So:

- A **single-entry** allow list matches no EVSE at all. `evseIds` comes out empty, and every driver holding that token is refused with `NotAllowedTypeEVSE` — the restriction rejects everyone, always.
- A multi-entry list silently ignores its first entry.

### `disallowedEvseIdPrefixes` — inverted

```ts
const evseIdAllowed: boolean = authorization.disallowedEvseIdPrefixes.some(
  (disallowedEvseId: string) => (evseIdAttribute.value as string).startsWith(disallowedEvseId),
);
if (evseIdAllowed && !authorization.allowedConnectorTypes) {
  evseIds.add(evseIdAttribute.evse?.id as number);
} else if (!evseIdAllowed && authorization.allowedConnectorTypes) {
  evseIds.delete(evseIdAttribute.evse?.id as number);
}
```

The `some(...)` answers *"is this EVSE **dis**allowed"*, but the result is bound to `evseIdAllowed` and both branches read it as "allowed". EVSEs matching a disallowed prefix get **added** to the permitted set; EVSEs matching none get **removed**. The restriction admits exactly the locations it was configured to keep the token out of.

### Empty-array inconsistency

The connector-type block tests `allowedConnectorTypes.length > 0`; the prefix block tests `!authorization.allowedConnectorTypes`. An empty array is truthy, so a token carrying `allowedConnectorTypes: []` skips the first block, is treated as restricted by the second, and ends up with an empty permitted set and `NotAtThisLocation`.

## The change

- `includes` instead of `indexOf(...) > 0`.
- Rename to `evseIdDisallowed` and act on it the right way round: a disallowed EVSE is always removed; a permitted one is added only when there was no connector-type filter that already decided membership.
- One hoisted `hasConnectorTypeRestriction` flag so both checks agree on what "restricted" means.

Adds `packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201Handler.test.ts` — the handler had no test file. It covers both restrictions individually, their interaction, and the unrestricted case.

## Verification

```
npx vitest run packages/core/test/handlers
 Test Files  11 passed (11)
      Tests  91 passed (91)
```

Six of the eight new tests fail on `next` before the source change, e.g. `expected 'NotAllowedTypeEVSE' to be 'Accepted'` for a token whose only allowed connector type is present on the station, and `expected [ 1 ] to deeply equal [ 2 ]` where EVSE 1 is the one carrying the disallowed prefix.
