### PR TITLE
fix(core): ignore a retried OCPP 1.6 StopTransaction instead of double-counting it

### DIFF
--- a/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
@@ -118,10 +118,6 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
     }
 
     if (!transaction.isActive) {
-      // A charger that misses our CallResult retries the StopTransaction. It has already been
-      // acknowledged above, so the retry only needs to be dropped here: writing it again adds a
-      // second StopTransaction row and re-inserts every meter value in transactionData, which
-      // double-counts the session's readings. The 2.x handler already guards this.
       this._logger.warn(
         `Received StopTransaction for already-ended transaction ${request.transactionId} on ${ocppConnectionName}. Ignoring.`,
       );
@@ -160,9 +156,6 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
       );
     }
     transaction.isActive = false;
-    // OCPP 1.6 makes reason optional and an absent reason means Local, so assigning it straight
-    // through left stoppedReason null for the commonest case - a session the driver ended at the
-    // charger - and out of step with the StopTransaction row, which already defaulted it.
     transaction.stoppedReason = stoppedReason;
     transaction.endTime = request.timestamp;
     await transaction.save();

--- a/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
@@ -117,6 +117,19 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
       return;
     }
 
+    if (!transaction.isActive) {
+      // A charger that misses our CallResult retries the StopTransaction. It has already been
+      // acknowledged above, so the retry only needs to be dropped here: writing it again adds a
+      // second StopTransaction row and re-inserts every meter value in transactionData, which
+      // double-counts the session's readings. The 2.x handler already guards this.
+      this._logger.warn(
+        `Received StopTransaction for already-ended transaction ${request.transactionId} on ${ocppConnectionName}. Ignoring.`,
+      );
+      return;
+    }
+
+    const stoppedReason = request.reason || (request.idTag ? 'Remote' : 'Local');
+
     const stopTransaction = await this._transactionEventRepository.createStopTransaction(
       tenantId,
       transaction.id,
@@ -128,7 +141,7 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
           data as OCPP1_6.MeterValuesRequest['meterValue'][0],
         ),
       ) || [],
-      request.reason || (request.idTag ? 'Remote' : 'Local'),
+      stoppedReason,
       authorization?.id,
     );
 
@@ -147,7 +160,10 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
       );
     }
     transaction.isActive = false;
-    transaction.stoppedReason = request.reason;
+    // OCPP 1.6 makes reason optional and an absent reason means Local, so assigning it straight
+    // through left stoppedReason null for the commonest case - a session the driver ended at the
+    // charger - and out of step with the StopTransaction row, which already defaulted it.
+    transaction.stoppedReason = stoppedReason;
     transaction.endTime = request.timestamp;
     await transaction.save();
   }

