### PR TITLE
fix(core): settle the delete-certificate attempt the station answered for

### DIFF
--- a/packages/core/src/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.ts
@@ -57,9 +57,6 @@ export class DeleteCertificateResponseOcpp2Handler extends AbstractHandler {
     const tenantId = message.context.tenantId;
     const ocppConnectionName = message.context.ocppConnectionName;
 
-    // The response says only whether the station accepted, so the certificate it answers for comes
-    // from the request that was sent out. Without it, a station with more than one delete in flight
-    // settles the wrong attempt and destroys the record of a certificate it still holds.
     const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
       where: {
         ocppConnectionName,

--- a/packages/core/src/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.ts
@@ -10,32 +10,39 @@ import {
 import {
   DeleteCertificateStatusEnum,
   type HandlerProperties,
+  MessageOrigin,
   OCPP_2_VER_LIST,
   OCPP_CallAction,
+  OCPP2_request_types,
   OCPP2_response_types,
 } from '@citrineos/types';
 import type {
   IDeleteCertificateAttemptRepository,
   IInstalledCertificateRepository,
+  IOCPPMessageRepository,
 } from '@dal/index.js';
 
 @AsResponseHandler(OCPP_2_VER_LIST, OCPP_CallAction.DeleteCertificate)
 export class DeleteCertificateResponseOcpp2Handler extends AbstractHandler {
   protected _deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
   protected _installedCertificateRepository: IInstalledCertificateRepository;
+  protected _ocppMessageRepository: IOCPPMessageRepository;
 
   constructor({
     logger,
     deleteCertificateAttemptRepository,
     installedCertificateRepository,
+    ocppMessageRepository,
   }: AbstractHandlerDependencies & {
     deleteCertificateAttemptRepository: IDeleteCertificateAttemptRepository;
     installedCertificateRepository: IInstalledCertificateRepository;
+    ocppMessageRepository: IOCPPMessageRepository;
   }) {
     super(logger);
 
     this._deleteCertificateAttemptRepository = deleteCertificateAttemptRepository;
     this._installedCertificateRepository = installedCertificateRepository;
+    this._ocppMessageRepository = ocppMessageRepository;
   }
 
   async handle(
@@ -49,11 +56,34 @@ export class DeleteCertificateResponseOcpp2Handler extends AbstractHandler {
     );
     const tenantId = message.context.tenantId;
     const ocppConnectionName = message.context.ocppConnectionName;
+
+    // The response says only whether the station accepted, so the certificate it answers for comes
+    // from the request that was sent out. Without it, a station with more than one delete in flight
+    // settles the wrong attempt and destroys the record of a certificate it still holds.
+    const originalRequest = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName,
+        correlationId: message.context.correlationId,
+        origin: MessageOrigin.ChargingStationManagementSystem,
+      },
+    });
+    const certificateHashData = (
+      originalRequest?.payload as OCPP2_request_types.DeleteCertificateRequest | undefined
+    )?.certificateHashData;
+
     const existingPendingDeleteCertificateAttempt =
       await this._deleteCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
         where: {
           ocppConnectionName: ocppConnectionName,
           status: null,
+          ...(certificateHashData
+            ? {
+                hashAlgorithm: certificateHashData.hashAlgorithm,
+                issuerNameHash: certificateHashData.issuerNameHash,
+                issuerKeyHash: certificateHashData.issuerKeyHash,
+                serialNumber: certificateHashData.serialNumber,
+              }
+            : {}),
         },
       });
     // should always be true

