### PR TITLE
fix(core): scope the GetBaseReport progress cache to the tenant

### DIFF
--- a/packages/core/src/handlers/requests/2/BootNotificationRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/BootNotificationRequestOcpp2Handler.ts
@@ -192,6 +192,7 @@ export class BootNotificationRequestOcpp2Handler extends AbstractHandler {
       await this._cache.remove(OCPP_CallAction.NotifyReport, identifier);
 
       const getBaseReportRequest = await this._bootService.createGetBaseReportRequest(
+        tenantId,
         ocppConnectionName,
         this._config.maxCachingSeconds,
       );
@@ -206,6 +207,7 @@ export class BootNotificationRequestOcpp2Handler extends AbstractHandler {
       });
 
       await this._bootService.confirmGetBaseReportSuccess(
+        tenantId,
         ocppConnectionName,
         getBaseReportRequest.requestId.toString(),
         getBaseReportConfirmation,

--- a/packages/core/src/handlers/requests/2/NotifyReportRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/NotifyReportRequestOcpp2Handler.ts
@@ -9,6 +9,7 @@ import {
   type ICache,
   type IMessage,
   type IOcppSender,
+  createIdentifier,
   OcppError,
 } from '@citrineos/base';
 import {
@@ -124,7 +125,7 @@ export class NotifyReportRequestOcpp2Handler extends AbstractHandler {
       const success = await this._cache.set(
         message.payload.requestId.toString(),
         NotifyReportRequestOcpp2Handler.GET_BASE_REPORT_COMPLETE_CACHE_VALUE,
-        ocppConnectionName,
+        createIdentifier(tenantId, ocppConnectionName),
       );
       this._logger.info('GetBaseReport Completed', success, message.payload.requestId);
     } else {
@@ -133,7 +134,7 @@ export class NotifyReportRequestOcpp2Handler extends AbstractHandler {
       const success = await this._cache.set(
         message.payload.requestId.toString(),
         NotifyReportRequestOcpp2Handler.GET_BASE_REPORT_ONGOING_CACHE_VALUE,
-        ocppConnectionName,
+        createIdentifier(tenantId, ocppConnectionName),
         this._config.maxCachingSeconds,
       );
       this._logger.info('GetBaseReport Ongoing', success, message.payload.requestId);

--- a/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
+++ b/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
@@ -8,6 +8,7 @@ import {
   type ICache,
   type IMessageConfirmation,
   BOOT_STATUS,
+  createIdentifier,
   OCPP1_6_CALL_SCHEMA_RECORD,
   OCPP2_0_1_CALL_SCHEMA_RECORD,
   OCPP2_1_CALL_SCHEMA_RECORD,
@@ -192,6 +193,7 @@ export class BootNotificationService {
   }
 
   async createGetBaseReportRequest(
+    tenantId: number,
     ocppConnectionName: string,
     maxCachingSeconds: number,
   ): Promise<OCPP2_0_1.GetBaseReportRequest> {
@@ -199,7 +201,12 @@ export class BootNotificationService {
     // Commenting out this line, using requestId === 0 until fixed (10/26/2023)
     // const requestId = Math.floor(Math.random() * ConfigurationModule.GET_BASE_REPORT_REQUEST_ID_MAX);
     const requestId = 0;
-    await this._cache.set(requestId.toString(), 'ongoing', ocppConnectionName, maxCachingSeconds);
+    await this._cache.set(
+      requestId.toString(),
+      'ongoing',
+      createIdentifier(tenantId, ocppConnectionName),
+      maxCachingSeconds,
+    );
 
     return {
       requestId: requestId,
@@ -211,17 +218,20 @@ export class BootNotificationService {
    * Based on the GetBaseReportMessageConfirmation, checks the cache to ensure GetBaseReport truly succeeded.
    * If GetBaseReport did not succeed, this method will throw. Otherwise, it will finish without throwing.
    *
+   * @param tenantId - The tenant the charging station belongs to
    * @param ocppConnectionName - The connection name of the charging station
    * @param requestId
    * @param getBaseReportMessageConfirmation
    * @param maxCachingSeconds
    */
   async confirmGetBaseReportSuccess(
+    tenantId: number,
     ocppConnectionName: string,
     requestId: string,
     getBaseReportMessageConfirmation: IMessageConfirmation,
     maxCachingSeconds: number,
   ): Promise<void> {
+    const identifier = createIdentifier(tenantId, ocppConnectionName);
     if (getBaseReportMessageConfirmation.success) {
       this._logger.debug(
         `GetBaseReport successfully sent to charger: ${getBaseReportMessageConfirmation}`,
@@ -231,14 +241,14 @@ export class BootNotificationService {
       let getBaseReportCacheValue = await this._cache.onChange(
         requestId,
         maxCachingSeconds,
-        ocppConnectionName,
+        identifier,
       );
 
       while (getBaseReportCacheValue === 'ongoing') {
         getBaseReportCacheValue = await this._cache.onChange(
           requestId,
           maxCachingSeconds,
-          ocppConnectionName,
+          identifier,
         );
       }
 

--- a/packages/core/test/modules/Configuration/module/BootNotificationService.test.ts
+++ b/packages/core/test/modules/Configuration/module/BootNotificationService.test.ts
@@ -21,6 +21,7 @@ describe('BootService', () => {
   const mockMaxCachingSeconds = 10;
   let bootService: BootNotificationService;
   const MOCK_STATION_ID = 'Station01';
+  const MOCK_IDENTIFIER = createIdentifier(DEFAULT_TENANT_ID, MOCK_STATION_ID);
 
   beforeEach(() => {
     mockBootRepository = {
@@ -324,7 +325,44 @@ describe('BootService', () => {
     });
   });
 
+  describe('createGetBaseReportRequest', () => {
+    it('marks the request ongoing under the tenant-scoped identifier', async () => {
+      // The request id is a hard-coded 0, so with the bare station name as the namespace two
+      // tenants that both have a station of that name share one cache entry.
+      await bootService.createGetBaseReportRequest(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        mockMaxCachingSeconds,
+      );
+
+      expect(mockCache.set).toHaveBeenCalledWith(
+        '0',
+        'ongoing',
+        MOCK_IDENTIFIER,
+        mockMaxCachingSeconds,
+      );
+    });
+  });
+
   describe('confirmGetBaseReportSuccess', () => {
+    it('waits on the tenant-scoped identifier', async () => {
+      mockCache.onChange.mockResolvedValueOnce('complete');
+
+      await bootService.confirmGetBaseReportSuccess(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        MOCK_REQUEST_ID.toString(),
+        aMessageConfirmation(),
+        mockMaxCachingSeconds,
+      );
+
+      expect(mockCache.onChange).toHaveBeenCalledWith(
+        MOCK_REQUEST_ID.toString(),
+        mockMaxCachingSeconds,
+        MOCK_IDENTIFIER,
+      );
+    });
+
     it('should throw because getBaseReport was not successful', async () => {
       const unsuccessfulConfirmation = aMessageConfirmation((mc) => {
         mc.success = false;
@@ -333,6 +371,7 @@ describe('BootService', () => {
       await expect(
         async () =>
           await bootService.confirmGetBaseReportSuccess(
+            DEFAULT_TENANT_ID,
             MOCK_STATION_ID,
             MOCK_REQUEST_ID.toString(),
             unsuccessfulConfirmation,
@@ -347,6 +386,7 @@ describe('BootService', () => {
       await expect(
         async () =>
           await bootService.confirmGetBaseReportSuccess(
+            DEFAULT_TENANT_ID,
             MOCK_STATION_ID,
             MOCK_REQUEST_ID.toString(),
             aMessageConfirmation(),
@@ -360,6 +400,7 @@ describe('BootService', () => {
 
       await expect(
         bootService.confirmGetBaseReportSuccess(
+          DEFAULT_TENANT_ID,
           MOCK_STATION_ID,
           MOCK_REQUEST_ID.toString(),
           aMessageConfirmation(),


### PR DESCRIPTION
Follow-up to #872, which @yuvenus suggested keeping as a separate PR.

## One cache entry shared by every tenant

`createGetBaseReportRequest` marks the request in progress:

```ts
const requestId = 0;
await this._cache.set(requestId.toString(), 'ongoing', ocppConnectionName, maxCachingSeconds);
```

`confirmGetBaseReportSuccess` then blocks on `onChange(requestId, ..., ocppConnectionName)` until
`NotifyReportRequestOcpp2Handler` writes `'complete'` to the same key, also under
`ocppConnectionName`.

The request id is a hard-coded 0 - the OCTT workaround noted in the comment there - so the key is
literally `"0"` in namespace `<stationName>`, with no tenant anywhere in it. Two tenants that each
have a station called `CP001` share that single entry.

The failure is a boot that completes on someone else's report: tenant A is waiting, tenant B's
station sends its `NotifyReport`, `'complete'` lands on the shared key, and A's
`confirmGetBaseReportSuccess` returns successfully. The boot handler then sets
`getBaseReportOnPending = false` and carries on with a device model it never actually received.

All four operations now use `createIdentifier(tenantId, ocppConnectionName)`, the namespace the rest
of the boot path already uses. `tenantId` is threaded into the two service methods rather than
resolved in the handler, so `BootNotificationRequestOcpp2Handler` only gains an argument on two
calls and does not collide with #872's changes in the same file.

## Verification

```
npx vitest run test/modules/Configuration test/handlers/requests/2   # 6 files, 58 tests passed
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
npx prettier --check / npx eslint <changed files>  # clean
```

Both new tests were confirmed failing first, with the parameter in place but the namespace left as
the bare station name, so the failure is about the namespace and nothing else:

```
× marks the request ongoing under the tenant-scoped identifier
  → expected "spy" to be called with arguments: [ '0', 'ongoing', '1:Station01', 10 ]
× waits on the tenant-scoped identifier
  → expected "spy" to be called with arguments: [ '1', 10, '1:Station01' ]
```