### PR TITLE
fix(core): populate the relations the Drizzle authorization repository promises

### DIFF
--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -17,6 +17,12 @@ import { type Explicit } from '../types.js';
 import { DrizzleRepository } from './Base.js';
 import type { AuthorizationQuerystring, IAuthorizationRepository } from '@/dal/index.js';
 import { and, eq, isNotNull } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import { type TariffEntity, tariffTable } from '../schema/Tariff.js';
+import { toTariffDto } from './Tariff.js';
+
+// Self-join target for the group Authorization a token belongs to.
+const groupAuthorizationTable = alias(authorizationTable, 'groupAuthorization');
 
 // ─── Mapper ──────────────────────────────────────────────────────────────────
 // Maps a Drizzle entity (DB row) to the external AuthorizationDto contract.
@@ -105,12 +111,23 @@ export class DrizzleAuthorizationRepository
   ): Promise<AuthorizationDto[]> {
     const conditions = this.createAuthorizationConditions(tenantId, query);
 
+    // The group Authorization is joined rather than left to the caller: it is what
+    // TransactionService turns into IdTokenInfo.groupIdToken.
     const rows = await this.db
-      .select()
+      .select({ authorization: authorizationTable, groupAuthorization: groupAuthorizationTable })
       .from(authorizationTable)
+      .leftJoin(
+        groupAuthorizationTable,
+        eq(authorizationTable.groupAuthorizationId, groupAuthorizationTable.id),
+      )
       .where(and(...conditions));
 
-    return rows.map((row) => this.toDto(row as AuthorizationEntity));
+    return rows.map(({ authorization, groupAuthorization }) => ({
+      ...this.toDto(authorization as AuthorizationEntity),
+      groupAuthorization: groupAuthorization
+        ? this.toDto(groupAuthorization as AuthorizationEntity)
+        : undefined,
+    }));
   }
 
   async readOnlyOneByQuerystring(
@@ -127,13 +144,19 @@ export class DrizzleAuthorizationRepository
   }
 
   async findAllAuthorizationsWithTariffs(tenantId: number): Promise<AuthorizationDto[]> {
+    // Inner join: callers read authorization.tariff and skip the row when it is unset, so an
+    // authorization whose tariffId no longer resolves must not be returned as though it had one.
     const rows = await this.db
-      .select()
+      .select({ authorization: authorizationTable, tariff: tariffTable })
       .from(authorizationTable)
+      .innerJoin(tariffTable, eq(authorizationTable.tariffId, tariffTable.id))
       .where(
         and(eq(authorizationTable.tenantId, tenantId), isNotNull(authorizationTable.tariffId)),
       );
 
-    return rows.map((row) => this.toDto(row as AuthorizationEntity));
+    return rows.map(({ authorization, tariff }) => ({
+      ...this.toDto(authorization as AuthorizationEntity),
+      tariff: toTariffDto(tariff as TariffEntity),
+    }));
   }
 }

--- a/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/Authorization.ts
@@ -21,11 +21,8 @@ import { alias } from 'drizzle-orm/pg-core';
 import { type TariffEntity, tariffTable } from '../schema/Tariff.js';
 import { toTariffDto } from './Tariff.js';
 
-// Self-join target for the group Authorization a token belongs to.
 const groupAuthorizationTable = alias(authorizationTable, 'groupAuthorization');
 
