### PR TITLE
fix(core): emit DC charging-profile limits in the unit they are labelled with

### DIFF
--- a/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
@@ -195,12 +195,6 @@ export class InternalSmartCharging implements ISmartCharging {
     }
   }
 
-  /**
-   * Picks the binding DC constraint and expresses it in its own unit. Per the OCPP 2.0.1
-   * DCChargingParametersType schema, evMaxPower is in W, evMaxCurrent in A and evMaxVoltage in V,
-   * and ChargingSchedulePeriod.limit is read in whichever unit chargingRateUnit names. So the two
-   * comparands are both W, but each limit must be returned as itself - not as the product.
-   */
   private _getChargingRateUnitAndLimit(
     evMaxCurrent: number,
     evMaxVoltage: number,

--- a/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
+++ b/packages/core/src/modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.ts
@@ -195,17 +195,21 @@ export class InternalSmartCharging implements ISmartCharging {
     }
   }
 
+  /**
+   * Picks the binding DC constraint and expresses it in its own unit. Per the OCPP 2.0.1
+   * DCChargingParametersType schema, evMaxPower is in W, evMaxCurrent in A and evMaxVoltage in V,
+   * and ChargingSchedulePeriod.limit is read in whichever unit chargingRateUnit names. So the two
+   * comparands are both W, but each limit must be returned as itself - not as the product.
+   */
   private _getChargingRateUnitAndLimit(
     evMaxCurrent: number,
     evMaxVoltage: number,
     evMaxPower?: number | null,
   ): [OCPP2_0_1.ChargingRateUnitEnumType, number] {
     if (evMaxPower && evMaxPower < evMaxCurrent * evMaxVoltage) {
-      // when charging rate unit is W, multiply by 1000
-      // based on OCPP 2.0.1 V3 Part 6 TC_K_57_CS
-      return [OCPP2_0_1.ChargingRateUnitEnumType.W, evMaxPower * 1000];
+      return [OCPP2_0_1.ChargingRateUnitEnumType.W, evMaxPower];
     }
-    return [OCPP2_0_1.ChargingRateUnitEnumType.A, evMaxCurrent * evMaxVoltage];
+    return [OCPP2_0_1.ChargingRateUnitEnumType.A, evMaxCurrent];
   }
 
   private async _findExistingChargingProfileWithHighestStackLevel(

--- a/packages/core/test/modules/SmartCharging/module/InternalSmartCharging.test.ts
+++ b/packages/core/test/modules/SmartCharging/module/InternalSmartCharging.test.ts
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1 } from '@citrineos/types';
+import type { IChargingProfileRepository } from '@dal/interfaces/repositories.js';
+import type { Transaction } from '@dal/layers/sequelize/model/TransactionEvent/index.js';
+import { InternalSmartCharging } from '@modules/SmartCharging/src/module/smartCharging/InternalSmartCharging.js';
+import { createTestContainer } from '@test/testContainer.js';
+
+const STATION = 'station-001';
+
+/**
+ * A truck-scale DC session: 500 A at 800 V, i.e. a 400 kW envelope, with the EV declaring a
+ * 350 kW ceiling. evMaxPower is in W and evMaxCurrent in A per the OCPP 2.0.1 schema for
+ * DCChargingParametersType.
+ */
+const EV_MAX_CURRENT_A = 500;
+const EV_MAX_VOLTAGE_V = 800;
+const EV_MAX_POWER_W = 350_000;
+
+function aRequest(
+  dcChargingParameters: Partial<OCPP2_0_1.DCChargingParametersType>,
+): OCPP2_0_1.NotifyEVChargingNeedsRequest {
+  return {
+    evseId: 1,
+    chargingNeeds: {
+      requestedEnergyTransfer: OCPP2_0_1.EnergyTransferModeEnumType.DC,
+      dcChargingParameters: dcChargingParameters as OCPP2_0_1.DCChargingParametersType,
+    },
+  } as OCPP2_0_1.NotifyEVChargingNeedsRequest;
+}
+
+function aTransaction(): Transaction {
+  return { id: 1, transactionId: 'tx-001' } as unknown as Transaction;
+}
+
+describe('InternalSmartCharging.calculateChargingProfile', () => {
+  let smartCharging: InternalSmartCharging;
+  let chargingProfileRepository: Mocked<IChargingProfileRepository>;
+
+  beforeEach(() => {
+    const { logger } = createTestContainer();
+
+    chargingProfileRepository = {
+      getNextChargingProfileId: vi.fn().mockResolvedValue(1),
+      getNextChargingScheduleId: vi.fn().mockResolvedValue(1),
+      getNextStackLevel: vi.fn().mockResolvedValue(0),
+      // No pre-existing profile, so the limit is not validated against anything.
+      readAllByQuery: vi.fn().mockResolvedValue([]),
+    } as unknown as Mocked<IChargingProfileRepository>;
+
+    smartCharging = new InternalSmartCharging({
+      chargingProfileRepository,
+      logger: logger as never,
+    });
+  });
+
+  /** The single period of the single schedule the profile is built from. */
+  async function periodFor(request: OCPP2_0_1.NotifyEVChargingNeedsRequest) {
+    const profile = await smartCharging.calculateChargingProfile(
+      request,
+      aTransaction(),
+      DEFAULT_TENANT_ID,
+      STATION,
+    );
+    const schedule = profile.chargingSchedule[0];
+    return { unit: schedule.chargingRateUnit, limit: schedule.chargingSchedulePeriod[0].limit };
+  }
+
+  it('limits a DC session to the EV max power in W when power is the binding constraint', async () => {
+    const { unit, limit } = await periodFor(
+      aRequest({
+        evMaxCurrent: EV_MAX_CURRENT_A,
+        evMaxVoltage: EV_MAX_VOLTAGE_V,
+        evMaxPower: EV_MAX_POWER_W,
+      }),
+    );
+
+    expect(unit).toBe(OCPP2_0_1.ChargingRateUnitEnumType.W);
+    expect(limit).toBe(EV_MAX_POWER_W);
+  });
+
+  it('limits a DC session to the EV max current in A when no power ceiling binds', async () => {
+    const { unit, limit } = await periodFor(
+      aRequest({ evMaxCurrent: EV_MAX_CURRENT_A, evMaxVoltage: EV_MAX_VOLTAGE_V }),
+    );
+
+    expect(unit).toBe(OCPP2_0_1.ChargingRateUnitEnumType.A);
+    expect(limit).toBe(EV_MAX_CURRENT_A);
+  });
+
+  it('limits to current in A when the declared power exceeds the current/voltage envelope', async () => {
+    const { unit, limit } = await periodFor(
+      aRequest({
+        evMaxCurrent: EV_MAX_CURRENT_A,
+        evMaxVoltage: EV_MAX_VOLTAGE_V,
+        // 500 kW declared against a 400 kW envelope: the envelope binds.
+        evMaxPower: 500_000,
+      }),
+    );
+
+    expect(unit).toBe(OCPP2_0_1.ChargingRateUnitEnumType.A);
+    expect(limit).toBe(EV_MAX_CURRENT_A);
+  });
+
+  it('never emits a limit larger than the EV can physically accept', async () => {
+    const { unit, limit } = await periodFor(
+      aRequest({
+        evMaxCurrent: EV_MAX_CURRENT_A,
+        evMaxVoltage: EV_MAX_VOLTAGE_V,
+        evMaxPower: EV_MAX_POWER_W,
+      }),
+    );
+
+    // Whichever unit is chosen, the value has to be readable in that unit. A limit of
+    // 350000000 W or 400000 A is not a limit, it is an unbounded profile.
+    const ceiling =
+      unit === OCPP2_0_1.ChargingRateUnitEnumType.W ? EV_MAX_POWER_W : EV_MAX_CURRENT_A;
+    expect(limit).toBeLessThanOrEqual(ceiling);
+  });
+});


