### PR TITLE
fix(core): update the reservation the station answered about, not row N

### DIFF
--- a/packages/core/src/handlers/responses/2/CancelReservationResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/CancelReservationResponseOcpp2Handler.ts
@@ -57,12 +57,17 @@ export class CancelReservationResponseOcpp2Handler extends AbstractHandler {
       },
     });
     if (request) {
-      await this._reservationRepository.updateByKey(
+      await this._reservationRepository.updateAllByQuery(
         message.context.tenantId,
         {
           isActive: message.payload.status === CancelReservationStatusEnum.Rejected,
         },
-        request.payload.reservationId,
+        {
+          where: {
+            ocppConnectionName: message.context.ocppConnectionName,
+            id: request.payload.reservationId,
+          },
+        },
       );
     } else {
       this._logger.error(

--- a/packages/core/src/handlers/responses/2/ReserveNowResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/ReserveNowResponseOcpp2Handler.ts
@@ -55,13 +55,18 @@ export class ReserveNowResponseOcpp2Handler extends AbstractHandler {
     });
     if (request) {
       const status = message.payload.status as ReserveNowStatusEnumType;
-      await this._reservationRepository.updateByKey(
+      await this._reservationRepository.updateAllByQuery(
         message.context.tenantId,
         {
           reserveStatus: status,
           isActive: status === ReserveNowStatusEnum.Accepted,
         },
-        request.payload.id,
+        {
+          where: {
+            ocppConnectionName: message.context.ocppConnectionName,
+            id: request.payload.id,
+          },
+        },
       );
     } else {
       this._logger.error(

--- a/packages/core/test/handlers/responses/2/ReservationResponseOcpp2Handlers.test.ts
+++ b/packages/core/test/handlers/responses/2/ReservationResponseOcpp2Handlers.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  CancelReservationStatusEnum,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+  ReserveNowStatusEnum,
+} from '@citrineos/types';
+import type {
+  IOCPPMessageRepository,
+  IReservationRepository,
+} from '@dal/interfaces/repositories.js';
+import {
+  CancelReservationResponseOcpp2Handler,
+  ReserveNowResponseOcpp2Handler,
+} from '@handlers/index.js';
+import { createTestContainer, getTestInstance } from '@test/testContainer.js';
+import type { Mocked } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const STATION = 'station-001';
+
+/**
+ * Reservation.databaseId is the primary key; Reservation.id is the OCPP-level reservation id,
+ * unique per station within a tenant. These differ for every reservation that is not the first
+ * row in the table, so the two must not be used interchangeably.
+ */
+const OCPP_RESERVATION_ID = 7;
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION,
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.ReserveNow,
+    state: MessageState.Response,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<T>;
+}
+
+describe('reservation response handlers address the reservation by its OCPP id', () => {
+  const { container } = createTestContainer();
+  let ocppMessageRepository: Mocked<IOCPPMessageRepository>;
+  let reservationRepository: Mocked<IReservationRepository>;
+
+  beforeEach(() => {
+    reservationRepository = {
+      updateAllByQuery: vi.fn().mockResolvedValue([]),
+      updateByKey: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<IReservationRepository>;
+  });
+
+  function withRequest(payload: unknown) {
+    ocppMessageRepository = {
+      readOnlyOneByQuery: vi.fn().mockResolvedValue({ payload }),
+    } as unknown as Mocked<IOCPPMessageRepository>;
+  }
+
+  it('ReserveNow updates the row matching the station and OCPP reservation id', async () => {
+    withRequest({ id: OCPP_RESERVATION_ID });
+    const handler = getTestInstance(container, ReserveNowResponseOcpp2Handler, {
+      ocppMessageRepository,
+      reservationRepository,
+    });
+
+    await handler.handle(
+      makeMessage({
+        status: OCPP2_0_1.ReserveNowStatusEnumType.Accepted,
+      } as never),
+    );
+
+    expect(reservationRepository.updateByKey).not.toHaveBeenCalled();
+    expect(reservationRepository.updateAllByQuery).toHaveBeenCalledWith(
+      DEFAULT_TENANT_ID,
+      { reserveStatus: ReserveNowStatusEnum.Accepted, isActive: true },
+      { where: { ocppConnectionName: STATION, id: OCPP_RESERVATION_ID } },
+    );
+  });
+
+  it('CancelReservation updates the row matching the station and OCPP reservation id', async () => {
+    withRequest({ reservationId: OCPP_RESERVATION_ID });
+    const handler = getTestInstance(container, CancelReservationResponseOcpp2Handler, {
+      ocppMessageRepository,
+      reservationRepository,
+    });
+
+    await handler.handle(
+      makeMessage({
+        status: CancelReservationStatusEnum.Accepted,
+      } as never),
+    );
+
+    expect(reservationRepository.updateByKey).not.toHaveBeenCalled();
+    expect(reservationRepository.updateAllByQuery).toHaveBeenCalledWith(
+      DEFAULT_TENANT_ID,
+      { isActive: false },
+      { where: { ocppConnectionName: STATION, id: OCPP_RESERVATION_ID } },
+    );
+  });
+
+  it('CancelReservation leaves the reservation active when the station refuses', async () => {
+    withRequest({ reservationId: OCPP_RESERVATION_ID });
+    const handler = getTestInstance(container, CancelReservationResponseOcpp2Handler, {
+      ocppMessageRepository,
+      reservationRepository,
+    });
+
+    await handler.handle(
+      makeMessage({
+        status: CancelReservationStatusEnum.Rejected,
+      } as never),
+    );
+
+    expect(reservationRepository.updateAllByQuery).toHaveBeenCalledWith(
+      DEFAULT_TENANT_ID,
+      { isActive: true },
+      { where: { ocppConnectionName: STATION, id: OCPP_RESERVATION_ID } },
+    );
+  });
+});


### PR DESCRIPTION
## Two identifiers, used interchangeably

`Reservation` carries both:

```ts
@PrimaryKey
@Column(DataType.INTEGER)
declare databaseId: number;

@Column({ unique: 'stationName_tenantId_id', ... })
declare id: number;          // the OCPP-level reservation id
```

`id` is the reservation id as the charging station knows it, unique per
`(ocppConnectionName, tenantId, id)`. `databaseId` is the table's primary key.

Both response handlers passed the OCPP id where the primary key is expected:

```ts
await this._reservationRepository.updateByKey(
  message.context.tenantId,
  { reserveStatus: status, isActive: status === ReserveNowStatusEnum.Accepted },
  request.payload.id,          // <- OCPP id
);
```

and `_updateByKey` matches on the primary key:

```ts
const pk = model.primaryKeyAttribute;
const where: WhereOptions<any> = { [pk]: key, tenantId };
```

## What that does

Two things, both silent:

- The reservation the station just answered about never has its `reserveStatus` or `isActive`
  recorded. A reservation the charger **rejected** stays whatever it was.
- Whichever reservation happens to have that `databaseId` - a different reservation, possibly on a
  different station - is updated instead.

The two ids coincide only while the table holds a single row, which is why this survives any test
that makes one reservation and checks it.

## The fix

Both handlers now address the row by its natural key. `updateAllByQuery` merges `tenantId` into the
`where` itself, so the tenant scope is not lost:

```ts
await this._reservationRepository.updateAllByQuery(
  message.context.tenantId,
  { reserveStatus: status, isActive: status === ReserveNowStatusEnum.Accepted },
  { where: { ocppConnectionName: message.context.ocppConnectionName, id: request.payload.id } },
);
```

## Tests

`ReservationResponseOcpp2Handlers.test.ts` is new - neither handler had any coverage. Three cases:
the ReserveNow update targets station and OCPP id, the CancelReservation update does the same, and a
`Rejected` cancellation leaves the reservation active. Each also asserts `updateByKey` is not called,
so the primary-key form cannot come back unnoticed.

All three were confirmed failing first.

## Verification

```
npx vitest run    # packages/core: 1388 passed / 6 skipped
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
prettier --check / eslint                          # clean
```