### PR TITLE
fix(core): settle the certificate attempt the station answered for

### DIFF
--- a/packages/core/src/handlers/responses/2/CertificateSignedResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/CertificateSignedResponseOcpp2Handler.ts
@@ -8,6 +8,7 @@ import {
   type IMessage,
 } from '@citrineos/base';
 import {
+  type CertificateUseEnumType,
   type HandlerProperties,
   type InstallCertificateStatusEnumType,
   MessageOrigin,
@@ -51,26 +52,30 @@ export class CertificateSignedResponseOcpp2Handler extends AbstractHandler {
     const tenantId = message.context.tenantId;
     const ocppConnectionName = message.context.ocppConnectionName;
 
-    let requestId: number | undefined;
-    if (message.protocol === OCPPVersion.OCPP2_1) {
-      const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
-        where: {
-          ocppConnectionName,
-          correlationId: message.context.correlationId,
-          origin: MessageOrigin.ChargingStationManagementSystem,
-        },
-      });
-      if (originalRequest) {
-        const certSignedPayload = originalRequest.payload as OCPP2_1.CertificateSignedRequest;
-        requestId = certSignedPayload?.requestId ?? undefined;
-      }
-    }
+    // The station can have more than one certificate in flight, so the attempt to settle is the one
+    // for the certificate this response answers for. Both are on the request that was sent out.
+    const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName,
+        correlationId: message.context.correlationId,
+        origin: MessageOrigin.ChargingStationManagementSystem,
+      },
+    });
+    const certSignedPayload = originalRequest?.payload as
+      | OCPP2_1.CertificateSignedRequest
+      | undefined;
+
+    const requestId =
+      message.protocol === OCPPVersion.OCPP2_1
+        ? (certSignedPayload?.requestId ?? undefined)
+        : undefined;
 
     await this._installCertificateHelperService.finalizeInstalledCertificate(
       tenantId,
       ocppConnectionName,
       message.payload.status as unknown as InstallCertificateStatusEnumType,
       requestId,
+      certSignedPayload?.certificateType as unknown as CertificateUseEnumType | undefined,
     );
     // TODO: If rejected, retry and/or send to callbackUrl if originally part of a triggered refresh
     // TODO: If accepted, revoke old certificate

--- a/packages/core/src/handlers/responses/2/CertificateSignedResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/CertificateSignedResponseOcpp2Handler.ts
@@ -52,8 +52,6 @@ export class CertificateSignedResponseOcpp2Handler extends AbstractHandler {
     const tenantId = message.context.tenantId;
     const ocppConnectionName = message.context.ocppConnectionName;
 
-    // The station can have more than one certificate in flight, so the attempt to settle is the one
-    // for the certificate this response answers for. Both are on the request that was sent out.
     const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
       where: {
         ocppConnectionName,

--- a/packages/core/src/handlers/responses/2/InstallCertificateResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/InstallCertificateResponseOcpp2Handler.ts
@@ -50,8 +50,6 @@ export class InstallCertificateResponseOcpp2Handler extends AbstractHandler {
     const tenantId = message.context.tenantId;
     const ocppConnectionName = message.context.ocppConnectionName;
 
-    // The station can have more than one certificate in flight, and the response says only whether
-    // it was accepted. The certificate it answers for is on the request that was sent out.
     const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
       where: {
         ocppConnectionName,

--- a/packages/core/src/handlers/responses/2/InstallCertificateResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/InstallCertificateResponseOcpp2Handler.ts
@@ -9,24 +9,31 @@ import {
 } from '@citrineos/base';
 import {
   type HandlerProperties,
+  MessageOrigin,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
+  OCPP2_request_types,
   OCPP2_response_types,
 } from '@citrineos/types';
+import type { IOCPPMessageRepository } from '@dal/index.js';
 import type { InstallCertificateHelperService } from '@modules/Certificates/src/index.js';
 
 @AsResponseHandler(OCPP_2_VER_LIST, OCPP_CallAction.InstallCertificate)
 export class InstallCertificateResponseOcpp2Handler extends AbstractHandler {
+  protected _ocppMessageRepository: IOCPPMessageRepository;
   protected _installCertificateHelperService: InstallCertificateHelperService;
 
   constructor({
     logger,
+    ocppMessageRepository,
     installCertificateHelperService,
   }: AbstractHandlerDependencies & {
+    ocppMessageRepository: IOCPPMessageRepository;
     installCertificateHelperService: InstallCertificateHelperService;
   }) {
     super(logger);
 
+    this._ocppMessageRepository = ocppMessageRepository;
     this._installCertificateHelperService = installCertificateHelperService;
   }
 
@@ -39,10 +46,29 @@ export class InstallCertificateResponseOcpp2Handler extends AbstractHandler {
       message,
       props,
     );
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+
+    // The station can have more than one certificate in flight, and the response says only whether
+    // it was accepted. The certificate it answers for is on the request that was sent out.
+    const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName,
+        correlationId: message.context.correlationId,
+        origin: MessageOrigin.ChargingStationManagementSystem,
+      },
+    });
+    const requestPayload = originalRequest?.payload as
+      | OCPP2_request_types.InstallCertificateRequest
+      | undefined;
+
     await this._installCertificateHelperService.finalizeInstalledCertificate(
-      message.context.tenantId,
-      message.context.ocppConnectionName,
+      tenantId,
+      ocppConnectionName,
       message.payload.status,
+      undefined,
+      requestPayload?.certificateType,
     );
   }
 }

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -1022,13 +1022,6 @@ export class InstallCertificateHelperService {
     return { certPem, keyPem, certificateId: record.id };
   }
 
