### PR TITLE
fix(ocpi): treat date_to as exclusive on Locations and Tariffs too

### DIFF
--- a/packages/ocpi-base/src/graphql/operations.ts
+++ b/packages/ocpi-base/src/graphql/operations.ts
@@ -57,6 +57,7 @@ export type Authorizations_Bool_Exp = {
 };
 export type Timestamptz_Comparison_Exp = {
   _gte?: InputMaybe<Scalars['timestamptz']['input']>;
+  _lt?: InputMaybe<Scalars['timestamptz']['input']>;
   _lte?: InputMaybe<Scalars['timestamptz']['input']>;
 };
 export type Numeric_Comparison_Exp = {

--- a/packages/ocpi-base/src/services/LocationsService.ts
+++ b/packages/ocpi-base/src/services/LocationsService.ts
@@ -67,7 +67,6 @@ export class LocationsService {
       },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (paginatedParams?.dateFrom) dateFilters._gte = paginatedParams.dateFrom.toISOString();
     if (paginatedParams?.dateTo) dateFilters._lt = paginatedParams.dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {

--- a/packages/ocpi-base/src/services/LocationsService.ts
+++ b/packages/ocpi-base/src/services/LocationsService.ts
@@ -28,6 +28,7 @@ import type {
   GetLocationsQueryResult,
   GetLocationsQueryVariables,
   Locations_Bool_Exp,
+  Timestamptz_Comparison_Exp,
 } from '../graphql/index.js';
 import {
   GET_CONNECTOR_BY_ID_QUERY,
@@ -65,9 +66,10 @@ export class LocationsService {
         partyId: { _eq: ocpiHeaders.toPartyId },
       },
     };
-    const dateFilters: any = {};
+    const dateFilters: Timestamptz_Comparison_Exp = {};
+    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (paginatedParams?.dateFrom) dateFilters._gte = paginatedParams.dateFrom.toISOString();
-    if (paginatedParams?.dateTo) dateFilters._lte = paginatedParams?.dateTo.toISOString();
+    if (paginatedParams?.dateTo) dateFilters._lt = paginatedParams.dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {
       where.updatedAt = dateFilters;
     }

--- a/packages/ocpi-base/src/services/TariffsService.ts
+++ b/packages/ocpi-base/src/services/TariffsService.ts
@@ -13,6 +13,7 @@ import type {
   GetTariffsQueryResult,
   GetTariffsQueryVariables,
   Tariffs_Bool_Exp,
+  Timestamptz_Comparison_Exp,
 } from '../graphql/index.js';
 import { GET_TARIFF_BY_KEY_QUERY, GET_TARIFFS_QUERY, OcpiGraphqlClient } from '../graphql/index.js';
 import { TariffMapper } from '../mapper/index.js';
@@ -50,9 +51,10 @@ export class TariffsService {
         partyId: { _eq: ocpiHeaders.toPartyId },
       },
     };
-    const dateFilters: any = {};
+    const dateFilters: Timestamptz_Comparison_Exp = {};
+    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (paginationParams?.dateFrom) dateFilters._gte = paginationParams.dateFrom.toISOString();
-    if (paginationParams?.dateTo) dateFilters._lte = paginationParams?.dateTo.toISOString();
+    if (paginationParams?.dateTo) dateFilters._lt = paginationParams.dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {
       where.updatedAt = dateFilters;
     }

--- a/packages/ocpi-base/src/services/TariffsService.ts
+++ b/packages/ocpi-base/src/services/TariffsService.ts
@@ -52,7 +52,6 @@ export class TariffsService {
       },
     };
     const dateFilters: Timestamptz_Comparison_Exp = {};
