### PR TITLE
fix(core): enforce the configured issuer and audience when verifying a JWT

### DIFF
--- a/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
+++ b/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
@@ -105,10 +105,6 @@ export class OIDCAuthProvider implements IApiAuthProvider {
         throw new Error('Invalid token format');
       }
       const publicKey = await this.fetchPublicKey(decoded.header.kid);
-      // Verify the token with the public key. The issuer and audience are configured but were not
-      // being enforced: an identity provider signs every client in the realm with the same keys, so
-      // a token issued to an unrelated service verified here and authenticated its bearer with
-      // whatever roles it carried.
       const payload = jwt.verify(token, createPublicKey(publicKey), {
         issuer: this._config.issuer,
         ...(this._config.audience ? { audience: this._config.audience } : {}),

--- a/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
+++ b/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
@@ -26,7 +26,7 @@ export interface OIDCConfig {
   issuer: string;
 
   // Expected audience of tokens (usually the client ID)
-  audience?: string;
+  audience: string;
 
   // How long to cache keys (ms)
   cacheTime?: number;
@@ -107,7 +107,7 @@ export class OIDCAuthProvider implements IApiAuthProvider {
       const publicKey = await this.fetchPublicKey(decoded.header.kid);
       const payload = jwt.verify(token, createPublicKey(publicKey), {
         issuer: this._config.issuer,
-        ...(this._config.audience ? { audience: this._config.audience } : {}),
+        audience: this._config.audience,
       }) as JwtPayload;
 
       // Extract user info from the decoded token

--- a/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
+++ b/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
@@ -105,8 +105,14 @@ export class OIDCAuthProvider implements IApiAuthProvider {
         throw new Error('Invalid token format');
       }
       const publicKey = await this.fetchPublicKey(decoded.header.kid);
-      // Verify the token with the public key
-      const payload = jwt.verify(token, createPublicKey(publicKey)) as JwtPayload;
+      // Verify the token with the public key. The issuer and audience are configured but were not
+      // being enforced: an identity provider signs every client in the realm with the same keys, so
+      // a token issued to an unrelated service verified here and authenticated its bearer with
+      // whatever roles it carried.
+      const payload = jwt.verify(token, createPublicKey(publicKey), {
+        issuer: this._config.issuer,
+        ...(this._config.audience ? { audience: this._config.audience } : {}),
+      }) as JwtPayload;
 
       // Extract user info from the decoded token
       const user: UserInfo = {

--- a/packages/core/test/util/authorization/OIDCAuthProvider.test.ts
+++ b/packages/core/test/util/authorization/OIDCAuthProvider.test.ts
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { generateKeyPairSync } from 'node:crypto';
+import jwt from 'jsonwebtoken';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { OIDCAuthProvider } from '@util/authorization/provider/OIDCAuthProvider.js';
+
+const ISSUER = 'https://idp.example.test/realms/citrineos';
+const AUDIENCE = 'citrineos-central-system';
+const KID = 'test-key';
+
+let privateKey: string;
+let publicKey: string;
+
+beforeAll(() => {
+  const pair = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+  privateKey = pair.privateKey;
+  publicKey = pair.publicKey;
+});
+
+/**
+ * Builds a provider whose JWKS lookup is short-circuited to the test key pair, so that the tests
+ * exercise the verification options rather than the network.
+ */
+function aProvider() {
+  const provider = new OIDCAuthProvider({
+    jwksUri: 'http://jwks.invalid/keys',
+    issuer: ISSUER,
+    audience: AUDIENCE,
+  });
+  (provider as unknown as { fetchPublicKey: (kid: string) => Promise<string> }).fetchPublicKey =
+    async () => publicKey;
+  return provider;
+}
+
+function aTokenSignedBy(payload: Record<string, unknown>) {
+  return jwt.sign(payload, privateKey, { algorithm: 'RS256', keyid: KID });
+}
+
+describe('OIDCAuthProvider.authenticateToken', () => {
+  it('accepts a token issued for this audience by the configured issuer', async () => {
+    const token = aTokenSignedBy({ sub: 'user-1', iss: ISSUER, aud: AUDIENCE, roles: ['admin'] });
+
+    const result = await aProvider().authenticateToken(token);
+
+    expect(result.isAuthenticated).toBe(true);
+    expect(result.user?.id).toBe('user-1');
+  });
+
+  it('rejects a token minted for a different audience', async () => {
+    // The identity provider signs tokens for every client in the realm with the same keys, so a
+    // token issued to an unrelated service verifies against the JWKS. Without an audience check
+    // that token authenticates here, granting its bearer whatever roles it happens to carry.
+    const token = aTokenSignedBy({
+      sub: 'user-1',
+      iss: ISSUER,
+      aud: 'some-other-service',
+      roles: ['admin'],
+    });
+
+    const result = await aProvider().authenticateToken(token);
+
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  it('rejects a token from a different issuer', async () => {
+    const token = aTokenSignedBy({
+      sub: 'user-1',
+      iss: 'https://attacker.example.test/realms/citrineos',
+      aud: AUDIENCE,
+      roles: ['admin'],
+    });
+
+    const result = await aProvider().authenticateToken(token);
+
+    expect(result.isAuthenticated).toBe(false);
+  });
+
+  it('rejects an expired token', async () => {
+    const token = aTokenSignedBy({
+      sub: 'user-1',
+      iss: ISSUER,
+      aud: AUDIENCE,
+      exp: Math.floor(Date.now() / 1000) - 60,
+    });
+
+    const result = await aProvider().authenticateToken(token);
+
+    expect(result.isAuthenticated).toBe(false);
+  });
+});


### PR DESCRIPTION
`OIDCConfig` requires an `issuer` and accepts an `audience` (`OIDCAuthProvider.ts:26,29`, mirrored in the config schema at `packages/types/src/config/types.ts:249-250`). `jwt.verify` was called with neither (`OIDCAuthProvider.ts:109`), so the only thing actually checked was that the token was signed by a key the configured JWKS endpoint would serve.

An identity provider signs every client in a realm with those same keys. A token minted for an unrelated service in the same realm therefore verified here, and `authenticateToken` returned success with whatever `roles` claim the token carried - which `authorizeUser` then feeds straight into the RBAC lookup. The configured issuer and audience were, in effect, documentation.

This passes `issuer` always and `audience` when it is set (it is optional on the interface). No behaviour changes for a correctly-issued token.

Adds `OIDCAuthProvider.test.ts`, which generates an RSA key pair and signs real tokens rather than stubbing the verifier. On `next`, both the wrong-audience and wrong-issuer cases authenticate successfully.

Note this only affects deployments that enable OIDC; none of the checked-in env configs do - `local.ts` and `docker.ts` both select `localByPass`.