### PR TITLE
fix(ocpi): make packages/ocpi-base loadable, so it can be tested at all

### DIFF
--- a/packages/ocpi-base/src/broadcaster/LocationsBroadcaster.ts
+++ b/packages/ocpi-base/src/broadcaster/LocationsBroadcaster.ts
@@ -22,7 +22,7 @@ import {
   type TenantDto,
   HttpMethod,
 } from '@citrineos/types';
-import { ConnectorMapper, EvseMapper, LocationMapper } from '../mapper/index.js';
+import { ConnectorMapper, EvseMapper, LocationMapper } from '../mapper/LocationMapper.js';
 import { OcpiEmptyResponseSchema } from '../model/OcpiEmptyResponse.js';
 
 @Service()

--- a/packages/ocpi-base/src/modules/Commands/module/CommandsModuleApi.ts
+++ b/packages/ocpi-base/src/modules/Commands/module/CommandsModuleApi.ts
@@ -89,7 +89,7 @@ for (const [commandType, { schema, name }] of Object.entries(COMMAND_REQUEST_SCH
 @JsonController(`/:${versionIdParam}/${ModuleId.Commands}`)
 @Service()
 export class CommandsModuleApi extends BaseController implements ICommandsModuleApi {
-  @Inject()
+  @Inject(() => CommandExecutor)
   private commandsExecutor!: CommandExecutor;
 
   constructor(readonly commandsService: CommandsService) {

--- a/packages/ocpi-base/src/services/CommandsService.ts
+++ b/packages/ocpi-base/src/services/CommandsService.ts
@@ -34,13 +34,13 @@ import { EXTRACT_STATION_ID } from '../model/DTO/EvseDTO.js';
 
 @Service()
 export class CommandsService {
-  @Inject()
+  @Inject(() => Logger)
   protected logger!: Logger<ILogObj>;
 
-  @Inject()
+  @Inject(() => OcpiGraphqlClient)
   protected ocpiGraphqlClient!: OcpiGraphqlClient;
 
-  @Inject()
+  @Inject(() => CommandExecutor)
   protected commandExecutor!: CommandExecutor;
 
   @Inject(OcpiConfigToken) readonly config!: OcpiConfig;

--- a/packages/ocpi-base/src/services/LocationsService.ts
+++ b/packages/ocpi-base/src/services/LocationsService.ts
@@ -36,7 +36,7 @@ import {
   GET_LOCATIONS_QUERY,
   OcpiGraphqlClient,
 } from '../graphql/index.js';
-import { ConnectorMapper, EvseMapper, LocationMapper } from '../mapper/index.js';
+import { ConnectorMapper, EvseMapper, LocationMapper } from '../mapper/LocationMapper.js';
 import type { ChargingStationDto, ConnectorDto, EvseDto, LocationDto } from '@citrineos/types';
 
 @Service()

--- a/packages/ocpi-base/src/trigger/BaseClientApi.ts
+++ b/packages/ocpi-base/src/trigger/BaseClientApi.ts
@@ -71,9 +71,9 @@ export interface TriggerRequestOptions extends IRequestOptions {
 }
 
 export abstract class BaseClientApi {
-  @Inject()
+  @Inject(() => Logger)
   protected logger!: Logger<ILogObj>;
-  @Inject()
+  @Inject(() => OcpiGraphqlClient)
   protected ocpiGraphqlClient!: OcpiGraphqlClient;
 
   CONTROLLER_PATH = 'null';

--- a/packages/ocpi-base/src/trigger/CommandsClientApi.ts
+++ b/packages/ocpi-base/src/trigger/CommandsClientApi.ts
@@ -20,7 +20,7 @@ import { CacheWrapper } from '../util/CacheWrapper.js';
 export class CommandsClientApi extends BaseClientApi {
   protected cache!: ICache;
 
-  constructor(@Inject() cacheWrapper: CacheWrapper) {
+  constructor(@Inject(() => CacheWrapper) cacheWrapper: CacheWrapper) {
     super();
     this.cache = cacheWrapper.cache;
   }

--- a/packages/ocpi-base/src/util/CommandExecutor.ts
+++ b/packages/ocpi-base/src/util/CommandExecutor.ts
@@ -29,11 +29,11 @@ import { OCPP_COMMAND_HANDLER, OCPPCommandHandler } from './ocppCommandHandlers/
 
 @Service()
 export class CommandExecutor {
-  @Inject()
+  @Inject(() => Logger)
   protected logger!: Logger<ILogObj>;
-  @Inject()
+  @Inject(() => OcpiGraphqlClient)
   protected ocpiGraphqlClient!: OcpiGraphqlClient;
-  @Inject()
+  @Inject(() => CommandsClientApi)
   protected commandsClientApi!: CommandsClientApi;
   @Inject(OcpiConfigToken)
   protected config!: OcpiConfig;
@@ -42,7 +42,7 @@ export class CommandExecutor {
   private handlerRegistry = new Map<OCPPVersion, OCPPCommandHandler>();
 
   constructor(
-    @Inject() cacheWrapper: CacheWrapper,
+    @Inject(() => CacheWrapper) cacheWrapper: CacheWrapper,
     @InjectMany(OCPP_COMMAND_HANDLER) handlers: OCPPCommandHandler[],
   ) {
     this.cache = cacheWrapper.cache;

--- a/packages/ocpi-base/src/util/ocppCommandHandlers/base.ts
+++ b/packages/ocpi-base/src/util/ocppCommandHandlers/base.ts
@@ -4,8 +4,14 @@
 
 import { type IMessageConfirmation } from '@citrineos/base';
 import { type ChargingStationDto, type TenantPartnerDto, OCPPVersion } from '@citrineos/types';
-import type { OcpiConfig, StartSession, StopSession, UnlockConnector } from '../../index.js';
-import { CommandResultType, CommandType, ModuleId, OcpiConfigToken } from '../../index.js';
+import type { OcpiConfig } from '../../config/ocpi.types.js';
+import { OcpiConfigToken } from '../../config/ocpi.types.js';
+import type { StartSession } from '../../model/StartSession.js';
+import type { StopSession } from '../../model/StopSession.js';
+import type { UnlockConnector } from '../../model/UnlockConnector.js';
+import { CommandResultType } from '../../model/CommandResult.js';
+import { CommandType } from '../../model/CommandType.js';
+import { ModuleId } from '../../model/ModuleId.js';
 import type { IRequestOptions } from 'typed-rest-client';
 import { RestClient } from 'typed-rest-client';
 import type { ILogObj } from 'tslog';

--- a/packages/ocpi-base/src/util/ocppCommandHandlers/base.ts
+++ b/packages/ocpi-base/src/util/ocppCommandHandlers/base.ts
@@ -21,16 +21,16 @@ export const OCPP_COMMAND_HANDLER = new Token<OCPPCommandHandler>('OCPP_COMMAND_
 export abstract class OCPPCommandHandler {
   abstract readonly supportedVersion: OCPPVersion;
 
-  @Inject()
+  @Inject(() => Ajv)
   private ajv!: Ajv;
 
-  @Inject()
+  @Inject(() => Logger)
   protected logger!: Logger<ILogObj>;
 
-  @Inject()
+  @Inject(() => OcpiGraphqlClient)
   protected ocpiGraphqlClient!: OcpiGraphqlClient;
 
-  @Inject()
+  @Inject(() => CommandsClientApi)
   protected commandsClientApi!: CommandsClientApi;
 
   @Inject(OcpiConfigToken)

--- a/packages/ocpi-base/test/containerWiring.test.ts
+++ b/packages/ocpi-base/test/containerWiring.test.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Container } from 'typedi';
+import { Logger } from 'tslog';
+
+import { CommandsService } from '../src/services/CommandsService.js';
+import { CommandExecutor } from '../src/util/CommandExecutor.js';
+import { OcpiGraphqlClient } from '../src/graphql/index.js';
+import { OcpiConfigToken } from '../src/config/ocpi.types.js';
+
+/**
+ * The property injections resolve through the container rather than from decorator metadata, so
+ * this covers the wiring itself: a lazy token that names the wrong class still loads, and only
+ * fails when something asks the container for the service.
+ */
+describe('container wiring', () => {
+  afterEach(() => {
+    Container.reset();
+  });
+
+  it('resolves the collaborators of a service built by the container', () => {
+    const logger = new Logger({ type: 'hidden' });
+    const graphqlClient = {} as OcpiGraphqlClient;
+    const commandExecutor = {} as CommandExecutor;
+
+    Container.set(Logger, logger);
+    Container.set(OcpiGraphqlClient, graphqlClient);
+    Container.set(CommandExecutor, commandExecutor);
+    Container.set(OcpiConfigToken, { commands: { timeout: 30 } });
+
+    const service = Container.get(CommandsService);
+
+    expect(service).toBeInstanceOf(CommandsService);
+    expect(service['logger']).toBe(logger);
+    expect(service['ocpiGraphqlClient']).toBe(graphqlClient);
+    expect(service['commandExecutor']).toBe(commandExecutor);
+    expect(service.config.commands.timeout).toBe(30);
+  });
+});

--- a/packages/ocpi-base/test/moduleLoading.test.ts
+++ b/packages/ocpi-base/test/moduleLoading.test.ts
@@ -2,12 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import 'reflect-metadata';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const SRC = fileURLToPath(new URL('../src', import.meta.url));
+
+/**
+ * Modules a test is likely to name as its first import. Each has to be able to load as the entry
+ * point of the graph, not only once something else has pulled its dependencies in.
+ */
+const ENTRY_POINTS = [
+  join('mapper', 'CdrMapper.ts'),
+  join('mapper', 'SessionMapper.ts'),
+  join('services', 'CdrsService.ts'),
+  join('services', 'CommandsService.ts'),
+  join('services', 'LocationsService.ts'),
+  join('services', 'SessionsService.ts'),
+  join('util', 'ocppCommandHandlers', 'OCPP1_6_CommandHandler.ts'),
+  join('util', 'ocppCommandHandlers', 'OCPP2_0_1_CommandHandler.ts'),
+];
 
 function sourceFiles(dir: string, found: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
@@ -21,11 +36,25 @@ function sourceFiles(dir: string, found: string[] = []): string[] {
   return found;
 }
 
+async function importFailure(file: string): Promise<string | undefined> {
+  try {
+    await import(pathToFileURL(file).href);
+    return undefined;
+  } catch (error) {
+    return `${relative(SRC, file)}: ${(error as Error).message.split('\n')[0]}`;
+  }
+}
+
 /**
- * typedi evaluates its decorators when a class is defined, so a container wiring mistake surfaces
- * as an exception on import rather than on resolution. A parameterless `@Inject()` is the usual
- * cause: it needs the `design:type` metadata that only tsc emits, and the transform used for tests
- * does not, so one such decorator makes every module that reaches it unloadable.
+ * Two faults in this package show up only as an exception on import, so nothing that imports the
+ * offending module can be tested at all.
+ *
+ * typedi evaluates its decorators when a class is defined, and a parameterless `@Inject()` needs
+ * the `design:type` metadata that only tsc emits, so it throws under any other transform.
+ *
+ * A module that reaches its own barrel closes an import cycle, and a class whose base class is
+ * still initialising extends `undefined`. That one depends on where the graph is entered, which is
+ * why the entry points are also loaded on their own below.
  */
 describe('module loading', () => {
   it('imports the package barrel', async () => {
@@ -36,13 +65,18 @@ describe('module loading', () => {
     const unloadable: string[] = [];
 
     for (const file of sourceFiles(SRC)) {
-      try {
-        await import(pathToFileURL(file).href);
-      } catch (error) {
-        unloadable.push(`${relative(SRC, file)}: ${(error as Error).message.split('\n')[0]}`);
+      const failure = await importFailure(file);
+      if (failure) {
+        unloadable.push(failure);
       }
     }
 
     expect(unloadable).toEqual([]);
+  });
+
+  it.each(ENTRY_POINTS)('imports %s as the entry point of a fresh graph', async (entryPoint) => {
+    vi.resetModules();
+
+    expect(await importFailure(join(SRC, entryPoint))).toBeUndefined();
   });
 });

--- a/packages/ocpi-base/test/moduleLoading.test.ts
+++ b/packages/ocpi-base/test/moduleLoading.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it } from 'vitest';
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const SRC = fileURLToPath(new URL('../src', import.meta.url));
+
+function sourceFiles(dir: string, found: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      sourceFiles(path, found);
+    } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+      found.push(path);
+    }
+  }
+  return found;
+}
+
+/**
+ * typedi evaluates its decorators when a class is defined, so a container wiring mistake surfaces
+ * as an exception on import rather than on resolution. A parameterless `@Inject()` is the usual
+ * cause: it needs the `design:type` metadata that only tsc emits, and the transform used for tests
+ * does not, so one such decorator makes every module that reaches it unloadable.
+ */
+describe('module loading', () => {
+  it('imports the package barrel', async () => {
+    await expect(import('../src/index.js')).resolves.toBeDefined();
+  });
+
+  it('imports every source module', async () => {
+    const unloadable: string[] = [];
+
+    for (const file of sourceFiles(SRC)) {
+      try {
+        await import(pathToFileURL(file).href);
+      } catch (error) {
+        unloadable.push(`${relative(SRC, file)}: ${(error as Error).message.split('\n')[0]}`);
+      }
+    }
+
+    expect(unloadable).toEqual([]);
+  });
+});

--- a/packages/ocpi-base/test/services/CommandsService.test.ts
+++ b/packages/ocpi-base/test/services/CommandsService.test.ts
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import type { ChargingStationDto, TenantPartnerDto } from '@citrineos/types';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+import { CommandsService } from '../../src/services/CommandsService.js';
+import { CommandType } from '../../src/model/CommandType.js';
+import { CommandResponseType } from '../../src/model/CommandResponse.js';
+import { OcpiResponseStatusCode } from '../../src/model/OcpiResponse.js';
+import type { StartSession } from '../../src/model/StartSession.js';
+import type { StopSession } from '../../src/model/StopSession.js';
+
+const TIMEOUT = 30;
+const STATION_ID = 'cs-001';
+const EVSE_UID = `${STATION_ID}::1`;
+const LOCATION_ID = '7';
+
+const partner = { countryCode: 'GB', partyId: 'VLT' } as TenantPartnerDto;
+
+function aChargingStation(overrides: Record<string, unknown> = {}): ChargingStationDto {
+  return {
+    id: STATION_ID,
+    locationId: Number(LOCATION_ID),
+    isOnline: true,
+    connectors: [{ id: 1 }],
+    ...overrides,
+  } as unknown as ChargingStationDto;
+}
+
+function aStartSession(overrides: Record<string, unknown> = {}): StartSession {
+  return {
+    response_url: 'https://emsp.test/commands/START_SESSION/1',
+    token: { country_code: 'GB', party_id: 'VLT', uid: 'token-1' },
+    location_id: LOCATION_ID,
+    evse_uid: EVSE_UID,
+    ...overrides,
+  } as unknown as StartSession;
+}
+
+/**
+ * CommandsService resolves its collaborators through typedi, but the guard logic under test is
+ * reachable by assigning them onto a plain instance.
+ */
+function aCommandsService(graphqlResult: unknown) {
+  const executor = {
+    executeStartSession: vi.fn().mockResolvedValue(undefined),
+    executeStopSession: vi.fn().mockResolvedValue(undefined),
+    executeUnlockConnector: vi.fn().mockResolvedValue(undefined),
+  };
+  const service = new CommandsService();
+  Object.assign(service, {
+    logger: new Logger({ type: 'hidden' }),
+    ocpiGraphqlClient: { request: vi.fn().mockResolvedValue(graphqlResult) },
+    commandExecutor: executor,
+    config: { commands: { timeout: TIMEOUT } },
+  });
+  return { service, executor };
+}
+
+const INVALID_PARAMS = OcpiResponseStatusCode.ClientInvalidOrMissingParameters;
+
+describe('CommandsService.postCommand START_SESSION', () => {
+  it('accepts a command for an online station and hands it to the executor', async () => {
+    const { service, executor } = aCommandsService({ ChargingStations: [aChargingStation()] });
+
+    const response = await service.postCommand(
+      CommandType.START_SESSION,
+      aStartSession({ connector_id: '1' }),
+      partner,
+    );
+
+    expect(response.status_code).toBe(OcpiResponseStatusCode.GenericSuccessCode);
+    expect(response.data?.result).toBe(CommandResponseType.ACCEPTED);
+    expect(response.data?.timeout).toBe(TIMEOUT);
+    expect(executor.executeStartSession).toHaveBeenCalledOnce();
+  });
+
+  it('refuses a command with no evse_uid', async () => {
+    const { service, executor } = aCommandsService({ ChargingStations: [aChargingStation()] });
+
+    const response = await service.postCommand(
+      CommandType.START_SESSION,
+      aStartSession({ evse_uid: undefined }),
+      partner,
+    );
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(response.data?.result).toBe(CommandResponseType.REJECTED);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses a token belonging to a different party than the caller', async () => {
+    const { service, executor } = aCommandsService({ ChargingStations: [aChargingStation()] });
+
+    const response = await service.postCommand(
+      CommandType.START_SESSION,
+      aStartSession({ token: { country_code: 'GB', party_id: 'OTH', uid: 'token-1' } }),
+      partner,
+    );
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses an evse_uid that resolves to a station at a different location', async () => {
+    const { service, executor } = aCommandsService({
+      ChargingStations: [aChargingStation({ locationId: 99 })],
+    });
+
+    const response = await service.postCommand(CommandType.START_SESSION, aStartSession(), partner);
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown station', async () => {
+    const { service, executor } = aCommandsService({ ChargingStations: [] });
+
+    const response = await service.postCommand(CommandType.START_SESSION, aStartSession(), partner);
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses a station that is offline', async () => {
+    const { service, executor } = aCommandsService({
+      ChargingStations: [aChargingStation({ isOnline: false })],
+    });
+
+    const response = await service.postCommand(CommandType.START_SESSION, aStartSession(), partner);
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses a connector the station does not have', async () => {
+    const { service, executor } = aCommandsService({ ChargingStations: [aChargingStation()] });
+
+    const response = await service.postCommand(
+      CommandType.START_SESSION,
+      aStartSession({ connector_id: '4' }),
+      partner,
+    );
+
+    expect(response.status_code).toBe(INVALID_PARAMS);
+    expect(executor.executeStartSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('CommandsService.postCommand STOP_SESSION', () => {
+  function aTransaction(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 1,
+      isActive: true,
+      station: aChargingStation(),
+      authorization: { tenantPartner: { countryCode: 'GB', partyId: 'VLT' } },
+      ...overrides,
+    };
+  }
+
+  const stopSession = {
+    response_url: 'https://emsp.test/commands/STOP_SESSION/1',
+    session_id: 'tx-1',
+  } as unknown as StopSession;
+
+  it('accepts a stop for an active session and hands it to the executor', async () => {
+    const { service, executor } = aCommandsService({ Transactions: [aTransaction()] });
+
+    const response = await service.postCommand(CommandType.STOP_SESSION, stopSession, partner);
+
+    expect(response.data?.result).toBe(CommandResponseType.ACCEPTED);
+    expect(executor.executeStopSession).toHaveBeenCalledOnce();
+  });
+
+  it('reports UNKNOWN_SESSION for a session id it cannot find', async () => {
+    const { service, executor } = aCommandsService({ Transactions: [] });
+
+    const response = await service.postCommand(CommandType.STOP_SESSION, stopSession, partner);
+
+    expect(response.data?.result).toBe(CommandResponseType.UNKNOWN_SESSION);
+    expect(executor.executeStopSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses to stop a session belonging to a different party', async () => {
+    const { service, executor } = aCommandsService({
+      Transactions: [
+        aTransaction({ authorization: { tenantPartner: { countryCode: 'GB', partyId: 'OTH' } } }),
+      ],
+    });
+
+    const response = await service.postCommand(CommandType.STOP_SESSION, stopSession, partner);
+
+    expect(response.data?.result).toBe(CommandResponseType.REJECTED);
+    expect(executor.executeStopSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses to stop a session that has already ended', async () => {
+    const { service, executor } = aCommandsService({
+      Transactions: [aTransaction({ isActive: false })],
+    });
+
+    const response = await service.postCommand(CommandType.STOP_SESSION, stopSession, partner);
+
+    expect(response.data?.result).toBe(CommandResponseType.REJECTED);
+    expect(executor.executeStopSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('CommandsService.postCommand unimplemented commands', () => {
+  it.each([CommandType.RESERVE_NOW, CommandType.CANCEL_RESERVATION])(
+    'reports %s as NOT_SUPPORTED rather than as done',
+    async (commandType) => {
+      const { service } = aCommandsService({});
+
+      const response = await service.postCommand(commandType, {} as never, partner);
+
+      expect(response.data?.result).toBe(CommandResponseType.NOT_SUPPORTED);
+    },
+  );
+
+  it('reports an unrecognised command type as NOT_SUPPORTED', async () => {
+    const { service } = aCommandsService({});
+
+    const response = await service.postCommand('TELEPORT' as CommandType, {} as never, partner);
+
+    expect(response.data?.result).toBe(CommandResponseType.NOT_SUPPORTED);
+  });
+});


### PR DESCRIPTION
One test file covers 310 source files (20.5k lines) in this package. That is not a decision about
priorities - the package could not be imported.

```
CannotInjectValueError: Cannot inject value into "BaseClientApi.logger".
  ❯ typedi/src/decorators/inject.decorator.ts:23:13
  ❯ __decorateClass src/trigger/BaseClientApi.ts:22:24
  ❯ src/trigger/SessionsClientApi.ts:5:1
```

That is `await import('../src/mapper/CdrMapper.js')` in a test with no mocking. There are two
independent causes.

## 1. A parameterless @Inject() needs metadata the test transform does not emit

```ts
// typedi/utils/resolve-to-type-wrapper.util.js
if (!typeOrIdentifier && propertyName) {
  const identifier = Reflect.getMetadata('design:type', target, propertyName);
  typeWrapper = { eagerType: identifier, lazyType: () => identifier };
}
```

`tsconfig.build.json` sets `emitDecoratorMetadata`, so `tsc` emits `design:type` and the build is
fine. Vitest transforms with **esbuild**, which does not implement it. `eagerType` is `undefined`
and the decorator throws.

Decorators run when the class is **defined**, so this fails on import, not on resolution. Every
module that transitively reaches such a class becomes unloadable - **56 modules** from the
`BaseClientApi.logger` site alone, measured by reverting it and counting.

`packages/core` is unaffected because it never relies on inferred types: `@Column(DataType.INTEGER)`
rather than `@Column()`.

Fifteen bare `@Inject()` across six files now name their type:

```ts
-  @Inject()
+  @Inject(() => Logger)
   protected logger!: Logger<ILogObj>;
```

This is the form the package already uses (`@Inject(OcpiConfigToken)`) and the one typedi documents
for cyclic dependencies. It needs no metadata, so it behaves the same under tsc, esbuild, swc or a
bundler - which also removes a latent production risk, since the same failure appears the moment
this package is built with anything but `tsc`.

The arrow matters. typedi *calls* a function argument:

```ts
if (typeOrIdentifier && typeof typeOrIdentifier === 'function') {
  typeWrapper = { eagerType: null, lazyType: () => typeOrIdentifier() };
}
```

so `@Inject(Logger)` would throw "Class constructor cannot be invoked without 'new'" at resolution.
It has to be `@Inject(() => Logger)`.

Adding an SWC or Babel transform to vitest instead would also work, but it needs a new dependency,
keeps the source dependent on a compiler feature it does not need, and helps nobody bundling this
package. Happy to go that way if maintainers prefer.

## 2. Three modules import a barrel that imports them back

With the decorators fixed, a second failure appears:

```
TypeError: Class extends value undefined is not a constructor or null
  ❯ src/mapper/CdrMapper.ts:31:32   export class CdrMapper extends BaseTransactionMapper
  ❯ src/mapper/index.ts:5:1
```

`SessionMapper` imports `LocationsService`, which imports the **mapper barrel** for three mappers
that all live in `LocationMapper.js`. The barrel re-exports `CdrMapper`, which extends a
`BaseTransactionMapper` that is still initialising.

Same shape in two more places:

- `util/ocppCommandHandlers/base.ts` imports the **package root barrel** for four values and four
  types. That reaches `OCPP2_0_1_CommandHandler`, which extends `base.ts` itself.
- `broadcaster/LocationsBroadcaster.ts` imports the mapper barrel, like `LocationsService`.

Each now imports from the module that declares what it needs. That is three import statements; the
package has 60 internal barrel imports in total and untangling them all is a separate piece of work.

Note this only throws for the module the graph is entered from, which is why importing every module
in sequence passes while a test naming one of them as its first import fails.

## Tests

- **`moduleLoading.test.ts`** imports the barrel, then every source module, then each likely entry
  point on its own with a reset module registry. Reverting one decorator fails it with 56 unloadable
  modules; reverting one barrel import fails the `SessionMapper` entry-point case.
- **`containerWiring.test.ts`** resolves a service through the container and checks each injection
  landed. A lazy token naming the wrong class still *loads*, so import coverage alone would not catch
  a mistake in part 1.
- **`services/CommandsService.test.ts`** - 14 tests over the `START_SESSION` and `STOP_SESSION`
  guards. `CommandsService` held a bare `@Inject()`, so it could not be tested before: with the
  decorator reverted the file reports `no tests` because it never collects. It also confirms
  `RESERVE_NOW` and `CANCEL_RESERVATION`, whose handler bodies are commented out, report
  `NOT_SUPPORTED` rather than success.

## Known remaining gap

`LocationsBroadcaster` still cannot be the entry point of the graph: it builds a JSON schema from a
zod schema as it loads, and a further cycle leaves one referenced schema `undefined`. Nothing
imports it first today, so it is not in `ENTRY_POINTS` and is left for its own change.

## Verification

```
packages/ocpi-base: 4 files, 33 tests passed
full suite:         96 files passed / 1 skipped, 2040 passed / 5 skipped
pnpm --filter ./packages/** run build    # clean
prettier --check / eslint                # 0 errors (11 pre-existing warnings)
```

`packages/core/test/dal/e2e/security-event.e2e.test.ts` fails on this branch, and fails identically
on unmodified `next` with these changes stashed - both server instances bind port 8080, which is
#873.

On our own branch, where the tests from #891, #898, #901-#906 are already applied, this change lets
every one of them drop its `vi.mock` workaround, including the file that had to stub `typedi`
itself: 15 files, 75 tests, no mocking of the package's own modules anywhere.