### PR DESCRIPTION
## The bug

`_getChargingRateUnitAndLimit` returns a `chargingRateUnit` and a `limit` that do not agree with each other, so every `TxProfile` CitrineOS derives from `NotifyEVChargingNeeds` for a **DC** session carries a meaningless ceiling.

Per the OCPP 2.0.1 `DCChargingParametersType` schema in this repo, `evMaxPower` is in **W**, `evMaxCurrent` in **A**, `evMaxVoltage` in **V**. `ChargingSchedulePeriod.limit` is read in whichever unit `chargingRateUnit` names.

```ts
if (evMaxPower && evMaxPower < evMaxCurrent * evMaxVoltage) {
  return [W, evMaxPower * 1000];            // evMaxPower is already W
}
return [A, evMaxCurrent * evMaxVoltage];    // that product is W, returned under unit A
```

For a truck-scale session declaring **500 A / 800 V / 350 kW**:

| branch | emitted | should be |
|---|---|---|
| power binds | `350000000 W` (350 MW) | `350000 W` |
| current binds | `400000 A` | `500 A` |

Either way the profile constrains nothing, and a station that range-checks the value rejects it outright — so EV-declared limits are silently not applied.

The two branches also contradict each other and the comparison that selects between them: `evMaxPower < evMaxCurrent * evMaxVoltage` compares W against V·A, so the same value cannot then be scaled by 1000 as though it were kW. Whichever unit you believe `evMaxPower` carries, the current code is wrong in one branch or the other.

The AC path already does this correctly — `limit = evMaxCurrent` with `chargingRateUnit = A`.

## The change

Return each limit as itself.

```ts
if (evMaxPower && evMaxPower < evMaxCurrent * evMaxVoltage) {
  return [W, evMaxPower];
}
return [A, evMaxCurrent];
```

Adds `packages/core/test/modules/SmartCharging/module/InternalSmartCharging.test.ts` — the class had no test file. It exercises both branches through the public `calculateChargingProfile`, plus a guard that the emitted limit is never larger than what the EV declared in the unit chosen.

## Verification

```
npx vitest run packages/core/test/modules/SmartCharging
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

All four fail on `next` before the source change, with the values in the table above:
`expected 350000000 to be 350000` and `expected 400000 to be 500`.
