### PR TITLE
fix(core): scope the ServerNetworkProfile lookups to the tenant

### DIFF
--- a/packages/core/src/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.ts
@@ -48,9 +48,12 @@ export class SetNetworkProfileResponseOcpp2Handler extends AbstractHandler {
       return;
     }
 
-    const serverNetworkProfile = await ServerNetworkProfile.findByPk(
-      setNetworkProfile.websocketServerConfigId!,
-    );
+    const serverNetworkProfile = await ServerNetworkProfile.findOne({
+      where: {
+        id: setNetworkProfile.websocketServerConfigId!,
+        tenantId: message.context.tenantId,
+      },
+    });
     if (!serverNetworkProfile) {
       return;
     }

--- a/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
+++ b/packages/core/src/util/networkconnection/authenticator/NetworkProfileFilter.ts
@@ -99,9 +99,12 @@ export class NetworkProfileFilter extends AuthenticatorFilter {
               },
             });
             if (chargingStationNetworkProfile) {
-              const serverNetworkProfile = await ServerNetworkProfile.findByPk(
-                chargingStationNetworkProfile.websocketServerConfigId,
-              );
+              const serverNetworkProfile = await ServerNetworkProfile.findOne({
+                where: {
+                  id: chargingStationNetworkProfile.websocketServerConfigId,
+                  tenantId,
+                },
+              });
               if (serverNetworkProfile && securityProfile >= serverNetworkProfile.securityProfile) {
                 this._logger.debug('Security profile allowed');
                 securityProfileAllowed = true;

--- a/packages/core/test/util/networkconnection/authenticator/NetworkProfileFilterTenantScoping.integration.test.ts
+++ b/packages/core/test/util/networkconnection/authenticator/NetworkProfileFilterTenantScoping.integration.test.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { AuthenticationOptions, BootstrapConfig } from '@citrineos/base';
+import { OCPPVersion } from '@citrineos/types';
+import {
+  ChargingStation,
+  ChargingStationNetworkProfile,
+  DefaultSequelizeInstance,
+  ServerNetworkProfile,
+  Tenant,
+} from '@dal/index.js';
+import type { IDeviceModelRepository } from '@dal/interfaces/repositories.js';
+import { NetworkProfileFilter } from '@util/networkconnection/authenticator/NetworkProfileFilter.js';
+import type { IncomingMessage } from 'http';
+import { Logger } from 'tslog';
+
+/**
+ * ServerNetworkProfile has a tenantId, but its primary key is an operator-chosen string shared
+ * across the whole table. A profile id named by one tenant's ChargingStationNetworkProfile can
+ * therefore belong to another tenant, and this filter gates a websocket connection on the
+ * securityProfile it finds there.
+ */
+const TENANT_A = 1;
+const TENANT_B = 2;
+const STATION = 'CP001';
+const SHARED_PROFILE_ID = 'websocket-server-0';
+const CONFIGURATION_SLOT = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+/** Exposes the protected filter hook. */
+class TestNetworkProfileFilter extends NetworkProfileFilter {
+  public check(tenantId: number, identifier: string, securityProfile: number): Promise<void> {
+    return this['filter'](
+      tenantId,
+      identifier,
+      {} as IncomingMessage,
+      { securityProfile } as AuthenticationOptions,
+    );
+  }
+}
+
+function aFilter(): TestNetworkProfileFilter {
+  const deviceModelRepository = {
+    readAllByQuerystring: vi.fn().mockResolvedValue([{ value: String(CONFIGURATION_SLOT) }]),
+  } as unknown as IDeviceModelRepository;
+
+  return new TestNetworkProfileFilter({
+    deviceModelRepository,
+    logger: new Logger({ type: 'hidden' }),
+  });
+}
+
+describe('NetworkProfileFilter tenant scoping', () => {
+  beforeEach(async () => {
+    await ChargingStationNetworkProfile.destroy({ where: {}, truncate: true, cascade: true });
+    await ChargingStation.destroy({ where: {}, truncate: true, cascade: true });
+    await ServerNetworkProfile.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: TENANT_A, name: 'A' } as never);
+    await Tenant.create({ id: TENANT_B, name: 'B' } as never);
+
+    // Only tenant B owns this profile, and it permits security profile 1.
+    await ServerNetworkProfile.create({
+      id: SHARED_PROFILE_ID,
+      host: 'localhost',
+      port: 8080,
+      pingInterval: 60,
+      protocols: [OCPPVersion.OCPP2_0_1],
+      messageTimeout: 30,
+      securityProfile: 1,
+      allowUnknownChargingStations: false,
+      dynamicTenantResolution: false,
+      tenantId: TENANT_B,
+    } as never);
+
+    const station = await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: false,
+      tenantId: TENANT_A,
+    } as never);
+
+    // Tenant A's station names it anyway. Nothing validates the reference on the way in.
+    await ChargingStationNetworkProfile.create({
+      stationId: (station as unknown as { id: number }).id,
+      ocppConnectionName: STATION,
+      configurationSlot: CONFIGURATION_SLOT,
+      websocketServerConfigId: SHARED_PROFILE_ID,
+      tenantId: TENANT_A,
+    } as never);
+  });
+
+  it('refuses a station whose profile reference resolves to another tenant', async () => {
+    await expect(aFilter().check(TENANT_A, STATION, 1)).rejects.toThrow(/SecurityProfile/);
+  });
+
+  it('allows the station once the profile belongs to its own tenant', async () => {
+    await ServerNetworkProfile.create({
+      id: 'websocket-server-a',
+      host: 'localhost',
+      port: 8080,
+      pingInterval: 60,
+      protocols: [OCPPVersion.OCPP2_0_1],
+      messageTimeout: 30,
+      securityProfile: 1,
+      allowUnknownChargingStations: false,
+      dynamicTenantResolution: false,
+      tenantId: TENANT_A,
+    } as never);
+    await ChargingStationNetworkProfile.update(
+      { websocketServerConfigId: 'websocket-server-a' },
+      { where: { tenantId: TENANT_A, ocppConnectionName: STATION } },
+    );
+
+    await expect(aFilter().check(TENANT_A, STATION, 1)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## A tenant-owned row fetched by a globally shared key

`ServerNetworkProfile` has a `tenantId`, but its primary key is an operator-chosen string:

```ts
@PrimaryKey
@Column(DataType.STRING)
declare id: string;
```

so profile ids live in one namespace shared by every tenant. Both lookups fetched by that key alone:

```ts
const serverNetworkProfile = await ServerNetworkProfile.findByPk(
  chargingStationNetworkProfile.websocketServerConfigId,
);
```

The `websocketServerConfigId` comes from a tenant-scoped row, but nothing validates that it names a
profile in the *same* tenant - it is written straight from the `SetNetworkProfile` request. So a
reference to another tenant's profile resolves to that tenant's row.

## Why it matters in NetworkProfileFilter

That is the websocket authentication path. The filter decides whether a station may connect at the
security profile it offered:

```ts
if (serverNetworkProfile && securityProfile >= serverNetworkProfile.securityProfile) {
  securityProfileAllowed = true;
}
```

With the wrong row, that comparison is made against another tenant's configuration - a connection
admitted or refused on a policy that does not belong to the station's operator.

The integration test demonstrates it: tenant B owns profile `websocket-server-0` permitting security
profile 1, tenant A's station references that id, and the filter admits the station. Reverting just
this lookup makes the test fail with `promise resolved "undefined" instead of rejecting`.

`SetNetworkProfileResponseOcpp2Handler` has the same lookup and is corrected with it.

## Fails closed

Both call sites already handle the profile not being found - the handler returns, the filter falls
through to `securityProfileAllowed` staying false - so an out-of-tenant reference is now refused
rather than honoured.

## Tests

`NetworkProfileFilterTenantScoping.integration.test.ts` is new; there was no coverage of this filter.
Two cases against a real database: a station whose profile reference resolves to another tenant is
refused, and the same station is allowed once the profile belongs to its own tenant.

## Verification

```
npx vitest run    # packages/core: 1389 passed / 4 skipped
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
prettier --check / eslint                          # clean
```