### PR TITLE
fix(core): match the SetNetworkProfile response to the station that sent it

### DIFF
--- a/packages/core/src/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.ts
@@ -42,7 +42,11 @@ export class SetNetworkProfileResponseOcpp2Handler extends AbstractHandler {
     }
 
     const setNetworkProfile = await SetNetworkProfile.findOne({
-      where: { tenantId: message.context.tenantId, correlationId: message.context.correlationId },
+      where: {
+        tenantId: message.context.tenantId,
+        correlationId: message.context.correlationId,
+        ocppConnectionName: message.context.ocppConnectionName,
+      },
     });
     if (!setNetworkProfile) {
       return;

--- a/packages/core/test/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.integration.test.ts
+++ b/packages/core/test/handlers/responses/2/SetNetworkProfileResponseOcpp2Handler.integration.test.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type IMessage, DEFAULT_TENANT_ID, type BootstrapConfig } from '@citrineos/base';
+import {
+  type OcppRequest,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP_CallAction,
+  OCPPVersion,
+  SetNetworkProfileStatusEnum,
+} from '@citrineos/types';
+import {
+  ChargingStation,
+  ChargingStationNetworkProfile,
+  DefaultSequelizeInstance,
+  ServerNetworkProfile,
+  SetNetworkProfile,
+  Tenant,
+} from '@dal/index.js';
+import { SetNetworkProfileResponseOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, getTestInstance } from '@test/testContainer.js';
+
+/**
+ * prepareSetNetworkProfile mints one correlation id for the whole batch and writes a
+ * SetNetworkProfile row per station under it, so the response handler has to pick out the row
+ * belonging to the station that answered.
+ */
+const CORRELATION_ID = 'corr-shared';
+const STATION_A = 'CP-A';
+const STATION_B = 'CP-B';
+const PROFILE_ID = 'websocket-server-0';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance({
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aResponse(ocppConnectionName: string): IMessage<OcppRequest> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      correlationId: CORRELATION_ID,
+      timestamp: new Date().toISOString(),
+    },
+    payload: { status: SetNetworkProfileStatusEnum.Accepted },
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Configuration,
+    action: OCPP_CallAction.SetNetworkProfile,
+    state: MessageState.Response,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<OcppRequest>;
+}
+
+async function aSetNetworkProfileRow(ocppConnectionName: string, configurationSlot: number) {
+  return SetNetworkProfile.build({
+    ocppConnectionName,
+    correlationId: CORRELATION_ID,
+    configurationSlot,
+    websocketServerConfigId: PROFILE_ID,
+    ocppVersion: OCPP2_0_1.OCPPVersionEnumType.OCPP20,
+    ocppTransport: OCPP2_0_1.OCPPTransportEnumType.JSON,
+    ocppCsmsUrl: 'ws://localhost:8080',
+    messageTimeout: 30,
+    securityProfile: 1,
+    ocppInterface: OCPP2_0_1.OCPPInterfaceEnumType.Wired0,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never).save();
+}
+
+describe('SetNetworkProfileResponseOcpp2Handler with a batched correlation id', () => {
+  const { container } = createTestContainer();
+
+  beforeEach(async () => {
+    await ChargingStationNetworkProfile.destroy({ where: {}, truncate: true, cascade: true });
+    await SetNetworkProfile.destroy({ where: {}, truncate: true, cascade: true });
+    await ChargingStation.destroy({ where: {}, truncate: true, cascade: true });
+    await ServerNetworkProfile.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ServerNetworkProfile.create({
+      id: PROFILE_ID,
+      host: 'localhost',
+      port: 8080,
+      pingInterval: 60,
+      protocols: [OCPPVersion.OCPP2_0_1],
+      messageTimeout: 30,
+      securityProfile: 1,
+      allowUnknownChargingStations: false,
+      dynamicTenantResolution: false,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+
+    for (const name of [STATION_A, STATION_B]) {
+      await ChargingStation.create({
+        ocppConnectionName: name,
+        isOnline: false,
+        tenantId: DEFAULT_TENANT_ID,
+      } as never);
+    }
+
+    // One row per station under the one correlation id, exactly as prepareSetNetworkProfile
+    // writes them: same slot and same profile, differing only by station.
+    await aSetNetworkProfileRow(STATION_A, 1);
+    await aSetNetworkProfileRow(STATION_B, 1);
+  });
+
+  it('links the station to the request that was sent to it', async () => {
+    const handler = getTestInstance(container, SetNetworkProfileResponseOcpp2Handler, {});
+
+    await handler.handle(aResponse(STATION_B));
+
+    const stored = await ChargingStationNetworkProfile.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName: STATION_B },
+    });
+    const ownRow = await SetNetworkProfile.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName: STATION_B },
+    });
+
+    expect(stored).not.toBeNull();
+    expect(stored!.setNetworkProfileId).toBe(ownRow!.id);
+  });
+});


### PR DESCRIPTION
## One correlation id, many rows

`NetworkProfileService.prepareSetNetworkProfile` mints a single correlation id for the whole batch
and writes one `SetNetworkProfile` row per station under it:

```ts
const correlationId = uuidv4();
await Promise.all(
  ocppConnectionNames.map((ocppConnectionName) =>
    this._setNetworkProfileRepository.createPending({ ...request.connectionData, ocppConnectionName, correlationId, ... }),
  ),
);
```

The response handler then looks the row up by tenant and correlation id alone:

```ts
const setNetworkProfile = await SetNetworkProfile.findOne({
  where: { tenantId: message.context.tenantId, correlationId: message.context.correlationId },
});
```

With more than one station in the batch that matches N rows and takes an arbitrary one - in
practice the first, regardless of which station answered.

## What it costs, and what it does not

The rows differ only by station: `configurationSlot` and `websocketServerConfigId` both come from
the one request, so what the station ends up configured with is still correct. I checked that before
claiming more.

What is wrong is the link. The handler writes:

```ts
chargingStationNetworkProfile.setNetworkProfileId = setNetworkProfile.id;
```

so every station in a batch is recorded as having been configured by the request sent to a different
station. The provenance of a station's network profile is not recoverable afterwards, and the row is
the one `NetworkProfileFilter` reads when gating that station's next connection.

The lookup now includes `ocppConnectionName`. The endpoint could equally mint a correlation id per
station, as both `SendLocalList` endpoints do, but scoping the read is the smaller change and does
not alter what goes on the wire.

## Tests

`SetNetworkProfileResponseOcpp2Handler` had no coverage. The new integration test seeds two stations
under one correlation id with identical slot and profile - exactly what `prepareSetNetworkProfile`
writes - and asserts the responding station is linked to its own request.

Confirmed failing first with `expected 1 to be 2`: station B linked to station A's row.

I first wrote the fixture with differing `configurationSlot` values and it failed more loudly, but
the batch path cannot produce that - one request carries one slot - so the fixture was corrected to
match what actually happens.

## Verification

```
npx vitest run    # packages/core: 1387 passed / 5 skipped
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
prettier --check / eslint                          # clean
```