### PR TITLE
fix(ocpi): price a session the same way the CDR that closes it is priced

### DIFF
--- a/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
+++ b/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
@@ -6,7 +6,6 @@ import type { AuthorizationDto, LocationDto, TariffDto, TransactionDto } from '@
 import type { TokenDTO } from '../model/DTO/TokenDTO.js';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
-import type { Price } from '../model/Price.js';
 import type { Session } from '../model/Session.js';
 import type { Tariff as OcpiTariff } from '../model/Tariff.js';
 import type { LocationDTO } from '../model/DTO/LocationDTO.js';
@@ -147,11 +146,5 @@ export abstract class BaseTransactionMapper {
         }),
     );
     return transactionIdToOcpiTariffMap;
-  }
-
-  protected calculateTotalCost(totalKwh: number, tariffCost: number): Price {
-    return {
-      excl_vat: Math.floor(totalKwh * tariffCost * 100) / 100,
-    };
   }
 }

--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -24,6 +24,7 @@ import { BaseTransactionMapper } from './BaseTransactionMapper.js';
 import { LocationsService } from '../services/LocationsService.js';
 import type { LocationDTO } from '../model/DTO/LocationDTO.js';
 import { UID_FORMAT } from '../model/DTO/EvseDTO.js';
+import { calculateTotalCdrCost } from './cdrCost.js';
 import { OcpiGraphqlClient } from '../graphql/index.js';
 
 @Service()