--- a/packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  AuthorizationStatusEnum,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP1_6,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type {
+  IAuthorizationRepository,
+  ITransactionEventRepository,
+} from '@dal/interfaces/repositories.js';
+import { Transaction } from '@dal/index.js';
+import { StopTransactionRequestOcpp16Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Transactions,
+    action: OCPP_CallAction.StopTransaction,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP1_6,
+  } as unknown as IMessage<T>;
+}
+
+/**
+ * A Transaction row as the handler finds it, with just enough surface for the handler to run:
+ * the StartTransaction association it reads meterStart from, and a no-op save().
+ */
+function aTransaction(isActive: boolean) {
+  return {
+    id: 1,
+    transactionId: '100',
+    isActive,
+    startTransaction: { meterStart: 1000 },
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeHandler(transaction: ReturnType<typeof aTransaction> | null) {
+  const { logger } = createTestContainer();
+  const ocppSender = makeMockOcppSender();
+
+  const authorizationRepository = {
+    readOnlyOneByQuerystring: vi.fn().mockResolvedValue({
+      id: 7,
+      idToken: 'TAG001',
+      status: AuthorizationStatusEnum.Accepted,
+    }),
+  };
+
+  const transactionEventRepository = {
+    createStopTransaction: vi.fn().mockResolvedValue({ id: 1 }),
+  };
+
+  const findOne = vi
+    .spyOn(Transaction, 'findOne')
+    .mockResolvedValue(transaction as unknown as Transaction);
+
+  const handler = new StopTransactionRequestOcpp16Handler({
+    logger,
+    ocppSender,
+    authorizationRepository: authorizationRepository as unknown as IAuthorizationRepository,
+    transactionEventRepository:
+      transactionEventRepository as unknown as ITransactionEventRepository,
+  } as never);
+
+  return { handler, ocppSender, transactionEventRepository, findOne };
+}
+
+const request: OCPP1_6.StopTransactionRequest = {
+  transactionId: 100,
+  idTag: 'TAG001',
+  meterStop: 25000,
+  timestamp: new Date().toISOString(),
+};
+
+describe('StopTransactionRequestOcpp16Handler', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('records the stop for an active transaction', async () => {
+    const transaction = aTransaction(true);
+    const { handler, transactionEventRepository } = makeHandler(transaction);
+
+    await handler.handle(makeMessage(request));
+
+    expect(transactionEventRepository.createStopTransaction).toHaveBeenCalledOnce();
+    expect(transaction.save).toHaveBeenCalledOnce();
+  });
+
+  it('does not record a second stop for an already-ended transaction', async () => {
+    const transaction = aTransaction(false);
+    const { handler, transactionEventRepository } = makeHandler(transaction);
+
+    await handler.handle(makeMessage(request));
+
+    // A charger that misses our CallResult retries the StopTransaction. Writing it again
+    // duplicates the StopTransaction row and every meter value in transactionData.
+    expect(transactionEventRepository.createStopTransaction).not.toHaveBeenCalled();
+    expect(transaction.save).not.toHaveBeenCalled();
+  });
+
+  it('still acknowledges a retried StopTransaction so the charger stops resending', async () => {
+    const { handler, ocppSender } = makeHandler(aTransaction(false));
+
+    await handler.handle(makeMessage(request));
+
+    expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalledOnce();
+  });
+
+  it('records the same stoppedReason on the transaction as on the StopTransaction row', async () => {
+    const transaction = aTransaction(true);
+    const { handler, transactionEventRepository } = makeHandler(transaction);
+
+    await handler.handle(makeMessage({ ...request, reason: undefined }));
+
+    // OCPP 1.6 makes reason optional, so the handler derives one. Assigning request.reason
+    // straight through left Transaction.stoppedReason null while the StopTransaction row
+    // carried the derived value - two rows disagreeing about why the same session ended.
+    const derived = transactionEventRepository.createStopTransaction.mock.calls[0][6];
+    expect(derived).toBeDefined();
+    expect((transaction as unknown as { stoppedReason?: string }).stoppedReason).toBe(derived);
+  });
+
+  it('derives Local as the stop reason when no idTag was presented', async () => {
+    const transaction = aTransaction(true);
+    const { handler } = makeHandler(transaction);
+
+    await handler.handle(makeMessage({ ...request, idTag: undefined, reason: undefined }));
+
+    expect((transaction as unknown as { stoppedReason?: string }).stoppedReason).toBe('Local');
+  });
+});


### PR DESCRIPTION
## The bug

`StopTransactionRequestOcpp16Handler` acknowledges the request, then writes a `StopTransaction` row and re-inserts every meter value in `transactionData` — with no check that the transaction is still active.

A charging station that does not receive our `CallResult` retries the `StopTransaction`. That is routine on a link that drops. Each retry adds:

- another `StopTransaction` row for the same session, and
- another copy of the entire `transactionData` meter-value set.

So anything aggregating `MeterValue` rows for a session — charge curve, energy profile, departure planning — counts the same readings several times. `createStopTransaction` has no dedup of its own, so nothing downstream catches it.

The 2.x path already guards this. `TransactionEventRequestOcpp2Handler` drops a non-`Started` event whose transaction is no longer active:

```ts
if (existingTransaction && !existingTransaction.isActive) {
  this._logger.warn(`Received ${eventType} for already-ended transaction ... Ignoring.`);
  await this._ocppSender.sendCallResultWithMessage(message, authorizeResponse ?? {});
  return;
}
```

1.6 has no equivalent.

## The change

Apply the same rule to 1.6. The `CallResult` is already sent before this point, so a retry is still acknowledged and the station stops resending — only the duplicate write is dropped.

**Also**: derive `stoppedReason` once and write the same value to both rows. OCPP 1.6 makes `reason` optional, and `transaction.stoppedReason = request.reason` assigned it straight through, so `Transaction.stoppedReason` was left null for the commonest case while the `StopTransaction` row carried the derived value (`request.reason || (request.idTag ? 'Remote' : 'Local')`) — two rows disagreeing about why the same session ended.

Adds `packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts` — the handler had none.

## Verification

```
npx vitest run packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Two fail on `next` before the source change: the duplicate-stop test (`expected "spy" to not be called at all, but actually been called 1 times`) and the stoppedReason-agreement test.
