### PR TITLE
fix(ocpi): say which transactions were dropped from a Sessions or CDRs page

### DIFF
--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -119,6 +119,7 @@ export class SessionMapper extends BaseTransactionMapper {
     transactionIdToTariffMap: Map<string, TariffDto>,
   ): Promise<Session[]> {
     const result: Session[] = [];
+    const skipped: string[] = [];
     for (const transaction of transactions) {
       const location = transactionIdToLocationMap.get(transaction.transactionId!);
       const token = transactionIdToTokenMap.get(transaction.transactionId!);
@@ -127,8 +128,21 @@ export class SessionMapper extends BaseTransactionMapper {
       if (location && token && tariff) {
         result.push(this.mapTransactionWithContextToSession(transaction, location, token, tariff));
       } else {
-        this.logger.debug(`Skipped transaction ${transaction.transactionId}`);
+        const missing = [
+          ...(location ? [] : ['location']),
+          ...(token ? [] : ['token']),
+          ...(tariff ? [] : ['tariff']),
+        ];
+        skipped.push(`${transaction.transactionId} (no ${missing.join(', ')})`);
       }
+    }
+    if (skipped.length > 0) {
+      // Sessions and CDRs are counted by a separate aggregate query, so anything dropped here
+      // leaves the page short of the total it was advertised with, and the caller has no other
+      // way to find out which records are missing.
+      this.logger.warn(
+        `Skipped ${skipped.length} of ${transactions.length} transactions: ${skipped.join('; ')}`,
+      );
     }
     return result;
   }

--- a/packages/ocpi-base/src/mapper/SessionMapper.ts
+++ b/packages/ocpi-base/src/mapper/SessionMapper.ts
@@ -137,9 +137,6 @@ export class SessionMapper extends BaseTransactionMapper {
       }
     }
     if (skipped.length > 0) {
-      // Sessions and CDRs are counted by a separate aggregate query, so anything dropped here
-      // leaves the page short of the total it was advertised with, and the caller has no other
-      // way to find out which records are missing.
       this.logger.warn(
         `Skipped ${skipped.length} of ${transactions.length} transactions: ${skipped.join('; ')}`,
       );

--- a/packages/ocpi-base/test/mapper/SessionMapperUnmapped.test.ts
+++ b/packages/ocpi-base/test/mapper/SessionMapperUnmapped.test.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { TariffDto, TransactionDto } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// LocationsService is a typedi-decorated service sitting on an import cycle with this mapper.
+// Mapping from maps that are already populated never reaches it.
+vi.mock('../../src/services/LocationsService.js', () => ({ LocationsService: class {} }));
+
+import { SessionMapper } from '../../src/mapper/SessionMapper.js';
+import type { LocationDTO } from '../../src/model/DTO/LocationDTO.js';
+import type { TokenDTO } from '../../src/model/DTO/TokenDTO.js';
+
+function aTransaction(transactionId: string): TransactionDto {
+  return {
+    id: transactionId,
+    transactionId,
+    startTime: '2026-08-20T10:00:00Z',
+    endTime: '2026-08-20T11:00:00Z',
+    totalKwh: 50,
+    connectorId: 1,
+    evseId: 1,
+    ocppConnectionName: 'cs-001',
+    updatedAt: new Date('2026-08-20T11:00:00Z'),
+    meterValues: [],
+  } as unknown as TransactionDto;
+}
+
+const aLocation = { id: 'loc-1', country_code: 'GB', party_id: 'VLT' } as LocationDTO;
+const aToken = { uid: 'token-1' } as TokenDTO;
+const aTariff = { id: 7, currency: 'GBP', pricePerKwh: 0.45 } as TariffDto;
+
+describe('SessionMapper.mapTransactionsToSessionsHelper', () => {
+  it('reports the transactions it dropped, and why', async () => {
+    // CdrsService counts transactions with an aggregate and maps the page separately, so anything
+    // dropped here leaves total higher than the number of records returned. At debug level nobody
+    // sees which records went missing.
+    const logger = new Logger({ type: 'hidden' });
+    const warn = vi.spyOn(logger, 'warn');
+    const mapper = new SessionMapper(logger, {} as never, {} as never);
+
+    const sessions = await mapper.mapTransactionsToSessionsHelper(
+      [aTransaction('tx-1'), aTransaction('tx-2')],
+      new Map([['tx-1', aLocation]]),
+      new Map([['tx-1', aToken]]),
+      new Map([['tx-1', aTariff]]),
+    );
+
+    expect(sessions).toHaveLength(1);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn.mock.calls[0][0]).toContain('tx-2');
+    expect(warn.mock.calls[0][0]).toMatch(/location/);
+  });
+
+  it('says nothing when every transaction maps', async () => {
+    const logger = new Logger({ type: 'hidden' });
+    const warn = vi.spyOn(logger, 'warn');
+    const mapper = new SessionMapper(logger, {} as never, {} as never);
+
+    await mapper.mapTransactionsToSessionsHelper(
+      [aTransaction('tx-1')],
+      new Map([['tx-1', aLocation]]),
+      new Map([['tx-1', aToken]]),
+      new Map([['tx-1', aTariff]]),
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## A short page with no explanation

`mapTransactionsToSessionsHelper` drops any transaction whose location, token or tariff is missing:

```ts
if (location && token && tariff) {
  result.push(this.mapTransactionWithContextToSession(transaction, location, token, tariff));
} else {
  this.logger.debug(`Skipped transaction ${transaction.transactionId}`);
}
```

`CdrsService` and `SessionsService` do not count what the mapper returns - `total` comes from a
separate `Transactions_aggregate` over the same `where`:

```ts
const response = buildOcpiPaginatedResponse(
  OcpiResponseStatusCode.GenericSuccessCode,
  result.Transactions_aggregate?.aggregate?.count ?? 0,
  limit, offset, mappedCdr,
);
```

So a client paging by `offset` against `total` gets fewer records than it was told exist and has no
way to discover which. For a CDR poll that is missing billing data, arriving as silence.

The most likely cause in practice is the token: `TokensMapper.getContractId` throws for any
authorization without an eMAID in `additionalInfo`, which is every token not created through OCPI.

One `warn` per page now names the transactions and what each was missing, instead of a `debug` line
per transaction that named neither:

```
Skipped 2 of 50 transactions: tx-41 (no token); tx-49 (no location, tariff)
```

It stays quiet when everything maps.

## Verification

```
npx vitest run                 # packages/ocpi-base: 2 files, 10 tests passed
npx tsc --noEmit -p packages/ocpi-base/tsconfig.json    # clean
npx prettier --check / npx eslint <changed files>       # clean
```

Confirmed failing first with `expected "warn" to be called once, but got 0 times`.