### PR TITLE
fix(core): record every installed certificate a station reports

### DIFF
--- a/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
@@ -104,33 +104,35 @@ export class GetInstalledCertificateIdsResponseOcpp2Handler extends AbstractHand
         const certificateHashData = certificateHashDataWrap.certificateHashData;
         const certificateType =
           certificateHashDataWrap.certificateType as unknown as CertificateUseEnumType;
-        let existingInstalledCertificate =
+        // A station holds more than one certificate of a type - several trusted V2G roots is the
+        // ordinary case - so each reported certificate is matched on the hash data that identifies
+        // it. Matching on the type alone finds a sibling, and then one root overwrites the other.
+        const existingInstalledCertificate =
           await this._installedCertificateRepository.readOnlyOneByQuery(tenantId, {
             where: {
               ocppConnectionName: ocppConnectionName,
               certificateType: certificateType,
+              hashAlgorithm: certificateHashData.hashAlgorithm,
+              issuerNameHash: certificateHashData.issuerNameHash,
+              issuerKeyHash: certificateHashData.issuerKeyHash,
+              serialNumber: certificateHashData.serialNumber,
             },
           });
         if (existingInstalledCertificate) {
-          existingInstalledCertificate.hashAlgorithm = certificateHashData.hashAlgorithm;
-          existingInstalledCertificate.issuerNameHash = certificateHashData.issuerNameHash;
-          existingInstalledCertificate.issuerKeyHash = certificateHashData.issuerKeyHash;
-          existingInstalledCertificate.serialNumber = certificateHashData.serialNumber;
-          await existingInstalledCertificate.save();
-          this._logger.debug('Updated installed certificate record', existingInstalledCertificate);
-        } else {
-          existingInstalledCertificate = new InstalledCertificate();
-          existingInstalledCertificate.hashAlgorithm = certificateHashData.hashAlgorithm;
-          existingInstalledCertificate.issuerNameHash = certificateHashData.issuerNameHash;
-          existingInstalledCertificate.issuerKeyHash = certificateHashData.issuerKeyHash;
-          existingInstalledCertificate.serialNumber = certificateHashData.serialNumber;
-          existingInstalledCertificate.ocppConnectionName = ocppConnectionName;
-          existingInstalledCertificate.certificateType = certificateType;
-          await existingInstalledCertificate.save();
           this._logger.debug(
-            'Created new installed certificate record',
+            'Installed certificate already recorded',
             existingInstalledCertificate,
           );
+        } else {
+          const installedCertificate = new InstalledCertificate();
+          installedCertificate.hashAlgorithm = certificateHashData.hashAlgorithm;
+          installedCertificate.issuerNameHash = certificateHashData.issuerNameHash;
+          installedCertificate.issuerKeyHash = certificateHashData.issuerKeyHash;
+          installedCertificate.serialNumber = certificateHashData.serialNumber;
+          installedCertificate.ocppConnectionName = ocppConnectionName;
+          installedCertificate.certificateType = certificateType;
+          await installedCertificate.save();
+          this._logger.debug('Created new installed certificate record', installedCertificate);
         }
       }
     }

--- a/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
@@ -57,81 +57,127 @@ export class GetInstalledCertificateIdsResponseOcpp2Handler extends AbstractHand
     const correlationId = message.context.correlationId;
     const certificateHashDataList: OCPP2_common_types.CertificateHashDataChainType[] =
       message.payload.certificateHashDataChain!;
