### PR TITLE
fix(core): run one contract certificate check, not both

### DIFF
--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -131,7 +131,14 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
       // If Charging Station is not able to validate a contract certificate,
       // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
       // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
-      if (request.certificate) {
+      // Only consulted while the hash data has not already refused the certificate: both results
+      // are written to the same field, so an unconditional call let a chain that still verifies
+      // overwrite a CertificateRevoked or CertificateExpired verdict from the OCSP data.
+      if (
+        request.certificate &&
+        (response.certificateStatus === undefined ||
+          response.certificateStatus === AuthorizeCertificateStatusEnum.Accepted)
+      ) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
       }

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -124,9 +124,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
       // TODO - implement validation using cached OCSP data described in C07.FR.05
       // If Charging Station is not able to validate a contract certificate,
       // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
-      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06. The chain check runs
-      // OCSP over every certificate in it, so the hash data adds nothing when it is present, and
-      // iso15118CertificateHashData is documented as not needed in that case.
+      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
       if (request.certificate) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -122,25 +122,19 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
     // Validate Contract Certificates based on OCPP 2.0.1 Part 2 C07
     if (request.iso15118CertificateHashData || request.certificate) {
       // TODO - implement validation using cached OCSP data described in C07.FR.05
-      if (request.iso15118CertificateHashData && request.iso15118CertificateHashData.length > 0) {
+      // If Charging Station is not able to validate a contract certificate,
+      // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
+      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06. The chain check runs
+      // OCSP over every certificate in it, so the hash data adds nothing when it is present, and
+      // iso15118CertificateHashData is documented as not needed in that case.
+      if (request.certificate) {
+        response.certificateStatus =
+          await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
+      } else if (request.iso15118CertificateHashData?.length) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateHashData(
             request.iso15118CertificateHashData,
           );
-      }
-      // If Charging Station is not able to validate a contract certificate,
-      // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
-      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
-      // Only consulted while the hash data has not already refused the certificate: both results
-      // are written to the same field, so an unconditional call let a chain that still verifies
-      // overwrite a CertificateRevoked or CertificateExpired verdict from the OCSP data.
-      if (
-        request.certificate &&
-        (response.certificateStatus === undefined ||
-          response.certificateStatus === AuthorizeCertificateStatusEnum.Accepted)
-      ) {
-        response.certificateStatus =
-          await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
       }
       if (response.certificateStatus !== AuthorizeCertificateStatusEnum.Accepted) {
         response = {

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -119,25 +119,19 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
     // Validate Contract Certificates based on OCPP 2.1 Part 2 C07
     if (request.iso15118CertificateHashData || request.certificate) {
       // TODO - implement validation using cached OCSP data described in C07.FR.05
-      if (request.iso15118CertificateHashData && request.iso15118CertificateHashData.length > 0) {
+      // If Charging Station is not able to validate a contract certificate,
+      // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
+      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06. The chain check runs
+      // OCSP over every certificate in it, so the hash data adds nothing when it is present, and
+      // iso15118CertificateHashData is documented as not needed in that case.
+      if (request.certificate) {
+        response.certificateStatus =
+          await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
+      } else if (request.iso15118CertificateHashData?.length) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateHashData(
             request.iso15118CertificateHashData,
           );
-      }
-      // If Charging Station is not able to validate a contract certificate,
-      // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
-      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
-      // Only consulted while the hash data has not already refused the certificate: both results
-      // are written to the same field, so an unconditional call let a chain that still verifies
-      // overwrite a CertificateRevoked or CertificateExpired verdict from the OCSP data.
-      if (
-        request.certificate &&
-        (response.certificateStatus === undefined ||
-          response.certificateStatus === AuthorizeCertificateStatusEnum.Accepted)
-      ) {
-        response.certificateStatus =
-          await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
       }
       if (response.certificateStatus !== AuthorizeCertificateStatusEnum.Accepted) {
         response = {

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -121,9 +121,7 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
       // TODO - implement validation using cached OCSP data described in C07.FR.05
       // If Charging Station is not able to validate a contract certificate,
       // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
-      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06. The chain check runs
-      // OCSP over every certificate in it, so the hash data adds nothing when it is present, and
-      // iso15118CertificateHashData is documented as not needed in that case.
+      // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
       if (request.certificate) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -128,7 +128,14 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
       // If Charging Station is not able to validate a contract certificate,
       // it SHALL pass the contract certificate chain to the CSMS in certificate attribute (in PEM
       // format) of AuthorizeRequest for validation by CSMS, see C07.FR.06
-      if (request.certificate) {
+      // Only consulted while the hash data has not already refused the certificate: both results
+      // are written to the same field, so an unconditional call let a chain that still verifies
+      // overwrite a CertificateRevoked or CertificateExpired verdict from the OCSP data.
+      if (
+        request.certificate &&
+        (response.certificateStatus === undefined ||
+          response.certificateStatus === AuthorizeCertificateStatusEnum.Accepted)
+      ) {
         response.certificateStatus =
           await this._certificateAuthorityService.validateCertificateChainPem(request.certificate);
       }

--- a/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201HandlerCertificates.test.ts
+++ b/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201HandlerCertificates.test.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it, vi } from 'vitest';
+import { type IAuthorizer, type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  AuthorizationStatusEnum,
+  EventGroup,
+  IdTokenEnum,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type {
+  IAuthorizationRepository,
+  IDeviceModelRepository,
+} from '@dal/interfaces/repositories.js';
+import { AuthorizeRequestOcpp201Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+import type { CertificateAuthorityService } from '@/util/index.js';
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.Authorize,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<T>;
+}
+
+/**
+ * Contract certificate validation runs before the authorization is ever looked up, so a rejected
+ * certificate returns without touching the repositories. They are stubbed only to satisfy the
+ * constructor.
+ */
+function makeHandler(certificateAuthorityService: Partial<CertificateAuthorityService>) {
+  const { logger } = createTestContainer();
+  const ocppSender = makeMockOcppSender();
+
+  const handler = new AuthorizeRequestOcpp201Handler({
+    logger,
+    ocppSender,
+    certificateAuthorityService: certificateAuthorityService as CertificateAuthorityService,
+    authorizers: [] as IAuthorizer[],
+    authorizationRepository: {
+      readOnlyOneByQuerystring: vi.fn(),
+    } as unknown as IAuthorizationRepository,
+    deviceModelRepository: {
+      readAllByQuerystring: vi.fn().mockResolvedValue([]),
+    } as unknown as IDeviceModelRepository,
+  } as never);
+
+  return { handler, ocppSender };
+}
+
+function sentResponse(
+  ocppSender: ReturnType<typeof makeMockOcppSender>,
+): OCPP2_0_1.AuthorizeResponse {
+  expect(ocppSender.sendCallResultWithMessage).toHaveBeenCalledOnce();
+  return ocppSender.sendCallResultWithMessage.mock.calls[0][1] as OCPP2_0_1.AuthorizeResponse;
+}
+
+// Not eMAID: validateIdToken enforces the eMAID check digit before the certificate block is
+// reached, and the token type is irrelevant to what these tests exercise.
+const request: OCPP2_0_1.AuthorizeRequest = {
+  idToken: { idToken: 'TAG001', type: IdTokenEnum.Central },
+};
+
+const A_CONTRACT_CERTIFICATE_CHAIN = '-----BEGIN CERTIFICATE-----abc-----END CERTIFICATE-----';
+
+const hashData = [
+  {
+    hashAlgorithm: OCPP2_0_1.HashAlgorithmEnumType.SHA256,
+    issuerNameHash: 'nameHash',
+    issuerKeyHash: 'keyHash',
+    serialNumber: 'serial',
+    responderURL: 'http://ocsp.example.test',
+  },
+] as OCPP2_0_1.OCSPRequestDataType[];
+
+describe('AuthorizeRequestOcpp201Handler contract certificate validation', () => {
+  it('refuses a contract certificate the OCSP hash data reports revoked', async () => {
+    const { handler, ocppSender } = makeHandler({
+      validateCertificateHashData: vi
+        .fn()
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked),
+    } as unknown as Partial<CertificateAuthorityService>);
+
+    await handler.handle(
+      makeMessage({ ...request, iso15118CertificateHashData: hashData } as never),
+    );
+
+    const response = sentResponse(ocppSender);
+    expect(response.certificateStatus).toBe(
+      OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked,
+    );
+    expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
+  });
+
+  it('does not let a chain that still verifies overwrite a revoked OCSP result', async () => {
+    // C07 lets a station send OCSP hash data, and the PEM chain as well when it cannot validate
+    // that chain itself. Both results were assigned to the same field, so the second call won and
+    // a contract certificate the responder had revoked was accepted on the strength of the chain.
+    const { handler, ocppSender } = makeHandler({
+      validateCertificateHashData: vi
+        .fn()
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked),
+      validateCertificateChainPem: vi
+        .fn()
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted),
+    } as unknown as Partial<CertificateAuthorityService>);
+
+    await handler.handle(
+      makeMessage({
+        ...request,
+        iso15118CertificateHashData: hashData,
+        certificate: A_CONTRACT_CERTIFICATE_CHAIN,
+      } as never),
+    );
+
+    const response = sentResponse(ocppSender);
+    expect(response.certificateStatus).toBe(
+      OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked,
+    );
+    expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
+  });
+
+  it('still validates the chain when the hash data accepted the certificate', async () => {
+    const validateCertificateChainPem = vi
+      .fn()
+      .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError);
+    const { handler, ocppSender } = makeHandler({
+      validateCertificateHashData: vi
+        .fn()
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted),
+      validateCertificateChainPem,
+    } as unknown as Partial<CertificateAuthorityService>);
+
+    await handler.handle(
+      makeMessage({
+        ...request,
+        iso15118CertificateHashData: hashData,
+        certificate: A_CONTRACT_CERTIFICATE_CHAIN,
+      } as never),
+    );
+
+    expect(validateCertificateChainPem).toHaveBeenCalledOnce();
+    expect(sentResponse(ocppSender).certificateStatus).toBe(
+      OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError,
+    );
+  });
+});

--- a/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201HandlerCertificates.test.ts
+++ b/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp201HandlerCertificates.test.ts
@@ -109,17 +109,17 @@ describe('AuthorizeRequestOcpp201Handler contract certificate validation', () =>
     expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
   });
 
-  it('does not let a chain that still verifies overwrite a revoked OCSP result', async () => {
-    // C07 lets a station send OCSP hash data, and the PEM chain as well when it cannot validate
-    // that chain itself. Both results were assigned to the same field, so the second call won and
-    // a contract certificate the responder had revoked was accepted on the strength of the chain.
+  it('validates the chain instead of the responder the station nominated, when both are sent', async () => {
+    // validateCertificateChainPem runs OCSP over every certificate in the chain using each one's
+    // own AIA responder URL, so the hash data adds nothing here - and its responderURL comes from
+    // the station. Running both meant an outbound request to a station-supplied URL whose result
+    // was then discarded.
+    const validateCertificateHashData = vi.fn();
     const { handler, ocppSender } = makeHandler({
-      validateCertificateHashData: vi
-        .fn()
-        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked),
+      validateCertificateHashData,
       validateCertificateChainPem: vi
         .fn()
-        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted),
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError),
     } as unknown as Partial<CertificateAuthorityService>);
 
     await handler.handle(
@@ -128,6 +128,25 @@ describe('AuthorizeRequestOcpp201Handler contract certificate validation', () =>
         iso15118CertificateHashData: hashData,
         certificate: A_CONTRACT_CERTIFICATE_CHAIN,
       } as never),
+    );
+
+    expect(validateCertificateHashData).not.toHaveBeenCalled();
+    const response = sentResponse(ocppSender);
+    expect(response.certificateStatus).toBe(
+      OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError,
+    );
+    expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
+  });
+
+  it('refuses a certificate the chain check reports revoked', async () => {
+    const { handler, ocppSender } = makeHandler({
+      validateCertificateChainPem: vi
+        .fn()
+        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertificateRevoked),
+    } as unknown as Partial<CertificateAuthorityService>);
+
+    await handler.handle(
+      makeMessage({ ...request, certificate: A_CONTRACT_CERTIFICATE_CHAIN } as never),
     );
 
     const response = sentResponse(ocppSender);
@@ -137,28 +156,16 @@ describe('AuthorizeRequestOcpp201Handler contract certificate validation', () =>
     expect(response.idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
   });
 
-  it('still validates the chain when the hash data accepted the certificate', async () => {
-    const validateCertificateChainPem = vi
-      .fn()
-      .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError);
+  it('refuses a request carrying neither a chain nor any hash data to check', async () => {
+    // iso15118CertificateHashData has minItems 1, so an empty list only reaches the handler if
+    // something bypassed schema validation. There is nothing to validate, so it fails closed.
     const { handler, ocppSender } = makeHandler({
-      validateCertificateHashData: vi
-        .fn()
-        .mockResolvedValue(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted),
-      validateCertificateChainPem,
+      validateCertificateHashData: vi.fn(),
+      validateCertificateChainPem: vi.fn(),
     } as unknown as Partial<CertificateAuthorityService>);
 
-    await handler.handle(
-      makeMessage({
-        ...request,
-        iso15118CertificateHashData: hashData,
-        certificate: A_CONTRACT_CERTIFICATE_CHAIN,
-      } as never),
-    );
+    await handler.handle(makeMessage({ ...request, iso15118CertificateHashData: [] } as never));
 
-    expect(validateCertificateChainPem).toHaveBeenCalledOnce();
-    expect(sentResponse(ocppSender).certificateStatus).toBe(
-      OCPP2_0_1.AuthorizeCertificateStatusEnumType.CertChainError,
-    );
+    expect(sentResponse(ocppSender).idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
   });
 });


### PR DESCRIPTION
> Rewritten after @lydiazcheng's review. My original premise was wrong - see the note at the bottom.

## Which check decides is currently an accident of ordering

```ts
if (request.iso15118CertificateHashData?.length) {
  response.certificateStatus = await validateCertificateHashData(...);
}
if (request.certificate) {
  response.certificateStatus = await validateCertificateChainPem(request.certificate);
}
if (response.certificateStatus !== Accepted) { /* reject */ }
```

Both write the same field, so when a station sends both, the outcome is decided by whichever
assignment happens to run second rather than by any stated rule.

`validateCertificateChainPem` already runs OCSP over every certificate in the chain, using each
certificate's own AIA responder URL, and additionally checks expiry and resolves the trust root. So
the hash data adds nothing when a chain is present, which is what the spec text @lydiazcheng quoted
says: `iso15118CertificateHashData` is *"Not needed if certificate is provided"*.

There is a second reason not to run both. `validateCertificateHashData` sends its OCSP request to
`reqData.responderURL` - a URL supplied by the charging station:

```ts
await sendOCSPRequest(ocspRequest, reqData.responderURL)
```

When a chain is also present, that outbound request is made and the result is then discarded. The
chain path instead uses the URL from the certificate's own AIA extension, which is not
station-controlled.

The chain is now used when present, the hash data otherwise.

## One deviation from the suggested snippet

The suggestion was:

```ts
if (request.certificate || request.iso15118CertificateHashData?.length) {
```

I kept the outer guard as `if (request.iso15118CertificateHashData || request.certificate)` and made
the inner branch an `else if` on `?.length`. The reason is an edge case: today, an empty
`iso15118CertificateHashData` array with no certificate enters the block, matches neither inner
branch, leaves `certificateStatus` undefined, and is rejected as `Invalid`. Moving the `?.length`
check to the outer guard would skip the block entirely and let the authorization proceed.

`minItems` is 1 on that field so a schema-valid request cannot do this, but the `else if` keeps the
fail-closed behaviour for anything that bypasses validation, at no cost. There is a test for it.
Happy to take the simpler guard if you'd rather.

## Where I was wrong

The original version of this PR made the hash data's refusal win, on the reasoning that the chain
check did not cover revocation. It does - `validateCertificateChainPem` returns `CertificateRevoked`
from its own OCSP loop. So there was no hole of the kind I described, and had my version been
merged it would have preferred the *station-supplied* responder's verdict over the certificate's
own. That was the wrong way round. Thanks for catching it.

The 2.0.1 and 2.1 handlers carry the same block and both are changed.

## Verification

```
npx vitest run test/handlers/requests/2/AuthorizeRequestOcpp201HandlerCertificates.test.ts   # 4 passed
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
npx prettier --check / npx eslint <changed files>  # clean
```