### PR TITLE
fix(ocpi): report COMMAND as the auth method for a remotely started session

### DIFF
--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -208,8 +208,7 @@ export class SessionMapper extends BaseTransactionMapper {
       session.status = this.getTransactionStatus(transaction as TransactionDto);
     }
 
-    // Set default auth method
-    session.auth_method = AuthMethod.WHITELIST;
+    session.auth_method = this.getAuthMethod(transaction);
 
     // Set optional fields that are typically null in your implementation
     session.authorization_reference = null;
@@ -259,7 +258,7 @@ export class SessionMapper extends BaseTransactionMapper {
     }
 
     // Set defaults for fields that don't depend on external context
-    session.auth_method = AuthMethod.WHITELIST;
+    session.auth_method = this.getAuthMethod(transaction);
     session.authorization_reference = null;
     session.meter_id = null;
 
@@ -287,8 +286,7 @@ export class SessionMapper extends BaseTransactionMapper {
       end_date_time: transaction.endTime ? new Date(transaction.endTime) : null,
       kwh: transaction.totalKwh || 0,
       cdr_token: this.createCdrToken(token),
-      // TODO: Implement other auth methods
-      auth_method: AuthMethod.WHITELIST,
+      auth_method: this.getAuthMethod(transaction),
       location_id: this.getLocationId(location),
       evse_uid: this.getEvseUid(transaction),
       connector_id: transaction.connectorId!.toString(),
@@ -435,6 +433,14 @@ export class SessionMapper extends BaseTransactionMapper {
 
     // Convert milliseconds to hours
     return timeDiffMs / (1000 * 60 * 60); // 1000 ms/sec * 60 sec/min * 60 min/hour
+  }
+
+  /**
+   * COMMAND is the OCPI method for a session a Command started, which is what remoteStartId
+   * records. Anything else was authorised by the CSMS from its own token list.
+   */
+  private getAuthMethod(transaction: Partial<TransactionDto>): AuthMethod {
+    return transaction.remoteStartId != null ? AuthMethod.COMMAND : AuthMethod.WHITELIST;
   }
 
   private getTransactionStatus(transaction: TransactionDto): SessionStatus {

--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -435,10 +435,6 @@ export class SessionMapper extends BaseTransactionMapper {
     return timeDiffMs / (1000 * 60 * 60); // 1000 ms/sec * 60 sec/min * 60 min/hour
   }
 
-  /**
-   * COMMAND is the OCPI method for a session a Command started, which is what remoteStartId
-   * records. Anything else was authorised by the CSMS from its own token list.
-   */
   private getAuthMethod(transaction: Partial<TransactionDto>): AuthMethod {
     return transaction.remoteStartId != null ? AuthMethod.COMMAND : AuthMethod.WHITELIST;
   }

--- a/packages/ocpi-base/test/mapper/SessionMapperAuthMethod.test.ts
+++ b/packages/ocpi-base/test/mapper/SessionMapperAuthMethod.test.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { TariffDto, TransactionDto } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// LocationsService is a typedi-decorated service sitting on an import cycle with this mapper.
+// Mapping from maps that are already populated never reaches it.
+vi.mock('../../src/services/LocationsService.js', () => ({ LocationsService: class {} }));
+
+import { SessionMapper } from '../../src/mapper/SessionMapper.js';
+import { AuthMethod } from '../../src/model/AuthMethod.js';
+import type { LocationDTO } from '../../src/model/DTO/LocationDTO.js';
+import type { TokenDTO } from '../../src/model/DTO/TokenDTO.js';
+
+const TRANSACTION_ID = 'tx-1';
+
+async function authMethodOf(overrides: Partial<TransactionDto>): Promise<AuthMethod> {
+  const mapper = new SessionMapper(new Logger({ type: 'hidden' }), {} as never, {} as never);
+  const transaction = {
+    id: 1,
+    transactionId: TRANSACTION_ID,
+    startTime: '2026-08-20T10:00:00Z',
+    endTime: '2026-08-20T11:00:00Z',
+    totalKwh: 50,
+    connectorId: 1,
+    evseId: 1,
+    ocppConnectionName: 'cs-001',
+    updatedAt: new Date('2026-08-20T11:00:00Z'),
+    meterValues: [],
+    ...overrides,
+  } as unknown as TransactionDto;
+
+  const sessions = await mapper.mapTransactionsToSessionsHelper(
+    [transaction],
+    new Map<string, LocationDTO>([
+      [TRANSACTION_ID, { id: 'loc-1', country_code: 'GB', party_id: 'VLT' } as LocationDTO],
+    ]),
+    new Map<string, TokenDTO>([[TRANSACTION_ID, { uid: 'token-1' } as TokenDTO]]),
+    new Map<string, TariffDto>([
+      [TRANSACTION_ID, { id: 7, currency: 'GBP', pricePerKwh: 0.45 } as TariffDto],
+    ]),
+  );
+  return sessions[0].auth_method;
+}
+
+describe('Session auth_method', () => {
+  it('reports COMMAND for a session a RequestStartTransaction started', async () => {
+    expect(await authMethodOf({ remoteStartId: 42 })).toBe(AuthMethod.COMMAND);
+  });
+
+  it('reports WHITELIST for a session the driver started at the charger', async () => {
+    expect(await authMethodOf({ remoteStartId: null })).toBe(AuthMethod.WHITELIST);
+  });
+});


### PR DESCRIPTION
## Every session claimed to be whitelist-authorised

```ts
// TODO: Implement other auth methods
auth_method: AuthMethod.WHITELIST,
```

All three mapping paths in `SessionMapper` set the constant, so `auth_method` was `WHITELIST` on
every Session and every CDR CitrineOS emits.

OCPI's `AuthMethod` separates a session a Command started (`COMMAND`) from one authorised out of
the CSMS's own token list (`WHITELIST`), and CitrineOS already records which is which:
`RequestStartTransactionResponseOcpp2Handler` writes `remoteStartId` on the transaction, and
`GET_TRANSACTIONS_QUERY` already selects it. Nothing new has to be fetched.

The practical effect is on a partner that sends `StartSession` through the Commands module: the CDR
that comes back says `WHITELIST`, so it cannot reconcile the sessions it initiated against the ones
it did not.

`AUTH_REQUEST` - a real-time authorisation asked of the eMSP - is a third case that is not derivable
from the transaction row and is left alone.

## Verification

```
npx vitest run                 # packages/ocpi-base: 2 files, 10 tests passed
npx tsc --noEmit -p packages/ocpi-base/tsconfig.json    # clean
npx prettier --check / npx eslint <changed files>       # clean
```

The `COMMAND` case was confirmed failing first with `expected 'WHITELIST' to be 'COMMAND'`.