### PR TITLE
fix(ocpi): scope the Locations by-id reads to the party that asked

### DIFF
--- a/packages/ocpi-base/src/graphql/operations.ts
+++ b/packages/ocpi-base/src/graphql/operations.ts
@@ -254,6 +254,8 @@ export type GetLocationsQueryResult = {
 
 export type GetLocationByIdQueryVariables = Exact<{
   id: Scalars['Int']['input'];
+  countryCode: Scalars['String']['input'];
+  partyId: Scalars['String']['input'];
 }>;
 
 export type GetLocationByIdQueryResult = {
@@ -340,6 +342,8 @@ export type GetEvseByIdQueryVariables = Exact<{
   locationId: Scalars['Int']['input'];
   stationId: Scalars['String']['input'];
   evseId: Scalars['Int']['input'];
+  countryCode: Scalars['String']['input'];
+  partyId: Scalars['String']['input'];
 }>;
 
 export type GetEvseByIdQueryResult = {
@@ -384,6 +388,8 @@ export type GetConnectorByIdQueryVariables = Exact<{
   stationId: Scalars['String']['input'];
   evseId: Scalars['Int']['input'];
   connectorId: Scalars['Int']['input'];
+  countryCode: Scalars['String']['input'];
+  partyId: Scalars['String']['input'];
 }>;
 
 export type GetConnectorByIdQueryResult = {

--- a/packages/ocpi-base/src/graphql/queries/location.queries.ts
+++ b/packages/ocpi-base/src/graphql/queries/location.queries.ts
@@ -92,8 +92,13 @@ export const GET_LOCATIONS_QUERY = gql`
 `;
 
 export const GET_LOCATION_BY_ID_QUERY = gql`
-  query GetLocationById($id: Int!) {
-    Locations(where: { id: { _eq: $id } }) {
+  query GetLocationById($id: Int!, $countryCode: String!, $partyId: String!) {
+    Locations(
+      where: {
+        id: { _eq: $id }
+        Tenant: { countryCode: { _eq: $countryCode }, partyId: { _eq: $partyId } }
+      }
+    ) {
       id
       name
       address
@@ -174,8 +179,19 @@ export const GET_LOCATION_BY_ID_QUERY = gql`
 `;
 
 export const GET_EVSE_BY_ID_QUERY = gql`
-  query GetEvseById($locationId: Int!, $stationId: String!, $evseId: Int!) {
-    Locations(where: { id: { _eq: $locationId } }) {
+  query GetEvseById(
+    $locationId: Int!
+    $stationId: String!
+    $evseId: Int!
+    $countryCode: String!
+    $partyId: String!
+  ) {
+    Locations(
+      where: {
+        id: { _eq: $locationId }
+        Tenant: { countryCode: { _eq: $countryCode }, partyId: { _eq: $partyId } }
+      }
+    ) {
       chargingPool: ChargingStations(where: { ocppConnectionName: { _eq: $stationId } }) {
         id
         ocppConnectionName
@@ -214,12 +230,19 @@ export const GET_EVSE_BY_ID_QUERY = gql`
 
 export const GET_CONNECTOR_BY_ID_QUERY = gql`
   query GetConnectorById(
+    $countryCode: String!
+    $partyId: String!
     $locationId: Int!
     $stationId: String!
     $evseId: Int!
     $connectorId: Int!
   ) {
-    Locations(where: { id: { _eq: $locationId } }) {
+    Locations(
+      where: {
+        id: { _eq: $locationId }
+        Tenant: { countryCode: { _eq: $countryCode }, partyId: { _eq: $partyId } }
+      }
+    ) {
       chargingPool: ChargingStations(where: { ocppConnectionName: { _eq: $stationId } }) {
         evses: Evses(where: { id: { _eq: $evseId } }) {
           connectors: Connectors(where: { connectorId: { _eq: $connectorId } }) {

--- a/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
+++ b/packages/ocpi-base/src/mapper/BaseTransactionMapper.ts
@@ -45,7 +45,11 @@ export abstract class BaseTransactionMapper {
         const result = await this.ocpiGraphqlClient.request<
           GetLocationByIdQueryResult,
           GetLocationByIdQueryVariables
-        >(GET_LOCATION_BY_ID_QUERY, { id: transaction.locationId });
+        >(GET_LOCATION_BY_ID_QUERY, {
+          id: transaction.locationId,
+          countryCode: transaction.tenant!.countryCode!,
+          partyId: transaction.tenant!.partyId!,
+        });
         transaction.location = result.Locations[0] as LocationDto;
       }
       const location = transaction.location;

--- a/packages/ocpi-base/src/modules/Locations/module/LocationsModuleApi.ts
+++ b/packages/ocpi-base/src/modules/Locations/module/LocationsModuleApi.ts
@@ -101,9 +101,10 @@ export class LocationsModuleApi extends BaseController implements ILocationsModu
   })
   async getLocationById(
     @VersionNumberParam() version: VersionNumber,
+    @FunctionalEndpointParams() ocpiHeaders: OcpiHeaders,
     @Param('location_id') locationId: string,
   ): Promise<LocationResponse> {
-    return this.locationsService.getLocationById(locationId);
+    return this.locationsService.getLocationById(ocpiHeaders, locationId);
   }
 
   @Get('/:location_id/:evse_uid')
@@ -117,13 +118,14 @@ export class LocationsModuleApi extends BaseController implements ILocationsModu
   })
   async getEvseById(
     @VersionNumberParam() version: VersionNumber,
+    @FunctionalEndpointParams() ocpiHeaders: OcpiHeaders,
     @Param('location_id') locationId: string,
     @Param('evse_uid') evseUid: string,
   ): Promise<EvseResponse> {
     const stationId = EXTRACT_STATION_ID(evseUid);
     const evseId = EXTRACT_EVSE_ID(evseUid);
 
-    return this.locationsService.getEvseById(locationId, stationId, Number(evseId));
+    return this.locationsService.getEvseById(ocpiHeaders, locationId, stationId, Number(evseId));
   }
 
   @Get('/:location_id/:evse_uid/:connector_id')
@@ -137,6 +139,7 @@ export class LocationsModuleApi extends BaseController implements ILocationsModu
   })
   async getConnectorById(
     @VersionNumberParam() version: VersionNumber,
+    @FunctionalEndpointParams() ocpiHeaders: OcpiHeaders,
     @Param('location_id') locationId: string,
     @Param('evse_uid') evseUid: string,
     @Param('connector_id') connectorId: string,
@@ -145,6 +148,7 @@ export class LocationsModuleApi extends BaseController implements ILocationsModu
     const evseId = EXTRACT_EVSE_ID(evseUid);
 
     return this.locationsService.getConnectorById(
+      ocpiHeaders,
       locationId,
       stationId,
       Number(evseId),

--- a/packages/ocpi-base/src/services/LocationsService.ts
+++ b/packages/ocpi-base/src/services/LocationsService.ts
@@ -103,12 +103,16 @@ export class LocationsService {
     return Number(locationId.trim());
   }
 
-  async getLocationById(locationId: string): Promise<LocationResponse> {
+  async getLocationById(ocpiHeaders: OcpiHeaders, locationId: string): Promise<LocationResponse> {
     this.logger.debug(`Getting location ${locationId}`);
 
     try {
       const id = this.parseLocationId(locationId);
-      const variables = { id };
+      const variables = {
+        id,
+        countryCode: ocpiHeaders.toCountryCode,
+        partyId: ocpiHeaders.toPartyId,
+      };
       const response = await this.ocpiGraphqlClient.request<
         GetLocationByIdQueryResult,
         GetLocationByIdQueryVariables
@@ -136,13 +140,24 @@ export class LocationsService {
     }
   }
 
-  async getEvseById(locationId: string, stationId: string, evseId: number): Promise<EvseResponse> {
+  async getEvseById(
+    ocpiHeaders: OcpiHeaders,
+    locationId: string,
+    stationId: string,
+    evseId: number,
+  ): Promise<EvseResponse> {
     this.logger.debug(
       `Getting EVSE ${evseId} from Charging Station ${stationId} in Location ${locationId}`,
     );
 
     try {
-      const variables = { locationId: this.parseLocationId(locationId), stationId, evseId };
+      const variables = {
+        locationId: this.parseLocationId(locationId),
+        stationId,
+        evseId,
+        countryCode: ocpiHeaders.toCountryCode,
+        partyId: ocpiHeaders.toPartyId,
+      };
       const response = await this.ocpiGraphqlClient.request<
         GetEvseByIdQueryResult,
         GetEvseByIdQueryVariables
@@ -164,6 +179,7 @@ export class LocationsService {
   }
 
   async getConnectorById(
+    ocpiHeaders: OcpiHeaders,
     locationId: string,
     stationId: string,
     evseId: number,
@@ -179,6 +195,8 @@ export class LocationsService {
         stationId,
         evseId,
         connectorId,
+        countryCode: ocpiHeaders.toCountryCode,
+        partyId: ocpiHeaders.toPartyId,
       };
       const response = await this.ocpiGraphqlClient.request<
         GetConnectorByIdQueryResult,

--- a/packages/ocpi-base/test/services/LocationsServicePartyScope.test.ts
+++ b/packages/ocpi-base/test/services/LocationsServicePartyScope.test.ts
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// The mapper barrel reaches BaseClientApi, whose parameterless @Inject() needs design:type
+// metadata the test transform does not emit. These tests never map a row, so a stub is enough.
+// citrineos/citrineos-core#913 removes the need for this.
+vi.mock('../../src/mapper/index.js', () => ({
+  ConnectorMapper: class {},
+  EvseMapper: class {},
+  LocationMapper: class {},
+  TariffMapper: class {},
+}));
+
+import { LocationsService } from '../../src/services/LocationsService.js';
+import { OcpiHeaders } from '../../src/model/OcpiHeaders.js';
+
+const COUNTRY_CODE = 'GB';
+const PARTY_ID = 'VLT';
+
+/**
+ * The Locations sender interface serves one CPO, named by the to_ headers. getLocations filters on
+ * them; the by-id reads addressed a numeric id alone, so any partner could read another CPO's
+ * location, EVSE or connector by walking ids.
+ */
+function aCapturingGraphqlClient() {
+  const request = vi.fn().mockResolvedValue({ Locations: [] });
+  return { client: { request } as never, request };
+}
+
+function someHeaders(): OcpiHeaders {
+  return { toCountryCode: COUNTRY_CODE, toPartyId: PARTY_ID } as OcpiHeaders;
+}
+
+function variablesFrom(request: ReturnType<typeof aCapturingGraphqlClient>['request']) {
+  expect(request).toHaveBeenCalledOnce();
+  return request.mock.calls[0][1] as Record<string, unknown>;
+}
+
+/** The party predicate has to be in the query itself; passing the variables alone filters nothing. */
+function expectPartyPredicate(request: ReturnType<typeof aCapturingGraphqlClient>['request']) {
+  const document = String(request.mock.calls[0][0]);
+  expect(document).toContain('countryCode: { _eq: $countryCode }');
+  expect(document).toContain('partyId: { _eq: $partyId }');
+}
+
+function aService(client: never) {
+  return new LocationsService(new Logger({ type: 'hidden' }), client);
+}
+
+describe('LocationsService by-id reads are scoped to the requesting party', () => {
+  it('scopes getLocationById to the CPO in the headers', async () => {
+    const { client, request } = aCapturingGraphqlClient();
+
+    await aService(client).getLocationById(someHeaders(), '7');
+
+    expect(variablesFrom(request)).toMatchObject({
+      id: 7,
+      countryCode: COUNTRY_CODE,
+      partyId: PARTY_ID,
+    });
+    expectPartyPredicate(request);
+  });
+
+  it('scopes getEvseById to the CPO in the headers', async () => {
+    const { client, request } = aCapturingGraphqlClient();
+
+    await aService(client).getEvseById(someHeaders(), '7', 'cs-001', 1);
+
+    expect(variablesFrom(request)).toMatchObject({
+      locationId: 7,
+      countryCode: COUNTRY_CODE,
+      partyId: PARTY_ID,
+    });
+    expectPartyPredicate(request);
+  });
+
+  it('scopes getConnectorById to the CPO in the headers', async () => {
+    const { client, request } = aCapturingGraphqlClient();
+
+    await aService(client).getConnectorById(someHeaders(), '7', 'cs-001', 1, 2);
+
+    expect(variablesFrom(request)).toMatchObject({
+      locationId: 7,
+      countryCode: COUNTRY_CODE,
+      partyId: PARTY_ID,
+    });
+    expectPartyPredicate(request);
+  });
+
+  it('reports a location outside the requesting party as unknown, not as an error', async () => {
+    const { client } = aCapturingGraphqlClient();
+
+    const response = await aService(client).getLocationById(someHeaders(), '7');
+
+    // 2003 is ClientUnknownLocation; a cross-party id must look exactly like a missing one.
+    expect(response.status_code).toBe(2003);
+  });
+});


### PR DESCRIPTION
## The list is scoped; the by-id reads are not

`LocationsService.getLocations` filters on the CPO named in the OCPI headers:

```ts
const where: Locations_Bool_Exp = {
  Tenant: {
    countryCode: { _eq: ocpiHeaders.toCountryCode },
    partyId: { _eq: ocpiHeaders.toPartyId },
  },
};
```

The three by-id reads beside it take no headers at all:

```ts
async getLocationById(locationId: string): Promise<LocationResponse>
async getEvseById(locationId: string, stationId: string, evseId: number): Promise<EvseResponse>
async getConnectorById(locationId: string, stationId: string, evseId: number, connectorId: number)
```

and their queries filter on the id alone:

```graphql
query GetLocationById($id: Int!) {
  Locations(where: { id: { _eq: $id } }) {
```

The routes do not request the headers either - `getLocations` declares
`@FunctionalEndpointParams() ocpiHeaders: OcpiHeaders`, the other three do not.

So on a CSMS hosting more than one CPO, an authenticated partner can read any CPO's location, EVSE
or connector by walking numeric ids, while `GET /locations` correctly returns only their
counterparty's. Location ids are sequential integers, so there is nothing to guess.

## The fix

All three queries carry the same party predicate the list uses, and the routes pass the headers
through. Both call sites already map an empty result to `ClientUnknownLocation`, so an id outside
the requesting party's estate is indistinguishable from one that does not exist - it fails closed
without disclosing that the id is real.

`GET_LOCATION_BY_ID_QUERY` has a second caller: `BaseTransactionMapper`, when a transaction arrives
without an eager-loaded location. That lookup now passes the transaction's own tenant. It was
already correct by construction - the transaction was fetched under that tenant - so this only
states it.

## Tests

Four cases. The three scope tests assert both halves, because they fail differently: the variables
must carry the country and party, **and** the query document must actually use them. Passing
variables a query ignores filters nothing, so the document is asserted directly.

Confirmed by removing only the predicate and leaving the plumbing in place - the three fail with:

```
→ expected '\n  query GetLocationById($id: Int!, …' to contain 'countryCode: { _eq: $countryCode }'
```

The fourth checks the response code for a location the party cannot see is `2003`
ClientUnknownLocation rather than a generic error.

## Verification

```
full suite:  2044 passed / 6 skipped
pnpm --filter ./packages/** run build    # clean
prettier --check / eslint                # 0 errors
```