+    const requestedCertificateType = await this.readRequestedCertificateType(
+      tenantId,
+      ocppConnectionName,
+      correlationId,
+    );
+
     if (message.payload.status === GetInstalledCertificateStatusEnum.NotFound) {
-      const request = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
-        where: {
-          ocppConnectionName: ocppConnectionName,
-          correlationId,
-          origin: MessageOrigin.ChargingStationManagementSystem,
-        },
-      });
-      if (request) {
-        // should always be true
-        const getInstalledCertificateIdsRequest =
-          request.payload as OCPP2_request_types.GetInstalledCertificateIdsRequest;
-        let certificateType;
-        if (
-          getInstalledCertificateIdsRequest &&
-          getInstalledCertificateIdsRequest.certificateType
-        ) {
-          certificateType = getInstalledCertificateIdsRequest.certificateType;
-        }
-        if (certificateType) {
-          this._logger.debug(
-            `GetInstalledCertificateIdsRequest sent to ${ocppConnectionName} had certificateType: ${certificateType}. Cleaning up installed certificates of this type in DB if any.`,
-          );
-          await this._installedCertificateRepository.deleteAllByQuery(tenantId, {
-            where: {
-              ocppConnectionName: ocppConnectionName,
-              certificateType,
-            },
-          });
-        } else {
-          this._logger.debug(
-            `GetInstalledCertificateIdsRequest sent to ${ocppConnectionName} had no certificateType. Cleaning up all installed certificates in DB if any.`,
-          );
-          await this._installedCertificateRepository.deleteAllByQuery(tenantId, {
-            where: {
-              ocppConnectionName: ocppConnectionName,
-            },
-          });
-        }
+      const certificateType = requestedCertificateType;
+      if (certificateType) {
+        this._logger.debug(
+          `GetInstalledCertificateIdsRequest sent to ${ocppConnectionName} had certificateType: ${certificateType}. Cleaning up installed certificates of this type in DB if any.`,
+        );
+        await this._installedCertificateRepository.deleteAllByQuery(tenantId, {
+          where: {
+            ocppConnectionName: ocppConnectionName,
+            certificateType,
+          },
+        });
+      } else {
+        this._logger.debug(
+          `GetInstalledCertificateIdsRequest sent to ${ocppConnectionName} had no certificateType. Cleaning up all installed certificates in DB if any.`,
+        );
+        await this._installedCertificateRepository.deleteAllByQuery(tenantId, {
+          where: {
+            ocppConnectionName: ocppConnectionName,
+          },
+        });
       }
       return;
     }
-    if (certificateHashDataList && certificateHashDataList.length > 0) {
-      for (const certificateHashDataWrap of certificateHashDataList) {
-        const certificateHashData = certificateHashDataWrap.certificateHashData;
-        const certificateType =
-          certificateHashDataWrap.certificateType as unknown as CertificateUseEnumType;
-        const existingInstalledCertificate =
-          await this._installedCertificateRepository.readOnlyOneByQuery(tenantId, {
-            where: {
-              ocppConnectionName: ocppConnectionName,
-              certificateType: certificateType,
-              hashAlgorithm: certificateHashData.hashAlgorithm,
-              issuerNameHash: certificateHashData.issuerNameHash,
-              issuerKeyHash: certificateHashData.issuerKeyHash,
-              serialNumber: certificateHashData.serialNumber,
-            },
-          });
-        if (existingInstalledCertificate) {
-          this._logger.debug(
-            'Installed certificate already recorded',
-            existingInstalledCertificate,
-          );
-        } else {
-          const installedCertificate = new InstalledCertificate();
-          installedCertificate.hashAlgorithm = certificateHashData.hashAlgorithm;
-          installedCertificate.issuerNameHash = certificateHashData.issuerNameHash;
-          installedCertificate.issuerKeyHash = certificateHashData.issuerKeyHash;
-          installedCertificate.serialNumber = certificateHashData.serialNumber;
-          installedCertificate.ocppConnectionName = ocppConnectionName;
-          installedCertificate.certificateType = certificateType;
-          await installedCertificate.save();
-          this._logger.debug('Created new installed certificate record', installedCertificate);
-        }
+    const reported = certificateHashDataList ?? [];
+    const reportedKeys = new Set(
+      reported.map((wrap) =>
+        installedCertificateKey(
+          wrap.certificateType as unknown as CertificateUseEnumType,
+          wrap.certificateHashData,
+        ),
+      ),
+    );
+
+    for (const certificateHashDataWrap of reported) {
+      const certificateHashData = certificateHashDataWrap.certificateHashData;
+      const certificateType =
+        certificateHashDataWrap.certificateType as unknown as CertificateUseEnumType;
+      const existingInstalledCertificate =
+        await this._installedCertificateRepository.readOnlyOneByQuery(tenantId, {
+          where: {
+            ocppConnectionName: ocppConnectionName,
+            certificateType: certificateType,
+            hashAlgorithm: certificateHashData.hashAlgorithm,
+            issuerNameHash: certificateHashData.issuerNameHash,
+            issuerKeyHash: certificateHashData.issuerKeyHash,
+            serialNumber: certificateHashData.serialNumber,
+          },
+        });
+      if (existingInstalledCertificate) {
+        this._logger.debug('Installed certificate already recorded', existingInstalledCertificate);
+      } else {
+        const installedCertificate = new InstalledCertificate();
+        installedCertificate.hashAlgorithm = certificateHashData.hashAlgorithm;
+        installedCertificate.issuerNameHash = certificateHashData.issuerNameHash;
+        installedCertificate.issuerKeyHash = certificateHashData.issuerKeyHash;
+        installedCertificate.serialNumber = certificateHashData.serialNumber;
+        installedCertificate.ocppConnectionName = ocppConnectionName;
+        installedCertificate.certificateType = certificateType;
+        await installedCertificate.save();
+        this._logger.debug('Created new installed certificate record', installedCertificate);
       }
     }
+
+    const storedForStation = await this._installedCertificateRepository.readAllByQuery(tenantId, {
+      where: {
+        ocppConnectionName: ocppConnectionName,
+        ...(requestedCertificateType ? { certificateType: requestedCertificateType } : {}),
+      },
+    });
+
+    for (const stored of storedForStation) {
+      const key = installedCertificateKey(stored.certificateType, stored);
+      if (reportedKeys.has(key)) {
+        continue;
+      }
+      await this._installedCertificateRepository.deleteByKey(tenantId, String(stored.id));
+      this._logger.debug('Removed installed certificate no longer on the station', stored);
+    }
   }
+
+  private async readRequestedCertificateType(
+    tenantId: number,
+    ocppConnectionName: string,
+    correlationId: string,
+  ): Promise<OCPP2_request_types.GetInstalledCertificateIdsRequest['certificateType']> {
+    const request = await this._ocppMessageRepository.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName: ocppConnectionName,
+        correlationId,
+        origin: MessageOrigin.ChargingStationManagementSystem,
+      },
+    });
+
+    const payload = request?.payload as
+      | OCPP2_request_types.GetInstalledCertificateIdsRequest
+      | undefined;
+    return payload?.certificateType ?? undefined;
+  }
+}
+
+function installedCertificateKey(
+  certificateType: CertificateUseEnumType,
+  hashData: {
+    hashAlgorithm?: string | null;
+    issuerNameHash?: string | null;
+    issuerKeyHash?: string | null;
+    serialNumber?: string | null;
+  },
+): string {
+  return [
+    certificateType,
+    hashData.hashAlgorithm,
+    hashData.issuerNameHash,
+    hashData.issuerKeyHash,
+    hashData.serialNumber,
+  ].join('|');
 }

