### PR TITLE
fix(core): identify a device model component by its EVSE

### DIFF
--- a/apps/ocpp-server/migrations/20260822100000-component-identity-includes-evse.ts
+++ b/apps/ocpp-server/migrations/20260822100000-component-identity-includes-evse.ts
@@ -6,14 +6,8 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// A charging station names the same component once per EVSE, so the EVSE belongs in a component's
-// identity. Widening the key can only reduce collisions, so no existing row can violate it. Rows
-// written before this migration keep whichever EVSE reported last; a fresh GetBaseReport repopulates
-// them one per EVSE.
 const TABLE_NAME = 'Components';
 
-// Both instance and evseDatabaseId are optional, and Postgres treats nulls in a unique constraint as
-// distinct, so each combination that leaves one out needs its own partial index.
 const OLD_INDEXES = ['components_tenantId_name'];
 const OLD_CONSTRAINTS = ['Components_tenantId_name_instance_key', 'Components_name_instance_key'];
 
@@ -81,8 +75,6 @@ export default {
     }
   },
 
-  // Narrowing the key back fails wherever a station has reported the same component for more than
-  // one EVSE, which is the state it was wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     for (const index of NEW_INDEXES) {
       await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${index.name}"`, {

--- a/apps/ocpp-server/migrations/20260822100000-component-identity-includes-evse.ts
+++ b/apps/ocpp-server/migrations/20260822100000-component-identity-includes-evse.ts
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// A charging station names the same component once per EVSE, so the EVSE belongs in a component's
+// identity. Widening the key can only reduce collisions, so no existing row can violate it. Rows
+// written before this migration keep whichever EVSE reported last; a fresh GetBaseReport repopulates
+// them one per EVSE.
+const TABLE_NAME = 'Components';
+
+// Both instance and evseDatabaseId are optional, and Postgres treats nulls in a unique constraint as
+// distinct, so each combination that leaves one out needs its own partial index.
+const OLD_INDEXES = ['components_tenantId_name'];
+const OLD_CONSTRAINTS = ['Components_tenantId_name_instance_key', 'Components_name_instance_key'];
+
+const NEW_CONSTRAINT = {
+  name: 'Components_tenantId_name_instance_evseDatabaseId_key',
+  columns: '"name", "instance", "evseDatabaseId", "tenantId"',
+};
+
+const NEW_INDEXES = [
+  {
+    name: 'components_tenantId_name',
+    columns: '"tenantId", "name"',
+    where: '"instance" IS NULL AND "evseDatabaseId" IS NULL',
+  },
+  {
+    name: 'components_tenantId_name_evseDatabaseId',
+    columns: '"tenantId", "name", "evseDatabaseId"',
+    where: '"instance" IS NULL',
+  },
+  {
+    name: 'components_tenantId_name_instance',
+    columns: '"tenantId", "name", "instance"',
+    where: '"evseDatabaseId" IS NULL',
+  },
+];
+
+const constraintExists = async (queryInterface: QueryInterface, name: string): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    for (const name of OLD_CONSTRAINTS) {
+      if (await constraintExists(queryInterface, name)) {
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${name}"`,
+          { type: QueryTypes.RAW },
+        );
+      }
+    }
+    for (const name of OLD_INDEXES) {
+      await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${name}"`, {
+        type: QueryTypes.RAW,
+      });
+    }
+
+    if (!(await constraintExists(queryInterface, NEW_CONSTRAINT.name))) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${NEW_CONSTRAINT.name}"
+           UNIQUE (${NEW_CONSTRAINT.columns})`,
+        { type: QueryTypes.RAW },
+      );
+    }
+    for (const index of NEW_INDEXES) {
+      await queryInterface.sequelize.query(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${index.name}" ON "${TABLE_NAME}" (${index.columns})
+           WHERE ${index.where}`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+
+  // Narrowing the key back fails wherever a station has reported the same component for more than
+  // one EVSE, which is the state it was wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    for (const index of NEW_INDEXES) {
+      await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${index.name}"`, {
+        type: QueryTypes.RAW,
+      });
+    }
+    if (await constraintExists(queryInterface, NEW_CONSTRAINT.name)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${NEW_CONSTRAINT.name}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+
+    await queryInterface.sequelize.query(
+      `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "Components_tenantId_name_instance_key"
+         UNIQUE ("name", "instance", "tenantId")`,
+      { type: QueryTypes.RAW },
+    );
+    await queryInterface.sequelize.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS "components_tenantId_name" ON "${TABLE_NAME}"
+         ("tenantId", "name") WHERE "instance" IS NULL`,
+      { type: QueryTypes.RAW },
+    );
+  },
+};

--- a/packages/core/src/dal/layers/sequelize/model/DeviceModel/Component.ts
+++ b/packages/core/src/dal/layers/sequelize/model/DeviceModel/Component.ts
@@ -33,6 +33,9 @@ import { EvseType } from './EvseType.js';
 import { Variable } from './Variable.js';
 import { VariableAttribute } from './VariableAttribute.js';
 
+// A station names the same component once per EVSE, so the EVSE is part of a component's identity.
+// Both instance and evseDatabaseId are optional, and Postgres treats nulls in a unique constraint as
+// distinct, so each combination that leaves one out needs its own partial index.
 @Table({
   indexes: [
     {
@@ -41,6 +44,23 @@ import { VariableAttribute } from './VariableAttribute.js';
       fields: ['tenantId', 'name'],
       where: {
         instance: null,
+        evseDatabaseId: null,
+      },
+    },
+    {
+      unique: true,
+      name: 'components_tenantId_name_evseDatabaseId',
+      fields: ['tenantId', 'name', 'evseDatabaseId'],
+      where: {
+        instance: null,
+      },
+    },
+    {
+      unique: true,
+      name: 'components_tenantId_name_instance',
+      fields: ['tenantId', 'name', 'instance'],
+      where: {
+        evseDatabaseId: null,
       },
     },
   ],
@@ -54,13 +74,13 @@ export class Component extends Model implements OCPP2_0_1.ComponentType, Compone
 
   @Column({
     type: DataType.STRING,
-    unique: 'tenantId_name_instance',
+    unique: 'tenantId_name_instance_evse',
   })
   declare name: string;
 
   @Column({
     type: DataType.STRING,
-    unique: 'tenantId_name_instance',
+    unique: 'tenantId_name_instance_evse',
   })
   declare instance?: string | null;
 
@@ -72,7 +92,10 @@ export class Component extends Model implements OCPP2_0_1.ComponentType, Compone
   declare evse?: EvseType;
 
   @ForeignKey(() => EvseType)
-  @Column(DataType.INTEGER)
+  @Column({
+    type: DataType.INTEGER,
+    unique: 'tenantId_name_instance_evse',
+  })
   declare evseDatabaseId?: number | null;
 
   @BelongsToMany(() => Variable, { through: () => ComponentVariable, foreignKey: 'componentId' })
@@ -97,7 +120,7 @@ export class Component extends Model implements OCPP2_0_1.ComponentType, Compone
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
-    unique: 'tenantId_name_instance',
+    unique: 'tenantId_name_instance_evse',
     onUpdate: 'CASCADE',
     onDelete: 'RESTRICT',
   })

--- a/packages/core/src/dal/layers/sequelize/model/DeviceModel/Component.ts
+++ b/packages/core/src/dal/layers/sequelize/model/DeviceModel/Component.ts
@@ -33,9 +33,6 @@ import { EvseType } from './EvseType.js';
 import { Variable } from './Variable.js';
 import { VariableAttribute } from './VariableAttribute.js';
 
-// A station names the same component once per EVSE, so the EVSE is part of a component's identity.
-// Both instance and evseDatabaseId are optional, and Postgres treats nulls in a unique constraint as
-// distinct, so each combination that leaves one out needs its own partial index.
 @Table({
   indexes: [
     {

--- a/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
@@ -231,21 +231,16 @@ export class SequelizeDeviceModelRepository
         )[0]
       : undefined;
 
+    // A station names the same component once per EVSE, so the EVSE is part of the identity. Leaving
+    // it out returns one row for every EVSE and rewrites its evse to whichever reported last.
     const [component, componentCreated] = await this.component.readOrCreateByQuery(tenantId, {
       where: {
         tenantId,
         name: componentType.name,
         instance: componentType.instance ? componentType.instance : null,
+        evseDatabaseId: evse?.databaseId ?? null,
       },
     });
-    // Note: this permits changing the evse related to the component
-    if (component.evseDatabaseId !== evse?.databaseId && evse) {
-      await this.component.updateByKey(
-        tenantId,
-        { evseDatabaseId: evse.databaseId },
-        component.get('id'),
-      );
-    }
 
     if (componentCreated && ocppConnectionName) {
       const defaultComponentVariableNames = ['Present', 'Available', 'Enabled'];
@@ -507,6 +502,17 @@ export class SequelizeDeviceModelRepository
         name: componentType.name,
         instance: componentType.instance ? componentType.instance : null,
       },
+      include: componentType.evse
+        ? [
+            {
+              model: EvseType,
+              where: {
+                id: componentType.evse.id,
+                connectorId: componentType.evse.connectorId ?? null,
+              },
+            },
+          ]
+        : [EvseType],
     });
     const variable = await this.variable.readOnlyOneByQuery(tenantId, {
       where: {

--- a/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/DeviceModel.ts
@@ -231,8 +231,6 @@ export class SequelizeDeviceModelRepository
         )[0]
       : undefined;
 
-    // A station names the same component once per EVSE, so the EVSE is part of the identity. Leaving
-    // it out returns one row for every EVSE and rewrites its evse to whichever reported last.
     const [component, componentCreated] = await this.component.readOrCreateByQuery(tenantId, {
       where: {
         tenantId,

--- a/packages/core/test/dal/layers/sequelize/repository/DeviceModelComponentPerEvse.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/DeviceModelComponentPerEvse.integration.test.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { AttributeEnum, OCPP2_0_1 } from '@citrineos/types';
+import {
+  ChargingStation,
+  Component,
+  DefaultSequelizeInstance,
+  SequelizeDeviceModelRepository,
+  Tenant,
+} from '@dal/index.js';
+
+/**
+ * An OCPP 2.0.1 station reports the same component name once per EVSE, telling them apart by the
+ * component's evse. Identifying a component by name and instance alone therefore collapses every
+ * EVSE onto one row, and the variable attributes hanging off it collapse with it.
+ */
+const STATION = 'CS-DEVICE-MODEL-1';
+const AVAILABILITY = 'AvailabilityState';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let deviceModelRepository: SequelizeDeviceModelRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  deviceModelRepository = new SequelizeDeviceModelRepository({
+    config,
+    logger: undefined,
+    sequelizeInstance,
+  } as never);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+/** What a station sends for one of its EVSEs in a NotifyReport. */
+async function reportEvseState(evseId: number, state: string) {
+  await deviceModelRepository.createOrUpdateDeviceModelByStationId(
+    DEFAULT_TENANT_ID,
+    {
+      component: { name: 'EVSE', evse: { id: evseId } },
+      variable: { name: AVAILABILITY },
+      variableAttribute: [{ type: OCPP2_0_1.AttributeEnumType.Actual, value: state }],
+    },
+    STATION,
+    new Date().toISOString(),
+  );
+}
+
+function readEvseState(evseId: number) {
+  return deviceModelRepository.readAllByQuerystring(DEFAULT_TENANT_ID, {
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName: STATION,
+    component_name: 'EVSE',
+    component_evse_id: evseId,
+    variable_name: AVAILABILITY,
+    type: AttributeEnum.Actual,
+  });
+}
+
+describe('A station reporting the same component for more than one EVSE', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+
+    await reportEvseState(1, 'Available');
+    await reportEvseState(2, 'Occupied');
+  });
+
+  it('keeps one component per EVSE', async () => {
+    const components = await Component.findAll({ where: { name: 'EVSE' } });
+
+    expect(components).toHaveLength(2);
+  });
+
+  it('keeps the state each EVSE reported', async () => {
+    const [firstEvse] = await readEvseState(1);
+    const [secondEvse] = await readEvseState(2);
+
+    expect(firstEvse?.value).toBe('Available');
+    expect(secondEvse?.value).toBe('Occupied');
+  });
+
+  it('resolves the component and variable for one EVSE', async () => {
+    const [component, variable] = await deviceModelRepository.findComponentAndVariable(
+      DEFAULT_TENANT_ID,
+      { name: 'EVSE', evse: { id: 2 } },
+      { name: AVAILABILITY },
+    );
+
+    expect(variable).toBeDefined();
+    expect(component?.evse?.id).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

`Components` was unique on `(tenantId, name, instance)`. An OCPP 2.0.1 station names the same component once per EVSE and tells them apart by `ComponentType.evse`, so the EVSE belongs in the key. Without it every EVSE collapses onto one row:

```ts
// findOrCreateEvseAndComponent, before
const [component, componentCreated] = await this.component.readOrCreateByQuery(tenantId, {
  where: { tenantId, name: componentType.name, instance: componentType.instance ?? null },
});
// Note: this permits changing the evse related to the component
if (component.evseDatabaseId !== evse?.databaseId && evse) {
  await this.component.updateByKey(tenantId, { evseDatabaseId: evse.databaseId }, component.get('id'));
}
```

The second EVSE to report finds the first EVSE's row and rewrites its `evseDatabaseId`.

## Why it matters

`VariableAttribute` is keyed on `(stationId, type, variableId, componentId)`. With one component per name, that key no longer distinguishes EVSEs either - a station with six EVSEs keeps **one** value per variable name for the whole station, and each `NotifyReport` overwrites the last. Reading back with `component_evse_id` joins through `Component.evseDatabaseId`, so it matches only whichever EVSE reported most recently.

The code downstream is already written for the correct shape. `StatusNotificationService` looks a connector component up by both EVSE and connector number:

```ts
let components = await this._componentRepository.readAllByQuery(tenantId, {
  where: { tenantId, name: 'Connector' },
  include: [
    { model: EvseType, where: { id: statusNotificationRequest.evseId,
                                connectorId: statusNotificationRequest.connectorId } },
    { model: Variable, where: { name: 'AvailabilityState' } },
  ],
});
...
if (components.length === 0) {
  this._logger.warn('Missing component or variable for status notification. ' +
                    'Status notification cannot be assigned to device model.');
}
```

On a multi-EVSE station that query can only ever match one EVSE, so the rest log that warning and never reach the device model.

## Fix

- `Component` identity becomes `(tenantId, name, instance, evseDatabaseId)`. Both `instance` and `evseDatabaseId` are optional and Postgres treats nulls in a unique constraint as distinct, so the combinations that leave one out get partial indexes, following the pattern already used on `EvseType`.
- `findOrCreateEvseAndComponent` includes the EVSE in the lookup, and the "permits changing the evse" mutation goes with it.
- `findComponentAndVariable` narrows by the component's EVSE, since more than one component can now share a name and `readOnlyOneByQuery` throws on more than one match.

`VariableAttribute` needs no change: once `componentId` differs per EVSE, its existing key is correct.

Widening a unique key can only reduce collisions, so no existing row can violate the new one and the migration cannot fail on live data. Rows written before it keep whichever EVSE reported last; a fresh `GetBaseReport` repopulates them one per EVSE.

## Test

`packages/core/test/dal/layers/sequelize/repository/DeviceModelComponentPerEvse.integration.test.ts` - testcontainers-backed, a real station reporting `EVSE.AvailabilityState` for EVSE 1 and EVSE 2.

Against the unpatched repository:

```
× keeps one component per EVSE
  → expected [ Component{ …(8) } ] to have a length of 2 but got 1
× keeps the state each EVSE reported
  → expected undefined to be 'Available'
× resolves the component and variable for one EVSE
  → expected undefined to be 2
```

After: 3 passed, and the full `packages/core` suite is green (75 files, 1390 tests).