### PR TITLE
fix(ocpi): skip an unmappable token instead of failing the whole CDR or Session batch

### DIFF
--- a/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
+++ b/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
@@ -79,15 +79,14 @@ export abstract class BaseTransactionMapper {
         }
       }
       if (transaction.authorization) {
-        // toDto throws for an authorization with no eMAID to use as contract_id; skip that
-        // transaction rather than failing the whole page.
-        try {
-          const tokenDto = await TokensMapper.toDto(transaction.authorization);
+        // An OCPI token carries an eMAID as its contract_id, and an authorization without one
+        // cannot be expressed as a token. That transaction is left out rather than failing the
+        // whole page; anything else that goes wrong here is still an error.
+        if (TokensMapper.findContractId(transaction.authorization)) {
+          const tokenDto = TokensMapper.toDto(transaction.authorization);
           transactionIdToTokenMap.set(transaction.transactionId!, tokenDto);
-        } catch (error) {
-          this.logger.debug(
-            `Unmapped token for transaction ${transaction.id}: ${error instanceof Error ? error.message : error}`,
-          );
+        } else {
+          this.logger.debug(`No contract id for transaction ${transaction.id}; token omitted`);
         }
       } else {
         this.logger.debug(`No token for transaction ${transaction.id}`);

--- a/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
+++ b/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
@@ -79,9 +79,6 @@ export abstract class BaseTransactionMapper {
         }
       }
       if (transaction.authorization) {
-        // An OCPI token carries an eMAID as its contract_id, and an authorization without one
-        // cannot be expressed as a token. That transaction is left out rather than failing the
-        // whole page; anything else that goes wrong here is still an error.
         if (TokensMapper.findContractId(transaction.authorization)) {
           const tokenDto = TokensMapper.toDto(transaction.authorization);
           transactionIdToTokenMap.set(transaction.transactionId!, tokenDto);

--- a/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
+++ b/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
@@ -79,11 +79,15 @@ export abstract class BaseTransactionMapper {
         }
       }
       if (transaction.authorization) {
-        const tokenDto = await TokensMapper.toDto(transaction.authorization);
-        if (tokenDto) {
+        // toDto throws for an authorization with no eMAID to use as contract_id; skip that
+        // transaction rather than failing the whole page.
+        try {
+          const tokenDto = await TokensMapper.toDto(transaction.authorization);
           transactionIdToTokenMap.set(transaction.transactionId!, tokenDto);
-        } else {
-          this.logger.debug(`Unmapped token for transaction ${transaction.id}`);
+        } catch (error) {
+          this.logger.debug(
+            `Unmapped token for transaction ${transaction.id}: ${error instanceof Error ? error.message : error}`,
+          );
         }
       } else {
         this.logger.debug(`No token for transaction ${transaction.id}`);

--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -171,11 +171,6 @@ export class TokensMapper {
     };
   }
 
-  /**
-   * The eMAID an OCPI token carries as its contract_id, or undefined when the authorization has
-   * none. An authorization without one cannot be expressed as a token at all, so callers building
-   * a page of tokens use this to leave it out rather than to catch the failure.
-   */
   public static findContractId(authorization: AuthorizationDto): string | undefined {
     return authorization.additionalInfo?.find(
       (info) => info.type === OCPP2_0_1.IdTokenEnumType.eMAID,

--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -172,7 +172,7 @@ export class TokensMapper {
   }
 
   public static getContractId(authorization: AuthorizationDto): string {
-    const contractId = authorization.additionalInfo!.find(
+    const contractId = authorization.additionalInfo?.find(
       (info) => info.type === OCPP2_0_1.IdTokenEnumType.eMAID,
     )?.additionalIdToken;
     if (!contractId) {
@@ -184,7 +184,7 @@ export class TokensMapper {
   }
 
   public static getVisualNumber(authorization: AuthorizationDto): string | undefined {
-    const visualNumber = authorization.additionalInfo!.find(
+    const visualNumber = authorization.additionalInfo?.find(
       (info) => info.type === 'visual_number',
     )?.additionalIdToken;
     if (!visualNumber) {
@@ -194,7 +194,7 @@ export class TokensMapper {
   }
 
   public static getIssuer(authorization: AuthorizationDto): string {
-    const issuer = authorization.additionalInfo!.find(
+    const issuer = authorization.additionalInfo?.find(
       (info) => info.type === 'issuer',
     )?.additionalIdToken;
     if (!issuer) {

--- a/packages/ocpi-base/src/mapper/TokensMapper.ts
+++ b/packages/ocpi-base/src/mapper/TokensMapper.ts
@@ -171,10 +171,19 @@ export class TokensMapper {
     };
   }
 
-  public static getContractId(authorization: AuthorizationDto): string {
-    const contractId = authorization.additionalInfo?.find(
+  /**
+   * The eMAID an OCPI token carries as its contract_id, or undefined when the authorization has
+   * none. An authorization without one cannot be expressed as a token at all, so callers building
+   * a page of tokens use this to leave it out rather than to catch the failure.
+   */
+  public static findContractId(authorization: AuthorizationDto): string | undefined {
+    return authorization.additionalInfo?.find(
       (info) => info.type === OCPP2_0_1.IdTokenEnumType.eMAID,
     )?.additionalIdToken;
+  }
+
+  public static getContractId(authorization: AuthorizationDto): string {
+    const contractId = TokensMapper.findContractId(authorization);
     if (!contractId) {
       throw new Error(
         'Contract ID not found in authorization additional info, authorization is incomplete for OCPI token mapping. Please add additional info with type eMAID.',

--- a/packages/ocpi-base/test/mapper/BaseTransactionMapper.test.ts
+++ b/packages/ocpi-base/test/mapper/BaseTransactionMapper.test.ts
@@ -92,4 +92,18 @@ describe('BaseTransactionMapper.getTokensForTransactions', () => {
     expect(tokens.has('tx-1')).toBe(false);
     expect(tokens.get('tx-2')?.contract_id).toBe('GB-VLT-C12345678-9');
   });
+
+  it('still raises anything other than a missing contract id', async () => {
+    // Only an authorization that cannot carry a contract_id is left out. A genuine fault - here a
+    // transaction whose partner never loaded - has to surface rather than be absorbed as one more
+    // unmappable token.
+    const brokenPartner = {
+      ...anOcpiAuthorization(),
+      tenantPartner: undefined,
+    } as unknown as AuthorizationDto;
+
+    await expect(
+      new TestTransactionMapper().tokensFor([aTransaction('tx-broken', brokenPartner)]),
+    ).rejects.toThrow();
+  });
 });

--- a/packages/ocpi-base/test/mapper/BaseTransactionMapper.test.ts
+++ b/packages/ocpi-base/test/mapper/BaseTransactionMapper.test.ts
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { AuthorizationDto, TransactionDto } from '@citrineos/types';
+import { OCPP2_0_1 } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+import { Container } from 'typedi';
+
+// LocationsService is a typedi-decorated service and sits on an import cycle with this mapper.
+// The batch token mapping never touches it, so a bare stub is enough to load the module.
+vi.mock('../../src/services/LocationsService.js', () => ({ LocationsService: class {} }));
+
+// TokensMapper resolves its logger from the typedi container when it meets a token type OCPI
+// cannot express, which is exactly the case under test here.
+Container.set(Logger, new Logger({ type: 'hidden' }));
+import { BaseTransactionMapper } from '../../src/mapper/BaseTransactionMapper.js';
+import { TokensMapper } from '../../src/mapper/TokensMapper.js';
+import type { TokenDTO } from '../../src/model/DTO/TokenDTO.js';
+
+/**
+ * Exposes the protected batch mapper. Nothing here reaches the GraphQL client: every transaction
+ * already carries its authorization, so the lazy-load branch is never taken.
+ */
+class TestTransactionMapper extends BaseTransactionMapper {
+  constructor() {
+    super(new Logger({ type: 'hidden' }), {} as never, {} as never);
+  }
+
+  public tokensFor(transactions: TransactionDto[]): Promise<Map<string, TokenDTO>> {
+    return this.getTokensForTransactions(transactions);
+  }
+}
+
+function anOcpiAuthorization(): AuthorizationDto {
+  return {
+    idToken: 'OCPI-TOKEN-1',
+    idTokenType: OCPP2_0_1.IdTokenEnumType.ISO14443,
+    status: 'Accepted',
+    updatedAt: new Date().toISOString(),
+    tenantPartner: { countryCode: 'GB', partyId: 'VLT' },
+    additionalInfo: [
+      { additionalIdToken: 'GB-VLT-C12345678-9', type: OCPP2_0_1.IdTokenEnumType.eMAID },
+      { additionalIdToken: 'Voltempo', type: 'issuer' },
+    ],
+  } as unknown as AuthorizationDto;
+}
+
+/** A vehicle enrolled directly against CitrineOS - no OCPI provenance, so no additionalInfo. */
+function aDepotVehicleAuthorization(): AuthorizationDto {
+  return {
+    idToken: 'AA:BB:CC:DD:EE:FF',
+    idTokenType: OCPP2_0_1.IdTokenEnumType.MacAddress,
+    status: 'Accepted',
+    updatedAt: new Date().toISOString(),
+    tenantPartner: { countryCode: 'GB', partyId: 'VLT' },
+  } as unknown as AuthorizationDto;
+}
+
+function aTransaction(id: string, authorization: AuthorizationDto): TransactionDto {
+  return { id, transactionId: id, authorization } as unknown as TransactionDto;
+}
+
+describe('TokensMapper.toDto on an authorization with no additionalInfo', () => {
+  it('reports what is missing rather than dereferencing null', () => {
+    // additionalInfo is nullable on AuthorizationDto, and every Authorization not created through
+    // OCPI has it unset. The getters used a non-null assertion, so the descriptive errors below
+    // them were unreachable and callers saw a TypeError instead.
+    expect(() => TokensMapper.toDto(aDepotVehicleAuthorization())).toThrowError(/Contract ID/i);
+  });
+});
+
+describe('BaseTransactionMapper.getTokensForTransactions', () => {
+  it('maps a transaction whose token came from OCPI', async () => {
+    const tokens = await new TestTransactionMapper().tokensFor([
+      aTransaction('tx-1', anOcpiAuthorization()),
+    ]);
+
+    expect(tokens.get('tx-1')?.contract_id).toBe('GB-VLT-C12345678-9');
+  });
+
+  it('skips an unmappable token instead of failing the whole batch', async () => {
+    // A depot session started by a vehicle MAC has no eMAID to put in an OCPI cdr_token. The loop
+    // already logs "Unmapped token for transaction" for that case, but toDto throws rather than
+    // returning nothing, so one such session aborted the entire CDR or Session page.
+    const tokens = await new TestTransactionMapper().tokensFor([
+      aTransaction('tx-1', aDepotVehicleAuthorization()),
+      aTransaction('tx-2', anOcpiAuthorization()),
+    ]);
+
+    expect(tokens.has('tx-1')).toBe(false);
+    expect(tokens.get('tx-2')?.contract_id).toBe('GB-VLT-C12345678-9');
+  });
+});


### PR DESCRIPTION
`getTokensForTransactions` (`BaseTransactionMapper.ts:65-92`) loops over a page of transactions and already has a branch for a token it cannot map:

```ts
if (tokenDto) { ... } else { this.logger.debug(`Unmapped token for transaction ${transaction.id}`); }
```

That branch is unreachable. `TokensMapper.toDto` never returns falsy - it throws - so one unmappable authorization aborts the entire page of Sessions or CDRs rather than being skipped.

Two things make it throw:

1. `additionalInfo` is `.nullable().optional()` on `AuthorizationDto` (`authorization.dto.ts:22`) and is unset on every Authorization not created through OCPI, yet `getContractId`, `getVisualNumber` and `getIssuer` reach through it with a non-null assertion. Callers get `TypeError: Cannot read properties of undefined (reading 'find')` instead of the descriptive error written directly below each lookup.
2. Even with `additionalInfo` present, a token carrying no eMAID genuinely has nothing to put in an OCPI `contract_id`, so the descriptive error is the right outcome for that token - just not for the other 99 in the batch.

This relaxes the three assertions so the intended errors are reachable, and catches per transaction so the rest of the batch still maps.

Worth flagging for anyone running a private or depot estate: sessions there are commonly authorised by tokens created directly against CitrineOS rather than received over OCPI, so they have no `additionalInfo` at all. Before this change, a single such session made the Sessions and CDRs endpoints unable to return the page containing it.