### PR TITLE
fix(core): treat 0 as a value in the smart charging criteria, not as absent

### DIFF
--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/ClearChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/ClearChargingProfileEndpoint.ts
@@ -74,14 +74,20 @@ export class ClearChargingProfileEndpoint extends AbstractMessageEndpoint {
   ): IMessageConfirmation | undefined {
     const criteria = request.chargingProfileCriteria;
 
-    if (!request.chargingProfileId) {
+    // Zero is a value, not an omission: evseId 0 means the charging station as a whole and
+    // stackLevel 0 is the lowest the schema allows, so both are matched on presence.
+    if (request.chargingProfileId === undefined || request.chargingProfileId === null) {
       if (!criteria) {
         return {
           success: false,
           payload: 'Either chargingProfileId or chargingProfileCriteria must be provided',
         };
       }
-      if (!criteria.chargingProfilePurpose && !criteria.stackLevel && !criteria.evseId) {
+      if (
+        criteria.chargingProfilePurpose === undefined &&
+        criteria.stackLevel === undefined &&
+        criteria.evseId === undefined
+      ) {
         return {
           success: false,
           payload:

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/ClearChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/ClearChargingProfileEndpoint.ts
@@ -74,8 +74,6 @@ export class ClearChargingProfileEndpoint extends AbstractMessageEndpoint {
   ): IMessageConfirmation | undefined {
     const criteria = request.chargingProfileCriteria;
 
-    // Zero is a value, not an omission: evseId 0 means the charging station as a whole and
-    // stackLevel 0 is the lowest the schema allows, so both are matched on presence.
     if (request.chargingProfileId === undefined || request.chargingProfileId === null) {
       if (!criteria) {
         return {

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/GetChargingProfilesEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/GetChargingProfilesEndpoint.ts
@@ -49,7 +49,6 @@ export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
   ): Promise<IMessageConfirmation[]> {
     const chargingProfile = request.chargingProfile;
 
-    // stackLevel 0 is the lowest the schema allows, so criteria are matched on presence.
     if (chargingProfile.chargingProfileId) {
       if (
         chargingProfile.chargingProfilePurpose ||

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/GetChargingProfilesEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/GetChargingProfilesEndpoint.ts
@@ -49,10 +49,11 @@ export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
   ): Promise<IMessageConfirmation[]> {
     const chargingProfile = request.chargingProfile;
 
+    // stackLevel 0 is the lowest the schema allows, so criteria are matched on presence.
     if (chargingProfile.chargingProfileId) {
       if (
         chargingProfile.chargingProfilePurpose ||
-        chargingProfile.stackLevel ||
+        chargingProfile.stackLevel !== undefined ||
         chargingProfile.chargingLimitSource
       ) {
         return identifiers.map(() => ({
@@ -63,7 +64,7 @@ export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
       }
     } else if (
       !chargingProfile.chargingProfilePurpose &&
-      !chargingProfile.stackLevel &&
+      chargingProfile.stackLevel === undefined &&
       !chargingProfile.chargingLimitSource
     ) {
       return identifiers.map(() => ({

--- a/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
@@ -63,6 +63,29 @@ describe('smartCharging message endpoints', () => {
       expect(sendCall).not.toHaveBeenCalled();
     });
 
+    it('sends for the whole station when the criteria name evseId 0', async () => {
+      // The spec: "An evseId of zero (0) specifies the charging profile for the overall
+      // Charging Station."
+      const confirmations = await handle({ chargingProfileCriteria: { evseId: 0 } });
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalledOnce();
+    });
+
+    it('sends when the criteria name stack level 0, the lowest the schema allows', async () => {
+      const confirmations = await handle({ chargingProfileCriteria: { stackLevel: 0 } });
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalledOnce();
+    });
+
+    it('treats charging profile id 0 as an id, not as an absent one', async () => {
+      const confirmations = await handle({ chargingProfileId: 0 });
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalledOnce();
+    });
+
     it('refuses criteria alongside an id as redundant', async () => {
       const confirmations = await handle({
         chargingProfileId: 1,
@@ -128,6 +151,26 @@ describe('smartCharging message endpoints', () => {
       });
 
       expect(confirmations[0].success).toBe(true);
+    });
+
+    it('sends when queried by stack level 0', async () => {
+      const confirmations = await handle({
+        requestId: 1,
+        chargingProfile: { stackLevel: 0 },
+      });
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalledOnce();
+    });
+
+    it('refuses stack level 0 alongside a profile id, like any other criterion', async () => {
+      const confirmations = await handle({
+        requestId: 1,
+        chargingProfile: { chargingProfileId: [1], stackLevel: 0 },
+      });
+
+      expect(confirmations[0].success).toBe(false);
+      expect(sendCall).not.toHaveBeenCalled();
     });
 
     it('refuses mixing profile ids with other criteria', async () => {


### PR DESCRIPTION
## Truthiness used to mean "supplied"

Both endpoints decide which criteria a caller gave by testing them for truthiness:

```ts
// ClearChargingProfileEndpoint
if (!request.chargingProfileId) {
  ...
  if (!criteria.chargingProfilePurpose && !criteria.stackLevel && !criteria.evseId) {
```

All three of those are integers where 0 is valid, so a request naming any of them as `0` reads as
naming nothing.

The one that matters most is spelled out in the schema:

> Specifies the id of the EVSE for which to clear charging profiles. **An evseId of zero (0)
> specifies the charging profile for the overall Charging Station.**

That is the value an operator sends to clear the station-wide profiles, and it was refused with
`At least one of chargingProfilePurpose, stackLevel, or evseId must be provided`.

`stackLevel` carries `minimum: 0` in `ChargingProfileCriterionType`, so 0 is not an edge case there
but the lowest legal value. `ClearChargingProfileRequest.chargingProfileId` has no positive floor
either (`minimum: -2147483648`), so profile id 0 fell through to the criteria branch and was refused
as having neither an id nor criteria.

## GetChargingProfiles has it wrong in both directions

```ts
if (chargingProfile.chargingProfileId) {
  if (purpose || stackLevel || chargingLimitSource) {  // -> "not needed when id is provided"
} else if (!purpose && !stackLevel && !chargingLimitSource) {  // -> "at least one required"
```

- `stackLevel: 0` on its own is refused as no criteria at all.
- `stackLevel: 0` **alongside** a `chargingProfileId` is accepted, though the same field at any other
  value is refused as redundant.

## The fix

Criteria are matched on presence rather than truthiness. `GetCompositeScheduleEndpoint`, in the same
directory, already special-cases `evseId === 0` before doing an EVSE lookup, so the semantics were
understood there - these two just tested the wrong thing.

## Tests

Five cases added to the existing `smartChargingEndpoints.test.ts`. Worth noting why they were
missing: every existing case uses `chargingProfileId: 1`, `evseId: 1`, `stackLevel: 1`, so the suite
reads as thorough while never touching the value that breaks.

All five were confirmed failing first, including the inverse one:

```
× sends for the whole station when the criteria name evseId 0        → expected false to be true
× sends when the criteria name stack level 0                         → expected false to be true
× treats charging profile id 0 as an id, not as an absent one        → expected false to be true
× sends when queried by stack level 0                                → expected false to be true
× refuses stack level 0 alongside a profile id                       → expected true to be false
```

## Verification

```
npx vitest run    # packages/core: 1390 passed / 6 skipped
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
prettier --check / eslint                          # clean
```