--- a/packages/core/test/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.integration.test.ts
+++ b/packages/core/test/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.integration.test.ts
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID, type IMessage } from '@citrineos/base';
+import {
+  CertificateUseEnum,
+  DeleteCertificateStatusEnum,
+  EventGroup,
+  HashAlgorithmEnum,
+  MessageOrigin,
+  MessageState,
+  MessageTypeId,
+  OCPP_CallAction,
+  type OcppRequest,
+  OCPPVersion,
+} from '@citrineos/types';
+import {
+  ChargingStation,
+  DefaultSequelizeInstance,
+  DeleteCertificateAttempt,
+  InstalledCertificate,
+  OCPPMessage,
+  SequelizeDeleteCertificateAttemptRepository,
+  SequelizeInstalledCertificateRepository,
+  SequelizeOCPPMessageRepository,
+  Tenant,
+} from '@dal/index.js';
+import { DeleteCertificateResponseOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, getTestInstance } from '@test/testContainer.js';
+
+/**
+ * DeleteCertificate carries the certificate to remove as certificateHashData, and the endpoint
+ * records a pending DeleteCertificateAttempt holding that hash before the request goes out. Two
+ * deletes on one station - clearing out a pair of superseded roots, say - therefore leave two
+ * pending rows.
+ *
+ * The response says only whether the station accepted, so the handler has to work out which
+ * certificate is being answered for. Getting it wrong destroys InstalledCertificate rows for a
+ * certificate the station still holds.
+ */
+const STATION = 'CP-CERT-1';
+const CORRELATION_A = 'corr-a';
+const CORRELATION_B = 'corr-b';
+
+const CERT_A = {
+  hashAlgorithm: HashAlgorithmEnum.SHA256,
+  issuerNameHash: 'issuer-name-hash-a',
+  issuerKeyHash: 'issuer-key-hash-a',
+  serialNumber: 'serial-a',
+};
+const CERT_B = {
+  hashAlgorithm: HashAlgorithmEnum.SHA256,
+  issuerNameHash: 'issuer-name-hash-b',
+  issuerKeyHash: 'issuer-key-hash-b',
+  serialNumber: 'serial-b',
+};
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let config: BootstrapConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+type CertificateHashData = typeof CERT_A;
+
+/** The request the endpoint sent, which is what says which certificate a response answers for. */
+async function aDeleteCertificateRequest(
+  correlationId: string,
+  certificateHashData: CertificateHashData,
+) {
+  const payload = { certificateHashData };
+  return OCPPMessage.create({
+    ocppConnectionName: STATION,
+    correlationId,
+    origin: MessageOrigin.ChargingStationManagementSystem,
+    type: MessageTypeId.Call,
+    protocol: OCPPVersion.OCPP2_0_1,
+    action: 'DeleteCertificate',
+    payload,
+    raw: JSON.stringify([MessageTypeId.Call, correlationId, 'DeleteCertificate', payload]),
+    timestamp: new Date().toISOString(),
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+/** A pending attempt, as prepareToDeleteCertificate leaves one before the request goes out. */
+async function aPendingDeleteAttempt(certificateHashData: CertificateHashData) {
+  return DeleteCertificateAttempt.create({
+    ocppConnectionName: STATION,
+    ...certificateHashData,
+    status: null,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+async function anInstalledCertificate(certificateHashData: CertificateHashData) {
+  return InstalledCertificate.create({
+    ocppConnectionName: STATION,
+    ...certificateHashData,
+    certificateType: CertificateUseEnum.V2GRootCertificate,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+function anAcceptedResponse(correlationId: string): IMessage<OcppRequest> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION,
+      correlationId,
+      timestamp: new Date().toISOString(),
+    },
+    payload: { status: DeleteCertificateStatusEnum.Accepted },
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Certificates,
+    action: OCPP_CallAction.DeleteCertificate,
+    state: MessageState.Response,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<OcppRequest>;
+}
+
+function statusOf(attempt: DeleteCertificateAttempt) {
+  return DeleteCertificateAttempt.findByPk((attempt as unknown as { id: number }).id).then(
+    (row) => row?.status ?? null,
+  );
+}
+
+function installedCertificatesFor(serialNumber: string) {
+  return InstalledCertificate.count({ where: { serialNumber } });
+}
+
+describe('DeleteCertificateResponseOcpp2Handler with more than one delete in flight', () => {
+  const { container } = createTestContainer();
+
+  function aHandler() {
+    const deps = { config, logger: undefined, sequelizeInstance } as never;
+    return getTestInstance(container, DeleteCertificateResponseOcpp2Handler, {
+      deleteCertificateAttemptRepository: new SequelizeDeleteCertificateAttemptRepository(deps),
+      installedCertificateRepository: new SequelizeInstalledCertificateRepository(deps),
+      ocppMessageRepository: new SequelizeOCPPMessageRepository(deps),
+    });
+  }
+
+  beforeEach(async () => {
+    await OCPPMessage.destroy({ where: {}, truncate: true, cascade: true });
+    await InstalledCertificate.destroy({ where: {}, truncate: true, cascade: true });
+    await DeleteCertificateAttempt.destroy({ where: {}, truncate: true, cascade: true });
+    await ChargingStation.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('settles the attempt for the certificate that was answered', async () => {
+    const attemptA = await aPendingDeleteAttempt(CERT_A);
+    const attemptB = await aPendingDeleteAttempt(CERT_B);
+    await aDeleteCertificateRequest(CORRELATION_B, CERT_B);
+
+    await aHandler().handle(anAcceptedResponse(CORRELATION_B) as never);
+
+    expect(await statusOf(attemptB)).toBe(DeleteCertificateStatusEnum.Accepted);
+    expect(await statusOf(attemptA)).toBeNull();
+  });
+
+  it('does not remove the record of a certificate the station still holds', async () => {
+    // Only the delete for B was answered, so A must survive untouched.
+    await aPendingDeleteAttempt(CERT_A);
+    await anInstalledCertificate(CERT_A);
+    await aDeleteCertificateRequest(CORRELATION_B, CERT_B);
+
+    await aHandler().handle(anAcceptedResponse(CORRELATION_B) as never);
+
+    expect(await installedCertificatesFor(CERT_A.serialNumber)).toBe(1);
+  });
+
+  it('removes the record of the certificate that was deleted', async () => {
+    await aPendingDeleteAttempt(CERT_A);
+    await anInstalledCertificate(CERT_A);
+    await aDeleteCertificateRequest(CORRELATION_A, CERT_A);
+
+    await aHandler().handle(anAcceptedResponse(CORRELATION_A) as never);
+
+    expect(await installedCertificatesFor(CERT_A.serialNumber)).toBe(0);
+  });
+});


### PR DESCRIPTION
## The defect

`DeleteCertificateResponseOcpp2Handler` finds the pending attempt to settle by station and a null status, and nothing else (`DeleteCertificateResponseOcpp2Handler.ts:51-57`):

```ts
const existingPendingDeleteCertificateAttempt =
  await this._deleteCertificateAttemptRepository.readOnlyOneByQuery(tenantId, {
    where: {
      ocppConnectionName: ocppConnectionName,
      status: null,
    },
  });
```

`DeleteCertificate` names its target as `certificateHashData`, and `prepareToDeleteCertificate` records a pending attempt holding those four fields before each request goes out (`DeleteCertificateEndpoint.ts:53`, `installCertificateHelperService.ts:169-189`). Two deletes on one station - clearing a pair of superseded roots - therefore leave two pending rows.

With both outstanding, `readOnlyOneByQuery` throws (`packages/base/src/interfaces/repository.ts:41`) and neither attempt is ever settled.

With one outstanding, a response for a *different* certificate settles it anyway, and on `Accepted` the handler goes on to `:63-78`:

```ts
const existingInstalledCertificates =
  await this._installedCertificateRepository.readAllByQuery(tenantId, {
    where: {
      ocppConnectionName,
      hashAlgorithm: existingPendingDeleteCertificateAttempt.hashAlgorithm,
      ...
```

and **destroys** every matching `InstalledCertificate`. The CSMS's record of a certificate the station still holds is deleted.

This is the same shape as #926 on the install side, but that one recorded the wrong type where this one removes rows.

## The fix

The certificate a response answers for is on the request that was sent out. The handler now reads that request back by correlation id - the pattern `CertificateSignedResponseOcpp2Handler` already uses - and narrows the attempt lookup on the same four hash fields the attempt stores.

The predicate is added only when the request is found, so a response whose request is missing behaves exactly as before.

## Verification

Before:

```
 × settles the attempt for the certificate that was answered 642ms
   → More than one value found for query: {"where":{"ocppConnectionName":"CP-CERT-1","status":null}}
 × does not remove the record of a certificate the station still holds 677ms
   → expected +0 to be 1 // Object.is equality
 ✓ removes the record of the certificate that was deleted 672ms

 Tests  2 failed | 1 passed (3)
```

`expected +0 to be 1` is the data loss: certificate A's `InstalledCertificate` row was destroyed by a response that answered for certificate B. The third test is the control - it passes before and after, so the ordinary single-delete path is unchanged.

After:

```
 ✓ packages/core/test/handlers/responses/2/DeleteCertificateResponseOcpp2Handler.integration.test.ts (3 tests) 8289ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite:

```
 Test Files  98 passed | 1 skipped (99)
      Tests  2045 passed | 4 skipped (2049)
```

`pnpm --filter @citrineos/core run lint` reports 0 errors and the 2 pre-existing warnings.
