### PR TITLE
fix(core): find charging needs by the EVSE the transaction is on

### DIFF
--- a/packages/core/src/util/util/validator.ts
+++ b/packages/core/src/util/util/validator.ts
@@ -16,7 +16,7 @@ import type {
   IDeviceModelRepository,
   ITransactionEventRepository,
 } from '@dal/interfaces/repositories.js';
-import type { ChargingNeeds, EvseType, Transaction } from '@dal/layers/sequelize/index.js';
+import type { ChargingNeeds, Transaction } from '@dal/layers/sequelize/index.js';
 import { VariableAttribute } from '@dal/layers/sequelize/index.js';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
@@ -42,7 +42,6 @@ export function validateLanguageTag(languageTag: string): boolean {
 
 export interface ChargingProfileTransactionContext {
   transaction: Transaction;
-  evse: EvseType;
   chargingNeeds: ChargingNeeds | undefined;
 }
 
@@ -106,19 +105,16 @@ export async function validateChargingProfileType(
         `Transaction ${chargingProfileType.transactionId} not found on station ${ocppConnectionName}.`,
       );
     }
-    const evse = await deviceModelRepository.findEvseByIdAndConnectorId(tenantId, evseId, null);
-    if (!evse) {
-      throw new Error(`Evse ${evseId} not found.`);
+    if (transaction.evseId != null) {
+      receivedChargingNeeds =
+        await chargingProfileRepository.findChargingNeedsByEvseDBIdAndTransactionDBId(
+          tenantId,
+          transaction.evseId,
+          transaction.id,
+        );
     }
-    logger.info(`Found evse: ${JSON.stringify(evse)}`);
-    receivedChargingNeeds =
-      await chargingProfileRepository.findChargingNeedsByEvseDBIdAndTransactionDBId(
-        tenantId,
-        evse.databaseId,
-        transaction.id,
-      );
     logger.info(`Found ChargingNeeds: ${JSON.stringify(receivedChargingNeeds)}`);
-    transactionContext = { transaction, evse, chargingNeeds: receivedChargingNeeds };
+    transactionContext = { transaction, chargingNeeds: receivedChargingNeeds };
   }
 
   const periodsPerSchedules: VariableAttribute[] = await deviceModelRepository.readAllByQuerystring(

--- a/packages/core/test/util/util/ChargingNeedsLookup.integration.test.ts
+++ b/packages/core/test/util/util/ChargingNeedsLookup.integration.test.ts
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { Logger } from 'tslog';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_common_types } from '@citrineos/types';
+import {
+  ChargingStation,
+  DefaultSequelizeInstance,
+  Evse,
+  EvseType,
+  SequelizeChargingProfileRepository,
+  SequelizeDeviceModelRepository,
+  SequelizeTransactionEventRepository,
+  Tenant,
+  Transaction,
+} from '@dal/index.js';
+import { validateChargingProfileType } from '@util/index.js';
+
+/**
+ * ChargingNeeds rows are written against the EVSE the transaction is on - Evse.id, taken from
+ * Transaction.evseId. Looking them up by EvseType.databaseId reads a different table's key: EvseType
+ * is the tenant-wide device model catalogue, and its rows are numbered independently of Evses.
+ */
+const STATION = 'CS-NEEDS-1';
+const OTHER_STATION = 'CS-NEEDS-2';
+const OCPP_EVSE_NUMBER = 1;
+const TRANSACTION_ID = 'T-NEEDS-1';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let config: BootstrapConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+let nextEvseTypeNumber = 1;
+
+async function aStation(ocppConnectionName: string) {
+  await ChargingStation.create({
+    ocppConnectionName,
+    isOnline: true,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+/** Adds one commissioned EVSE to a station and returns its database id. */
+async function anEvseOn(ocppConnectionName: string, ocppEvseNumber: number): Promise<number> {
+  await EvseType.create({
+    tenantId: DEFAULT_TENANT_ID,
+    id: nextEvseTypeNumber++,
+    connectorId: null,
+  } as never);
+  const evse = await Evse.create({
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName,
+    evseTypeId: ocppEvseNumber,
+  } as never);
+  return (evse as unknown as { id: number }).id;
+}
+
+function aTxProfile() {
+  return {
+    id: 1,
+    stackLevel: 1,
+    chargingProfilePurpose: 'TxProfile',
+    chargingProfileKind: 'Relative',
+    transactionId: TRANSACTION_ID,
+    chargingSchedule: [
+      {
+        id: 1,
+        chargingRateUnit: 'A',
+        chargingSchedulePeriod: [{ startPeriod: 0, limit: 32 }],
+      },
+    ],
+  } as unknown as OCPP2_common_types.ChargingProfileType;
+}
+
+describe('Charging needs for a transaction on a station EVSE', () => {
+  let chargingProfileRepository: SequelizeChargingProfileRepository;
+  let deviceModelRepository: SequelizeDeviceModelRepository;
+  let transactionEventRepository: SequelizeTransactionEventRepository;
+  let ownEvseDatabaseId: number;
+
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    nextEvseTypeNumber = 1;
+
+    // A neighbouring station is commissioned first, so the EvseType catalogue and the Evses table
+    // stop numbering in step.
+    await aStation(OTHER_STATION);
+    await anEvseOn(OTHER_STATION, 1);
+    await anEvseOn(OTHER_STATION, 2);
+
+    await aStation(STATION);
+    ownEvseDatabaseId = await anEvseOn(STATION, OCPP_EVSE_NUMBER);
+
+    await Transaction.create({
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION,
+      transactionId: TRANSACTION_ID,
+      isActive: true,
+      evseId: ownEvseDatabaseId,
+    } as never);
+
+    const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+    chargingProfileRepository = new SequelizeChargingProfileRepository(dependencies);
+    deviceModelRepository = new SequelizeDeviceModelRepository(dependencies);
+    transactionEventRepository = new SequelizeTransactionEventRepository(dependencies);
+
+    await chargingProfileRepository.createChargingNeeds(
+      DEFAULT_TENANT_ID,
+      {
+        evseId: OCPP_EVSE_NUMBER,
+        maxScheduleTuples: 5,
+        chargingNeeds: {
+          requestedEnergyTransfer: 'AC_three_phase',
+          acChargingParameters: {
+            energyAmount: 40000,
+            evMinCurrent: 6,
+            evMaxCurrent: 32,
+            evMaxVoltage: 400,
+          },
+        },
+      } as never,
+      STATION,
+    );
+  });
+
+  function validate() {
+    return validateChargingProfileType(
+      aTxProfile(),
+      DEFAULT_TENANT_ID,
+      STATION,
+      deviceModelRepository,
+      chargingProfileRepository,
+      transactionEventRepository,
+      new Logger({ type: 'hidden' }),
+      OCPP_EVSE_NUMBER,
+    );
+  }
+
+  it('finds the charging needs the EV reported for this transaction', async () => {
+    // The EVSE is the third row in Evses but the first in the EvseType catalogue, so the two keys
+    // no longer coincide.
+    expect(ownEvseDatabaseId).not.toBe(OCPP_EVSE_NUMBER);
+
+    const { transactionContext } = await validate();
+
+    expect(transactionContext?.chargingNeeds).toBeDefined();
+  });
+
+  it('defaults numberPhases from the AC charging parameters the EV reported', async () => {
+    const profile = aTxProfile();
+
+    await validateChargingProfileType(
+      profile,
+      DEFAULT_TENANT_ID,
+      STATION,
+      deviceModelRepository,
+      chargingProfileRepository,
+      transactionEventRepository,
+      new Logger({ type: 'hidden' }),
+      OCPP_EVSE_NUMBER,
+    );
+
+    expect(profile.chargingSchedule[0].chargingSchedulePeriod[0].numberPhases).toBe(3);
+  });
+});

--- a/packages/core/test/util/util/validator.test.ts
+++ b/packages/core/test/util/util/validator.test.ts
@@ -29,7 +29,6 @@ import {
   aConsumptionCost,
   aCost,
   aMessageContent,
-  anEvse,
   aSalesTariff,
   aSalesTariffEntry,
   aTransactionEvent,
@@ -300,7 +299,6 @@ describe('validateChargingProfileType', () => {
 
     // Default mock returns
     mockDeviceModelRepo.readAllByQuerystring.mockResolvedValue([]);
-    mockDeviceModelRepo.findEvseByIdAndConnectorId.mockResolvedValue(null);
     mockChargingProfileRepo.findChargingNeedsByEvseDBIdAndTransactionDBId.mockResolvedValue(null);
     mockTransactionEventRepo.readTransactionByStationIdAndTransactionId.mockResolvedValue(null);
   });
@@ -435,35 +433,38 @@ describe('validateChargingProfileType', () => {
       ).rejects.toThrow(`Transaction ${transactionId} not found on station ${testStationId}.`);
     });
 
-    it('should throw error when evse is not found', async () => {
+    it('should read charging needs for the evse the transaction is on', async () => {
       const transactionId = faker.string.uuid();
-      const evseId = 1;
+      const evseDatabaseId = 42;
+      const transaction = aTransactionEvent({
+        evseId: evseDatabaseId,
+        transactionInfo: {
+          transactionId,
+        } as OCPP2_0_1.TransactionType,
+      });
       const chargingProfile = aChargingProfileType({
         chargingProfilePurpose: OCPP2_0_1.ChargingProfilePurposeEnumType.TxProfile,
         transactionId,
       });
 
       mockTransactionEventRepo.readTransactionByStationIdAndTransactionId.mockResolvedValue(
-        aTransactionEvent({
-          transactionInfo: {
-            transactionId,
-          } as OCPP2_0_1.TransactionType,
-        }),
+        transaction,
       );
-      mockDeviceModelRepo.findEvseByIdAndConnectorId.mockResolvedValue(null);
 
-      await expect(
-        validateChargingProfileType(
-          chargingProfile,
-          testTenantId,
-          testStationId,
-          mockDeviceModelRepo,
-          mockChargingProfileRepo,
-          mockTransactionEventRepo,
-          mockLogger,
-          evseId,
-        ),
-      ).rejects.toThrow(`Evse ${evseId} not found.`);
+      await validateChargingProfileType(
+        chargingProfile,
+        testTenantId,
+        testStationId,
+        mockDeviceModelRepo,
+        mockChargingProfileRepo,
+        mockTransactionEventRepo,
+        mockLogger,
+        1,
+      );
+
+      expect(
+        mockChargingProfileRepo.findChargingNeedsByEvseDBIdAndTransactionDBId,
+      ).toHaveBeenCalledWith(testTenantId, evseDatabaseId, transaction.id);
     });
   });
 
@@ -614,17 +615,16 @@ describe('validateChargingProfileType', () => {
       });
 
       const mockTransaction = aTransactionEvent({
+        evseId,
         transactionInfo: {
           transactionId,
         } as OCPP2_0_1.TransactionType,
       });
-      const mockEvse = anEvse({ id: evseId });
       const mockChargingNeeds = aChargingNeeds({ maxScheduleTuples: maxTuples });
 
       mockTransactionEventRepo.readTransactionByStationIdAndTransactionId.mockResolvedValue(
         mockTransaction,
       );
-      mockDeviceModelRepo.findEvseByIdAndConnectorId.mockResolvedValue(mockEvse);
       mockChargingProfileRepo.findChargingNeedsByEvseDBIdAndTransactionDBId.mockResolvedValue(
         mockChargingNeeds,
       );
@@ -742,11 +742,11 @@ describe('validateChargingProfileType', () => {
       });
 
       const mockTransaction = aTransactionEvent({
+        evseId,
         transactionInfo: {
           transactionId,
         } as OCPP2_0_1.TransactionType,
       });
-      const mockEvse = anEvse({ id: evseId });
       const mockChargingNeeds = aChargingNeeds({
         acChargingParameters: {
           energyAmount: 10000,
@@ -760,7 +760,6 @@ describe('validateChargingProfileType', () => {
       mockTransactionEventRepo.readTransactionByStationIdAndTransactionId.mockResolvedValue(
         mockTransaction,
       );
-      mockDeviceModelRepo.findEvseByIdAndConnectorId.mockResolvedValue(mockEvse);
       mockChargingProfileRepo.findChargingNeedsByEvseDBIdAndTransactionDBId.mockResolvedValue(
         mockChargingNeeds,
       );
@@ -799,11 +798,11 @@ describe('validateChargingProfileType', () => {
       });
 
       const mockTransaction = aTransactionEvent({
+        evseId,
         transactionInfo: {
           transactionId,
         } as OCPP2_0_1.TransactionType,
       });
-      const mockEvse = anEvse({ id: evseId });
       const mockChargingNeeds = aChargingNeeds({
         acChargingParameters: undefined,
         dcChargingParameters: {
@@ -816,7 +815,6 @@ describe('validateChargingProfileType', () => {
       mockTransactionEventRepo.readTransactionByStationIdAndTransactionId.mockResolvedValue(
         mockTransaction,
       );
-      mockDeviceModelRepo.findEvseByIdAndConnectorId.mockResolvedValue(mockEvse);
       mockChargingProfileRepo.findChargingNeedsByEvseDBIdAndTransactionDBId.mockResolvedValue(
         mockChargingNeeds,
       );


### PR DESCRIPTION
## What

`validateChargingProfileType` looked up the charging needs an EV reported by resolving an `EvseType` and passing its primary key:

```ts
const evse = await deviceModelRepository.findEvseByIdAndConnectorId(tenantId, evseId, null);
if (!evse) throw new Error(`Evse ${evseId} not found.`);
receivedChargingNeeds =
  await chargingProfileRepository.findChargingNeedsByEvseDBIdAndTransactionDBId(
    tenantId,
    evse.databaseId,   // EvseTypes.databaseId
    transaction.id,
  );
```

`ChargingNeeds.evseId` is a foreign key to `Evse.id`, and that is what writes it:

```ts
// SequelizeChargingProfileRepository.createChargingNeeds
ChargingNeeds.build({ ..., evseId: activeTransaction.evseId, ... })
```

`EvseTypes` is the tenant-wide device-model catalogue; `Evses` is per station. Two tables, two independent auto-increment keys. They only line up on a database where nothing else has been created.

## Why it matters

When the lookup misses, the CSMS behaves as though the EV never sent `NotifyEVChargingNeeds`:

- `SetChargingProfileEndpoint` refuses a `TxProfile` carrying more than one charging schedule - *"No prior NotifyEVChargingNeedsReq found for this transaction"* - even though one arrived and was stored.
- `numberPhases` is neither defaulted to 3 for an AC-charging EV nor cleared for a DC-charging one, so the profile that reaches the station differs from the one the code intended to send.
- `maxScheduleTuples` is not enforced against the sales tariff.

It can also hit rather than miss, and match another station's charging needs, since `EvseTypes.databaseId` is tenant-wide.

## Fix

Take the reference from the transaction, which already names the EVSE it runs on. That removes the second resolution step rather than repairing it. Nothing read the resolved `EvseType` - `ChargingProfileTransactionContext.evse` was never touched by either caller - so the field goes with it.

## Test

`packages/core/test/util/util/ChargingNeedsLookup.integration.test.ts` - testcontainers-backed, real repositories. A neighbouring station is commissioned first so the two key spaces stop coinciding.

Against the unpatched validator:

```
× finds the charging needs the EV reported for this transaction
  → expected undefined to be defined
× defaults numberPhases from the AC charging parameters the EV reported
  → expected undefined to be 3
```

After: 2 passed.