-    // OCPI defines date_from as inclusive and date_to as exclusive.
     if (paginationParams?.dateFrom) dateFilters._gte = paginationParams.dateFrom.toISOString();
     if (paginationParams?.dateTo) dateFilters._lt = paginationParams.dateTo.toISOString();
     if (Object.keys(dateFilters).length > 0) {

--- a/packages/ocpi-base/test/services/LocationAndTariffDateFilters.test.ts
+++ b/packages/ocpi-base/test/services/LocationAndTariffDateFilters.test.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// The mapper barrel reaches BaseClientApi, whose parameterless @Inject() needs design:type
+// metadata the test transform does not emit. These tests never map a row, so a stub is enough.
+// citrineos/citrineos-core#913 removes the need for this.
+vi.mock('../../src/mapper/index.js', () => ({
+  ConnectorMapper: class {},
+  EvseMapper: class {},
+  LocationMapper: class {},
+  TariffMapper: class {},
+}));
+
+import { LocationsService } from '../../src/services/LocationsService.js';
+import { TariffsService } from '../../src/services/TariffsService.js';
+import { OcpiHeaders } from '../../src/model/OcpiHeaders.js';
+import { PaginatedParams } from '../../src/controllers/param/PaginatedParams.js';
+
+const DATE_FROM = new Date('2026-08-01T00:00:00.000Z');
+const DATE_TO = new Date('2026-08-19T00:00:00.000Z');
+
+/** Captures the Hasura variables the service builds, and returns an empty result set. */
+function aCapturingGraphqlClient(payload: Record<string, unknown>) {
+  const request = vi.fn().mockResolvedValue(payload);
+  return { client: { request } as never, request };
+}
+
+function whereFrom(request: ReturnType<typeof aCapturingGraphqlClient>['request']) {
+  expect(request).toHaveBeenCalledOnce();
+  return (request.mock.calls[0][1] as { where: Record<string, any> }).where;
+}
+
+function someHeaders(): OcpiHeaders {
+  return { toCountryCode: 'GB', toPartyId: 'VLT' } as OcpiHeaders;
+}
+
+function paginatedParams(dateFrom?: Date, dateTo?: Date): PaginatedParams {
+  return { dateFrom, dateTo } as PaginatedParams;
+}
+
+describe('OCPI date_from / date_to filters on Locations and Tariffs', () => {
+  it('LocationsService treats date_to as exclusive', async () => {
+    // OCPI defines date_from as inclusive and date_to as exclusive. An inclusive upper bound
+    // returns a record sitting exactly on the boundary to both the poll that ends there and the
+    // poll that starts there. CdrsService and SessionsService already use _lt.
+    const { client, request } = aCapturingGraphqlClient({ Locations: [] });
+    const service = new LocationsService(new Logger({ type: 'hidden' }), client);
+
+    await service.getLocations(someHeaders(), paginatedParams(DATE_FROM, DATE_TO));
+
+    expect(whereFrom(request).updatedAt).toEqual({
+      _gte: DATE_FROM.toISOString(),
+      _lt: DATE_TO.toISOString(),
+    });
+  });
+
+  it('TariffsService treats date_to as exclusive', async () => {
+    const { client, request } = aCapturingGraphqlClient({ Tariffs: [] });
+    const service = new TariffsService(client);
+
+    await service.getTariffs(someHeaders(), paginatedParams(DATE_FROM, DATE_TO));
+
+    expect(whereFrom(request).updatedAt).toEqual({
+      _gte: DATE_FROM.toISOString(),
+      _lt: DATE_TO.toISOString(),
+    });
+  });
+
+  it('omits the filter entirely when neither bound is given', async () => {
+    const { client, request } = aCapturingGraphqlClient({ Tariffs: [] });
+    const service = new TariffsService(client);
+
+    await service.getTariffs(someHeaders(), paginatedParams());
+
+    expect(whereFrom(request).updatedAt).toBeUndefined();
+  });
+
+  it('applies a lower bound on its own', async () => {
+    const { client, request } = aCapturingGraphqlClient({ Locations: [] });
+    const service = new LocationsService(new Logger({ type: 'hidden' }), client);
+
+    await service.getLocations(someHeaders(), paginatedParams(DATE_FROM, undefined));
+
+    expect(whereFrom(request).updatedAt).toEqual({ _gte: DATE_FROM.toISOString() });
+  });
+});


### PR DESCRIPTION
> Completes #898, which corrected this on Cdrs and Sessions.

OCPI defines `date_from` as inclusive and `date_to` as **exclusive**. Four sender endpoints accept
that pair. After #898, two of them use `_lt` and two still use `_lte`:

| service | upper bound |
|---|---|
| CdrsService | `_lt` |
| SessionsService | `_lt` |
| **LocationsService** | **`_lte`** |
| **TariffsService** | **`_lte`** |

An inclusive upper bound hands a record whose `updatedAt` falls exactly on the boundary to both the
poll that ends there and the poll that starts there. A client walking time in contiguous windows -
which is what `date_from`/`date_to` are for - sees that location or tariff twice.

Both now use `_lt`, and both filter objects are typed `Timestamptz_Comparison_Exp` instead of `any`,
so the next one cannot be assembled from a field the type does not have. That is what let this
diverge: with `any`, `_lte` and `_lt` are equally valid to the compiler.

## Overlap with #898

`Timestamptz_Comparison_Exp` does not carry `_lt` on `next` yet - #898 adds it. This PR adds the
same line so it builds standalone. Whichever merges second will conflict on that one line and should
simply drop it.

## Tests

Four cases in a new spec file, following the shape of `CdrAndSessionDateFilters.test.ts`: each
service is asserted to build `{ _gte, _lt }`, plus a lower bound on its own and neither bound at all.

The two boundary cases were confirmed failing first.

The file needs a `vi.mock` of the mapper barrel because `LocationsService` transitively reaches
`BaseClientApi`, whose parameterless `@Inject()` throws under the test transform. #913 removes that
need; the comment in the file says so.

## Verification

```
npx vitest run    # packages/ocpi-base: 21 tests passed
npx tsc --noEmit -p packages/ocpi-base/tsconfig.json    # clean
prettier --check / eslint                               # 0 errors
```