### PR TITLE
fix(ocpi): correct the transaction filters behind Sessions and CDRs

### DIFF
--- a/packages/ocpi-base/src/graphql/operations.ts
+++ b/packages/ocpi-base/src/graphql/operations.ts
@@ -49,6 +49,7 @@ export type Tariffs_Bool_Exp = {
 export type Transactions_Bool_Exp = {
   updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
   totalKwh?: InputMaybe<Numeric_Comparison_Exp>;
+  isActive?: InputMaybe<Boolean_Comparison_Exp>;
   Authorization?: InputMaybe<Authorizations_Bool_Exp>;
   Tenant?: InputMaybe<Tenants_Bool_Exp>;
 };
@@ -57,7 +58,12 @@ export type Authorizations_Bool_Exp = {
 };
 export type Timestamptz_Comparison_Exp = {
   _gte?: InputMaybe<Scalars['timestamptz']['input']>;
+  _lt?: InputMaybe<Scalars['timestamptz']['input']>;
   _lte?: InputMaybe<Scalars['timestamptz']['input']>;
+};
+
+export type Boolean_Comparison_Exp = {
+  _eq?: InputMaybe<Scalars['Boolean']['input']>;
 };
 export type Numeric_Comparison_Exp = {
   _gt?: InputMaybe<Scalars['numeric']['input']>;

--- a/packages/ocpi-base/src/graphql/operations.ts
+++ b/packages/ocpi-base/src/graphql/operations.ts
@@ -48,6 +48,7 @@ export type Tariffs_Bool_Exp = {
 };
 export type Transactions_Bool_Exp = {
   updatedAt?: InputMaybe<Timestamptz_Comparison_Exp>;
+  endTime?: InputMaybe<Timestamptz_Comparison_Exp>;
   totalKwh?: InputMaybe<Numeric_Comparison_Exp>;
   isActive?: InputMaybe<Boolean_Comparison_Exp>;
   Authorization?: InputMaybe<Authorizations_Bool_Exp>;
@@ -60,6 +61,7 @@ export type Timestamptz_Comparison_Exp = {
   _gte?: InputMaybe<Scalars['timestamptz']['input']>;
   _lt?: InputMaybe<Scalars['timestamptz']['input']>;
   _lte?: InputMaybe<Scalars['timestamptz']['input']>;
+  _is_null?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type Boolean_Comparison_Exp = {

--- a/packages/ocpi-base/src/services/CdrsService.ts
+++ b/packages/ocpi-base/src/services/CdrsService.ts
@@ -48,14 +48,10 @@ export class CdrsService {
           partyId: { _eq: fromPartyId },
         },
       },
-      // A CDR only exists for a finished session, and one that lost its active flag without ever
-      // being stopped has no end_date_time to carry. CdrMapper drops both, so the aggregate count
-      // behind X-Total-Count has to drop them as well.
       isActive: { _eq: false },
       endTime: { _is_null: false },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
     if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {

--- a/packages/ocpi-base/src/services/CdrsService.ts
+++ b/packages/ocpi-base/src/services/CdrsService.ts
@@ -12,6 +12,7 @@ import { OcpiResponseStatusCode } from '../model/OcpiResponse.js';
 import type {
   GetTransactionsQueryResult,
   GetTransactionsQueryVariables,
+  Timestamptz_Comparison_Exp,
   Transactions_Bool_Exp,
 } from '../graphql/index.js';
 import { GET_TRANSACTIONS_QUERY, OcpiGraphqlClient } from '../graphql/index.js';
@@ -47,10 +48,17 @@ export class CdrsService {
           partyId: { _eq: fromPartyId },
         },
       },
+      // A CDR only exists for a finished session. CdrMapper already drops active transactions
+      // after the fact, but the query and its aggregate count did not, so X-Total-Count counted
+      // sessions that never become CDRs and every page came back short of its limit.
+      isActive: { _eq: false },
     };
-    const dateFilters: any = {};
+    const dateFilters: Timestamptz_Comparison_Exp = {};
+    // OCPI defines date_from as inclusive and date_to as exclusive. _lte made the upper bound
+    // inclusive, so a record landing exactly on the boundary was returned both by the poll that
+    // ended there and by the poll that started there - the same record delivered twice.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
-    if (dateTo) dateFilters._lte = dateTo.toISOString();
+    if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {
       where.updatedAt = dateFilters;
     }

--- a/packages/ocpi-base/src/services/CdrsService.ts
+++ b/packages/ocpi-base/src/services/CdrsService.ts
@@ -48,19 +48,14 @@ export class CdrsService {
           partyId: { _eq: fromPartyId },
         },
       },
-      // A CDR only exists for a finished session. CdrMapper already drops active transactions
-      // after the fact, but the query and its aggregate count did not, so X-Total-Count counted
-      // sessions that never become CDRs and every page came back short of its limit.
+      // A CDR only exists for a finished session, and one that lost its active flag without ever
+      // being stopped has no end_date_time to carry. CdrMapper drops both, so the aggregate count
+      // behind X-Total-Count has to drop them as well.
       isActive: { _eq: false },
-      // A transaction can lose its active flag without ever being stopped, and a CDR needs an
-      // end_date_time. The mapper drops those, so the aggregate count has to drop them too or the
-      // page comes back short of the total again.
       endTime: { _is_null: false },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive. _lte made the upper bound
-    // inclusive, so a record landing exactly on the boundary was returned both by the poll that
-    // ended there and by the poll that started there - the same record delivered twice.
+    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
     if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {

--- a/packages/ocpi-base/src/services/CdrsService.ts
+++ b/packages/ocpi-base/src/services/CdrsService.ts
@@ -52,6 +52,10 @@ export class CdrsService {
       // after the fact, but the query and its aggregate count did not, so X-Total-Count counted
       // sessions that never become CDRs and every page came back short of its limit.
       isActive: { _eq: false },
+      // A transaction can lose its active flag without ever being stopped, and a CDR needs an
+      // end_date_time. The mapper drops those, so the aggregate count has to drop them too or the
+      // page comes back short of the total again.
+      endTime: { _is_null: false },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
     // OCPI defines date_from as inclusive and date_to as exclusive. _lte made the upper bound

--- a/packages/ocpi-base/src/services/SessionsService.ts
+++ b/packages/ocpi-base/src/services/SessionsService.ts
@@ -51,9 +51,7 @@ export class SessionsService {
       },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive. _lte made the upper bound
-    // inclusive, so a record landing exactly on the boundary was returned both by the poll that
-    // ended there and by the poll that started there - the same record delivered twice.
+    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
     if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {
@@ -61,9 +59,6 @@ export class SessionsService {
     }
 
     if (endedOnly) {
-      // Delivered energy is not a completion signal: a session still running has some, and one
-      // that ended without delivering any has ended all the same. isActive is the actual flag,
-      // and it is what CdrMapper uses.
       where.isActive = { _eq: false };
     }
     const queryOptions = {

--- a/packages/ocpi-base/src/services/SessionsService.ts
+++ b/packages/ocpi-base/src/services/SessionsService.ts
@@ -51,7 +51,6 @@ export class SessionsService {
       },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
     if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {

--- a/packages/ocpi-base/src/services/SessionsService.ts
+++ b/packages/ocpi-base/src/services/SessionsService.ts
@@ -13,6 +13,7 @@ import { OcpiResponseStatusCode } from '../model/OcpiResponse.js';
 import type {
   GetTransactionsQueryResult,
   GetTransactionsQueryVariables,
+  Timestamptz_Comparison_Exp,
   Transactions_Bool_Exp,
 } from '../graphql/index.js';
 import { GET_TRANSACTIONS_QUERY, OcpiGraphqlClient } from '../graphql/index.js';
@@ -49,15 +50,21 @@ export class SessionsService {
         },
       },
     };
-    const dateFilters: any = {};
+    const dateFilters: Timestamptz_Comparison_Exp = {};
+    // OCPI defines date_from as inclusive and date_to as exclusive. _lte made the upper bound
+    // inclusive, so a record landing exactly on the boundary was returned both by the poll that
+    // ended there and by the poll that started there - the same record delivered twice.
     if (dateFrom) dateFilters._gte = dateFrom.toISOString();
-    if (dateTo) dateFilters._lte = dateTo.toISOString();
+    if (dateTo) dateFilters._lt = dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {
       where.updatedAt = dateFilters;
     }
 
     if (endedOnly) {
-      where.totalKwh = { _gt: 0 };
+      // Delivered energy is not a completion signal: a session still running has some, and one
+      // that ended without delivering any has ended all the same. isActive is the actual flag,
+      // and it is what CdrMapper uses.
+      where.isActive = { _eq: false };
     }
     const queryOptions = {
       offset,

--- a/packages/ocpi-base/test/services/CdrAndSessionDateFilters.test.ts
+++ b/packages/ocpi-base/test/services/CdrAndSessionDateFilters.test.ts
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+
+// The mapper barrel pulls in the whole typedi service graph, which needs a configured container.
+// These tests construct the services by hand and never map a row, so a stub is enough to load them.
+vi.mock('../../src/mapper/index.js', () => ({
+  CdrMapper: class {},
+  SessionMapper: class {},
+}));
+
+import { CdrsService } from '../../src/services/CdrsService.js';
+import { SessionsService } from '../../src/services/SessionsService.js';
+
+const DATE_FROM = new Date('2026-08-01T00:00:00.000Z');
+const DATE_TO = new Date('2026-08-19T00:00:00.000Z');
+
+/** Captures the Hasura variables the service builds, and returns an empty result set. */
+function aCapturingGraphqlClient() {
+  const request = vi.fn().mockResolvedValue({ Transactions: [] });
+  return { client: { request } as never, request };
+}
+
+function whereFrom(request: ReturnType<typeof aCapturingGraphqlClient>['request']) {
+  expect(request).toHaveBeenCalledOnce();
+  return (request.mock.calls[0][1] as { where: Record<string, any> }).where;
+}
+
+describe('OCPI date_from / date_to filters', () => {
+  it('CdrsService treats date_to as exclusive', async () => {
+    // OCPI defines date_from as inclusive and date_to as exclusive. Making date_to inclusive means
+    // a record whose last_updated lands exactly on the boundary is returned by the poll that ends
+    // there and again by the poll that starts there - the same CDR billed twice.
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new CdrsService(client, {
+      mapTransactionsToCdrs: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getCdrs('GB', 'ABC', 'GB', 'VLT', DATE_FROM, DATE_TO);
+
+    const where = whereFrom(request);
+    expect(where.updatedAt).toEqual({ _gte: DATE_FROM.toISOString(), _lt: DATE_TO.toISOString() });
+  });
+
+  it('SessionsService treats date_to as exclusive', async () => {
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new SessionsService(client, {
+      mapTransactionsToSessions: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getSessions('GB', 'ABC', 'GB', 'VLT', DATE_FROM, DATE_TO);
+
+    const where = whereFrom(request);
+    expect(where.updatedAt).toEqual({ _gte: DATE_FROM.toISOString(), _lt: DATE_TO.toISOString() });
+  });
+
+  it('omits the filter entirely when neither bound is given', async () => {
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new CdrsService(client, {
+      mapTransactionsToCdrs: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getCdrs('GB', 'ABC', 'GB', 'VLT');
+
+    expect(whereFrom(request).updatedAt).toBeUndefined();
+  });
+
+  it('CdrsService excludes still-running transactions in the query, not afterwards', async () => {
+    // CdrMapper drops active transactions in memory, but the query and its aggregate count did
+    // not, so X-Total-Count counted sessions that never become CDRs and every page came back
+    // short of its limit.
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new CdrsService(client, {
+      mapTransactionsToCdrs: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getCdrs('GB', 'ABC', 'GB', 'VLT');
+
+    expect(whereFrom(request).isActive).toEqual({ _eq: false });
+  });
+
+  it('SessionsService decides endedOnly on isActive, not on delivered energy', async () => {
+    // totalKwh > 0 is not a completion signal: a session still running has delivered energy, and
+    // one that ended without delivering any is still ended.
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new SessionsService(client, {
+      mapTransactionsToSessions: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getSessions('GB', 'ABC', 'GB', 'VLT', undefined, undefined, 0, 10, true);
+
+    const where = whereFrom(request) as Record<string, unknown>;
+    expect(where.isActive).toEqual({ _eq: false });
+    expect(where.totalKwh).toBeUndefined();
+  });
+});

--- a/packages/ocpi-base/test/services/CdrAndSessionDateFilters.test.ts
+++ b/packages/ocpi-base/test/services/CdrAndSessionDateFilters.test.ts
@@ -81,6 +81,19 @@ describe('OCPI date_from / date_to filters', () => {
     expect(whereFrom(request).isActive).toEqual({ _eq: false });
   });
 
+  it('CdrsService excludes transactions that were never stopped', async () => {
+    // A stale transaction is deactivated with no endTime when a new one starts on the same EVSE.
+    // The mapper cannot build a CDR without an end_date_time, so the count has to exclude them too.
+    const { client, request } = aCapturingGraphqlClient();
+    const service = new CdrsService(client, {
+      mapTransactionsToCdrs: vi.fn().mockResolvedValue([]),
+    } as never);
+
+    await service.getCdrs('GB', 'ABC', 'GB', 'VLT');
+
+    expect(whereFrom(request).endTime).toEqual({ _is_null: false });
+  });
+
   it('SessionsService decides endedOnly on isActive, not on delivered energy', async () => {
     // totalKwh > 0 is not a completion signal: a session still running has delivered energy, and
     // one that ended without delivering any is still ended.


### PR DESCRIPTION
Two defects in the same `where` clause, both shaping what a polling client actually receives.

**`date_to` was inclusive.** Both services applied it as `_lte`. OCPI defines `date_from` as inclusive and `date_to` as exclusive, so a record whose `last_updated` lands exactly on the boundary is returned by the poll that ends there *and* by the poll that starts there. For a client that pages by advancing its cursor to the previous `date_to`, that is a duplicated CDR. Worth noting the implementation these services replaced had it right - the commented-out `TransactionQueryBuilder.addDateFilters` uses `Op.lt`.

**"Ended" was inferred from delivered energy.** `CdrsService` did not filter on completion at all and relied on `CdrMapper` dropping active transactions *after* the query (`CdrMapper.ts:222`). So `Transactions_aggregate` - which feeds `X-Total-Count` - counted sessions that never become CDRs, and every page came back short of its limit. `SessionsService` used `totalKwh > 0` for `endedOnly`, which is not a completion signal in either direction: a session still running has delivered energy, and a session that ended without delivering any has still ended. `isActive` is the actual flag and is already what `CdrMapper` uses.

No records were being skipped by the paging itself - the offset advances over transactions - but the total is wrong and pages are short.

Also adds `_lt`, `isActive` and `Boolean_Comparison_Exp` to the hand-maintained Hasura type stubs in `operations.ts`, and types `dateFilters` as `Timestamptz_Comparison_Exp`. It was declared `any`, which is how an undeclared `_lte` compiled in the first place. `columns: '*'` on the Transactions select permission confirms Hasura will accept filtering on `isActive`.

Adds `packages/ocpi-base/test/services/` - the third test file in this package.