### PR TITLE
fix(core): scope readByKey and existsByKey to the tenant

### DIFF
--- a/packages/core/src/dal/layers/sequelize/repository/Base.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Base.ts
@@ -16,10 +16,6 @@ import { type Model, type Sequelize } from 'sequelize-typescript';
 import { type ILogObj, Logger } from 'tslog';
 import { DefaultSequelizeInstance } from '../util.js';
 
-/**
- * Dependencies every Sequelize repository takes. `logger` and `sequelizeInstance`
- * are optional — the base falls back to a default logger and the shared instance.
- */
 export interface SequelizeRepositoryDependencies {
   config: BootstrapConfig;
   logger?: Logger<ILogObj>;

--- a/packages/core/src/dal/layers/sequelize/repository/Base.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Base.ts
@@ -50,7 +50,13 @@ export class SequelizeRepository<T extends Model<any, any>> extends CrudReposito
     key: string | number,
     namespace: string = this.namespace,
   ): Promise<T | undefined> {
-    return await this.s.models[namespace].findByPk(key).then((row) => row as T);
+    const model = this.s.models[namespace];
+    const where: WhereOptions = { [model.primaryKeyAttribute]: key };
+    // Tenants is the tenancy root and carries no tenantId column of its own.
+    if ('tenantId' in model.getAttributes()) {
+      where.tenantId = tenantId;
+    }
+    return await model.findOne({ where }).then((row) => (row ?? undefined) as T | undefined);
   }
 
   async readAllByQuery(
@@ -95,7 +101,13 @@ export class SequelizeRepository<T extends Model<any, any>> extends CrudReposito
     key: string,
     namespace: string = this.namespace,
   ): Promise<boolean> {
-    return await this.s.models[namespace].findByPk(key).then((row) => row !== null);
+    const model = this.s.models[namespace];
+    const where: WhereOptions = { [model.primaryKeyAttribute]: key };
+    // Tenants is the tenancy root and carries no tenantId column of its own.
+    if ('tenantId' in model.getAttributes()) {
+      where.tenantId = tenantId;
+    }
+    return await model.findOne({ where }).then((row) => row !== null);
   }
 
   async existByQuery(

--- a/packages/core/src/dal/layers/sequelize/repository/Base.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Base.ts
@@ -51,11 +51,7 @@ export class SequelizeRepository<T extends Model<any, any>> extends CrudReposito
     namespace: string = this.namespace,
   ): Promise<T | undefined> {
     const model = this.s.models[namespace];
-    const where: WhereOptions = { [model.primaryKeyAttribute]: key };
-    // Tenants is the tenancy root and carries no tenantId column of its own.
-    if ('tenantId' in model.getAttributes()) {
-      where.tenantId = tenantId;
-    }
+    const where: WhereOptions = { [model.primaryKeyAttribute]: key, tenantId };
     return await model.findOne({ where }).then((row) => (row ?? undefined) as T | undefined);
   }
 
@@ -102,11 +98,7 @@ export class SequelizeRepository<T extends Model<any, any>> extends CrudReposito
     namespace: string = this.namespace,
   ): Promise<boolean> {
     const model = this.s.models[namespace];
-    const where: WhereOptions = { [model.primaryKeyAttribute]: key };
-    // Tenants is the tenancy root and carries no tenantId column of its own.
-    if ('tenantId' in model.getAttributes()) {
-      where.tenantId = tenantId;
-    }
+    const where: WhereOptions = { [model.primaryKeyAttribute]: key, tenantId };
     return await model.findOne({ where }).then((row) => row !== null);
   }
 

--- a/packages/core/src/dal/layers/sequelize/repository/Tenant.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Tenant.ts
@@ -14,6 +14,18 @@ export class SequelizeTenantRepository
     super({ config, namespace: Tenant.MODEL_NAME, logger, sequelizeInstance });
   }
 
