### PR TITLE
fix(ocpi): stop the middleware chain emitting "undefined" headers and throwing on error bodies

### DIFF
--- a/packages/ocpi-base/src/util/middleware/BaseMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/BaseMiddleware.ts
@@ -13,10 +13,6 @@ export class BaseMiddleware {
     return headers[header.toLowerCase()];
   }
 
-  /**
-   * Sets a response header only when there is a value for it. Koa stringifies whatever it is
-   * given, so passing an absent header through would put the text "undefined" on the response.
-   */
   protected setHeaderIfPresent(context: Context, header: string, value: unknown) {
     if (value === undefined || value === null) {
       return;

--- a/packages/ocpi-base/src/util/middleware/BaseMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/BaseMiddleware.ts
@@ -12,4 +12,15 @@ export class BaseMiddleware {
     const headers = context.req.headers;
     return headers[header.toLowerCase()];
   }
+
+  /**
+   * Sets a response header only when there is a value for it. Koa stringifies whatever it is
+   * given, so passing an absent header through would put the text "undefined" on the response.
+   */
+  protected setHeaderIfPresent(context: Context, header: string, value: unknown) {
+    if (value === undefined || value === null) {
+      return;
+    }
+    context.response.set(header, value);
+  }
 }

--- a/packages/ocpi-base/src/util/middleware/OcpiHeaderMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/OcpiHeaderMiddleware.ts
@@ -20,10 +20,10 @@ export class OcpiHeaderMiddleware extends BaseMiddleware implements KoaMiddlewar
     const fromPartyId = this.getHeader(context, OcpiHttpHeader.OcpiFromPartyId);
     const toCountryCode = this.getHeader(context, OcpiHttpHeader.OcpiToCountryCode);
     const toPartyId = this.getHeader(context, OcpiHttpHeader.OcpiToPartyId);
-    context.response.set(OcpiHttpHeader.OcpiFromCountryCode, toCountryCode);
-    context.response.set(OcpiHttpHeader.OcpiFromPartyId, toPartyId);
-    context.response.set(OcpiHttpHeader.OcpiToCountryCode, fromCountryCode);
-    context.response.set(OcpiHttpHeader.OcpiToPartyId, fromPartyId);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.OcpiFromCountryCode, toCountryCode);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.OcpiFromPartyId, toPartyId);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.OcpiToCountryCode, fromCountryCode);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.OcpiToPartyId, fromPartyId);
     await next();
   }
 }