@@ -180,9 +181,17 @@ export class SessionMapper extends BaseTransactionMapper {
     if (tariff) {
       session.currency = tariff.currency;
       if (transaction.totalKwh !== undefined && transaction.endTime !== undefined) {
-        session.total_cost = transaction.endTime
-          ? this.calculateTotalCost(transaction.totalKwh || 0, tariff.pricePerKwh)
-          : null;
+        session.total_cost =
+          session.start_date_time && session.end_date_time
+            ? calculateTotalCdrCost(
+                {
+                  kwh: session.kwh ?? 0,
+                  start_date_time: session.start_date_time,
+                  end_date_time: session.end_date_time,
+                },
+                tariff,
+              )
+            : null;
       }
     }
 
@@ -272,7 +281,7 @@ export class SessionMapper extends BaseTransactionMapper {
     token: TokenDTO,
     tariff: TariffDto,
   ): Session {
-    return {
+    const session: Session = {
       country_code: location.country_code,
       party_id: location.party_id,
       id: transaction.transactionId!,
@@ -298,11 +307,11 @@ export class SessionMapper extends BaseTransactionMapper {
       last_updated: transaction.updatedAt!,
       // TODO: Fill in optional values
       authorization_reference: null,
-      total_cost: transaction.endTime
-        ? this.calculateTotalCost(transaction.totalKwh || 0, tariff.pricePerKwh)
-        : null,
+      total_cost: null,
       meter_id: null,
     };
+    session.total_cost = session.end_date_time ? calculateTotalCdrCost(session, tariff) : null;
+    return session;
   }
 
   private getLatestEvent(transactionEvents: TransactionEventDto[]): Date {

--- a/packages/ocpi-base/src/mapper/cdrCost.ts
+++ b/packages/ocpi-base/src/mapper/cdrCost.ts
@@ -8,7 +8,6 @@ import type { Price } from '../model/Price.js';
 import type { Session } from '../model/Session.js';
 import { MINUTES_IN_HOUR } from '../util/Consts.js';
 
-/** The part of a session that determines what it costs. */
 export type PricedSession = Pick<Session, 'kwh' | 'start_date_time' | 'end_date_time'>;
 
 export function buildPrice(amount: number, currency: string, taxRate?: number | null): Price {

--- a/packages/ocpi-base/src/mapper/cdrCost.ts
+++ b/packages/ocpi-base/src/mapper/cdrCost.ts
@@ -8,6 +8,9 @@ import type { Price } from '../model/Price.js';
 import type { Session } from '../model/Session.js';
 import { MINUTES_IN_HOUR } from '../util/Consts.js';
 
+/** The part of a session that determines what it costs. */
+export type PricedSession = Pick<Session, 'kwh' | 'start_date_time' | 'end_date_time'>;
+
 export function buildPrice(amount: number, currency: string, taxRate?: number | null): Price {
   const money = Money.of(amount, currency);
   const price: Price = { excl_vat: money.roundToCurrencyScale().toNumber() };
@@ -40,7 +43,7 @@ export function sumPrices(currency: string, prices: (Price | undefined)[]): Pric
   return { excl_vat: exclVat.toNumber(), incl_vat: inclVat.toNumber() };
 }
 
-export function calculateTotalTimeHours(session: Session): number {
+export function calculateTotalTimeHours(session: PricedSession): number {
   if (session.end_date_time) {
     return (session.end_date_time.getTime() - session.start_date_time.getTime()) / 3600000;
   }
@@ -54,11 +57,11 @@ export function calculateFixedCost(tariff: TariffDto): Price | undefined {
   return buildPrice(tariff.pricePerSession, tariff.currency, tariff.taxRate);
 }
 
-export function calculateEnergyCost(session: Session, tariff: TariffDto): Price {
+export function calculateEnergyCost(session: PricedSession, tariff: TariffDto): Price {
   return buildPrice(session.kwh * tariff.pricePerKwh, tariff.currency, tariff.taxRate);
 }
 
-export function calculateTimeCost(session: Session, tariff: TariffDto): Price | undefined {
+export function calculateTimeCost(session: PricedSession, tariff: TariffDto): Price | undefined {
   if (!tariff.pricePerMin) {
     return undefined;
   }
@@ -66,7 +69,7 @@ export function calculateTimeCost(session: Session, tariff: TariffDto): Price | 
   return buildPrice(totalMinutes * tariff.pricePerMin, tariff.currency, tariff.taxRate);
 }
 
-export function calculateTotalCdrCost(session: Session, tariff: TariffDto): Price {
+export function calculateTotalCdrCost(session: PricedSession, tariff: TariffDto): Price {
   return sumPrices(tariff.currency, [
     calculateFixedCost(tariff),
     calculateEnergyCost(session, tariff),

--- a/packages/ocpi-base/test/mapper/SessionMapperTotalCost.test.ts
+++ b/packages/ocpi-base/test/mapper/SessionMapperTotalCost.test.ts
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { TariffDto, TransactionDto } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// LocationsService is a typedi-decorated service sitting on an import cycle with this mapper.
+// Mapping from maps that are already populated never reaches it.
+vi.mock('../../src/services/LocationsService.js', () => ({ LocationsService: class {} }));
+
+import { SessionMapper } from '../../src/mapper/SessionMapper.js';
+import { calculateTotalCdrCost } from '../../src/mapper/cdrCost.js';
+import type { LocationDTO } from '../../src/model/DTO/LocationDTO.js';
+import type { TokenDTO } from '../../src/model/DTO/TokenDTO.js';
+
+const TRANSACTION_ID = 'tx-1';
+
+function mapper(): SessionMapper {
+  return new SessionMapper(new Logger({ type: 'hidden' }), {} as never, {} as never);
+}
+
+/** An hour of charging: 50 kWh at 0.45, a 1.50 session fee, 0.02 a minute, 20% VAT. */
+function aTariff(): TariffDto {
+  return {
+    id: 7,
+    currency: 'GBP',
+    pricePerKwh: 0.45,
+    pricePerSession: 1.5,
+    pricePerMin: 0.02,
+    taxRate: 20,
+  } as TariffDto;
+}
+
+function aCompletedTransaction(): TransactionDto {
+  return {
+    id: 1,
+    transactionId: TRANSACTION_ID,
+    startTime: '2026-08-20T10:00:00Z',
+    endTime: '2026-08-20T11:00:00Z',
+    totalKwh: 50,
+    connectorId: 1,
+    evseId: 1,
+    ocppConnectionName: 'cs-001',
+    updatedAt: new Date('2026-08-20T11:00:00Z'),
+    meterValues: [],
+  } as unknown as TransactionDto;
+}
+
+async function sessionFor(transaction: TransactionDto, tariff: TariffDto) {
+  const sessions = await mapper().mapTransactionsToSessionsHelper(
+    [transaction],
+    new Map<string, LocationDTO>([
+      [TRANSACTION_ID, { id: 'loc-1', country_code: 'GB', party_id: 'VLT' } as LocationDTO],
+    ]),
+    new Map<string, TokenDTO>([[TRANSACTION_ID, { uid: 'token-1' } as TokenDTO]]),
+    new Map<string, TariffDto>([[TRANSACTION_ID, tariff]]),
+  );
+  return sessions[0];
+}
+
+describe('Session total_cost', () => {
+  it('matches the total_cost of the CDR built from the same session', async () => {
+    // DepotCharge reconciles a live session against the CDR that closes it. The two have to
+    // agree, so the session has to be priced by the same rules the CDR is.
+    const tariff = aTariff();
+
+    const session = await sessionFor(aCompletedTransaction(), tariff);
+
+    expect(session.total_cost).toEqual(calculateTotalCdrCost(session, tariff));
+  });
+
+  it('includes the session fee and the time component, not energy alone', async () => {
+    const session = await sessionFor(aCompletedTransaction(), aTariff());
+
+    // 50 kWh x 0.45 = 22.50, plus a 1.50 session fee, plus 60 min x 0.02 = 1.20.
+    expect(session.total_cost?.excl_vat).toBe(25.2);
+  });
+
+  it('carries the VAT-inclusive amount when the tariff has a tax rate', async () => {
+    const session = await sessionFor(aCompletedTransaction(), aTariff());
+
+    expect(session.total_cost?.incl_vat).toBe(30.24);
+  });
+
+  it('leaves an unfinished session unpriced', async () => {
+    const running = { ...aCompletedTransaction(), endTime: null } as unknown as TransactionDto;
+
+    const session = await sessionFor(running, aTariff());
+
+    expect(session.total_cost).toBeNull();
+  });
+});


### PR DESCRIPTION
## Two formulas for the same money

A CDR is the billing record of a Session, so `Session.total_cost` and `Cdr.total_cost` for one
transaction have to agree. They were computed by different code.

`CdrMapper` uses `calculateTotalCdrCost`, which sums the fixed, energy and time components through
`Money` and fills in `incl_vat` from the tariff's tax rate. `SessionMapper` used
`BaseTransactionMapper.calculateTotalCost`:

```ts
protected calculateTotalCost(totalKwh: number, tariffCost: number): Price {
  return { excl_vat: Math.floor(totalKwh * tariffCost * 100) / 100 };
}
```

Energy only. No `pricePerSession`, no `pricePerMin`, no `incl_vat`.

For a one-hour, 50 kWh session on a tariff of 0.45/kWh + 1.50 session fee + 0.02/min at 20% VAT:

| | excl_vat | incl_vat |
|---|---|---|
| Session (before) | 22.50 | - |
| CDR | 25.20 | 30.24 |

A portal showing the running session cost and then storing the CDR sees the price jump by 2.70 the
moment the session closes, and never has a VAT-inclusive figure to show while it is running.

`SessionMapper` now calls `calculateTotalCdrCost`. The four cost functions take
`Pick<Session, 'kwh' | 'start_date_time' | 'end_date_time'>` rather than a whole `Session`, which
is what they actually read - that lets the partial-session path pass the three fields directly
instead of casting a `Partial<Session>`. `Session` is still assignable, so `CdrMapper` and the
existing `cdrCost` tests are unchanged.

`calculateTotalCost` had no other callers and is deleted rather than left beside the shared
version.

## One thing to flag

`calculateTotalCdrCost` goes through `Money`, so it throws `Unsupported currency code` for anything
outside `USD`, `EUR`, `CAD`, `GBP` - `Currency.test.ts` asserts that deliberately for `PLN` and
`CHF`. The session path did not go through `Money`, so it never hit that; after this change it does.

For a CPO on one of those currencies the CDR endpoint already fails - `Money.of` throws inside
`CdrMapper`, `mapTransactionsToCdrs` rethrows, and the whole page 500s rather than one record
dropping. So the population affected here has no working OCPI billing today either way. Worth
saying explicitly, though, since this change is what makes the Sessions endpoint fail in the same
place. The same throw reaches `CostCalculator.calculateTotalCost`, which is called from
`TransactionEventRequestOcpp2Handler` with no `try`/`catch` around it - that is a separate issue and
not touched here.

## Verification

```
npx vitest run test/mapper/         # 2 files, 12 tests passed (8 pre-existing cdrCost + 4 new)
npx tsc --noEmit -p packages/ocpi-base/tsconfig.json    # clean
npx prettier --check / npx eslint <changed files>       # clean
```

Three of the four new tests were confirmed failing first: the CDR-equality invariant, `22.5` where
`25.2` was expected, and `undefined` for `incl_vat`.