### PR TITLE
fix(core): stop treating a reported connector number as a Connector reference

### DIFF
--- a/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
+++ b/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Both columns hold a connector number reported by a charging station, not a reference to a
+// Connector row. The associations that made them foreign keys have been removed; these drop the
+// constraints they left behind.
+const CONSTRAINTS: { table: string; name: string; columns: string }[] = [
+  {
+    table: 'StatusNotifications',
+    name: 'StatusNotifications_connectorId_fkey',
+    columns: '"connectorId"',
+  },
+  { table: 'EvseTypes', name: 'EvseTypes_connectorId_fkey', columns: '"connectorId"' },
+];
+
+const constraintExists = async (
+  queryInterface: QueryInterface,
+  table: string,
+  name: string,
+): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table, name }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    for (const { table, name } of CONSTRAINTS) {
+      if (await constraintExists(queryInterface, table, name)) {
+        await queryInterface.sequelize.query(`ALTER TABLE "${table}" DROP CONSTRAINT "${name}"`, {
+          type: QueryTypes.RAW,
+        });
+      }
+    }
+  },
+
+  // Restoring the constraints fails wherever a stored connector number does not happen to be a
+  // Connector id, which is the state they were wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    for (const { table, name, columns } of CONSTRAINTS) {
+      if (!(await constraintExists(queryInterface, table, name))) {
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${table}" ADD CONSTRAINT "${name}" FOREIGN KEY (${columns})
+             REFERENCES "Connectors" ("id") ON UPDATE CASCADE ON DELETE SET NULL`,
+          { type: QueryTypes.RAW },
+        );
+      }
+    }
+  },
+};

--- a/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
+++ b/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
@@ -6,9 +6,6 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// Both columns hold a connector number reported by a charging station, not a reference to a
-// Connector row. The associations that made them foreign keys have been removed; these drop the
-// constraints they left behind.
 const CONSTRAINTS: { table: string; name: string; columns: string }[] = [
   {
     table: 'StatusNotifications',
@@ -42,8 +39,6 @@ export default {
     }
   },
 
-  // Restoring the constraints fails wherever a stored connector number does not happen to be a
-  // Connector id, which is the state they were wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     for (const { table, name, columns } of CONSTRAINTS) {
       if (!(await constraintExists(queryInterface, table, name))) {

--- a/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
@@ -13,7 +13,6 @@ import type {
   EvseTypeDto,
   MeterValueDto,
   StartTransactionDto,
-  StatusNotificationDto,
   TariffDto,
   TenantDto,
   TransactionDto,
@@ -38,7 +37,6 @@ import { StartTransaction } from '../TransactionEvent/StartTransaction.js';
 import { Transaction } from '../TransactionEvent/Transaction.js';
 import { ChargingStation } from './ChargingStation.js';
 import { Evse } from './Evse.js';
-import { StatusNotification } from './StatusNotification.js';
 
 @Table
 export class Connector extends Model implements ConnectorDto {
@@ -140,9 +138,6 @@ export class Connector extends Model implements ConnectorDto {
   @BelongsTo(() => EvseType, 'evseTypeConnectorId')
   declare evseTypeByConnector?: EvseTypeDto;
 
-  @HasMany(() => EvseType, 'connectorId')
-  declare evseTypes?: EvseTypeDto[];
-
   @ForeignKey(() => Tariff)
   @Column({
     type: DataType.INTEGER,
@@ -154,9 +149,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Tariff, 'tariffId')
   declare tariff?: TariffDto | null;
-
-  @HasMany(() => StatusNotification, 'connectorId')
-  declare statusNotifications?: StatusNotificationDto[];
 
   @HasMany(() => MeterValue, 'connectorId')
   declare meterValues?: MeterValueDto[];

--- a/packages/core/src/dal/layers/sequelize/model/Location/StatusNotification.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/StatusNotification.ts
@@ -4,7 +4,6 @@
 import type {
   ChargingStationDto,
   ConnectorStatusEnumType,
-  ConnectorDto,
   StatusNotificationDto,
   TenantDto,
 } from '@citrineos/types';
@@ -20,7 +19,6 @@ import {
   Table,
 } from 'sequelize-typescript';
 import { ChargingStation } from './ChargingStation.js';
-import { Connector } from './Connector.js';
 import { Tenant } from '../Tenant.js';
 
 @Table
@@ -68,9 +66,6 @@ export class StatusNotification extends Model implements StatusNotificationDto {
   declare vendorErrorCode?: string | null;
 
   declare customData?: object | null;
-
-  @BelongsTo(() => Connector, 'connectorId')
-  declare connector?: ConnectorDto;
 
   @ForeignKey(() => Tenant)
   @Column({

--- a/packages/core/test/modules/Transactions/module/StatusNotificationConnectorNumber.integration.test.ts
+++ b/packages/core/test/modules/Transactions/module/StatusNotificationConnectorNumber.integration.test.ts
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import {
+  type BootstrapConfig,
+  type ICache,
+  type IWebsocketConnection,
+  DEFAULT_TENANT_ID,
+} from '@citrineos/base';
+import { OCPP2_0_1 } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  Evse,
+  EvseType,
+  SequelizeLocationRepository,
+  StatusNotification,
+  Tenant,
+} from '@dal/index.js';
+import { StatusNotificationService } from '@modules/Transactions/src/module/StatusNotificationService.js';
+
+/**
+ * StatusNotification.connectorId holds the connector number the station sent. That number restarts
+ * at 1 on every station, so it is not a reference to a Connector row - and treating it as one
+ * resolves a station's connector 1 to whichever connector happens to hold database id 1.
+ */
+const STATION = 'CS-STATUS-1';
+const OTHER_STATION = 'CS-STATUS-2';
+const OCPP_CONNECTOR_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let locationRepository: SequelizeLocationRepository;
+let cache: ICache;
+let nextEvseNumber = 1;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance({
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  locationRepository = new SequelizeLocationRepository({
+    config: {} as BootstrapConfig,
+    sequelizeInstance,
+  });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+async function aStation(ocppConnectionName: string) {
+  await ChargingStation.create({
+    ocppConnectionName,
+    isOnline: true,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+/** Adds one commissioned connector to a station and returns its database id. */
+async function aConnectorOn(ocppConnectionName: string, connectorNumber: number): Promise<number> {
+  const evseNumber = nextEvseNumber++;
+  const evseType = await EvseType.create({
+    tenantId: DEFAULT_TENANT_ID,
+    id: evseNumber,
+    connectorId: null,
+  } as never);
+  const evse = await Evse.create({
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName,
+    evseTypeId: evseNumber,
+  } as never);
+  const connector = await Connector.create({
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName,
+    connectorId: connectorNumber,
+    evseId: (evse as unknown as { id: number }).id,
+    evseTypeConnectorId: (evseType as unknown as { databaseId: number }).databaseId,
+    status: 'Available',
+    errorCode: 'NoError',
+    timestamp: new Date().toISOString(),
+  } as never);
+  return (connector as unknown as { id: number }).id;
+}
+
+function aService() {
+  cache = {
+    get: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        id: 'test-server',
+        protocol: 'ocpp1.6',
+        allowUnknownChargingStations: true,
+      } as IWebsocketConnection),
+    ),
+  } as unknown as ICache;
+
+  return new StatusNotificationService({
+    componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as never,
+    deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as never,
+    locationRepository,
+    cache,
+  });
+}
+
+describe('A station reporting status for its own connector number', () => {
+  let ownConnectorDatabaseId: number;
+
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    nextEvseNumber = 1;
+
+    // A neighbouring station is commissioned first, so it holds the low database ids - the range
+    // an OCPP connector number falls in.
+    await aStation(OTHER_STATION);
+    await aConnectorOn(OTHER_STATION, 1);
+    await aConnectorOn(OTHER_STATION, 2);
+
+    await aStation(STATION);
+    ownConnectorDatabaseId = await aConnectorOn(STATION, OCPP_CONNECTOR_NUMBER);
+  });
+
+  it('records the connector number the station sent', async () => {
+    await aService().processOcpp16StatusNotification(DEFAULT_TENANT_ID, STATION, {
+      connectorId: OCPP_CONNECTOR_NUMBER,
+      status: OCPP2_0_1.ConnectorStatusEnumType.Available,
+      errorCode: 'NoError',
+      timestamp: new Date().toISOString(),
+    } as never);
+
+    const stored = await StatusNotification.findOne({ where: { ocppConnectionName: STATION } });
+    expect(stored).not.toBeNull();
+    expect(stored!.connectorId).toBe(OCPP_CONNECTOR_NUMBER);
+  });
+
+  it('leaves the number alone rather than forcing it to name a connector row', async () => {
+    // Constraining this column to Connector.id makes the station's connector 1 mean whichever
+    // connector was created first across the whole database - here, one on the other station.
+    expect(ownConnectorDatabaseId).not.toBe(OCPP_CONNECTOR_NUMBER);
+
+    await aService().processOcpp16StatusNotification(DEFAULT_TENANT_ID, STATION, {
+      connectorId: OCPP_CONNECTOR_NUMBER,
+      status: OCPP2_0_1.ConnectorStatusEnumType.Available,
+      errorCode: 'NoError',
+      timestamp: new Date().toISOString(),
+    } as never);
+
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'StatusNotifications'
+          AND kcu.column_name = 'connectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+
+  it('does not constrain the EvseType connector number to a connector row either', async () => {
+    // EvseTypes.connectorId is the connector number within an EVSE, written straight from a
+    // reported component, and is not a reference to a Connector row.
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'EvseTypes'
+          AND kcu.column_name = 'connectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The defect

`StatusNotifications.connectorId` and `EvseTypes.connectorId` both hold a connector number a charging station reported - the station's own numbering, restarting at 1 on every station, and within every EVSE for the 2.0.1 one. Neither is a reference to a `Connector` row.

Three declarations made them foreign keys to `Connector.id` anyway:

- `StatusNotification.ts:72` - `@BelongsTo(() => Connector, 'connectorId')`
- `Connector.ts:158` - `@HasMany(() => StatusNotification, 'connectorId')`
- `Connector.ts:143` - `@HasMany(() => EvseType, 'connectorId')`

Confirmed against a live schema:

```
StatusNotifications_connectorId_fkey   connectorId  -> Connectors.id
EvseTypes_connectorId_fkey             connectorId  -> Connectors.id
```

Two outcomes:

- **A Connector holds that id.** The row resolves to it. Ids are handed out across every station, so connector 1 on one station means whichever connector was created first anywhere.
- **None does.** The insert fails. An OCPP 2.0.1 `StatusNotification` for a station whose connectors are not yet recorded cannot be stored at all - `insert or update on table "StatusNotifications" violates foreign key constraint "StatusNotifications_connectorId_fkey"`.

The 1.6 path avoids the second only by upserting the Connector first, and says so at `StatusNotificationService.ts:205`:

> We upsert the Connector BEFORE saving the StatusNotification because StatusNotifications.connectorId has an FK to Connectors.connectorId.

The constraint is actually to `Connectors.id`, and the 2.0.1 path saves the StatusNotification first.

## The fix

Neither navigation is read anywhere - `connector.statusNotifications`, `connector.evseTypes` and `statusNotification.connector` have no callers - so the three declarations go, and a migration drops the constraints they left on already-migrated databases.

`Connectors.evseTypeConnectorId -> EvseTypes.databaseId` is a genuine reference and is untouched.

## Verification

Before, on a database where the ids do not happen to line up with the connector numbers:

```
 ✓ records the connector number the station sent
 × leaves the number alone rather than forcing it to name a connector row
   → expected [ Array(1) ] to have a length of +0 but got 1
 × does not constrain the EvseType connector number to a connector row either
   → expected [ Array(1) ] to have a length of +0 but got 1
```

After:

```
 ✓ packages/core/test/modules/Transactions/module/StatusNotificationConnectorNumber.integration.test.ts (3 tests)
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Full suite:

```
 Test Files  98 passed | 1 skipped (99)
      Tests  2045 passed | 4 skipped (2049)
```

0 lint errors, the 2 pre-existing warnings.

## Still open, not fixed here

With the constraint gone, an OCPP 2.0.1 `StatusNotification` from a station whose connectors are not yet recorded fails differently: `Connector.evseTypeConnectorId cannot be null`. `StatusNotificationService.ts:96` takes it from a matching connector, and there is none to match yet.

The 1.6 path handles exactly this with `commissionEvseForOcpp16Connector`; 2.0.1 has no equivalent, so its connectors only ever come into existence through the transaction path. That looked like a design decision rather than an oversight, so I have left it alone - happy to open something if it is not.