--- a/packages/ocpi-base/src/util/middleware/PaginatedMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/PaginatedMiddleware.ts
@@ -20,8 +20,6 @@ export class PaginatedMiddleware extends BaseMiddleware implements KoaMiddleware
   async use(context: Context, next: (err?: any) => Promise<any>): Promise<any> {
     await next();
     const paginatedResponse = context.response.body as PaginatedResponse<any> | undefined;
-    // The endpoint is paginated but the response need not be: an exception handled downstream
-    // leaves an OCPI error body here, and a 204 leaves none at all.
     if (!paginatedResponse || paginatedResponse.total === undefined) {
       return;
     }

--- a/packages/ocpi-base/src/util/middleware/PaginatedMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/PaginatedMiddleware.ts
@@ -19,7 +19,12 @@ import { OcpiHttpHeader } from '../OcpiHttpHeader.js';
 export class PaginatedMiddleware extends BaseMiddleware implements KoaMiddlewareInterface {
   async use(context: Context, next: (err?: any) => Promise<any>): Promise<any> {
     await next();
-    const paginatedResponse = context.response.body as PaginatedResponse<any>;
+    const paginatedResponse = context.response.body as PaginatedResponse<any> | undefined;
+    // The endpoint is paginated but the response need not be: an exception handled downstream
+    // leaves an OCPI error body here, and a 204 leaves none at all.
+    if (!paginatedResponse || paginatedResponse.total === undefined) {
+      return;
+    }
     const link = this.createLink(context, paginatedResponse);
     if (link) {
       context.response.set(OcpiHttpHeader.Link, `<${link}>; rel="next"`);

--- a/packages/ocpi-base/src/util/middleware/UniqueMessageIdsMiddleware.ts
+++ b/packages/ocpi-base/src/util/middleware/UniqueMessageIdsMiddleware.ts
@@ -17,8 +17,8 @@ export class UniqueMessageIdsMiddleware extends BaseMiddleware implements KoaMid
   public async use(context: Context, next: (err?: any) => Promise<any>): Promise<any> {
     const xRequestId = this.getHeader(context, OcpiHttpHeader.XRequestId);
     const xCorrelationId = this.getHeader(context, OcpiHttpHeader.XCorrelationId);
-    context.response.set(OcpiHttpHeader.XRequestId, xRequestId);
-    context.response.set(OcpiHttpHeader.XCorrelationId, xCorrelationId);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.XRequestId, xRequestId);
+    this.setHeaderIfPresent(context, OcpiHttpHeader.XCorrelationId, xCorrelationId);
     await next();
   }
 }

--- a/packages/ocpi-base/test/util/middleware/PaginatedMiddleware.test.ts
+++ b/packages/ocpi-base/test/util/middleware/PaginatedMiddleware.test.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('typedi', () => ({
+  Service: () => () => undefined,
+  Inject: () => () => undefined,
+  Container: { get: () => undefined, set: () => undefined },
+}));
+
+import { PaginatedMiddleware } from '../../../src/util/middleware/PaginatedMiddleware.js';
+
+function aContext(body: unknown) {
+  const set: Record<string, unknown> = {};
+  return {
+    ctx: {
+      request: { protocol: 'https', host: 'cpo.test', url: '/ocpi/2.2.1/cdrs?limit=10' },
+      response: {
+        body,
+        set: (field: string, value: unknown) => {
+          set[field] = value;
+        },
+      },
+    } as never,
+    set,
+  };
+}
+
+const next = () => Promise.resolve();
+
+describe('PaginatedMiddleware', () => {
+  it('publishes the paging headers and strips the paging fields from the body', async () => {
+    const body: any = { data: [1, 2], total: 30, limit: 10, offset: 0 };
+    const { ctx, set } = aContext(body);
+
+    await new PaginatedMiddleware().use(ctx, next);
+
+    expect(set['X-Total-Count']).toBe(30);
+    expect(set['X-Limit']).toBe(10);
+    expect(String(set['Link'])).toContain('offset=10');
+    expect(body).not.toHaveProperty('total');
+    expect(body).not.toHaveProperty('limit');
+    expect(body).not.toHaveProperty('offset');
+  });
+
+  it('offers no next link on the last page', async () => {
+    const { ctx, set } = aContext({ data: [1], total: 30, limit: 10, offset: 20 });
+
+    await new PaginatedMiddleware().use(ctx, next);
+
+    expect(set).not.toHaveProperty('Link');
+  });
+
+  it('leaves a response that carries no paging alone', async () => {
+    // The middleware is attached per endpoint, but an endpoint that throws is answered by the
+    // exception handler with an OCPI error body, and a 204 has no body at all. Reading paging
+    // fields off either threw a TypeError out of the middleware.
+    const { ctx } = aContext(undefined);
+
+    await expect(new PaginatedMiddleware().use(ctx, next)).resolves.not.toThrow();
+  });
+
+  it('leaves an error response body alone', async () => {
+    const errorBody: any = { status_code: 2001, status_message: 'Invalid parameters' };
+    const { ctx, set } = aContext(errorBody);
+
+    await new PaginatedMiddleware().use(ctx, next);
+
+    expect(errorBody).toEqual({ status_code: 2001, status_message: 'Invalid parameters' });
+    expect(set).not.toHaveProperty('X-Total-Count');
+  });
+});

--- a/packages/ocpi-base/test/util/middleware/headerMiddleware.test.ts
+++ b/packages/ocpi-base/test/util/middleware/headerMiddleware.test.ts
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+
+// These middlewares carry a bare @Service(), which typedi evaluates as the class is defined and
+// which needs design:type metadata esbuild does not emit. They take no constructor dependencies,
+// so the decorator can be inert here.
+vi.mock('typedi', () => ({
+  Service: () => () => undefined,
+  Inject: () => () => undefined,
+  Container: { get: () => undefined, set: () => undefined },
+}));
+
+import { OcpiHeaderMiddleware } from '../../../src/util/middleware/OcpiHeaderMiddleware.js';
+import { UniqueMessageIdsMiddleware } from '../../../src/util/middleware/UniqueMessageIdsMiddleware.js';
+
+/** Mirrors the parts of the Koa context these middlewares touch, recording what they set. */
+function aContext(headers: Record<string, string>) {
+  const set: Record<string, unknown> = {};
+  return {
+    ctx: {
+      req: { headers },
+      response: {
+        set: (field: string, value: unknown) => {
+          set[field] = value;
+        },
+      },
+    } as never,
+    set,
+  };
+}
+
+const next = () => Promise.resolve();
+
+describe('UniqueMessageIdsMiddleware', () => {
+  it('echoes the request and correlation ids back', async () => {
+    const { ctx, set } = aContext({
+      'x-request-id': 'req-1',
+      'x-correlation-id': 'corr-1',
+    });
+
+    await new UniqueMessageIdsMiddleware().use(ctx, next);
+
+    expect(set['X-Request-ID']).toBe('req-1');
+    expect(set['X-Correlation-ID']).toBe('corr-1');
+  });
+
+  it('omits an id the caller did not send rather than echoing the string "undefined"', async () => {
+    // Koa stringifies a non-string header value, so setting an absent header put the six
+    // characters u-n-d-e-f-i-n-e-d on the response - which a partner validating the echoed id
+    // reads as a mismatch.
+    const { ctx, set } = aContext({});
+
+    await new UniqueMessageIdsMiddleware().use(ctx, next);
+
+    expect(set).not.toHaveProperty('X-Request-ID');
+    expect(set).not.toHaveProperty('X-Correlation-ID');
+  });
+});
+
+describe('OcpiHeaderMiddleware', () => {
+  it('swaps the from and to routing headers on the response', async () => {
+    const { ctx, set } = aContext({
+      'ocpi-from-country-code': 'GB',
+      'ocpi-from-party-id': 'MSP',
+      'ocpi-to-country-code': 'NL',
+      'ocpi-to-party-id': 'CPO',
+    });
+
+    await new OcpiHeaderMiddleware().use(ctx, next);
+
+    expect(set['OCPI-from-country-code']).toBe('NL');
+    expect(set['OCPI-from-party-id']).toBe('CPO');
+    expect(set['OCPI-to-country-code']).toBe('GB');
+    expect(set['OCPI-to-party-id']).toBe('MSP');
+  });
+
+  it('omits routing headers the caller did not send', async () => {
+    const { ctx, set } = aContext({});
+
+    await new OcpiHeaderMiddleware().use(ctx, next);
+
+    expect(Object.keys(set)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Three issues in the OCPI middleware chain, all confirmed by the tests added here (each fails on `next`).

**Absent headers are echoed as the string `undefined`.** Koa's `response.set` does `String(val)` for anything non-string, so `set(field, undefined)` writes the six characters `undefined` as the header value. `UniqueMessageIdsMiddleware` echoes `X-Request-ID` and `X-Correlation-ID`, and `OcpiHeaderMiddleware` echoes the four routing headers, both unconditionally.

All six are `required: true` on `AsOcpiFunctionalEndpoint`, so the case that actually reaches this is the 400 answering a request that omitted one — the response telling a partner what it got wrong carries a bogus correlation id, which is exactly when they are trying to correlate. `AsOcpiRegistrationEndpoint` applies `UniqueMessageIdsMiddleware` without the routing-header requirement, so it is reachable there too.

**`PaginatedMiddleware` assumes the body is paginated.** It reads `total`, `limit` and `offset` off `context.response.body` after `next()` with no check. It is attached per endpoint via `@Paginated()`, but a paginated endpoint does not always return a paginated body: an exception handled by `OcpiExceptionHandler` leaves an OCPI error envelope, and a 204 leaves no body at all. The first throws `TypeError: Cannot read properties of undefined (reading 'offset')` out of the middleware; the second publishes `X-Total-Count: undefined` and mangles the error body.

The fix is `BaseMiddleware.setHeaderIfPresent` for the header cases and an early return for the paging one. **The link arithmetic is unchanged** — I checked it against the last-page boundary and it is correct; it now has tests to keep it that way.

Two things I looked at and did **not** change, for the record:

- `OcpiExceptionHandler` dispatches on `err.constructor.name`, and if that is falsy (a thrown non-Error) it sets neither status nor body, so the request falls through silently. `WrongClientAccessException` sets a 404 status with no OCPI error envelope, unlike every other branch. Both are real but felt like a separate PR.
- `oidcAuthMiddleware` is correct: it passes `issuer`, `audience` **and** `algorithms: [RS256]` to `jwt.verify`. Worth noting because core's `OIDCAuthProvider` passes none of them — that is citrineos/citrineos-core#885, and this file is the pattern it brings core into line with.