### PR TITLE
fix(ocpp-server): make the Authorizations token uniqueness actually hold

### DIFF
--- a/apps/ocpp-server/migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.ts
+++ b/apps/ocpp-server/migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+const TABLE_NAME = 'Authorizations';
+const NAME = 'idToken_type';
+const COLUMNS = '"tenantId", "idToken", "idTokenType"';
+
+// sync() names the constraint it derives from the model's `unique: 'idToken_type'` group after the
+// table and columns, so a database built that way carries a different name from a migrated one.
+const SYNC_DERIVED_NAME = 'Authorizations_idToken_idTokenType_tenantId_key';
+
+const constraintExists = async (queryInterface: QueryInterface, name: string): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+const dropUniqueness = async (queryInterface: QueryInterface) => {
+  for (const name of [NAME, SYNC_DERIVED_NAME]) {
+    if (await constraintExists(queryInterface, name)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${name}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  }
+  // A plain unique index shares the namespace but is not a constraint, so it needs its own drop.
+  await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${NAME}"`, { type: QueryTypes.RAW });
+};
+
+export default {
+  // Two defects share one cause: uniqueness was expressed as a unique INDEX over three columns,
+  // one of which is nullable.
+  //
+  // Postgres treats NULLs in a unique index as distinct from one another, so the index does not
+  // constrain rows whose idTokenType is null - the same token can be inserted repeatedly. OCPP 1.6
+  // then resolves an idTag against every row carrying that string and refuses the token outright
+  // once more than one comes back, so a duplicate silently and permanently deauthorises it.
+  //
+  // Separately, Hasura resolves `on_conflict` against unique CONSTRAINTS. An index is not one, so
+  // an upsert naming this target fails at runtime and callers are pushed into a query-then-insert
+  // that races. NULLS NOT DISTINCT closes the first; expressing it as a constraint closes the
+  // second.
+  up: async (queryInterface: QueryInterface) => {
+    const duplicates = await queryInterface.sequelize.query<{
+      tenantId: number;
+      idToken: string;
+      idTokenType: string | null;
+      count: string;
+    }>(
+      `SELECT "tenantId", "idToken", "idTokenType", COUNT(*) AS count
+         FROM "${TABLE_NAME}"
+        GROUP BY "tenantId", "idToken", "idTokenType"
+       HAVING COUNT(*) > 1
+        ORDER BY "tenantId", "idToken"`,
+      { type: QueryTypes.SELECT },
+    );
+
+    if (duplicates.length > 0) {
+      const listed = duplicates
+        .map(
+          (row) =>
+            `  - tenantId: ${row.tenantId}, idToken: "${row.idToken}", idTokenType: ${
+              row.idTokenType === null ? 'NULL' : `"${row.idTokenType}"`
+            }, count: ${row.count}`,
+        )
+        .join('\n');
+      throw new Error(
+        `Migration failed: found ${duplicates.length} duplicate tenantId/idToken/idTokenType ` +
+          `combinations in "${TABLE_NAME}". These are rows the previous unique index permitted ` +
+          `because it treated NULL idTokenType values as distinct. Resolve them before ` +
+          `migrating:\n${listed}`,
+      );
+    }
+
+    await dropUniqueness(queryInterface);
+
+    await queryInterface.sequelize.query(
+      `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${NAME}" UNIQUE NULLS NOT DISTINCT (${COLUMNS})`,
+      { type: QueryTypes.RAW },
+    );
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await dropUniqueness(queryInterface);
+
+    await queryInterface.sequelize.query(
+      `CREATE UNIQUE INDEX "${NAME}" ON "${TABLE_NAME}" (${COLUMNS})`,
+      { type: QueryTypes.RAW },
+    );
+  },
+};

--- a/apps/ocpp-server/migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.ts
+++ b/apps/ocpp-server/migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.ts
@@ -10,8 +10,6 @@ const TABLE_NAME = 'Authorizations';
 const NAME = 'idToken_type';
 const COLUMNS = '"tenantId", "idToken", "idTokenType"';
 
-// sync() names the constraint it derives from the model's `unique: 'idToken_type'` group after the
-// table and columns, so a database built that way carries a different name from a migrated one.
 const SYNC_DERIVED_NAME = 'Authorizations_idToken_idTokenType_tenantId_key';
 
 const constraintExists = async (queryInterface: QueryInterface, name: string): Promise<boolean> => {
@@ -32,23 +30,10 @@ const dropUniqueness = async (queryInterface: QueryInterface) => {
       );
     }
   }
