### PR TITLE
fix(base): keep the station name intact through the connection identifier

### DIFF
--- a/packages/base/src/util/identifiers.ts
+++ b/packages/base/src/util/identifiers.ts
@@ -25,8 +25,6 @@ export const getTenantIdFromIdentifier = (identifier: string): number => {
   return Number.isInteger(tenantId) ? tenantId : DEFAULT_TENANT_ID;
 };
 export const getStationIdFromIdentifier = (identifier: string): string => {
-  // Only the first delimiter separates the tenant from the name; the rest belong to the name,
-  // which is the last segment of the connection URL and can contain anything.
   const delimiterIndex = identifier.indexOf(IDENTIFIER_DELIMITER);
   return delimiterIndex === -1 ? identifier : identifier.slice(delimiterIndex + 1);
 };

--- a/packages/base/src/util/identifiers.ts
+++ b/packages/base/src/util/identifiers.ts
@@ -17,10 +17,16 @@ export const IDENTIFIER_DELIMITER = ':';
 export const createIdentifier = (tenantId: number, ...args: any[]): string =>
   [tenantId, ...(args ?? [])].join(IDENTIFIER_DELIMITER);
 export const getTenantIdFromIdentifier = (identifier: string): number => {
-  const identifierSplit = identifier.split(IDENTIFIER_DELIMITER);
-  return identifierSplit?.[0] ? Number(identifierSplit?.[0]) : DEFAULT_TENANT_ID;
+  const segment = identifier.split(IDENTIFIER_DELIMITER, 1)[0];
+  if (!segment) {
+    return DEFAULT_TENANT_ID;
+  }
+  const tenantId = Number(segment);
+  return Number.isInteger(tenantId) ? tenantId : DEFAULT_TENANT_ID;
 };
 export const getStationIdFromIdentifier = (identifier: string): string => {
-  const identifierSplit = identifier.split(IDENTIFIER_DELIMITER);
-  return identifierSplit?.[1] ?? identifier;
+  // Only the first delimiter separates the tenant from the name; the rest belong to the name,
+  // which is the last segment of the connection URL and can contain anything.
+  const delimiterIndex = identifier.indexOf(IDENTIFIER_DELIMITER);
+  return delimiterIndex === -1 ? identifier : identifier.slice(delimiterIndex + 1);
 };

--- a/packages/base/test/util/identifiers.test.ts
+++ b/packages/base/test/util/identifiers.test.ts
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from 'vitest';
+import {
+  createIdentifier,
+  getStationIdFromIdentifier,
+  getTenantIdFromIdentifier,
+} from '../../src/util/identifiers.js';
+import { DEFAULT_TENANT_ID } from '../../src/config/defineConfig.js';
+
+/**
+ * The station name is the last segment of the websocket URL, so its content is chosen by whoever
+ * connects. It reaches createIdentifier unaltered, and every inbound message is attributed to
+ * whatever getStationIdFromIdentifier reads back out.
+ */
+const STATION_NAMES = ['CP001', 'CP:001', 'A:B', 'a:b:c:d', ':leading', 'trailing:', ''];
+
+describe('identifier round trip', () => {
+  it.each(STATION_NAMES)('recovers the station name %j unchanged', (ocppConnectionName) => {
+    const identifier = createIdentifier(7, ocppConnectionName);
+
+    expect(getStationIdFromIdentifier(identifier)).toBe(ocppConnectionName);
+    expect(getTenantIdFromIdentifier(identifier)).toBe(7);
+  });
+
+  it('does not let one station be read back as another', () => {
+    // Without splitting on the first delimiter only, "A:B" reads back as "A", so a station
+    // connecting under that name has its messages attributed to a different station.
+    expect(getStationIdFromIdentifier(createIdentifier(1, 'A:B'))).not.toBe(
+      getStationIdFromIdentifier(createIdentifier(1, 'A')),
+    );
+  });
+});
+
+describe('getStationIdFromIdentifier', () => {
+  it('returns the input when there is no delimiter at all', () => {
+    expect(getStationIdFromIdentifier('CP001')).toBe('CP001');
+  });
+});
+
+describe('getTenantIdFromIdentifier', () => {
+  it('reads the tenant from the first segment', () => {
+    expect(getTenantIdFromIdentifier('42:CP001')).toBe(42);
+  });
+
+  it('falls back to the default tenant when the first segment is empty', () => {
+    expect(getTenantIdFromIdentifier(':CP001')).toBe(DEFAULT_TENANT_ID);
+  });
+
+  it('falls back to the default tenant rather than returning NaN', () => {
+    // Number('abc') is NaN, which is truthy-checked as a string and so was returned as-is.
+    // A NaN tenant matches no row, so it surfaces as an empty result rather than an error.
+    expect(getTenantIdFromIdentifier('abc:CP001')).toBe(DEFAULT_TENANT_ID);
+  });
+});


### PR DESCRIPTION
## The identifier round trip is lossy

An identifier is `tenantId:ocppConnectionName`:

```ts
export const IDENTIFIER_DELIMITER = ':';
export const createIdentifier = (tenantId: number, ...args: any[]): string =>
  [tenantId, ...(args ?? [])].join(IDENTIFIER_DELIMITER);

export const getStationIdFromIdentifier = (identifier: string): string => {
  const identifierSplit = identifier.split(IDENTIFIER_DELIMITER);
  return identifierSplit?.[1] ?? identifier;      // <- segment 1 only
};
```

Taking segment `[1]` recovers the name only when the name itself contains no colon.

The name is not ours to constrain. It is the last segment of the connection URL:

```ts
return url.split('?')[0].split('/').pop() as string;
```

so it is whatever the connecting client put there, and a colon is a legal character in a URL path
segment.

| station name | identifier | reads back as |
|---|---|---|
| `CP001` | `1:CP001` | `CP001` |
| `CP:001` | `1:CP:001` | `CP` |
| `A:B` | `1:A:B` | `A` |
| `a:b:c:d` | `1:a:b:c:d` | `a` |

## What that costs

`MessageRouterImpl.onMessage` derives the station for **every inbound OCPP message** this way:

```ts
const tenantId = getTenantIdFromIdentifier(identifier);
const ocppConnectionName = getStationIdFromIdentifier(identifier);
```

So a station connected as `A:B` has its messages attributed to station `A` - a station that may well
exist. The same helper is used by the webhook dispatcher and by `deregisterConnection` on close.

The tenant id is unaffected; it is the first segment either way.

## The fix

The tenant is everything before the first delimiter, the name is everything after it:

```ts
const delimiterIndex = identifier.indexOf(IDENTIFIER_DELIMITER);
return delimiterIndex === -1 ? identifier : identifier.slice(delimiterIndex + 1);
```

`getTenantIdFromIdentifier` gets the matching treatment. It checked the *string* segment for
truthiness and then returned `Number(segment)` regardless, so a non-numeric first segment returned
`NaN` as a tenant id rather than falling back. Empty still falls back to `DEFAULT_TENANT_ID`, as
before.

## Tests

`identifiers.test.ts` is new - these helpers had no coverage. The round trip is asserted as a
property over a set of names including several containing the delimiter, plus one case stating the
consequence directly: `A:B` and `A` must not read back the same.

Seven of twelve were confirmed failing first, the sharpest being
`expected 'A' not to be 'A'`.

## Verification

```
full suite:  2054 passed / 4 skipped
pnpm --filter ./packages/** run build    # clean
prettier --check / eslint                # 0 errors
```