### PR TITLE
fix(core): apply the BytesPerMessage limit in SetVariables and GetMonitoringReport

### DIFF
--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/monitoring/SetVariablesEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/monitoring/SetVariablesEndpoint.ts
@@ -17,6 +17,7 @@ import {
 } from '@citrineos/types';
 import type { IDeviceModelRepository } from '@dal/interfaces/repositories.js';
 import type { DeviceModelService } from '@util/deviceModel/DeviceModelService.js';
+import { getSizeOfRequest } from '@util/index.js';
 import { COMPONENT_DEVICE_DATA_CTRLR } from '../components.js';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 import { sendInBatches } from './sendInBatches.js';
@@ -57,6 +58,21 @@ export class SetVariablesEndpoint extends AbstractMessageEndpoint {
 
     for (const ocppConnectionName of identifiers) {
       try {
+        const maxBytes =
+          await this._deviceModelService.getBytesPerMessageByComponentAndVariableInstanceAndStationId(
+            COMPONENT_DEVICE_DATA_CTRLR,
+            OCPP_CallAction.SetVariables,
+            tenantId,
+            ocppConnectionName,
+          );
+        const requestBytes = getSizeOfRequest(request);
+
+        if (maxBytes && requestBytes > maxBytes) {
+          throw new Error(
+            `The request size exceeds the limit of ${maxBytes} bytes for identifier ${ocppConnectionName}.`,
+          );
+        }
+
         const setVariableData = request.setVariableData;
 
         await this._deviceModelRepository.createOrUpdateBySetVariablesDataAndStationId(

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/reporting/GetMonitoringReportEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/reporting/GetMonitoringReportEndpoint.ts
@@ -18,7 +18,7 @@ import {
 } from '@citrineos/types';
 import { getBatches, getSizeOfRequest } from '@util/index.js';
 import type { DeviceModelService } from '@util/deviceModel/DeviceModelService.js';
-import { COMPONENT_MONITORING_CTRLR } from '../components.js';
+import { COMPONENT_DEVICE_DATA_CTRLR } from '../components.js';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
@@ -64,8 +64,8 @@ export class GetMonitoringReportEndpoint extends AbstractMessageEndpoint {
     for (const ocppConnectionName of identifiers) {
       const maxBytes =
         await this._deviceModelService.getBytesPerMessageByComponentAndVariableInstanceAndStationId(
-          COMPONENT_MONITORING_CTRLR,
-          OCPP_CallAction.GetMonitoringReport,
+          COMPONENT_DEVICE_DATA_CTRLR,
+          OCPP_CallAction.GetReport,
           tenantId,
           ocppConnectionName,
         );
@@ -79,8 +79,8 @@ export class GetMonitoringReportEndpoint extends AbstractMessageEndpoint {
 
       const itemsPerMessageGetReport =
         (await this._deviceModelService.getItemsPerMessageByComponentAndVariableInstanceAndStationId(
-          COMPONENT_MONITORING_CTRLR,
-          OCPP_CallAction.GetMonitoringReport,
+          COMPONENT_DEVICE_DATA_CTRLR,
+          OCPP_CallAction.GetReport,
           tenantId,
           ocppConnectionName,
         )) ?? componentVariable.length;

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/reporting/GetMonitoringReportEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/reporting/GetMonitoringReportEndpoint.ts
@@ -16,9 +16,9 @@ import {
   type OCPPVersion,
   type OCPP2_request_types,
 } from '@citrineos/types';
-import { getBatches } from '@util/index.js';
+import { getBatches, getSizeOfRequest } from '@util/index.js';
 import type { DeviceModelService } from '@util/deviceModel/DeviceModelService.js';
-import { COMPONENT_DEVICE_DATA_CTRLR } from '../components.js';
+import { COMPONENT_MONITORING_CTRLR } from '../components.js';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
@@ -62,10 +62,25 @@ export class GetMonitoringReportEndpoint extends AbstractMessageEndpoint {
 
     const confirmations: IMessageConfirmation[] = [];
     for (const ocppConnectionName of identifiers) {
+      const maxBytes =
+        await this._deviceModelService.getBytesPerMessageByComponentAndVariableInstanceAndStationId(
+          COMPONENT_MONITORING_CTRLR,
+          OCPP_CallAction.GetMonitoringReport,
+          tenantId,
+          ocppConnectionName,
+        );
+      if (maxBytes && getSizeOfRequest(request) > maxBytes) {
+        confirmations.push({
+          success: false,
+          payload: `${ocppConnectionName}: the request size exceeds the limit of ${maxBytes} bytes.`,
+        });
+        continue;
+      }
+
       const itemsPerMessageGetReport =
         (await this._deviceModelService.getItemsPerMessageByComponentAndVariableInstanceAndStationId(
-          COMPONENT_DEVICE_DATA_CTRLR,
-          OCPP_CallAction.GetReport,
+          COMPONENT_MONITORING_CTRLR,
+          OCPP_CallAction.GetMonitoringReport,
           tenantId,
           ocppConnectionName,
         )) ?? componentVariable.length;

--- a/packages/core/test/modules/Api/endpoints/ocpp/monitoringEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/monitoringEndpoints.test.ts
@@ -116,6 +116,25 @@ describe('monitoring message endpoints', () => {
       }
     });
 
+    it('refuses a request larger than the station byte limit', async () => {
+      // The three sibling endpoints in this file all enforce DeviceDataCtrlr.BytesPerMessage.
+      getBytesPerMessage.mockResolvedValue(1);
+
+      const confirmations = await handle({ setVariableData: [aSetVariableData('A')] });
+
+      expect(confirmations[0].success).toBe(false);
+      expect(String(confirmations[0].payload)).toContain('exceeds the limit of 1 bytes');
+      expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    it('does not persist the values when the request is over the byte limit', async () => {
+      getBytesPerMessage.mockResolvedValue(1);
+
+      await handle({ setVariableData: [aSetVariableData('A')] });
+
+      expect(createOrUpdateBySetVariablesDataAndStationId).not.toHaveBeenCalled();
+    });
+
     it('reports a persistence failure as an unsuccessful confirmation', async () => {
       createOrUpdateBySetVariablesDataAndStationId.mockRejectedValue(new Error('db down'));
 

--- a/packages/core/test/modules/Api/endpoints/ocpp/reportingTransactionsEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/reportingTransactionsEndpoints.test.ts
@@ -137,17 +137,15 @@ describe('reporting and transactions message endpoints', () => {
       }
     });
 
-    it('reads its limits from MonitoringCtrlr, not the GetReport ones', async () => {
-      // GetMonitoringReport has its own ItemsPerMessage and BytesPerMessage on MonitoringCtrlr.
-      // Reading DeviceDataCtrlr/GetReport applies the limit configured for a different message.
+    it('reads its byte limit from the same variable as its item limit', async () => {
+      // ItemsPerMessageGetReport and BytesPerMessageGetReport both sit on DeviceDataCtrlr under the
+      // GetReport instance, and each is defined as constraining GetReportRequest or
+      // GetMonitoringReportRequest, so both messages share them.
       await handle({ requestId: 1, componentVariable: [aComponentVariable('A')] });
 
-      expect(getItemsPerMessage).toHaveBeenCalledWith(
-        'MonitoringCtrlr',
-        OCPP_CallAction.GetMonitoringReport,
-        DEFAULT_TENANT_ID,
-        STATION,
-      );
+      const expected = ['DeviceDataCtrlr', OCPP_CallAction.GetReport, DEFAULT_TENANT_ID, STATION];
+      expect(getItemsPerMessage).toHaveBeenCalledWith(...expected);
+      expect(getBytesPerMessage).toHaveBeenCalledWith(...expected);
     });
 
     it('refuses a request larger than the station byte limit', async () => {

--- a/packages/core/test/modules/Api/endpoints/ocpp/reportingTransactionsEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/reportingTransactionsEndpoints.test.ts
@@ -137,6 +137,31 @@ describe('reporting and transactions message endpoints', () => {
       }
     });
 
+    it('reads its limits from MonitoringCtrlr, not the GetReport ones', async () => {
+      // GetMonitoringReport has its own ItemsPerMessage and BytesPerMessage on MonitoringCtrlr.
+      // Reading DeviceDataCtrlr/GetReport applies the limit configured for a different message.
+      await handle({ requestId: 1, componentVariable: [aComponentVariable('A')] });
+
+      expect(getItemsPerMessage).toHaveBeenCalledWith(
+        'MonitoringCtrlr',
+        OCPP_CallAction.GetMonitoringReport,
+        DEFAULT_TENANT_ID,
+        STATION,
+      );
+    });
+
+    it('refuses a request larger than the station byte limit', async () => {
+      getBytesPerMessage.mockResolvedValue(1);
+
+      const confirmations = await handle({
+        requestId: 1,
+        componentVariable: [aComponentVariable('A')],
+      });
+
+      expect(confirmations[0].success).toBe(false);
+      expect(sendCall).not.toHaveBeenCalled();
+    });
+
     it('captures a send failure as an unsuccessful batch', async () => {
       getItemsPerMessage.mockResolvedValue(1);
       sendCall.mockRejectedValueOnce(new Error('offline')).mockResolvedValueOnce({


### PR DESCRIPTION
## The defect

Both endpoints batch by `ItemsPerMessage` but never check `BytesPerMessage`, so a request under the item limit still goes out when it is over the station's byte limit. OCPP defines both constraints; only one was applied.

`ClearVariableMonitoringEndpoint` and `GetVariablesEndpoint` already check both, so this brings the two that did not into line with them.

## The fix

Each endpoint reads `BytesPerMessage` from the same component and instance its `ItemsPerMessage` read already used:

| Endpoint | Component | Instance |
| --- | --- | --- |
| `SetVariables` | `DeviceDataCtrlr` | `SetVariables` |
| `GetMonitoringReport` | `DeviceDataCtrlr` | `GetReport` |

`GetMonitoringReport` sharing the `GetReport` variable is per spec, not an oversight: `ItemsPerMessageGetReport` (2.1.17) and `BytesPerMessageGetReport` (2.1.19) are each defined as constraining `GetReportRequest` **or** `GetMonitoringReportRequest`.

An unset limit means unlimited, as elsewhere, so a station that does not report the variable is unaffected.

## Changes since review

@yuvenus caught that an earlier revision of this PR pointed `GetMonitoringReport` at `MonitoringCtrlr`/`GetMonitoringReport`. That was wrong - thank you. Reverted in 8137ec8f, and the test that asserted it now asserts the spec behaviour instead.

## Verification

```
 ✓ packages/core/test/modules/Api/endpoints/ocpp/reportingTransactionsEndpoints.test.ts (17 tests)
 ✓ packages/core/test/modules/Api/endpoints/ocpp/monitoringEndpoints.test.ts
```
