### PR TITLE
fix(core): enforce the OCPP 1.6 local auth list size limits

### DIFF
--- a/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
+++ b/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
@@ -6,6 +6,7 @@ import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { v4 as uuidv4 } from 'uuid';
 import type {
+  IChangeConfigurationRepository,
   IDeviceModelRepository,
   ILocalAuthListRepository,
 } from '@dal/interfaces/repositories.js';
@@ -20,19 +21,23 @@ import {
 export class LocalAuthListService {
   protected _localAuthListRepository: ILocalAuthListRepository;
   protected _deviceModelRepository: IDeviceModelRepository;
+  protected _changeConfigurationRepository: IChangeConfigurationRepository;
   protected _logger: Logger<ILogObj>;
 
   constructor({
     localAuthListRepository,
     deviceModelRepository,
+    changeConfigurationRepository,
     logger,
   }: {
     localAuthListRepository: ILocalAuthListRepository;
     deviceModelRepository: IDeviceModelRepository;
+    changeConfigurationRepository: IChangeConfigurationRepository;
     logger: Logger<ILogObj>;
   }) {
     this._localAuthListRepository = localAuthListRepository;
     this._deviceModelRepository = deviceModelRepository;
+    this._changeConfigurationRepository = changeConfigurationRepository;
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
       : new Logger<ILogObj>({ name: this.constructor.name });
@@ -221,8 +226,9 @@ export class LocalAuthListService {
 
   /**
    * OCPP 1.6 variant: validate and persist a SendLocalListRequest, returning the persisted row.
-   * Mirrors the 2.0.1 path but uses flat idTag and 1.6 update enum. Item-count limits for 1.6
-   * come from the chargepoint via `LocalAuthListMaxLength` configuration; absence is non-fatal.
+   * Mirrors the 2.0.1 path but uses flat idTag and the 1.6 update enum. The size limits come from
+   * the SendLocalListMaxLength and LocalAuthListMaxLength configuration keys rather than from the
+   * device model, and a key the station has not reported is not enforced.
    */
   async persistSendLocalListForStationIdAndCorrelationIdAndSendLocalListRequest16(
     tenantId: number,
@@ -255,6 +261,39 @@ export class LocalAuthListService {
       }
     }
 
+    const sendLocalListMaxLength = await this.getOcpp16ConfigurationNumber(
+      tenantId,
+      stationId,
+      'SendLocalListMaxLength',
+    );
+    if (sendLocalListMaxLength !== null && list.length > sendLocalListMaxLength) {
+      throw new Error(
+        `Number of authorizations (${list.length}) in SendLocalListRequest exceeds ` +
+          `SendLocalListMaxLength (${sendLocalListMaxLength}) reported by ${stationId} ` +
+          `(break the list up into a Full request followed by Differential ones)`,
+      );
+    }
+
+    const localAuthListMaxLength = await this.getOcpp16ConfigurationNumber(
+      tenantId,
+      stationId,
+      'LocalAuthListMaxLength',
+    );
+    if (localAuthListMaxLength === null) {
+      this._logger.warn(
+        `Station ${stationId} has not reported LocalAuthListMaxLength; forwarding SendLocalList ` +
+          `without enforcing the maximum list length.`,
+      );
+    } else {
+      const updatedLength = this.countUpdatedAuthList16(sendLocalListRequest, localListVersion);
+      if (updatedLength > localAuthListMaxLength) {
+        throw new Error(
+          `Updated local auth list length (${updatedLength}) will exceed ` +
+            `LocalAuthListMaxLength (${localAuthListMaxLength}) reported by ${stationId}`,
+        );
+      }
+    }
+
     return await this._localAuthListRepository.createSendLocalListFromRequestData16(
       tenantId,
       stationId,
@@ -263,6 +302,52 @@ export class LocalAuthListService {
       sendLocalListRequest.listVersion,
       sendLocalListRequest.localAuthorizationList ?? undefined,
     );
+  }
+
+  /**
+   * The number of idTags the station will hold once this request is applied. A Differential entry
+   * carrying no idTagInfo is a delete, so it frees a slot rather than filling one.
+   */
+  private countUpdatedAuthList16(
+    sendLocalListRequest: OCPP1_6.SendLocalListRequest,
+    localListVersion?: LocalListVersion,
+  ): number {
+    const list = sendLocalListRequest.localAuthorizationList ?? [];
+    if (sendLocalListRequest.updateType === OCPP1_6.SendLocalListRequestUpdateType.Full) {
+      return list.length;
+    }
+
+    const idTags = new Set(
+      (localListVersion?.localAuthorizationList ?? []).map((auth) => auth.idToken),
+    );
+    for (const entry of list) {
+      // createSendLocalListFromRequestData16 skips an entry with no idTag, so it never lands.
+      if (!entry.idTag) {
+        continue;
+      }
+      if (entry.idTagInfo) {
+        idTags.add(entry.idTag);
+      } else {
+        idTags.delete(entry.idTag);
+      }
+    }
+    return idTags.size;
+  }
+
+  /** Reads an OCPP 1.6 configuration key as a number, or null when the station has not reported it. */
+  private async getOcpp16ConfigurationNumber(
+    tenantId: number,
+    ocppConnectionName: string,
+    key: string,
+  ): Promise<number | null> {
+    const configuration = await this._changeConfigurationRepository.readOnlyOneByQuery(tenantId, {
+      where: { tenantId, ocppConnectionName, key },
+    });
+    if (configuration?.value == null) {
+      return null;
+    }
+    const value = Number(configuration.value);
+    return Number.isFinite(value) ? value : null;
   }
 
   private async getMaxLocalAuthListEntries(

--- a/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
+++ b/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
@@ -260,7 +260,12 @@ export class LocalAuthListService {
       stationId,
       'SendLocalListMaxLength',
     );
-    if (sendLocalListMaxLength !== null && list.length > sendLocalListMaxLength) {
+    if (sendLocalListMaxLength === null) {
+      this._logger.warn(
+        `Station ${stationId} has not reported SendLocalListMaxLength; forwarding SendLocalList ` +
+          `without enforcing the per-message length.`,
+      );
+    } else if (list.length > sendLocalListMaxLength) {
       throw new Error(
         `Number of authorizations (${list.length}) in SendLocalListRequest exceeds ` +
           `SendLocalListMaxLength (${sendLocalListMaxLength}) reported by ${stationId} ` +

--- a/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
+++ b/packages/core/src/modules/EVDriver/src/module/LocalAuthListService.ts
@@ -224,12 +224,6 @@ export class LocalAuthListService {
     }
   }
 
-  /**
-   * OCPP 1.6 variant: validate and persist a SendLocalListRequest, returning the persisted row.
-   * Mirrors the 2.0.1 path but uses flat idTag and the 1.6 update enum. The size limits come from
-   * the SendLocalListMaxLength and LocalAuthListMaxLength configuration keys rather than from the
-   * device model, and a key the station has not reported is not enforced.
-   */
   async persistSendLocalListForStationIdAndCorrelationIdAndSendLocalListRequest16(
     tenantId: number,
     stationId: string,
@@ -304,10 +298,6 @@ export class LocalAuthListService {
     );
   }
 
-  /**
-   * The number of idTags the station will hold once this request is applied. A Differential entry
-   * carrying no idTagInfo is a delete, so it frees a slot rather than filling one.
-   */
   private countUpdatedAuthList16(
     sendLocalListRequest: OCPP1_6.SendLocalListRequest,
     localListVersion?: LocalListVersion,
@@ -321,7 +311,6 @@ export class LocalAuthListService {
       (localListVersion?.localAuthorizationList ?? []).map((auth) => auth.idToken),
     );
     for (const entry of list) {
-      // createSendLocalListFromRequestData16 skips an entry with no idTag, so it never lands.
       if (!entry.idTag) {
         continue;
       }
@@ -334,7 +323,6 @@ export class LocalAuthListService {
     return idTags.size;
   }
 
-  /** Reads an OCPP 1.6 configuration key as a number, or null when the station has not reported it. */
   private async getOcpp16ConfigurationNumber(
     tenantId: number,
     ocppConnectionName: string,

--- a/packages/core/test/modules/EVDriver/module/LocalAuthListService.test.ts
+++ b/packages/core/test/modules/EVDriver/module/LocalAuthListService.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  IChangeConfigurationRepository,
   IDeviceModelRepository,
   ILocalAuthListRepository,
   LocalListVersion,
@@ -20,6 +21,7 @@ describe('LocalAuthListService', () => {
   const { container } = createTestContainer();
   let mockLocalAuthListRepository: Mocked<ILocalAuthListRepository>;
   let mockDeviceModelRepository: Mocked<IDeviceModelRepository>;
+  let mockChangeConfigurationRepository: Mocked<IChangeConfigurationRepository>;
   let localAuthListService: LocalAuthListService;
 
   const tenantId = DEFAULT_TENANT_ID;
@@ -45,9 +47,15 @@ describe('LocalAuthListService', () => {
       readAllByQuerystring: vi.fn(),
     } as unknown as Mocked<IDeviceModelRepository>;
 
+    // Only the OCPP 1.6 path reads configuration keys; these specs all exercise 2.0.1.
+    mockChangeConfigurationRepository = {
+      readOnlyOneByQuery: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<IChangeConfigurationRepository>;
+
     localAuthListService = getTestInstance(container, LocalAuthListService, {
       localAuthListRepository: mockLocalAuthListRepository,
       deviceModelRepository: mockDeviceModelRepository,
+      changeConfigurationRepository: mockChangeConfigurationRepository,
     });
   });
 

--- a/packages/core/test/modules/EVDriver/module/LocalAuthListService16.test.ts
+++ b/packages/core/test/modules/EVDriver/module/LocalAuthListService16.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type {
+  IChangeConfigurationRepository,
+  IDeviceModelRepository,
+  ILocalAuthListRepository,
+} from '@citrineos/core';
+import { ChangeConfiguration, LocalListVersion, SendLocalList } from '@citrineos/core';
+import { LocalAuthListService } from '@modules/EVDriver/src/module/LocalAuthListService.js';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP1_6 } from '@citrineos/types';
+import type { Mocked } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestContainer, getTestInstance } from '@test/testContainer.js';
+
+/**
+ * The 2.0.1 path reads its limits from the device model. OCPP 1.6 has no device model: the
+ * equivalents are the LocalAuthListMaxLength and SendLocalListMaxLength configuration keys, which
+ * GetConfigurationResponseOcpp16Handler stores as ChangeConfiguration rows.
+ */
+describe('LocalAuthListService OCPP 1.6 limits', () => {
+  const { container } = createTestContainer();
+  const tenantId = DEFAULT_TENANT_ID;
+  const ocppConnectionName = 'station-1';
+  const correlationId = 'test-correlation-id';
+
+  let localAuthListRepository: Mocked<ILocalAuthListRepository>;
+  let deviceModelRepository: Mocked<IDeviceModelRepository>;
+  let changeConfigurationRepository: Mocked<IChangeConfigurationRepository>;
+  let service: LocalAuthListService;
+  let configuration: Record<string, string>;
+
+  beforeEach(() => {
+    configuration = {};
+
+    localAuthListRepository = {
+      readOnlyOneByQuery: vi.fn().mockResolvedValue(undefined),
+      createSendLocalListFromRequestData16: vi.fn().mockResolvedValue({} as SendLocalList),
+    } as unknown as Mocked<ILocalAuthListRepository>;
+
+    deviceModelRepository = {
+      readAllByQuerystring: vi.fn().mockResolvedValue([]),
+    } as unknown as Mocked<IDeviceModelRepository>;
+
+    changeConfigurationRepository = {
+      readOnlyOneByQuery: vi.fn(async (_tenantId: number, query: { where: { key: string } }) => {
+        const value = configuration[query.where.key];
+        return value === undefined ? undefined : ({ value } as ChangeConfiguration);
+      }),
+    } as unknown as Mocked<IChangeConfigurationRepository>;
+
+    service = getTestInstance(container, LocalAuthListService, {
+      localAuthListRepository,
+      deviceModelRepository,
+      changeConfigurationRepository,
+    });
+  });
+
+  function aRequest(
+    idTags: string[],
+    updateType = OCPP1_6.SendLocalListRequestUpdateType.Full,
+    listVersion = 3,
+  ): OCPP1_6.SendLocalListRequest {
+    return {
+      listVersion,
+      updateType,
+      localAuthorizationList: idTags.map((idTag) => ({
+        idTag,
+        idTagInfo: { status: OCPP1_6.SendLocalListRequestStatus.Accepted },
+      })),
+    } as unknown as OCPP1_6.SendLocalListRequest;
+  }
+
+  function send(request: OCPP1_6.SendLocalListRequest) {
+    return service.persistSendLocalListForStationIdAndCorrelationIdAndSendLocalListRequest16(
+      tenantId,
+      ocppConnectionName,
+      correlationId,
+      request,
+    );
+  }
+
+  describe('SendLocalListMaxLength', () => {
+    it('refuses a list longer than the station accepts in one message', async () => {
+      configuration.SendLocalListMaxLength = '2';
+
+      await expect(send(aRequest(['A', 'B', 'C']))).rejects.toThrow(/SendLocalListMaxLength/);
+      expect(localAuthListRepository.createSendLocalListFromRequestData16).not.toHaveBeenCalled();
+    });
+
+    it('accepts a list exactly at the limit', async () => {
+      configuration.SendLocalListMaxLength = '3';
+
+      await expect(send(aRequest(['A', 'B', 'C']))).resolves.toBeDefined();
+    });
+
+    it('forwards the request when the station has not reported the key', async () => {
+      await expect(send(aRequest(['A', 'B', 'C']))).resolves.toBeDefined();
+    });
+  });
+
+  describe('LocalAuthListMaxLength', () => {
+    it('refuses a full list that would not fit on the station', async () => {
+      configuration.LocalAuthListMaxLength = '2';
+
+      await expect(send(aRequest(['A', 'B', 'C']))).rejects.toThrow(/LocalAuthListMaxLength/);
+      expect(localAuthListRepository.createSendLocalListFromRequestData16).not.toHaveBeenCalled();
+    });
+
+    it('counts a differential update against what the station already holds', async () => {
+      configuration.LocalAuthListMaxLength = '3';
+      localAuthListRepository.readOnlyOneByQuery.mockResolvedValue({
+        versionNumber: 2,
+        localAuthorizationList: [{ idToken: 'A' }, { idToken: 'B' }],
+      } as unknown as LocalListVersion);
+
+      await expect(
+        send(aRequest(['C', 'D'], OCPP1_6.SendLocalListRequestUpdateType.Differential)),
+      ).rejects.toThrow(/LocalAuthListMaxLength/);
+    });
+
+    it('does not count a differential entry that replaces one already held', async () => {
+      configuration.LocalAuthListMaxLength = '2';
+      localAuthListRepository.readOnlyOneByQuery.mockResolvedValue({
+        versionNumber: 2,
+        localAuthorizationList: [{ idToken: 'A' }, { idToken: 'B' }],
+      } as unknown as LocalListVersion);
+
+      await expect(
+        send(aRequest(['B'], OCPP1_6.SendLocalListRequestUpdateType.Differential)),
+      ).resolves.toBeDefined();
+    });
+
+    it('counts a differential delete as freeing a slot', async () => {
+      // A differential entry with no idTagInfo removes that idTag, per the 1.6 spec.
+      configuration.LocalAuthListMaxLength = '2';
+      localAuthListRepository.readOnlyOneByQuery.mockResolvedValue({
+        versionNumber: 2,
+        localAuthorizationList: [{ idToken: 'A' }, { idToken: 'B' }],
+      } as unknown as LocalListVersion);
+
+      const request = {
+        listVersion: 3,
+        updateType: OCPP1_6.SendLocalListRequestUpdateType.Differential,
+        localAuthorizationList: [{ idTag: 'A' }, { idTag: 'C', idTagInfo: { status: 'Accepted' } }],
+      } as unknown as OCPP1_6.SendLocalListRequest;
+
+      await expect(send(request)).resolves.toBeDefined();
+    });
+
+    it('forwards the request when the station has not reported the key', async () => {
+      await expect(send(aRequest(['A', 'B', 'C']))).resolves.toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## The 1.6 path forwards a list the station cannot hold

`LocalAuthListService` validates a `SendLocalList` before forwarding it. On 2.0.1 that includes two
size checks:

- `LocalAuthListCtrlr.Entries` `maxLimit` - the most the station can store (D01.FR.12)
- `LocalAuthListCtrlr.ItemsPerMessage` - the most it accepts in one message (D01.FR.11)

The 1.6 method checks the version number and duplicate idTags, and then forwards whatever it was
given. Both size checks are absent, so an oversized list goes to the charger and is refused there -
or silently truncated, depending on the vendor.

1.6 has both equivalents, as configuration keys rather than device model variables:

| 2.0.1 | 1.6 |
|---|---|
| `LocalAuthListCtrlr.Entries` maxLimit | `LocalAuthListMaxLength` |
| `LocalAuthListCtrlr.ItemsPerMessage` | `SendLocalListMaxLength` |

`GetConfigurationResponseOcpp16Handler` already persists every reported key as a
`ChangeConfiguration` row, so the values are there. Nothing read them. Before this change the only
occurrence of either key name in the repository was a doc comment on this very method:

```ts
 * Mirrors the 2.0.1 path but uses flat idTag and 1.6 update enum. Item-count limits for 1.6
 * come from the chargepoint via `LocalAuthListMaxLength` configuration; absence is non-fatal.
```

which describes a read that has never existed. That comment is corrected too.

## What changed

Both keys are now read from `ChangeConfiguration` and enforced. A key the station has not reported
is not enforced - the same posture the 2.0.1 path takes for a missing `Entries` maxLimit, with the
same warning.

Two details worth calling out:

**The checks run before persisting.** The 2.0.1 path calls
`createSendLocalListFromStationIdAndRequestAndCurrentVersion` first and then throws on a size
violation, which leaves a `SendLocalList` row behind for a request that was rejected. The 1.6 path
validates first so that does not happen here. I have not changed the 2.0.1 ordering in this PR -
happy to, in a separate one, if you agree it is a problem.

**The maximum counts the resulting list, not the request.** For `Full` that is the request length.
For `Differential` it is what the station already holds, plus the additions, less the deletes - a
1.6 entry carrying no `idTagInfo` removes that idTag, which `createSendLocalListFromRequestData16`
already treats as a tombstone.

## Tests

`LocalAuthListService16.test.ts` is new; the existing file has 12 specs and every one of them
exercises 2.0.1, so the 1.6 method had no coverage at all. Eight cases:

- a list longer than `SendLocalListMaxLength` is refused, and nothing is persisted
- a list exactly at the limit is accepted
- an unreported `SendLocalListMaxLength` is not enforced
- a `Full` list longer than `LocalAuthListMaxLength` is refused, and nothing is persisted
- a `Differential` update is counted against what the station already holds
- a `Differential` entry replacing one already held does not count as a new slot
- a `Differential` delete frees a slot
- an unreported `LocalAuthListMaxLength` is not enforced

The three refusal cases were confirmed failing first with `promise resolved "{}" instead of
rejecting`.

`LocalAuthListService` gains a `changeConfigurationRepository` dependency, already registered in the
container, so the existing 2.0.1 spec file supplies a stub for it.

## Verification

```
npx vitest run test/modules/EVDriver     # 2 files, 20 tests passed
full suite:                              # 98 files passed / 1 skipped, 2050 passed / 4 skipped
pnpm --filter ./packages/** run build    # clean
prettier --check / eslint                # clean
```