### PR TITLE
fix(core): stop writing bearer tokens to the logs

### DIFF
--- a/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
+++ b/packages/core/src/util/authorization/provider/OIDCAuthProvider.ts
@@ -87,7 +87,6 @@ export class OIDCAuthProvider implements IApiAuthProvider {
 
     // Return the token without the "Bearer " prefix
     const token = authHeader.slice(7).trim();
-    this._logger.debug('Extracted token from request:', token);
     return token;
   }
 

--- a/packages/core/src/util/util/swagger.ts
+++ b/packages/core/src/util/util/swagger.ts
@@ -131,12 +131,10 @@ export const getAuthorizationTokenFromRequest = (request: FastifyRequest): strin
 
 const registerFastifyAuth = async (server: FastifyInstance) => {
   await server.register(FastifyAuth as any).after();
-  console.log((server as any).authorization);
 
   server.decorate('authorization', function (request: any, reply: any, done: any) {
     try {
-      const token = getAuthorizationTokenFromRequest(request);
-      console.log('Received authorization token', token);
+      getAuthorizationTokenFromRequest(request);
       done();
     } catch (e) {
       reply.code(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
Two places logged the credential itself rather than a fact about it:

- `swagger.ts:138` - `console.log('Received authorization token', token)` inside the `authorization` decorator.
- `OIDCAuthProvider.ts:88` - `this._logger.debug('Extracted token from request:', token)` in `extractToken`, which runs on every authenticated request. `local.ts` runs at a log level where debug is emitted.

A bearer token in a log is reusable until it expires, and logs are routinely shipped off-host to somewhere with a different access model from the API itself.

Also removes a stray `console.log((server as any).authorization)` at `swagger.ts:133`, which ran at startup and printed `undefined` - the decorator is registered on the line after it.

No behaviour change: `getAuthorizationTokenFromRequest` is still called for its throw-on-missing side effect, so the decorator's 401 path is unchanged.