### PR TITLE
fix(core): scope the local authorisation list queries to the tenant

### DIFF
--- a/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/LocalAuthList.ts
@@ -72,6 +72,7 @@ export class SequelizeLocalAuthListRepository
     for (const authData of localAuthorizationList ?? []) {
       const auth = await Authorization.findOne({
         where: {
+          tenantId,
           idToken: authData.idToken.idToken,
           idTokenType: AuthorizationMapper.fromIdTokenEnumType(authData.idToken.type),
         },
@@ -85,6 +86,7 @@ export class SequelizeLocalAuthListRepository
       if (authData.idTokenInfo?.groupIdToken) {
         const groupAuth = await Authorization.findOne({
           where: {
+            tenantId,
             idToken: authData.idTokenInfo.groupIdToken.idToken,
             idTokenType: AuthorizationMapper.fromIdTokenEnumType(
               authData.idTokenInfo.groupIdToken.type,
@@ -92,11 +94,6 @@ export class SequelizeLocalAuthListRepository
           },
         });
         const groupAuthorizationAuthId = groupAuth?.id;
-        if (!auth.groupAuthorizationId || groupAuthorizationAuthId !== auth.groupAuthorizationId) {
-          throw new Error(
-            `Authorization groupIdToken in SendLocalListRequest ${JSON.stringify(authData.idTokenInfo.groupIdToken)} does not match groupAuthorizationId in database ${JSON.stringify(auth.groupAuthorizationId)} (update the groupAuthorization first)`,
-          );
-        }
         if (!auth.groupAuthorizationId || groupAuthorizationAuthId !== auth.groupAuthorizationId) {
           throw new Error(
             `Authorization groupIdToken in SendLocalListRequest ${JSON.stringify(authData.idTokenInfo.groupIdToken)} does not match groupAuthorizationId in database ${JSON.stringify(auth.groupAuthorizationId)} (update the groupAuthorization first)`,
@@ -168,7 +165,7 @@ export class SequelizeLocalAuthListRepository
         updateType === OCPP1_6.SendLocalListRequestUpdateType.Differential && !authData.idTagInfo;
 
       const auth = await Authorization.findOne({
-        where: { idToken: authData.idTag },
+        where: { tenantId, idToken: authData.idTag },
       });
 
       if (!auth && !isDelete) {
@@ -180,7 +177,7 @@ export class SequelizeLocalAuthListRepository
       let groupAuthorizationId: number | undefined;
       if (authData.idTagInfo?.parentIdTag) {
         const parent = await Authorization.findOne({
-          where: { idToken: authData.idTagInfo.parentIdTag },
+          where: { tenantId, idToken: authData.idTagInfo.parentIdTag },
         });
         if (!parent) {
           throw new Error(
@@ -238,7 +235,7 @@ export class SequelizeLocalAuthListRepository
   ): Promise<void> {
     await this.s.transaction(async (transaction) => {
       const localListVersion = await LocalListVersion.findOne({
-        where: { ocppConnectionName: ocppConnectionName },
+        where: { tenantId, ocppConnectionName: ocppConnectionName },
         transaction,
       });
       if (localListVersion && localListVersion.versionNumber === versionNumber) {
@@ -309,19 +306,19 @@ export class SequelizeLocalAuthListRepository
   ): Promise<LocalListVersion> {
     const localListVersion = await this.s.transaction(async (transaction) => {
       const oldLocalListVersion = await LocalListVersion.findOne({
-        where: { ocppConnectionName: ocppConnectionName },
+        where: { tenantId, ocppConnectionName: ocppConnectionName },
         include: [LocalListAuthorization],
         transaction,
       });
       if (oldLocalListVersion) {
         // Remove associations
         await LocalListVersionAuthorization.destroy({
-          where: { localListVersionId: oldLocalListVersion.id },
+          where: { tenantId, localListVersionId: oldLocalListVersion.id },
           transaction,
         });
         // Destroy old version
         await LocalListVersion.destroy({
-          where: { ocppConnectionName: ocppConnectionName },
+          where: { tenantId, ocppConnectionName: ocppConnectionName },
           transaction,
         });
       }
@@ -381,7 +378,7 @@ export class SequelizeLocalAuthListRepository
       }
 
       const localListVersion = await LocalListVersion.findOne({
-        where: { ocppConnectionName: ocppConnectionName },
+        where: { tenantId, ocppConnectionName: ocppConnectionName },
         include: [LocalListAuthorization],
         transaction,
       });
@@ -407,6 +404,7 @@ export class SequelizeLocalAuthListRepository
         for (const oldAuth of matches) {
           await LocalListVersionAuthorization.destroy({
             where: {
+              tenantId,
               localListVersionId: localListVersion.id,
               authorizationId: oldAuth.id,
             },

--- a/packages/core/test/dal/layers/sequelize/repository/LocalAuthListTenantScoping.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/LocalAuthListTenantScoping.integration.test.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { BootstrapConfig } from '@citrineos/base';
+import { AuthorizationStatusEnum, IdTokenEnum, OCPP2_0_1 } from '@citrineos/types';
+import {
+  Authorization,
+  DefaultSequelizeInstance,
+  SequelizeLocalAuthListRepository,
+  Tenant,
+} from '@dal/index.js';
+
+const TENANT_A = 1;
+const TENANT_B = 2;
+const SHARED_TOKEN = 'SHARED-TAG-001';
+const STATION = 'CS001';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance.close();
+  await pgContainer.stop();
+});
+
+beforeEach(async () => {
+  await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+  await Tenant.create({ id: TENANT_A as any });
+  await Tenant.create({ id: TENANT_B as any });
+});
+
+function aRepo(): SequelizeLocalAuthListRepository {
+  return new SequelizeLocalAuthListRepository({
+    config: {} as BootstrapConfig,
+    sequelizeInstance,
+  } as never);
+}
+
+/** The same idToken enrolled by two operators - the unique index is (tenantId, idToken, type). */
+async function enrolSharedTokenForBothTenants() {
+  // B is inserted first so it holds the lower id: an unscoped findOne returns it, which is what
+  // makes the missing tenant predicate observable rather than accidentally right.
+  const acceptedForB = await Authorization.create({
+    tenantId: TENANT_B,
+    idToken: SHARED_TOKEN,
+    idTokenType: IdTokenEnum.ISO14443,
+    status: AuthorizationStatusEnum.Accepted,
+  } as any);
+  const blockedForA = await Authorization.create({
+    tenantId: TENANT_A,
+    idToken: SHARED_TOKEN,
+    idTokenType: IdTokenEnum.ISO14443,
+    status: AuthorizationStatusEnum.Blocked,
+  } as any);
+  return { blockedForA, acceptedForB };
+}
+
+const authorizationData = [
+  {
+    idToken: { idToken: SHARED_TOKEN, type: IdTokenEnum.ISO14443 },
+  },
+] as unknown as OCPP2_0_1.AuthorizationData[];
+
+describe('SequelizeLocalAuthListRepository tenant scoping', () => {
+  it("builds a station's local list from its own tenant's authorization", async () => {
+    // The list is copied into LocalListAuthorization and sent to the charger to use while it is
+    // offline. Resolving the idToken without the tenant hands one operator's charger another
+    // operator's authorization status.
+    const { blockedForA } = await enrolSharedTokenForBothTenants();
+
+    const sendLocalList = await aRepo().createSendLocalListFromRequestData(
+      TENANT_A,
+      STATION,
+      'corr-1',
+      OCPP2_0_1.UpdateEnumType.Full,
+      1,
+      authorizationData,
+    );
+
+    const [entry] = sendLocalList.localAuthorizationList!;
+    expect(Number(entry.authorizationId)).toBe(blockedForA.id);
+    expect(entry.status).toBe(AuthorizationStatusEnum.Blocked);
+  });
+
+  it('refuses when the tenant has no authorization for the token, even if another tenant does', async () => {
+    await Authorization.create({
+      tenantId: TENANT_B,
+      idToken: SHARED_TOKEN,
+      idTokenType: IdTokenEnum.ISO14443,
+      status: AuthorizationStatusEnum.Accepted,
+    } as any);
+
+    await expect(
+      aRepo().createSendLocalListFromRequestData(
+        TENANT_A,
+        STATION,
+        'corr-2',
+        OCPP2_0_1.UpdateEnumType.Full,
+        1,
+        authorizationData,
+      ),
+    ).rejects.toThrow(/Authorization not found/);
+  });
+});


### PR DESCRIPTION
Every method on `SequelizeLocalAuthListRepository` takes a `tenantId`, and ten of its queries ignored it.

Both keys these queries use are ambiguous across tenants. `Authorization` is unique on `(tenantId, idToken, idTokenType)` since `20260413000000-fix-authorization-unique-index-add-tenant`, so two operators can legitimately enrol the same token. `ChargingStation` documents `ocppConnectionName` as *"Unique per tenant, but two different tenants may share the same value"*. With no tenant predicate and no ordering, Postgres returns an arbitrary match.

The consequences differ by site:

- **`createSendLocalListFromRequestData` / `...16`** resolve the idToken (and the group/parent token) without the tenant, then copy that row's `status`, `cacheExpiryDateTime`, `chargingPriority` and `groupAuthorizationId` into the `LocalListAuthorization` sent to *this* tenant's charger — which the charger then uses to authorise locally while offline.
- **`validateOrReplaceLocalListVersionForStation`** and both commit paths read `LocalListVersion` by station name alone, and `replaceLocalListVersionFromStationIdAndSendLocalList` **destroys** it and its junction rows on the same unscoped key.

Because it depends on row order rather than being consistently wrong, it would not show up reliably in testing. The added integration test therefore pins the deterministic case: the requesting tenant has no authorization for the token at all, another tenant does, and today the request succeeds using the other tenant's row instead of failing.

Also removes a group-authorization check that appeared twice in `createSendLocalListFromRequestData`, character for character — the second copy can never fire.

Companion to citrineos/citrineos-core#884, which fixed the same class of omission in `SequelizeRepository.readByKey`/`existsByKey`.