### PR TITLE
fix(core): follow up on the station's own protocol, not a hard-coded OCPP 2.1

### DIFF
--- a/packages/core/src/handlers/requests/2/NotifyEVChargingNeedsRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/NotifyEVChargingNeedsRequestOcpp2Handler.ts
@@ -15,7 +15,6 @@ import {
   NotifyEVChargingNeedsStatusEnum,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
-  OCPPVersion,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
@@ -138,7 +137,7 @@ export class NotifyEVChargingNeedsRequestOcpp2Handler extends AbstractHandler {
     await this._ocppSender.sendCall({
       ocppConnectionName,
       tenantId: message.context.tenantId,
-      protocol: OCPPVersion.OCPP2_1,
+      protocol: message.protocol,
       action: OCPP_CallAction.SetChargingProfile,
       eventGroup: EventGroup.SmartCharging,
       payload: {

--- a/packages/core/src/handlers/responses/2/ClearChargingProfileResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/ClearChargingProfileResponseOcpp2Handler.ts
@@ -16,7 +16,6 @@ import {
   type HandlerProperties,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
-  OCPPVersion,
   OCPP2_common_types,
   OCPP2_request_types,
   OCPP2_response_types,
@@ -78,7 +77,7 @@ export class ClearChargingProfileResponseOcpp2Handler extends AbstractHandler {
       await this._ocppSender.sendCall({
         ocppConnectionName,
         tenantId: message.context.tenantId,
-        protocol: OCPPVersion.OCPP2_1,
+        protocol: message.protocol,
         action: OCPP_CallAction.GetChargingProfiles,
         eventGroup: EventGroup.SmartCharging,
         payload: {

--- a/packages/core/src/handlers/responses/2/SendLocalListResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/SendLocalListResponseOcpp2Handler.ts
@@ -13,7 +13,6 @@ import {
   type HandlerProperties,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
-  OCPPVersion,
   SendLocalListStatusEnum,
   OCPP2_request_types,
   OCPP2_response_types,
@@ -90,7 +89,7 @@ export class SendLocalListResponseOcpp2Handler extends AbstractHandler {
         const messageConfirmation = await this._ocppSender.sendCall({
           ocppConnectionName,
           tenantId: message.context.tenantId,
-          protocol: OCPPVersion.OCPP2_1,
+          protocol: message.protocol,
           action: OCPP_CallAction.GetLocalListVersion,
           eventGroup: EventGroup.EVDriver,
           payload: {} as OCPP2_request_types.GetLocalListVersionRequest,


### PR DESCRIPTION
## The bug

Three handlers are registered for `OCPP_2_VER_LIST` — so they serve **2.0.1** stations as well as 2.1 — but hard-code `OCPPVersion.OCPP2_1` on the call they send in response:

| handler | follow-up call |
|---|---|
| `NotifyEVChargingNeedsRequestOcpp2Handler` | `SetChargingProfile` |
| `ClearChargingProfileResponseOcpp2Handler` | `GetChargingProfiles` |
| `SendLocalListResponseOcpp2Handler` | `GetLocalListVersion` |

None is guarded by a version check — unlike the 2.1-only blocks in `TransactionEventRequestOcpp2Handler`, which sit behind `isOcpp21` and are correct as they stand.

## What actually breaks

Being precise about the blast radius: **the frame still reaches a 2.0.1 station.** `_sendMessage` writes the raw JSON to the socket, and inbound traffic resolves its protocol from `ChargingStation.protocol`, so the station's reply is still routed to the right handler.

What is wrong is everything derived from the argument:

- the `OCPPMessages` audit row and the webhook `dispatchMessageSent` record the message as `ocpp2.1` for a station that is not, so the message history for a 2.0.1 station is wrong at exactly the point an operator goes looking after a failed charging profile;
- `recordOcppCallSent(action, protocol, …)` attributes the call to the wrong protocol in metrics;
- `_sendCallIsAllowed` maps the action through `mapToCallAction(OCPP2_1, …)` rather than the station's own action table.

## The change

Use `message.protocol` — by definition the protocol the station is speaking — and drop the now-unused `OCPPVersion` import from each file.

## Verification

```
pnpm --filter @citrineos/core run lint
✖ 2 problems (0 errors, 2 warnings)
```

Both warnings are pre-existing, in `OcppRouter/DataApi.ts` and `Reporting/2/MessageApi.ts`; neither file is touched here. `tsc --noEmit` clean, full `packages/core` suite passing.