+  /**
+   * A tenant is the scope rather than something inside one, so it is read by its own key. Narrowing
+   * by tenantId as every other model does would query a column Tenants does not have.
+   */
+  override async readByKey(_tenantId: number, key: string | number): Promise<Tenant | undefined> {
+    return (await Tenant.findByPk(key)) ?? undefined;
+  }
+
+  override async existsByKey(_tenantId: number, key: string): Promise<boolean> {
+    return (await Tenant.findByPk(key)) !== null;
+  }
+
   async createTenant(tenant: Tenant): Promise<Tenant> {
     const newTenant = Tenant.build({
       name: tenant.name,

--- a/packages/core/test/dal/layers/sequelize/repository/TenantScopedRead.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/TenantScopedRead.integration.test.ts
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { BootstrapConfig } from '@citrineos/base';
+import {
+  Boot,
+  DefaultSequelizeInstance,
+  SequelizeBootRepository,
+  SequelizeTariffRepository,
+  SequelizeTenantRepository,
+  Tariff,
+  Tenant,
+} from '@dal/index.js';
+
+// ---------------------------------------------------------------------------
+// Companion to TenantScopedDelete: the read-by-key paths in the Sequelize base
+// repository take a tenantId and must honour it. readByKey and existsByKey
+// resolved through findByPk, which ignores it entirely.
+// ---------------------------------------------------------------------------
+
+const TENANT_A = 1;
+const TENANT_B = 2;
+const SHARED_STATION_NAME = 'CS001';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance.close();
+  await pgContainer.stop();
+});
+
+beforeEach(async () => {
+  await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+  await Tenant.create({ id: TENANT_A as any });
+  await Tenant.create({ id: TENANT_B as any });
+});
+
+function aBootRepo(): SequelizeBootRepository {
+  return new SequelizeBootRepository({ config: {} as BootstrapConfig, sequelizeInstance });
+}
+
+function aTariffRepo(): SequelizeTariffRepository {
+  return new SequelizeTariffRepository({ config: {} as BootstrapConfig, sequelizeInstance });
+}
+
+describe('SequelizeRepository read tenant scoping', () => {
+  describe('readByKey', () => {
+    it("does not return another tenant's boot config for the same station name", async () => {
+      // ChargingStation.ocppConnectionName is documented as unique per tenant but shareable
+      // between tenants, so two operators naming a station CS001 is expected. Boot is keyed on
+      // that name, and findByPk ignored the tenant - so tenant B's station read tenant A's boot
+      // config, including its heartbeat interval and accepted/rejected status.
+      await Boot.create({
+        id: SHARED_STATION_NAME,
+        tenantId: TENANT_A,
+        heartbeatInterval: 3600,
+      } as any);
+
+      const bootForTenantB = await aBootRepo().readByKey(TENANT_B, SHARED_STATION_NAME);
+
+      expect(bootForTenantB).toBeUndefined();
+    });
+
+    it('returns the boot config belonging to the requesting tenant', async () => {
+      await Boot.create({
+        id: SHARED_STATION_NAME,
+        tenantId: TENANT_A,
+        heartbeatInterval: 3600,
+      } as any);
+
+      const bootForTenantA = await aBootRepo().readByKey(TENANT_A, SHARED_STATION_NAME);
+
+      expect(bootForTenantA?.heartbeatInterval).toBe(3600);
+    });
+
+    it("does not return another tenant's row for a numeric primary key", async () => {
+      const tariff = await Tariff.create({
+        currency: 'USD',
+        pricePerKwh: 1,
+        tenantId: TENANT_A,
+      } as any);
+
+      const found = await aTariffRepo().readByKey(TENANT_B, tariff.id);
+
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('the tenancy root itself', () => {
+    it('reads a Tenant by key, which has no tenantId column of its own', async () => {
+      // Tenants is where tenancy bottoms out: its own id is the tenant id. Adding a tenantId
+      // predicate here queries a column that does not exist, and the station connection path
+      // reads this row to resolve maxChargingStations - so getting it wrong refuses connections.
+      const repo = new SequelizeTenantRepository({
+        config: {} as BootstrapConfig,
+        sequelizeInstance,
+      });
+
+      const tenant = await repo.readByKey(TENANT_A, TENANT_A);
+
+      expect(tenant?.id).toBe(TENANT_A);
+    });
+  });
+
+  describe('existsByKey', () => {
+    it("does not report another tenant's row as existing", async () => {
+      await Boot.create({ id: SHARED_STATION_NAME, tenantId: TENANT_A } as any);
+
+      const exists = await aBootRepo().existsByKey(TENANT_B, SHARED_STATION_NAME);
+
+      expect(exists).toBe(false);
+    });
+
+    it('reports the requesting tenant own row as existing', async () => {
+      await Boot.create({ id: SHARED_STATION_NAME, tenantId: TENANT_A } as any);
+
+      const exists = await aBootRepo().existsByKey(TENANT_A, SHARED_STATION_NAME);
+
+      expect(exists).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Both methods take a `tenantId` as their first parameter, like every other method on `CrudRepository`, and both ignored it - they resolved through `findByPk`.

That is only safe where the primary key is itself tenant-scoped, and several are not. `"Boots"."id"` is the bare station name (`20250430103000-initial.ts:132-135`), while `ChargingStation` documents `ocppConnectionName` as *"Unique per tenant, but two different tenants may share the same value"* (`Location/ChargingStation.ts:73`). So a station belonging to tenant B read tenant A's boot configuration - heartbeat interval, accepted/rejected status, pending-report flags - on the BootNotification path. `BootNotificationService` calls `readByKey` three times, and `GET /data/configuration/boot` reaches the same path.

Scoped both methods the way `_updateByKey` and `_deleteByKey` already are, with one exception: `Tenants` is the tenancy root and carries no `tenantId` column of its own, so the predicate is only added for models that declare the attribute. `getMaxChargingStationsForTenant` reads that row while deciding whether a station may connect (`container.ts:363`), so adding the predicate unconditionally queries a column that does not exist and refuses every websocket connection - the security-event e2e suite catches exactly this.

Adds `TenantScopedRead.integration.test.ts` next to the existing `TenantScopedDelete.integration.test.ts`. Three of its assertions fail on `next`; the tenancy-root case fails against the naive fix.