### PR TITLE
fix(ocpi): read the real charging current, not the neutral conductor

### DIFF
--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -375,7 +375,7 @@ export class SessionMapper extends BaseTransactionMapper {
     for (const sampledValue of meterValue.sampledValue) {
       switch (sampledValue.measurand) {
         case MeasurandEnum['Current.Import']:
-          if (sampledValue.phase === 'N') {
+          if (!sampledValue.phase) {
             cdrDimensions.push({
               type: CdrDimensionType.CURRENT,
               volume: Number(sampledValue.value),

--- a/packages/ocpi-base/test/mapper/SessionMapperChargingPeriods.test.ts
+++ b/packages/ocpi-base/test/mapper/SessionMapperChargingPeriods.test.ts
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { MeterValueDto, SampledValue } from '@citrineos/types';
+import { MeasurandEnum } from '@citrineos/types';
+import { MeterValueUtils } from '@citrineos/base';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// LocationsService is a typedi-decorated service sitting on an import cycle with this mapper.
+// Charging period mapping never reaches it.
+vi.mock('../../src/services/LocationsService.js', () => ({ LocationsService: class {} }));
+
+import { SessionMapper } from '../../src/mapper/SessionMapper.js';
+import { CdrDimensionType } from '../../src/model/CdrDimensionType.js';
+import type { CdrDimension } from '../../src/model/CdrDimension.js';
+
+const TARIFF_ID = '7';
+
+function mapper(): SessionMapper {
+  return new SessionMapper(new Logger({ type: 'hidden' }), {} as never, {} as never);
+}
+
+function meterValue(timestamp: string, ...sampledValue: SampledValue[]): MeterValueDto {
+  return { timestamp, sampledValue } as unknown as MeterValueDto;
+}
+
+function energyRegister(value: number, unit?: string, multiplier?: number): SampledValue {
+  return {
+    value,
+    measurand: MeasurandEnum['Energy.Active.Import.Register'],
+    ...(unit !== undefined || multiplier !== undefined
+      ? { unitOfMeasure: { unit, multiplier } }
+      : {}),
+  } as SampledValue;
+}
+
+function volumeOf(dimensions: CdrDimension[], type: CdrDimensionType): number | undefined {
+  return dimensions.find((dimension) => dimension.type === type)?.volume;
+}
+
+describe('SessionMapper.getChargingPeriods energy dimensions', () => {
+  it('reports ENERGY_IMPORT in kWh when the meter reports Wh', () => {
+    const periods = mapper().getChargingPeriods(
+      [meterValue('2026-08-20T10:00:00Z', energyRegister(5000, 'Wh'))],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.ENERGY_IMPORT)).toBe(5);
+  });
+
+  it('treats an absent unitOfMeasure as Wh, the OCPP default', () => {
+    const periods = mapper().getChargingPeriods(
+      [meterValue('2026-08-20T10:00:00Z', energyRegister(5000))],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.ENERGY_IMPORT)).toBe(5);
+  });
+
+  it('leaves a kWh reading alone', () => {
+    const periods = mapper().getChargingPeriods(
+      [meterValue('2026-08-20T10:00:00Z', energyRegister(5, 'kWh'))],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.ENERGY_IMPORT)).toBe(5);
+  });
+
+  it('applies the unitOfMeasure multiplier', () => {
+    const periods = mapper().getChargingPeriods(
+      [meterValue('2026-08-20T10:00:00Z', energyRegister(5, 'Wh', 3))],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.ENERGY_IMPORT)).toBe(5);
+  });
+
+  it('reports the per-period ENERGY delta in kWh', () => {
+    const periods = mapper().getChargingPeriods(
+      [
+        meterValue('2026-08-20T10:00:00Z', energyRegister(5000, 'Wh')),
+        meterValue('2026-08-20T10:30:00Z', energyRegister(12000, 'Wh')),
+      ],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[1].dimensions, CdrDimensionType.ENERGY)).toBe(7);
+  });
+
+  it('sums to the same total energy the CDR reports', () => {
+    // cdr.total_energy comes from transaction.totalKwh, which MeterValueUtils normalises. The
+    // charging periods have to reconcile against it or a CDR contradicts itself.
+    const meterValues = [
+      meterValue('2026-08-20T10:00:00Z', energyRegister(0, 'Wh')),
+      meterValue('2026-08-20T10:30:00Z', energyRegister(21500, 'Wh')),
+      meterValue('2026-08-20T11:00:00Z', energyRegister(48250, 'Wh')),
+    ];
+
+    const periods = mapper().getChargingPeriods(meterValues, TARIFF_ID);
+    const summed = periods.reduce(
+      (total, period) => total + (volumeOf(period.dimensions, CdrDimensionType.ENERGY) ?? 0),
+      0,
+    );
+
+    expect(summed).toBeCloseTo(MeterValueUtils.getTotalKwh(meterValues, 0), 6);
+  });
+});
+
+describe('SessionMapper.getChargingPeriods CURRENT dimension', () => {
+  it('reports the charging current of a DC session, which carries no phase', () => {
+    const periods = mapper().getChargingPeriods(
+      [
+        meterValue('2026-08-20T10:00:00Z', {
+          value: 350,
+          measurand: MeasurandEnum['Current.Import'],
+        } as SampledValue),
+      ],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.CURRENT)).toBe(350);
+  });
+
+  it('does not report the neutral conductor current as the charging current', () => {
+    // OCPI CURRENT is the current over all phases. Phase N is the neutral imbalance, which on a
+    // balanced three-phase supply is near zero.
+    const periods = mapper().getChargingPeriods(
+      [
+        meterValue(
+          '2026-08-20T10:00:00Z',
+          { value: 32, measurand: MeasurandEnum['Current.Import'], phase: 'L1' } as SampledValue,
+          { value: 0.4, measurand: MeasurandEnum['Current.Import'], phase: 'N' } as SampledValue,
+        ),
+      ],
+      TARIFF_ID,
+    );
+
+    expect(volumeOf(periods[0].dimensions, CdrDimensionType.CURRENT)).not.toBe(0.4);
+  });
+});


### PR DESCRIPTION
> Rebased onto #857, which fixed the energy half of this independently. What is left is the
> `CURRENT` dimension, which #857 did not touch.

## CURRENT was reading the neutral conductor

```ts
case MeasurandEnum['Current.Import']:
  if (sampledValue.phase === 'N') {
    cdrDimensions.push({ type: CdrDimensionType.CURRENT, volume: Number(sampledValue.value) });
  }
```

Phase `N` is the neutral. On a balanced three-phase supply it carries the imbalance, which is near
zero, and OCPI's `CURRENT` is the current over all phases - not the neutral. So an AC session
reports roughly zero amps.

DC carries no phase at all, so the condition never matches and **a DC session never produces a
`CURRENT` dimension**.

It now reads the unphased total, which is exactly what the energy measurand in the same `switch`
was already doing.

A station that reports only per-phase currents and no total still yields no `CURRENT` dimension.
Summing those is a separate change and is not attempted here.

## Tests

`SessionMapperChargingPeriods.test.ts` is new and is the only coverage of `getChargingPeriods`. It
covers the `CURRENT` fix and, since #857 added no tests, the energy dimensions that PR fixed:

- `ENERGY_IMPORT` in kWh for a meter reporting Wh
- an absent `unitOfMeasure` treated as Wh, the OCPP default
- a kWh reading passed through unchanged
- `unitOfMeasure.multiplier` applied
- the per-period `ENERGY` delta in kWh
- the periods summing to `MeterValueUtils.getTotalKwh` for the same meter values, which is the
  invariant that matters: `cdr.total_energy` comes from that, so a CDR has to reconcile against its
  own charging periods
- `CURRENT` present for a DC sample
- `CURRENT` not taken from the neutral

The two `CURRENT` cases were confirmed failing against the rebased branch with the condition put
back:

```
× reports the charging current of a DC session, which carries no phase
  → expected undefined to be 350
× does not report the neutral conductor current as the charging current
  → expected 0.4 not to be 0.4
```

## Verification

```
npx vitest run test/mapper/SessionMapperChargingPeriods.test.ts   # 8 passed
npx tsc --noEmit -p packages/ocpi-base/tsconfig.json              # clean
npx prettier --check                                              # clean
```