-  /**
-   * Reads and extracts the subCA certificate from a server's currently-configured
-   * certificate chain file (chain = leaf + subCA concatenation). This is the only
-   * config field relied on to identify a server's current lineage — the optional
-   * `rootCACertificateFilePath`/`mtlsCertificateAuthorityKeyFilePath` fields are not
-   * used, since they may not be set (e.g. typically absent for securityProfile 2).
-   */
   private async _readCurrentSubCACertPem(config: WebsocketServerConfig): Promise<string> {
     if (!config.tlsCertificateChainFilePath) {
       throw new BadRequestError(

--- a/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
+++ b/packages/core/src/modules/Certificates/src/module/installCertificateHelperService.ts
@@ -253,6 +253,7 @@ export class InstallCertificateHelperService {
     ocppConnectionName: string,
     status: InstallCertificateStatusEnumType,
     requestId?: number,
+    certificateType?: CertificateUseEnumType,
   ) {
     const existingPendingInstallCertificateAttempt =
       await this.installCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
@@ -260,6 +261,7 @@ export class InstallCertificateHelperService {
           ocppConnectionName: ocppConnectionName,
           status: null,
           ...(requestId != null ? { requestId } : {}),
+          ...(certificateType != null ? { certificateType } : {}),
         },
       });
     // should always be true

--- a/packages/core/test/modules/Certificates/FinalizeInstalledCertificate.integration.test.ts
+++ b/packages/core/test/modules/Certificates/FinalizeInstalledCertificate.integration.test.ts
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { Logger } from 'tslog';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { CertificateUseEnum, InstallCertificateStatusEnum } from '@citrineos/types';
+import {
+  Certificate,
+  ChargingStation,
+  DefaultSequelizeInstance,
+  InstallCertificateAttempt,
+  InstalledCertificate,
+  SequelizeCertificateRepository,
+  SequelizeDeleteCertificateAttemptRepository,
+  SequelizeInstallCertificateAttemptRepository,
+  SequelizeInstalledCertificateRepository,
+  Tenant,
+} from '@dal/index.js';
+import { InstallCertificateHelperService } from '@modules/Certificates/src/index.js';
+
+/**
+ * A station can have more than one certificate install in flight: the endpoint prepares an attempt
+ * before sending InstallCertificate, and SignCertificate prepares another before sending
+ * CertificateSigned. Both write a row with a null status, and the two paths use disjoint
+ * certificateType values - roots from the former, leaves from the latter.
+ *
+ * finalizeInstalledCertificate has to settle the attempt the station is answering. It reaches the
+ * pending row by station, narrowing by requestId only when one is present, and requestId is an
+ * OCPP 2.1 field - so on 2.0.1 there is nothing to tell two pending attempts apart.
+ */
+const STATION = 'CP-PNC-1';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let config: BootstrapConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aService() {
+  const deps = { config, logger: undefined, sequelizeInstance } as never;
+  return new InstallCertificateHelperService({
+    certificateRepository: new SequelizeCertificateRepository(deps),
+    installedCertificateRepository: new SequelizeInstalledCertificateRepository(deps),
+    installCertificateAttemptRepository: new SequelizeInstallCertificateAttemptRepository(deps),
+    deleteCertificateAttemptRepository: new SequelizeDeleteCertificateAttemptRepository(deps),
+    // Unreachable for a finalize that settles an attempt row.
+    deviceModelRepository: {} as never,
+    certificateAuthorityService: {} as never,
+    fileStorage: { getFile: async () => undefined } as never,
+    logger: new Logger({ type: 'hidden' }),
+  });
+}
+
+let nextSerialNumber = 1;
+
+/** A pending attempt, as either prepare path leaves one before the request goes out. */
+async function aPendingAttempt(certificateType: string) {
+  const certificate = await Certificate.create({
+    serialNumber: nextSerialNumber++,
+    issuerName: 'issuer',
+    organizationName: 'org',
+    commonName: certificateType,
+    certificateFileHash: `${certificateType}-hash`,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+
+  return InstallCertificateAttempt.create({
+    ocppConnectionName: STATION,
+    certificateType,
+    certificateId: (certificate as unknown as { id: number }).id,
+    status: null,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+function statusOf(attempt: InstallCertificateAttempt) {
+  return InstallCertificateAttempt.findByPk((attempt as unknown as { id: number }).id).then(
+    (row) => row?.status ?? null,
+  );
+}
+
+describe('finalizeInstalledCertificate with more than one certificate in flight', () => {
+  beforeEach(async () => {
+    await InstalledCertificate.destroy({ where: {}, truncate: true, cascade: true });
+    await InstallCertificateAttempt.destroy({ where: {}, truncate: true, cascade: true });
+    await Certificate.destroy({ where: {}, truncate: true, cascade: true });
+    await ChargingStation.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('settles the attempt for the certificate that was answered', async () => {
+    const root = await aPendingAttempt(CertificateUseEnum.V2GRootCertificate);
+    const leaf = await aPendingAttempt('ChargingStationCertificate');
+
+    await aService().finalizeInstalledCertificate(
+      DEFAULT_TENANT_ID,
+      STATION,
+      InstallCertificateStatusEnum.Accepted,
+      undefined,
+      'ChargingStationCertificate' as never,
+    );
+
+    expect(await statusOf(leaf)).toBe(InstallCertificateStatusEnum.Accepted);
+    expect(await statusOf(root)).toBeNull();
+  });
+
+  it('settles a lone pending attempt, the case that already worked', async () => {
+    const root = await aPendingAttempt(CertificateUseEnum.V2GRootCertificate);
+
+    await aService().finalizeInstalledCertificate(
+      DEFAULT_TENANT_ID,
+      STATION,
+      InstallCertificateStatusEnum.Accepted,
+      undefined,
+      CertificateUseEnum.V2GRootCertificate,
+    );
+
+    expect(await statusOf(root)).toBe(InstallCertificateStatusEnum.Accepted);
+  });
+
+  it('does not settle an attempt for a certificate type the station did not answer for', async () => {
+    const root = await aPendingAttempt(CertificateUseEnum.V2GRootCertificate);
+
+    await aService().finalizeInstalledCertificate(
+      DEFAULT_TENANT_ID,
+      STATION,
+      InstallCertificateStatusEnum.Accepted,
+      undefined,
+      'ChargingStationCertificate' as never,
+    );
+
+    expect(await statusOf(root)).toBeNull();
+  });
+});


### PR DESCRIPTION
## The defect

`finalizeInstalledCertificate` finds the pending attempt to settle by station and a null status (`installCertificateHelperService.ts:257-264`):

```ts
await this.installCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
  where: {
    ocppConnectionName: ocppConnectionName,
    status: null,
    ...(requestId != null ? { requestId } : {}),
  },
});
```

`requestId` is an OCPP 2.1 field, so on 2.0.1 nothing narrows this beyond the station.

A station can have more than one certificate in flight. There are two prepare paths, and both leave a row with a null status:

- `InstallCertificateEndpoint.ts:54`, before sending `InstallCertificate` - a root, e.g. `V2GRootCertificate`.
- `SignCertificateRequestOcpp2Handler.ts:143`, before sending `CertificateSigned` - a leaf, e.g. `ChargingStationCertificate`.

Both are ordinary on a Plug and Charge station, which needs a V2G root installed and its own certificate signed.

With two pending, `readOnlyOneByQuery` throws (`packages/base/src/interfaces/repository.ts:41`):

```ts
if (results.length > 1) {
  throw new Error(`More than one value found for query: ${JSON.stringify(query)}`);
}
```

so **neither** attempt is ever settled and no `InstalledCertificate` row is written - the CSMS silently loses track of what the station is carrying. With one pending, a response for a *different* certificate settles it anyway, and `:276` then reads `existingPendingInstallCertificateAttempt.certificateType` to update `InstalledCertificate` - recording the wrong certificate as installed.

## The fix

The certificate a response answers for is on the request that was sent out.

`CertificateSignedResponseOcpp2Handler` already reads that request to recover `requestId` on 2.1. It now reads it on every version and takes `certificateType` from it as well. `InstallCertificateResponseOcpp2Handler` gains the same lookup, which needs `ocppMessageRepository` as a dependency.

The predicate is only added when a type is known, so a `CertificateSigned` whose optional `certificateType` was omitted behaves exactly as before.

The two prepare paths write disjoint values into that column - roots from the endpoint, leaves from `SignCertificate` - so it discriminates them cleanly.

## Verification

Before, with two certificates in flight:

```
 × settles the attempt for the certificate that was answered 677ms
   → More than one value found for query: {"where":{"ocppConnectionName":"CP-PNC-1","status":null}}
 ✓ settles a lone pending attempt, the case that already worked 640ms
 × does not settle an attempt for a certificate type the station did not answer for 617ms
   → expected 'Accepted' to be null

 Tests  2 failed | 1 passed (3)
```

The middle test is the control: it passes before and after, so the single-attempt path is unchanged.

After:

```
 ✓ packages/core/test/modules/Certificates/FinalizeInstalledCertificate.integration.test.ts (3 tests) 8775ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite:

```
 Test Files  98 passed | 1 skipped (99)
      Tests  2045 passed | 4 skipped (2049)
```

`pnpm --filter @citrineos/core run lint` reports 0 errors and the 2 pre-existing warnings.
