### PR TITLE
fix(core): match excluded routes on the path, not the raw url

### DIFF
--- a/packages/core/src/util/authorization/ApiAuthPlugin.ts
+++ b/packages/core/src/util/authorization/ApiAuthPlugin.ts
@@ -85,12 +85,13 @@ const apiAuthPlugin: FastifyPluginAsync<{
 
   // Helper to check if a route is excluded from authentication
   function isExcludedRoute(url: string): boolean {
+    const path = url.split('?', 1)[0];
     // Always exclude health check
-    if (url === '/health') {
+    if (path === '/health') {
       return true;
     }
     const isExcluded = !!options.excludedRoutes?.some(
-      (route) => url === route || url.startsWith(`${route}/`),
+      (route) => path === route || path.startsWith(`${route}/`),
     );
     if (isExcluded && options.debug) {
       _logger.debug(`Skipping authentication for excluded route: ${url}`);

--- a/packages/core/test/util/authorization/ApiAuthPlugin.test.ts
+++ b/packages/core/test/util/authorization/ApiAuthPlugin.test.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IApiAuthProvider } from '@citrineos/base';
+import { apiAuthPluginFp } from '@util/authorization/ApiAuthPlugin.js';
+
+/**
+ * An auth provider that refuses everything, so that any route reaching the provider is observable as a
+ * 401 and any route skipping it is observable as a 200.
+ */
+function aRefusingProvider() {
+  return {
+    extractToken: vi.fn().mockResolvedValue(undefined),
+    authenticateToken: vi.fn().mockResolvedValue({ isAuthenticated: false, error: 'no token' }),
+    authorizeUser: vi.fn().mockResolvedValue({ isAuthorized: false, error: 'denied' }),
+  } as unknown as IApiAuthProvider & {
+    extractToken: ReturnType<typeof vi.fn>;
+    authenticateToken: ReturnType<typeof vi.fn>;
+    authorizeUser: ReturnType<typeof vi.fn>;
+  };
+}
+
+async function anAuthenticatedServer(provider: ReturnType<typeof aRefusingProvider>) {
+  const app = Fastify();
+  await app.register(apiAuthPluginFp, {
+    provider,
+    options: { excludedRoutes: ['/health', '/health/live', '/health/ready', '/docs'] },
+  });
+  app.get('/health', async () => ({ ok: true }));
+  app.get('/health/live', async () => ({ ok: true }));
+  app.get('/data/transactions/transaction', async () => ({ data: [] }));
+  await app.ready();
+  return app;
+}
+
+describe('apiAuthPlugin', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    await app?.close();
+    app = undefined;
+    vi.restoreAllMocks();
+  });
+
+  it('protects a route that is not excluded', async () => {
+    const provider = aRefusingProvider();
+    app = await anAuthenticatedServer(provider);
+
+    const response = await app.inject({ method: 'GET', url: '/data/transactions/transaction' });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('skips authentication for an excluded route', async () => {
+    const provider = aRefusingProvider();
+    app = await anAuthenticatedServer(provider);
+
+    const response = await app.inject({ method: 'GET', url: '/health' });
+
+    expect(response.statusCode).toBe(200);
+    expect(provider.extractToken).not.toHaveBeenCalled();
+  });
+
+  it('skips authentication for an excluded route that carries a query string', async () => {
+    const provider = aRefusingProvider();
+    app = await anAuthenticatedServer(provider);
+
+    // Load balancers and probes routinely append a cache-busting parameter. Matching the exclusion
+    // list against the raw url - which includes '?...' - made every such probe fail closed with 401.
+    const response = await app.inject({ method: 'GET', url: '/health?cache-bust=1' });
+
+    expect(response.statusCode).toBe(200);
+    expect(provider.extractToken).not.toHaveBeenCalled();
+  });
+
+  it('skips authentication for an excluded route prefix that carries a query string', async () => {
+    const provider = aRefusingProvider();
+    app = await anAuthenticatedServer(provider);
+
+    const response = await app.inject({ method: 'GET', url: '/health/live?probe=kubelet' });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('does not attempt authorization once authentication has already answered the request', async () => {
+    const provider = aRefusingProvider();
+    app = await anAuthenticatedServer(provider);
+
+    const response = await app.inject({ method: 'GET', url: '/data/transactions/transaction' });
+
+    // authenticate() answers the request and returns; authorize() must not then consult the
+    // provider for a caller that never authenticated.
+    expect(response.statusCode).toBe(401);
+    expect(provider.authorizeUser).not.toHaveBeenCalled();
+    expect(JSON.parse(response.body).message).toBe('Missing or invalid authorization header');
+  });
+});


### PR DESCRIPTION
The global `onRequest` hook is handed `request.url`, which includes the query string, and `isExcludedRoute` compared that against `excludedRoutes` with `url === route || url.startsWith(`${route}/`)` (`ApiAuthPlugin.ts:87-99`).

So `/health` was excluded but `/health?cache-bust=1` matched neither test and was answered 401. Load balancers and liveness probes routinely append a parameter, so the health endpoint failed closed for precisely the callers it exists to serve. `/docs?...` behaves the same way.

Stripping the query string before matching fixes it. The prefix cases (`/health/live?probe=kubelet`) happened to work already, because they still start with `/health/` - the new test pins both.

For anyone wondering about the other direction: a crafted `/health/../data/...` does skip the auth hook, because the raw url starts with `/health/`. It is not exploitable - Fastify's router does not normalise `..`, so every such request 404s rather than reaching a handler. I verified that over a raw socket rather than through `inject()`, which normalises the path itself and would have hidden the behaviour. Worth knowing if the router is ever configured differently.