### PR TITLE
fix(ocpi): map the Other idToken type instead of warning that it is unmapped

### DIFF
--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -73,9 +73,6 @@ export class TokensMapper {
       case null:
         return TokenType.OTHER;
       default: {
-        // OCPI has only 4 token types; every other OCPP idTokenType (eMAID, ISO15693, KeyCode,
-        // MacAddress) maps to OTHER rather than throwing. Other is handled above, without a
-        // warning: it is what mapOcpiTokenTypeToOcppIdTokenType produces for TokenType.OTHER.
         Container.get(Logger).warn(
           `Unmapped OCPP idToken type "${type}"; defaulting to OCPI TokenType.OTHER`,
         );

--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -69,11 +69,14 @@ export class TokensMapper {
         return TokenType.AD_HOC_USER;
       case IdTokenEnum.Central:
         return TokenType.APP_USER;
+      case IdTokenEnum.Other:
       case null:
         return TokenType.OTHER;
       default: {
-        // OCPI has only 4 token types; every other OCPP idTokenType (Other, eMAID, ISO15693,
-        // KeyCode, MacAddress) maps to OTHER rather than throwing.
+        // OCPI has only 4 token types; every other OCPP idTokenType (eMAID, ISO15693, KeyCode,
+        // MacAddress) maps to OTHER rather than throwing. Other is deliberately not warned about:
+        // it is what mapOcpiTokenTypeToOcppIdTokenType produces for TokenType.OTHER, so warning on
+        // it fired for ordinary tokens and buried the types that genuinely cannot round-trip.
         Container.get(Logger).warn(
           `Unmapped OCPP idToken type "${type}"; defaulting to OCPI TokenType.OTHER`,
         );

--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -74,9 +74,8 @@ export class TokensMapper {
         return TokenType.OTHER;
       default: {
         // OCPI has only 4 token types; every other OCPP idTokenType (eMAID, ISO15693, KeyCode,
-        // MacAddress) maps to OTHER rather than throwing. Other is deliberately not warned about:
-        // it is what mapOcpiTokenTypeToOcppIdTokenType produces for TokenType.OTHER, so warning on
-        // it fired for ordinary tokens and buried the types that genuinely cannot round-trip.
+        // MacAddress) maps to OTHER rather than throwing. Other is handled above, without a
+        // warning: it is what mapOcpiTokenTypeToOcppIdTokenType produces for TokenType.OTHER.
         Container.get(Logger).warn(
           `Unmapped OCPP idToken type "${type}"; defaulting to OCPI TokenType.OTHER`,
         );

--- a/packages/ocpi-base/test/mapper/TokensMapper.test.ts
+++ b/packages/ocpi-base/test/mapper/TokensMapper.test.ts
@@ -1,12 +1,17 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { AuthorizationStatusEnum } from '@citrineos/types';
-import { describe, expect, it } from 'vitest';
+import { AuthorizationStatusEnum, IdTokenEnum } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Container } from 'typedi';
+import { Logger } from 'tslog';
 import type { TokenDTO } from '../../src/model/DTO/TokenDTO.js';
 import { TokenType } from '../../src/model/TokenType.js';
 import { WhitelistType } from '../../src/model/WhitelistType.js';
 import { TokensMapper } from '../../src/mapper/TokensMapper.js';
+
+// The mapper resolves its logger from the typedi container at call time.
+Container.set(Logger, new Logger({ type: 'hidden' }));
 
 // A full token as an eMSP would PUT. Individual specs pass a subset of these
 // fields to mimic a partial PATCH body.
@@ -46,5 +51,52 @@ describe('TokensMapper.mapOcpiTokenToPartialOcppAuthorization', () => {
   it('leaves realTimeAuth undefined when `whitelist` is absent (parallel already-correct field)', () => {
     const result = TokensMapper.mapOcpiTokenToPartialOcppAuthorization({ language: 'en' });
     expect(result.realTimeAuth).toBeUndefined();
+  });
+});
+
+describe('TokensMapper token type mapping', () => {
+  it('round-trips the four token types OCPI can express', () => {
+    const pairs: Array<
+      [TokenType, ReturnType<typeof TokensMapper.mapOcpiTokenTypeToOcppIdTokenType>]
+    > = [
+      [TokenType.RFID, IdTokenEnum.ISO14443],
+      [TokenType.AD_HOC_USER, IdTokenEnum.Local],
+      [TokenType.APP_USER, IdTokenEnum.Central],
+      [TokenType.OTHER, IdTokenEnum.Other],
+    ];
+
+    for (const [ocpi, ocpp] of pairs) {
+      expect(TokensMapper.mapOcpiTokenTypeToOcppIdTokenType(ocpi)).toBe(ocpp);
+      expect(TokensMapper.mapOcppIdTokenTypeToOcpiTokenType(ocpp)).toBe(ocpi);
+    }
+  });
+
+  it('maps Other without warning about it being unmapped', () => {
+    // Other is what the forward mapping produces for TokenType.OTHER, so treating it as unmapped on
+    // the way back warned on every ordinary token and buried the warning that matters - the one for
+    // a type OCPI genuinely cannot carry, such as MacAddress.
+    const warn = vi
+      .spyOn(Container.get(Logger), 'warn')
+      .mockImplementation(() => undefined as never);
+
+    expect(TokensMapper.mapOcppIdTokenTypeToOcpiTokenType(IdTokenEnum.Other)).toBe(TokenType.OTHER);
+    expect(warn).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+
+  it('warns and falls back to OTHER for a type OCPI cannot express', () => {
+    const warn = vi
+      .spyOn(Container.get(Logger), 'warn')
+      .mockImplementation(() => undefined as never);
+
+    // Autocharge enrols a vehicle by its MAC. OCPI has no equivalent token type, so a token pushed
+    // or read over OCPI cannot carry it - vehicle enrolment has to go through another channel.
+    expect(TokensMapper.mapOcppIdTokenTypeToOcpiTokenType(IdTokenEnum.MacAddress)).toBe(
+      TokenType.OTHER,
+    );
+    expect(warn).toHaveBeenCalledOnce();
+
+    warn.mockRestore();
   });
 });


### PR DESCRIPTION
`mapOcpiTokenTypeToOcppIdTokenType` maps `TokenType.OTHER` to `IdTokenEnum.Other`, but `mapOcppIdTokenTypeToOcpiTokenType` had no `case` for `Other` (`TokensMapper.ts:62-82`). It fell through to `default`, which logs *"Unmapped OCPP idToken type"* - for a value the forward mapping produces itself.

So the warning fired on ordinary token reads, at whatever rate tokens are read, and buried the cases it was presumably added for: `eMAID`, `ISO15693`, `KeyCode` and `MacAddress` genuinely have no representation in OCPI's four-value `TokenType` and collapse to `OTHER` irreversibly. Those are worth a log line; `Other` is not.

Adds `TokensMapper.test.ts` - only the second test file in `packages/ocpi-base` - covering the round trip for all four OCPI types, that `Other` maps without warning, and that `MacAddress` still warns.

Context for anyone integrating: the `MacAddress` collapse is load-bearing if you use autocharge. OCPP 2.0.1 resolves an idToken on `(idToken, type)`, so a vehicle enrolled through OCPI Tokens comes back as `Other` and will not match. That is a protocol limitation rather than a bug, but it means vehicle enrolment has to go through a channel that can set `idTokenType` directly.