-// ─── Mapper ──────────────────────────────────────────────────────────────────
-// Maps a Drizzle entity (DB row) to the external AuthorizationDto contract.
 export function toAuthorizationDto(entity: AuthorizationEntity): AuthorizationDto {
   const dto: Explicit<AuthorizationDto> = {
     id: entity.id,
@@ -47,7 +44,6 @@ export function toAuthorizationDto(entity: AuthorizationEntity): AuthorizationDt
     customData: undefined,
     concurrentTransaction: entity.concurrentTransaction ?? undefined,
     isPrepaid: entity.isPrepaid ?? undefined,
-    // Sequelize DECIMAL → numeric returns string; DTO contract is number.
     prepaidBalance: entity.prepaidBalance != null ? Number(entity.prepaidBalance) : null,
     realTimeAuth: entity.realTimeAuth as AuthorizationWhitelistEnumType | null,
     realTimeAuthLastAttempt: entity.realTimeAuthLastAttempt,
@@ -103,16 +99,12 @@ export class DrizzleAuthorizationRepository
     return conditions;
   }
 
-  // ─── IAuthorizationRepository methods ────────────────────────────────────
-
   async readAllByQuerystring(
     tenantId: number,
     query: AuthorizationQuerystring,
   ): Promise<AuthorizationDto[]> {
     const conditions = this.createAuthorizationConditions(tenantId, query);
 
-    // The group Authorization is joined rather than left to the caller: it is what
-    // TransactionService turns into IdTokenInfo.groupIdToken.
     const rows = await this.db
       .select({ authorization: authorizationTable, groupAuthorization: groupAuthorizationTable })
       .from(authorizationTable)
@@ -144,8 +136,6 @@ export class DrizzleAuthorizationRepository
   }
 
   async findAllAuthorizationsWithTariffs(tenantId: number): Promise<AuthorizationDto[]> {
-    // Inner join: callers read authorization.tariff and skip the row when it is unset, so an
-    // authorization whose tariffId no longer resolves must not be returned as though it had one.
     const rows = await this.db
       .select({ authorization: authorizationTable, tariff: tariffTable })
       .from(authorizationTable)

--- a/packages/core/test/dal/layers/drizzle/repository/DrizzleAuthorization.integration.test.ts
+++ b/packages/core/test/dal/layers/drizzle/repository/DrizzleAuthorization.integration.test.ts
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import type { BootstrapConfig } from '@citrineos/base';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import { IdTokenEnum } from '@citrineos/types';
+import {
+  Authorization,
+  DefaultSequelizeInstance,
+  DrizzleAuthorizationRepository,
+  Tariff,
+  Tenant,
+} from '@dal/index.js';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+
+/**
+ * The Sequelize repository eager-loads the group Authorization on every querystring read, and
+ * inner-joins the Tariff in findAllAuthorizationsWithTariffs. Both relations are part of the
+ * IAuthorizationRepository contract its callers rely on, so the Drizzle implementation - which
+ * serves the same interface behind CITRINEOS_USE_DRIZZLE - has to populate them too.
+ */
+const GROUP_TOKEN = 'FLEET-PARENT';
+const CARD_TOKEN = 'DRIVER-CARD-1';
+const TARIFF_TOKEN = 'DRIVER-CARD-2';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let drizzleInstance: NodePgDatabase;
+let drizzlePool: pg.Pool;
+let config: BootstrapConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  // Both layers describe the same schema; Sequelize is used to create it.
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  // Own the pool here rather than the shared singleton, which exposes no way to close it.
+  drizzlePool = new pg.Pool({
+    host: config.database.host,
+    port: config.database.port,
+    database: config.database.database,
+    user: config.database.username,
+    password: config.database.password,
+  });
+  drizzleInstance = drizzle(drizzlePool);
+}, 90_000);
+
+afterAll(async () => {
+  await drizzlePool?.end();
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aRepository(): DrizzleAuthorizationRepository {
+  return new DrizzleAuthorizationRepository({ config, drizzleInstance });
+}
+
+describe('DrizzleAuthorizationRepository relations', () => {
+  beforeEach(async () => {
+    await Authorization.destroy({ where: {}, truncate: true, cascade: true });
+    await Tariff.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+
+    const group = await Authorization.create({
+      idToken: GROUP_TOKEN,
+      idTokenType: IdTokenEnum.ISO14443,
+      status: 'Accepted',
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+
+    await Authorization.create({
+      idToken: CARD_TOKEN,
+      idTokenType: IdTokenEnum.ISO14443,
+      status: 'Accepted',
+      groupAuthorizationId: (group as unknown as { id: number }).id,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+
+    const tariff = await Tariff.create({
+      currency: 'GBP',
+      pricePerKwh: 0.45,
+      tariffId: 'driver-tariff-1',
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+
+    await Authorization.create({
+      idToken: TARIFF_TOKEN,
+      idTokenType: IdTokenEnum.ISO14443,
+      status: 'Accepted',
+      tariffId: (tariff as unknown as { id: number }).id,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('surfaces the group authorization, which becomes IdTokenInfo.groupIdToken', async () => {
+    const found = await aRepository().readOnlyOneByQuerystring(DEFAULT_TENANT_ID, {
+      idToken: CARD_TOKEN,
+    });
+
+    expect(found).toBeDefined();
+    expect(found!.groupAuthorization?.idToken).toBe(GROUP_TOKEN);
+  });
+
+  it('leaves groupAuthorization unset for a token that belongs to no group', async () => {
+    const found = await aRepository().readOnlyOneByQuerystring(DEFAULT_TENANT_ID, {
+      idToken: GROUP_TOKEN,
+    });
+
+    expect(found).toBeDefined();
+    expect(found!.groupAuthorization).toBeUndefined();
+  });
+
+  it('returns the tariff alongside each authorization that has one', async () => {
+    // GetTariffsRequestOcpp21Handler skips any authorization whose tariff is falsy, so an
+    // unpopulated relation drops every driver tariff from the response without an error.
+    const found = await aRepository().findAllAuthorizationsWithTariffs(DEFAULT_TENANT_ID);
+
+    expect(found).toHaveLength(1);
+    expect(found[0].idToken).toBe(TARIFF_TOKEN);
+    expect(found[0].tariff?.tariffId).toBe('driver-tariff-1');
+  });
+});


### PR DESCRIPTION
## Two implementations of one interface, answering differently

`SequelizeAuthorizationRepository` and `DrizzleAuthorizationRepository` both implement
`IAuthorizationRepository`, and `CITRINEOS_USE_DRIZZLE=true` swaps one for the other in the
container. The Drizzle mapper is explicit about what it does not do:

```ts
// Relation, not a scalar column.
groupAuthorization: undefined,
...
// Relation, not a scalar column.
tariff: undefined,
```

and nothing fills them in afterwards. The Sequelize repository loads both.

## groupIdToken is never populated under Drizzle

```ts
// SequelizeAuthorizationRepository._constructQuery
// Eager-load the group Authorization so IdTokenInfo.groupIdToken can be surfaced.
include: [{ model: Authorization, as: 'groupAuthorization' }],
```

The comment names the consumer, and it is real - `TransactionService`:

```ts
groupIdToken: dto.groupAuthorization
  ? ({ idToken: dto.groupAuthorization?.idToken ?? '', ... })
  : null,
```

The Drizzle version does a plain `select().from(authorizationTable)`, so `groupAuthorization` is
always undefined and every authorization response carries `groupIdToken: null`. A charging station
never learns which group a token belongs to, which is the whole point of the field.

## Every driver tariff is dropped, silently

```ts
// Sequelize
include: [{ model: Tariff, as: 'tariff', required: true }]

// Drizzle
.where(and(eq(authorizationTable.tenantId, tenantId), isNotNull(authorizationTable.tariffId)))
```

The Drizzle version filters on `tariffId` being set but attaches no tariff, despite the method name.
`GetTariffsRequestOcpp21Handler` then does:

```ts
const tariff = authorization.tariff;
if (tariff && tariff.tariffId) {
```

so under Drizzle the loop body never runs and every `DriverTariff` is missing from the
`GetTariffs` response. No error, no log - the list is just empty.

## The fix

A self-join through `groupAuthorizationId` for the group, and an inner join to `Tariffs` for the
tariff. The tariff join is inner rather than left for the same reason `required: true` is set on the
Sequelize side: an authorization whose `tariffId` no longer resolves must not come back as though it
had a tariff.

## Tests

`packages/core/test/dal/layers/drizzle/` is new - the Drizzle repositories had no coverage at all
beyond one e2e that flips the env var and checks the server boots, which is how two missing joins
went unnoticed.

Three cases against a real database, the schema created with Sequelize since both layers describe
the same one. Two were confirmed failing first:

```
× surfaces the group authorization    → expected undefined to be 'FLEET-PARENT'
× returns the tariff alongside each authorization that has one
                                      → expected undefined to be 'driver-tariff-1'
```

The third - that `groupAuthorization` stays unset for a token in no group - passed before and after,
and is there so the left join cannot quietly become an inner one.

## Verification

```
npx vitest run    # packages/core: 1390 passed / 4 skipped
npx tsc --noEmit -p packages/core/tsconfig.json    # clean
prettier --check / eslint                          # 0 errors
```