-  // A plain unique index shares the namespace but is not a constraint, so it needs its own drop.
   await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${NAME}"`, { type: QueryTypes.RAW });
 };
 
 export default {
-  // Two defects share one cause: uniqueness was expressed as a unique INDEX over three columns,
-  // one of which is nullable.
-  //
-  // Postgres treats NULLs in a unique index as distinct from one another, so the index does not
-  // constrain rows whose idTokenType is null - the same token can be inserted repeatedly. OCPP 1.6
-  // then resolves an idTag against every row carrying that string and refuses the token outright
-  // once more than one comes back, so a duplicate silently and permanently deauthorises it.
-  //
-  // Separately, Hasura resolves `on_conflict` against unique CONSTRAINTS. An index is not one, so
-  // an upsert naming this target fails at runtime and callers are pushed into a query-then-insert
-  // that races. NULLS NOT DISTINCT closes the first; expressing it as a constraint closes the
-  // second.
   up: async (queryInterface: QueryInterface) => {
     const duplicates = await queryInterface.sequelize.query<{
       tenantId: number;

--- a/apps/ocpp-server/test/migrations/AuthorizationUniqueConstraint.integration.test.ts
+++ b/apps/ocpp-server/test/migrations/AuthorizationUniqueConstraint.integration.test.ts
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { QueryTypes, type QueryInterface } from 'sequelize';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { Authorization, DefaultSequelizeInstance, Tenant } from '@dal/index.js';
+import migration from '../../migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.js';
+
+/**
+ * Uniqueness on Authorizations was a unique INDEX over (tenantId, idToken, idTokenType). Postgres
+ * treats NULLs in a unique index as distinct, and idTokenType is nullable, so the index permitted
+ * unlimited copies of a token enrolled without a type. OCPP 1.6 resolves an idTag against every row
+ * carrying that string and refuses once more than one is returned, so a duplicate deauthorises the
+ * token permanently.
+ *
+ * The tests start from the pre-migration shape a deployed database is actually in, so the defect is
+ * demonstrated on the same schema the migration then repairs.
+ */
+const TOKEN = 'DEPOT-TOKEN-1';
+const OTHER_TENANT_ID = DEFAULT_TENANT_ID + 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let queryInterface: QueryInterface;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance({
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+  queryInterface = sequelizeInstance.getQueryInterface();
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+/** Puts the table back into the shape 20260413000000 left it in: a unique index, not a constraint. */
+async function restorePreMigrationShape() {
+  await sequelizeInstance.query(
+    'ALTER TABLE "Authorizations" DROP CONSTRAINT IF EXISTS "idToken_type"',
+  );
+  await sequelizeInstance.query(
+    'ALTER TABLE "Authorizations" DROP CONSTRAINT IF EXISTS "Authorizations_idToken_idTokenType_tenantId_key"',
+  );
+  await sequelizeInstance.query('DROP INDEX IF EXISTS "idToken_type"');
+  await sequelizeInstance.query(
+    'CREATE UNIQUE INDEX "idToken_type" ON "Authorizations" ("tenantId", "idToken", "idTokenType")',
+  );
+}
+
+function enrol(idToken: string, idTokenType: string | null, tenantId = DEFAULT_TENANT_ID) {
+  return Authorization.create({
+    idToken,
+    idTokenType,
+    status: 'Accepted',
+    tenantId,
+  } as never);
+}
+
+async function uniqueConstraintNames(): Promise<string[]> {
+  const rows = await sequelizeInstance.query<{ constraint_name: string }>(
+    `SELECT constraint_name FROM information_schema.table_constraints
+      WHERE table_schema = 'public' AND table_name = 'Authorizations'
+        AND constraint_type = 'UNIQUE'`,
+    { type: QueryTypes.SELECT },
+  );
+  return rows.map((row) => row.constraint_name);
+}
+
+describe('Authorizations uniqueness across a nullable idTokenType', () => {
+  beforeEach(async () => {
+    await Authorization.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await Tenant.create({ id: OTHER_TENANT_ID, name: 'B' } as never);
+    await restorePreMigrationShape();
+  });
+
+  it('is not enforced by the pre-migration index when idTokenType is null', async () => {
+    await enrol(TOKEN, null);
+
+    await expect(enrol(TOKEN, null)).resolves.toBeDefined();
+
+    const rows = await Authorization.findAll({ where: { idToken: TOKEN } });
+    expect(rows).toHaveLength(2);
+  });
+
+  it('rejects the duplicate once migrated', async () => {
+    await migration.up(queryInterface);
+    await enrol(TOKEN, null);
+
+    await expect(enrol(TOKEN, null)).rejects.toThrow();
+  });
+
+  it('still allows one token under two different types', async () => {
+    // 2.0.1 resolves on the pair, so this remains a legitimate pair of rows.
+    await migration.up(queryInterface);
+
+    await enrol(TOKEN, 'MacAddress');
+
+    await expect(enrol(TOKEN, 'Central')).resolves.toBeDefined();
+  });
+
+  it('still allows the same untyped token in two tenants', async () => {
+    await migration.up(queryInterface);
+
+    await enrol(TOKEN, null, DEFAULT_TENANT_ID);
+
+    await expect(enrol(TOKEN, null, OTHER_TENANT_ID)).resolves.toBeDefined();
+  });
+
+  it('leaves uniqueness as a named constraint, which is what on_conflict resolves against', async () => {
+    // Hasura resolves `on_conflict` against unique constraints; a unique index of the same name is
+    // not one, so an upsert naming it fails at runtime.
+    await migration.up(queryInterface);
+
+    expect(await uniqueConstraintNames()).toContain('idToken_type');
+  });
+
+  it('refuses to migrate over existing duplicates, naming them', async () => {
+    await enrol(TOKEN, null);
+    await enrol(TOKEN, null);
+
+    await expect(migration.up(queryInterface)).rejects.toThrow(/idTokenType: NULL, count: 2/);
+  });
+
+  it('restores the unique index on down', async () => {
+    await migration.up(queryInterface);
+
+    await migration.down(queryInterface);
+
+    expect(await uniqueConstraintNames()).not.toContain('idToken_type');
+    const [indexes] = await sequelizeInstance.query(
+      `SELECT indexname FROM pg_indexes WHERE tablename = 'Authorizations' AND indexname = 'idToken_type'`,
+    );
+    expect(indexes).toHaveLength(1);
+  });
+});

--- a/apps/ocpp-server/test/migrations/authorization-unique-constraint-integration.test.ts
+++ b/apps/ocpp-server/test/migrations/authorization-unique-constraint-integration.test.ts
@@ -7,19 +7,9 @@ import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainer
 import type { Sequelize } from 'sequelize-typescript';
 import { QueryTypes, type QueryInterface } from 'sequelize';
 import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
-import { Authorization, DefaultSequelizeInstance, Tenant } from '@dal/index.js';
+import { Authorization, DefaultSequelizeInstance, Tenant } from '@citrineos/dal';
 import migration from '../../migrations/20260821120000-authorization-unique-constraint-nulls-not-distinct.js';
 
-/**
- * Uniqueness on Authorizations was a unique INDEX over (tenantId, idToken, idTokenType). Postgres
- * treats NULLs in a unique index as distinct, and idTokenType is nullable, so the index permitted
- * unlimited copies of a token enrolled without a type. OCPP 1.6 resolves an idTag against every row
- * carrying that string and refuses once more than one is returned, so a duplicate deauthorises the
- * token permanently.
- *
- * The tests start from the pre-migration shape a deployed database is actually in, so the defect is
- * demonstrated on the same schema the migration then repairs.
- */
 const TOKEN = 'DEPOT-TOKEN-1';
 const OTHER_TENANT_ID = DEFAULT_TENANT_ID + 1;
 
@@ -63,7 +53,6 @@ afterAll(async () => {
   await pgContainer?.stop();
 });
 
-/** Puts the table back into the shape 20260413000000 left it in: a unique index, not a constraint. */
 async function restorePreMigrationShape() {
   await sequelizeInstance.query(
     'ALTER TABLE "Authorizations" DROP CONSTRAINT IF EXISTS "idToken_type"',
@@ -122,7 +111,6 @@ describe('Authorizations uniqueness across a nullable idTokenType', () => {
   });
 
   it('still allows one token under two different types', async () => {
-    // 2.0.1 resolves on the pair, so this remains a legitimate pair of rows.
     await migration.up(queryInterface);
 
     await enrol(TOKEN, 'MacAddress');
@@ -139,8 +127,6 @@ describe('Authorizations uniqueness across a nullable idTokenType', () => {
   });
 
   it('leaves uniqueness as a named constraint, which is what on_conflict resolves against', async () => {
-    // Hasura resolves `on_conflict` against unique constraints; a unique index of the same name is
-    // not one, so an upsert naming it fails at runtime.
     await migration.up(queryInterface);
 
     expect(await uniqueConstraintNames()).toContain('idToken_type');


### PR DESCRIPTION
## The defect

Uniqueness on `Authorizations` is a unique **index** over `(tenantId, idToken, idTokenType)`, created by `20260413000000-fix-authorization-unique-index-add-tenant.ts:53`. `idTokenType` is nullable (`Authorization.ts:51-55`).

Postgres treats NULLs in a unique index as distinct from one another, so the index constrains nothing at all for rows enrolled without a token type. The same token can be inserted any number of times.

That matters because OCPP 1.6 has no token type to match on. `authorize-request-ocpp-16-handler.ts:65` looks the `idTag` up by string alone and `:81` refuses when more than one row comes back:

```ts
if (authorizations.length > 1) {
  this._logger.error(`Too many authorizations found for idToken: ${request.idTag}`);
  response.idTagInfo.status = OCPP1_6.AuthorizeResponseStatus.Invalid;
```

So one accidental duplicate deauthorises that token permanently, on every station, with nothing surfaced beyond a log line. `SequelizeAuthorizationRepository._constructQuery:60` applies the type predicate only when a caller supplies a type, so 2.0.1 keeps working and only 1.6 breaks.

## The second half

`addIndex(..., { unique: true })` creates an index, not a constraint. Hasura resolves `on_conflict` against unique **constraints**, so an upsert naming this target fails at runtime. The operator-ui e2e fixture already documents working around exactly this (`apps/operator-ui/tests/e2e/fixtures/everest.ts:374`):

> Idempotency: the Authorizations table has a unique INDEX on (idToken, idTokenType) but no matching unique CONSTRAINT, so Hasura cannot resolve `on_conflict: { constraint: idToken_type }` at runtime even though its enum lists the name. Query-then-insert keeps the helper idempotent without depending on a constraint Hasura cannot apply.

This is load-bearing because **no CitrineOS code path creates an `Authorization`** - there is no `Authorization.create` anywhere in `packages/ocpp`, `packages/dal` or `packages/ocpi-base`, and no REST endpoint for it. Hasura is the only way a token is enrolled, so query-then-insert is currently the only idempotent option, and it races.

Both halves have one cause: uniqueness expressed as an index over a nullable column.

## The fix

One migration replacing the index with a `UNIQUE NULLS NOT DISTINCT` constraint of the same name. It:

- refuses to run over pre-existing duplicates and lists them, following the pattern in `20260413000000`;
- drops uniqueness under either the migrated name or the one `sync()` derives, so it applies to a database built either way.

Note `sync()` and the migrations had already diverged: a `sync()`-built database gets a constraint named `Authorizations_idToken_idTokenType_tenantId_key`, a migrated one an index named `idToken_type`. Both are handled.

`NULLS NOT DISTINCT` requires Postgres 15; the shipped compose is `postgis/postgis:16-3.5`.

Sequelize has no `NULLS NOT DISTINCT` option, so a database built by `sync()` alone keeps the looser constraint until it is migrated. Happy to add an `@AfterSync` hook if you would rather the two paths converge now.

## Verification

First run is with `up()` doing what `20260413000000` did, so the failures are the defect itself:

```
 ✓ is not enforced by the pre-migration index when idTokenType is null 447ms
 × rejects the duplicate once migrated 459ms
 ✓ still allows one token under two different types 442ms
 ✓ still allows the same untyped token in two tenants 440ms
 × leaves uniqueness as a named constraint, which is what on_conflict resolves against 351ms
   → expected [] to include 'idToken_type'
 × refuses to migrate over existing duplicates, naming them 433ms
 ✓ restores the unique index on down 351ms

AssertionError: promise resolved "Authorization{ …(6) }" instead of rejecting
AssertionError: expected [] to include 'idToken_type'
AssertionError: promise resolved "undefined" instead of rejecting

 Tests  3 failed | 4 passed (7)
```

`expected [] to include 'idToken_type'` is the Hasura half: there is no unique constraint on the table at all.

With the migration as committed:

```
 ✓ apps/ocpp-server/test/migrations/authorization-unique-constraint-integration.test.ts (7 tests) 9204ms

 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The suite starts from the shape `20260413000000` leaves a database in, so the defect is demonstrated on the schema the migration then repairs.