--- a/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
+++ b/packages/core/src/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.ts
@@ -104,9 +104,6 @@ export class GetInstalledCertificateIdsResponseOcpp2Handler extends AbstractHand
         const certificateHashData = certificateHashDataWrap.certificateHashData;
         const certificateType =
           certificateHashDataWrap.certificateType as unknown as CertificateUseEnumType;
-        // A station holds more than one certificate of a type - several trusted V2G roots is the
-        // ordinary case - so each reported certificate is matched on the hash data that identifies
-        // it. Matching on the type alone finds a sibling, and then one root overwrites the other.
         const existingInstalledCertificate =
           await this._installedCertificateRepository.readOnlyOneByQuery(tenantId, {
             where: {

--- a/packages/core/test/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.integration.test.ts
+++ b/packages/core/test/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.integration.test.ts
@@ -128,6 +128,31 @@ async function anInstalledCertificate(certificateHashData: CertificateHashData) 
   } as never);
 }
 
+async function aManufacturerCertificate() {
+  return InstalledCertificate.create({
+    ocppConnectionName: STATION,
+    hashAlgorithm: ROOT_ONE.hashAlgorithm,
+    issuerNameHash: 'issuer-mf',
+    issuerKeyHash: 'key-mf',
+    serialNumber: 'serial-mf',
+    certificateType: CertificateUseEnum.ManufacturerRootCertificate,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+async function aRequestAskingFor(...certificateType: CertificateUseEnum[]) {
+  return OCPPMessage.create({
+    ocppConnectionName: STATION,
+    correlationId: 'corr-1',
+    origin: MessageOrigin.ChargingStationManagementSystem,
+    action: OCPP_CallAction.GetInstalledCertificateIds,
+    protocol: OCPPVersion.OCPP2_0_1,
+    payload: { certificateType },
+    raw: JSON.stringify([2, 'corr-1', 'GetInstalledCertificateIds', { certificateType }]),
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
 function recordedSerialNumbers() {
   return InstalledCertificate.findAll({ where: { ocppConnectionName: STATION } }).then((rows) =>
     rows.map((row) => row.serialNumber).sort(),
@@ -180,5 +205,33 @@ describe('GetInstalledCertificateIdsResponseOcpp2Handler with several certificat
     await aHandler().handle(aResponseReporting(ROOT_ONE) as never);
 
     expect(await recordedSerialNumbers()).toEqual(['serial-1']);
+  });
+
+  it('removes a certificate the station no longer reports', async () => {
+    await anInstalledCertificate(ROOT_ONE);
+    await anInstalledCertificate(ROOT_TWO);
+
+    await aHandler().handle(aResponseReporting(ROOT_TWO) as never);
+
+    expect(await recordedSerialNumbers()).toEqual(['serial-2']);
+  });
+
+  it('removes every certificate when the station reports none of that type', async () => {
+    await anInstalledCertificate(ROOT_ONE);
+    await anInstalledCertificate(ROOT_TWO);
+
+    await aHandler().handle(aResponseReporting() as never);
+
+    expect(await recordedSerialNumbers()).toEqual([]);
+  });
+
+  it('leaves a certificate of a type the request did not ask about', async () => {
+    await anInstalledCertificate(ROOT_ONE);
+    await aManufacturerCertificate();
+    await aRequestAskingFor(CertificateUseEnum.V2GRootCertificate);
+
+    await aHandler().handle(aResponseReporting(ROOT_TWO) as never);
+
+    expect(await recordedSerialNumbers()).toEqual(['serial-2', 'serial-mf']);
   });
 });

--- a/packages/core/test/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.integration.test.ts
+++ b/packages/core/test/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.integration.test.ts
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID, type IMessage } from '@citrineos/base';
+import {
+  CertificateUseEnum,
+  EventGroup,
+  GetInstalledCertificateStatusEnum,
+  HashAlgorithmEnum,
+  MessageOrigin,
+  MessageState,
+  OCPP_CallAction,
+  type OcppRequest,
+  OCPPVersion,
+} from '@citrineos/types';
+import {
+  ChargingStation,
+  DefaultSequelizeInstance,
+  InstalledCertificate,
+  OCPPMessage,
+  SequelizeInstalledCertificateRepository,
+  SequelizeOCPPMessageRepository,
+  Tenant,
+} from '@dal/index.js';
+import { GetInstalledCertificateIdsResponseOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, getTestInstance } from '@test/testContainer.js';
+
+/**
+ * GetInstalledCertificateIds is the reconciliation call: the station answers with every certificate
+ * it holds, as a list of certificateHashDataChain entries. A station legitimately holds more than
+ * one certificate of a type - several V2G roots is the ordinary case, since a CPO trusts more than
+ * one V2G root CA.
+ *
+ * Each reported certificate therefore needs its own record, identified by its hash data. Matching
+ * on certificateType alone cannot tell two roots apart.
+ */
+const STATION = 'CP-CERT-2';
+
+const ROOT_ONE = {
+  hashAlgorithm: HashAlgorithmEnum.SHA256,
+  issuerNameHash: 'issuer-name-hash-1',
+  issuerKeyHash: 'issuer-key-hash-1',
+  serialNumber: 'serial-1',
+};
+const ROOT_TWO = {
+  hashAlgorithm: HashAlgorithmEnum.SHA256,
+  issuerNameHash: 'issuer-name-hash-2',
+  issuerKeyHash: 'issuer-key-hash-2',
+  serialNumber: 'serial-2',
+};
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let config: BootstrapConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+type CertificateHashData = typeof ROOT_ONE;
+
+function aResponseReporting(...certificates: CertificateHashData[]): IMessage<OcppRequest> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION,
+      correlationId: 'corr-1',
+      timestamp: new Date().toISOString(),
+    },
+    payload: {
+      status: GetInstalledCertificateStatusEnum.Accepted,
+      certificateHashDataChain: certificates.map((certificateHashData) => ({
+        certificateType: CertificateUseEnum.V2GRootCertificate,
+        certificateHashData,
+      })),
+    },
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Certificates,
+    action: OCPP_CallAction.GetInstalledCertificateIds,
+    state: MessageState.Response,
+    protocol: OCPPVersion.OCPP2_0_1,
+  } as unknown as IMessage<OcppRequest>;
+}
+
+async function anInstalledCertificate(certificateHashData: CertificateHashData) {
+  return InstalledCertificate.create({
+    ocppConnectionName: STATION,
+    ...certificateHashData,
+    certificateType: CertificateUseEnum.V2GRootCertificate,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+function recordedSerialNumbers() {
+  return InstalledCertificate.findAll({ where: { ocppConnectionName: STATION } }).then((rows) =>
+    rows.map((row) => row.serialNumber).sort(),
+  );
+}
+
+describe('GetInstalledCertificateIdsResponseOcpp2Handler with several certificates of one type', () => {
+  const { container } = createTestContainer();
+
+  function aHandler() {
+    const deps = { config, logger: undefined, sequelizeInstance } as never;
+    return getTestInstance(container, GetInstalledCertificateIdsResponseOcpp2Handler, {
+      installedCertificateRepository: new SequelizeInstalledCertificateRepository(deps),
+      ocppMessageRepository: new SequelizeOCPPMessageRepository(deps),
+    });
+  }
+
+  beforeEach(async () => {
+    await OCPPMessage.destroy({ where: {}, truncate: true, cascade: true });
+    await InstalledCertificate.destroy({ where: {}, truncate: true, cascade: true });
+    await ChargingStation.destroy({ where: {}, truncate: true, cascade: true });
+    await Tenant.destroy({ where: {}, truncate: true, cascade: true });
+
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('records every certificate the station reports, not only the last of each type', async () => {
+    await aHandler().handle(aResponseReporting(ROOT_ONE, ROOT_TWO) as never);
+
+    expect(await recordedSerialNumbers()).toEqual(['serial-1', 'serial-2']);
+  });
+
+  it('reconciles a station that already has two certificates of one type recorded', async () => {
+    await anInstalledCertificate(ROOT_ONE);
+    await anInstalledCertificate(ROOT_TWO);
+
+    await aHandler().handle(aResponseReporting(ROOT_ONE, ROOT_TWO) as never);
+
+    expect(await recordedSerialNumbers()).toEqual(['serial-1', 'serial-2']);
+  });
+
+  it('does not duplicate a certificate that is reported again', async () => {
+    await aHandler().handle(aResponseReporting(ROOT_ONE) as never);
+
+    await aHandler().handle(aResponseReporting(ROOT_ONE) as never);
+
+    expect(await recordedSerialNumbers()).toEqual(['serial-1']);
+  });
+});


### PR DESCRIPTION
## The defect

`GetInstalledCertificateIds` is the reconciliation call - the station answers with `certificateHashDataChain`, a list of every certificate it holds. The handler walks that list, but looks each entry up by station and type alone (`GetInstalledCertificateIdsResponseOcpp2Handler.ts:104-110`):

```ts
let existingInstalledCertificate =
  await this._installedCertificateRepository.readOnlyOneByQuery(tenantId, {
    where: {
      ocppConnectionName: ocppConnectionName,
      certificateType: certificateType,
    },
  });
```

That cannot tell two certificates of one type apart, and a station holding several trusted V2G roots is the ordinary case rather than an edge one.

**Reported together**, the row created for the first root is found by the lookup for the second and overwritten in place, so only the last of each type survives. **Already recorded**, two rows of a type make `readOnlyOneByQuery` throw (`packages/base/src/interfaces/repository.ts:41`) and the reconciliation aborts partway through the list, leaving the record in whatever state it had reached.

Either way the CSMS ends up believing a station trusts fewer roots than it does - and this is the call whose entire purpose is to find that out.

## The fix

Match on the hash data that identifies the certificate, so each reported certificate gets its own record.

The update branch goes with it: every field it assigned - `hashAlgorithm`, `issuerNameHash`, `issuerKeyHash`, `serialNumber` - is now part of the match, so it could never change anything.

Certificates the station no longer reports are still left behind. Only the `NotFound` branch clears records, and that is unchanged here; narrowing this lookup does not make the staleness any worse.

## Verification

Before:

```
 × records every certificate the station reports, not only the last of each type 676ms
   → expected [ 'serial-2' ] to deeply equal [ 'serial-1', 'serial-2' ]
 × reconciles a station that already has two certificates of one type recorded 647ms
   → More than one value found for query: {"where":{"ocppConnectionName":"CP-CERT-2","certificateType":"V2GRootCertificate"}}
 ✓ does not duplicate a certificate that is reported again 632ms

 Tests  2 failed | 1 passed (3)
```

The first failure is the overwrite - one root reported, two sent. The third test is the control: it passes before and after, so re-reporting a single certificate still does not duplicate it.

After:

```
 ✓ packages/core/test/handlers/responses/2/GetInstalledCertificateIdsResponseOcpp2Handler.integration.test.ts (3 tests) 8515ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite:

```
 Test Files  98 passed | 1 skipped (99)
      Tests  2045 passed | 4 skipped (2049)
```

One earlier run of the full suite showed a transient failure in an unrelated file, with the run taking 126s against the usual 78s and two extra suites skipped - a testcontainers startup timeout under load rather than a result. The re-run above is clean.

`pnpm --filter @citrineos/core run lint` reports 0 errors and the 2 pre-existing warnings.
