### PR TITLE
fix(core): send the transaction's SetChargingProfile on the station's own protocol

### DIFF
--- a/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
@@ -514,7 +514,12 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
                     await this._ocppSender.sendCall({
                       ocppConnectionName,
                       tenantId,
-                      protocol: OCPPVersion.OCPP2_1,
+                      // This handler serves OCPP_2_VER_LIST, so the station may be 2.0.1, and
+                      // the profile above is built by the 2.0.1 mapper. Hard-coding 2.1 filed the
+                      // outbound SetChargingProfile against the wrong protocol in the message
+                      // audit and in the call metrics, and mapped its action through the wrong
+                      // action table.
+                      protocol: message.protocol,
                       action: OCPP_CallAction.SetChargingProfile,
                       eventGroup: EventGroup.Transactions,
                       payload: {

--- a/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
@@ -299,7 +299,6 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
                 if (qrLimits.maxEnergy != null) {
                   ocpp21Response.transactionLimit.maxEnergy = qrLimits.maxEnergy;
                 }
-                // Clear the session from cache — limits are consumed on first transaction start
                 await this._cache.remove(cacheKey, CacheNamespace.Other);
                 this._logger.info(
                   `Set transactionLimit from QR payment session for station ${ocppConnectionName}, ` +
@@ -514,8 +513,6 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
                     await this._ocppSender.sendCall({
                       ocppConnectionName,
                       tenantId,
-                      // This handler serves OCPP_2_VER_LIST, so the station may be 2.0.1, and
-                      // the profile above is built by the 2.0.1 mapper.
                       protocol: message.protocol,
                       action: OCPP_CallAction.SetChargingProfile,
                       eventGroup: EventGroup.Transactions,

--- a/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
@@ -515,10 +515,7 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
                       ocppConnectionName,
                       tenantId,
                       // This handler serves OCPP_2_VER_LIST, so the station may be 2.0.1, and
-                      // the profile above is built by the 2.0.1 mapper. Hard-coding 2.1 filed the
-                      // outbound SetChargingProfile against the wrong protocol in the message
-                      // audit and in the call metrics, and mapped its action through the wrong
-                      // action table.
+                      // the profile above is built by the 2.0.1 mapper.
                       protocol: message.protocol,
                       action: OCPP_CallAction.SetChargingProfile,
                       eventGroup: EventGroup.Transactions,


### PR DESCRIPTION
`TransactionEventRequestOcpp2Handler` is registered for `OCPP_2_VER_LIST` but hard-codes `protocol: OCPPVersion.OCPP2_1` on the `SetChargingProfile` it sends after applying a transaction charging profile (`TransactionEventRequestOcpp2Handler.ts:517`). The profile passed in it is built by `OCPP2_0_1_Mapper.ChargingProfileMapper` three lines above.

So a 2.0.1 station's outbound call is recorded and metered under 2.1 and its action mapped through the wrong action table.

This is the same defect as citrineos/citrineos-core#881, which fixed `NotifyEVChargingNeedsRequestOcpp2Handler`, `ClearChargingProfileResponseOcpp2Handler` and `SendLocalListResponseOcpp2Handler`. This is a fourth site that pass missed - I found it by checking every `OCPP_2_VER_LIST` handler that calls `sendCall`, and this is now the only remaining one; every other such handler already passes `message.protocol`.

`OCPPVersion` stays imported - it is still used at `:115` for `isOcpp21`.