### PR TITLE
fix(core): read ACPhaseSwitchingSupported instead of testing that the row exists

### DIFF
--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -361,10 +361,9 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
             payload: `chargingSchedulePeriod with phaseToUse requires numberPhases=1`,
           };
         }
-        // Presence of the variable is not the same as support for the feature: a station that
-        // reports ACPhaseSwitchingSupported=false has a row, so testing only the length accepted
-        // the profile and forwarded it to hardware that cannot honour it. Read the value, and
-        // treat anything that is not an explicit true - including an absent row - as unsupported.
+        // Presence of the variable is not the same as support for the feature, so read the value
+        // and treat anything that is not an explicit true - including an absent row - as
+        // unsupported.
         const phaseSwitchingSupported =
           acPhaseSwitchingSupported[0]?.value?.toLowerCase() === 'true';
         if (!phaseSwitchingSupported) {

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -361,7 +361,13 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
             payload: `chargingSchedulePeriod with phaseToUse requires numberPhases=1`,
           };
         }
-        if (!acPhaseSwitchingSupported.length) {
+        // Presence of the variable is not the same as support for the feature: a station that
+        // reports ACPhaseSwitchingSupported=false has a row, so testing only the length accepted
+        // the profile and forwarded it to hardware that cannot honour it. Read the value, and
+        // treat anything that is not an explicit true - including an absent row - as unsupported.
+        const phaseSwitchingSupported =
+          acPhaseSwitchingSupported[0]?.value?.toLowerCase() === 'true';
+        if (!phaseSwitchingSupported) {
           return {
             success: false,
             payload: `phaseToUse not allowed if AC phase switching is not supported by station ${ocppConnectionName}.`,

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -361,9 +361,6 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
             payload: `chargingSchedulePeriod with phaseToUse requires numberPhases=1`,
           };
         }
-        // Presence of the variable is not the same as support for the feature, so read the value
-        // and treat anything that is not an explicit true - including an absent row - as
-        // unsupported.
         const phaseSwitchingSupported =
           acPhaseSwitchingSupported[0]?.value?.toLowerCase() === 'true';
         if (!phaseSwitchingSupported) {

--- a/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
@@ -276,8 +276,18 @@ describe('smartCharging message endpoints', () => {
     const build = () =>
       getTestInstance(container, SetChargingProfileEndpoint, {
         ocppSender: { sendCall },
-        deviceModelRepository: { readAllByQuerystring },
-        chargingProfileRepository: { createOrUpdateChargingProfile },
+        deviceModelRepository: {
+          readAllByQuerystring,
+          // No RateUnit characteristics stored, so the member-list check is skipped.
+          findVariableCharacteristicsByVariableNameAndVariableInstance: vi
+            .fn()
+            .mockResolvedValue(undefined),
+        },
+        chargingProfileRepository: {
+          createOrUpdateChargingProfile,
+          readAllByQuery: vi.fn().mockResolvedValue([]),
+          existByQuery: vi.fn().mockResolvedValue(0),
+        },
         transactionEventRepository: {},
       });
 
@@ -313,6 +323,59 @@ describe('smartCharging message endpoints', () => {
       expect(confirmations[0].success).toBe(false);
       expect(String(confirmations[0].payload)).toContain('should not be in the future');
       expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    /** A schedule whose single period asks the station to charge on one specific phase. */
+    const aPhaseToUseSchedule = () => ({
+      chargingSchedule: [
+        {
+          id: 1,
+          // Absolute is the kind aProfile() uses, so a startSchedule is required.
+          startSchedule: new Date().toISOString(),
+          chargingRateUnit: OCPP2_0_1.ChargingRateUnitEnumType.A,
+          chargingSchedulePeriod: [{ startPeriod: 0, limit: 16, numberPhases: 1, phaseToUse: 1 }],
+        },
+      ],
+    });
+
+    /** Mocks the device model so ACPhaseSwitchingSupported reports the given value. */
+    const withPhaseSwitching = (value: string | undefined) => {
+      readAllByQuerystring.mockImplementation(async (_tenantId: number, query: any) =>
+        query.variable_name === 'ACPhaseSwitchingSupported' && value !== undefined
+          ? [{ value }]
+          : [],
+      );
+    };
+
+    it('refuses phaseToUse when the station reports AC phase switching unsupported', async () => {
+      // The guard tested only whether the variable row existed, not what it said. A station that
+      // explicitly reports ACPhaseSwitchingSupported=false has a row, so the profile was accepted
+      // and forwarded to hardware that cannot honour it.
+      withPhaseSwitching('false');
+
+      const confirmations = await handle(aProfile(aPhaseToUseSchedule()));
+
+      expect(confirmations[0].success).toBe(false);
+      expect(String(confirmations[0].payload)).toContain('phaseToUse not allowed');
+      expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    it('refuses phaseToUse when the station does not report the variable at all', async () => {
+      withPhaseSwitching(undefined);
+
+      const confirmations = await handle(aProfile(aPhaseToUseSchedule()));
+
+      expect(confirmations[0].success).toBe(false);
+      expect(String(confirmations[0].payload)).toContain('phaseToUse not allowed');
+    });
+
+    it('allows phaseToUse when the station reports AC phase switching supported', async () => {
+      withPhaseSwitching('true');
+
+      const confirmations = await handle(aProfile(aPhaseToUseSchedule()));
+
+      expect(confirmations[0].success).not.toBe(false);
+      expect(sendCall).toHaveBeenCalled();
     });
 
     it('refuses a profile that has already expired', async () => {


### PR DESCRIPTION
In `SetChargingProfileEndpoint._rejectOnSchedules`, `phaseToUse` is guarded by:

```ts
if (!acPhaseSwitchingSupported.length) {
  return { success: false, payload: `phaseToUse not allowed if AC phase switching is not supported ...` };
}
```

`acPhaseSwitchingSupported` is the result of reading `SmartChargingCtrlr.ACPhaseSwitchingSupported` (Actual) from the device model, so `.length` only tells you whether the station has ever reported the variable - not what it said. A station that explicitly reports `false` **has** a row, so the guard passes and the profile is accepted and forwarded to hardware that cannot switch phases. That is precisely the case the check exists to catch; it currently only rejects stations that never reported at all.

This reads the value and treats anything that is not an explicit `true` - including an absent row - as unsupported, so the check fails closed either way. The same file already uses this idiom a few lines away for `SmartChargingCtrlr.Enabled` (`smartChargingEnabled[0].value === 'false'`), so it is only this site that is inconsistent.

Pre-existing rather than a regression: the identical `!acPhaseSwitchingSupported.length` check was at `SmartCharging/src/module/2/MessageApi.ts:507` before #849 and was carried over verbatim.

Three tests added to the existing smart-charging endpoint suite: reported `false` (fails on `next`), variable absent, and reported `true`.