### PR TITLE
fix(core): treat a connector's EVSE-scoped number as a number, not a row reference

### DIFF
--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -6,9 +6,6 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
-// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
-// has been removed; this drops the constraint it left behind.
 const TABLE_NAME = 'Connectors';
 const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
 
@@ -31,8 +28,6 @@ export default {
     }
   },
 
-  // Restoring the constraint fails wherever a stored connector number does not happen to be an
-  // EvseType key, which is the state it was wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     if (!(await constraintExists(queryInterface))) {
       await queryInterface.sequelize.query(

--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
+// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
+// has been removed; this drops the constraint it left behind.
+const TABLE_NAME = 'Connectors';
+const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
+
+const constraintExists = async (queryInterface: QueryInterface): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name: CONSTRAINT_NAME }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    if (await constraintExists(queryInterface)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+
+  // Restoring the constraint fails wherever a stored connector number does not happen to be an
+  // EvseType key, which is the state it was wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    if (!(await constraintExists(queryInterface))) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}"
+           FOREIGN KEY ("evseTypeConnectorId") REFERENCES "EvseTypes" ("databaseId")
+           ON UPDATE CASCADE ON DELETE SET NULL`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+};

--- a/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
@@ -73,7 +73,6 @@ export class Connector extends Model implements ConnectorDto {
   })
   declare connectorId: number; // This is the serial int starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station.
 
-  @ForeignKey(() => EvseType)
   @Column({
     unique: 'evseId_evseTypeConnectorId',
     allowNull: false,
@@ -136,9 +135,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Evse, 'evseId')
   declare evse?: EvseDto;
-
-  @BelongsTo(() => EvseType, 'evseTypeConnectorId')
-  declare evseTypeByConnector?: EvseTypeDto;
 
   @HasMany(() => EvseType, 'connectorId')
   declare evseTypes?: EvseTypeDto[];

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -15,7 +15,6 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
-/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
 const OCPP_2_0_1_FIRST_CONNECTOR = 1;
 
 export class SequelizeLocationRepository
@@ -368,7 +367,6 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      // The EVSE holds this one connector, so its number within that EVSE is 1.
       return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -15,6 +15,9 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
+/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
+const OCPP_2_0_1_FIRST_CONNECTOR = 1;
+
 export class SequelizeLocationRepository
   extends SequelizeRepository<Location>
   implements ILocationRepository
@@ -355,7 +358,7 @@ export class SequelizeLocationRepository
       // is implicit (single-connector hardware abstraction). The Evse's
       // stationId FK is auto-resolved from ocppConnectionName by the
       // BeforeCreate hook on the Evse model.
-      const [evseType] = await EvseType.findOrCreate({
+      await EvseType.findOrCreate({
         where: { tenantId, id: connectorId, connectorId: null },
         defaults: { tenantId, id: connectorId, connectorId: null },
         transaction: sequelizeTransaction,
@@ -365,7 +368,8 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      return { evseId: evse.id, evseTypeConnectorId: evseType.databaseId };
+      // The EVSE holds this one connector, so its number within that EVSE is 1.
+      return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }
 

--- a/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1, type OCPP2_request_types } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  SequelizeLocationRepository,
+  SequelizeTransactionEventRepository,
+  Tenant,
+} from '@dal/index.js';
+
+/**
+ * Connector.evseTypeConnectorId holds the connector number within its EVSE, which is what an OCPP
+ * 2.0.1 station sends and what every 2.0.1 read compares against. Constraining it to
+ * EvseTypes.databaseId makes that number mean a row in the tenant-wide device model catalogue
+ * instead.
+ */
+const STATION = 'CS-CONNECTOR-REF-1';
+const OCPP_201_CONNECTOR_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let transactionEventRepository: SequelizeTransactionEventRepository;
+let locationRepository: SequelizeLocationRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+  transactionEventRepository = new SequelizeTransactionEventRepository(dependencies);
+  locationRepository = new SequelizeLocationRepository(dependencies);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aStartedEvent(): OCPP2_request_types.TransactionEventRequest {
+  return {
+    eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+    timestamp: new Date().toISOString(),
+    triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+    seqNo: 1,
+    transactionInfo: { transactionId: 'TX-CONNECTOR-REF' },
+    evse: { id: 1, connectorId: OCPP_201_CONNECTOR_NUMBER },
+  } as unknown as OCPP2_request_types.TransactionEventRequest;
+}
+
+describe('A connector number scoped to its EVSE', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('records the connector a 2.0.1 transaction names on an uncommissioned station', async () => {
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      aStartedEvent(),
+      STATION,
+    );
+
+    const connectors = await Connector.findAll();
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].evseTypeConnectorId).toBe(OCPP_201_CONNECTOR_NUMBER);
+  });
+
+  it('commissions an OCPP 1.6 connector with a connector number, not a catalogue key', async () => {
+    // Each 1.6 connector becomes its own single-connector EVSE, so its number within that EVSE is 1
+    // however many rows the tenant-wide EvseType catalogue already holds.
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 1);
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 2);
+
+    const commissioned = await locationRepository.commissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      STATION,
+      3,
+    );
+
+    expect(commissioned.evseTypeConnectorId).toBe(1);
+  });
+
+  it('does not tie the connector number to a device model catalogue row', async () => {
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'Connectors'
+          AND kcu.column_name = 'evseTypeConnectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

`Connector.evseTypeConnectorId` is documented as *"the serial int starting at 1 used in OCPP 2.0.1 to refer to the connector, unique per EVSE"*, and its unique key `(evseId, evseTypeConnectorId)` says the same. It was also `@ForeignKey(() => EvseType)`, making it a reference to `EvseTypes.databaseId` - a key over the tenant-wide device-model catalogue.

Every OCPP 2.0.1 path already treats it as a connector number:

```ts
// SequelizeLocationRepository.readConnectorByStationIdAndOcpp201EvseType
where: { tenantId, ocppConnectionName, evseTypeConnectorId: ocpp201EvseType.connectorId }

// SequelizeTransactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId
where: { tenantId, ocppConnectionName, evseId: evse.id, evseTypeConnectorId: value.evse.connectorId }

// StatusNotificationService.processStatusNotification
matchingEvse?.connectors?.find((c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId)
```

Only `commissionEvseForOcpp16Connector` wrote a database key, and it did so to satisfy the constraint.

## Why it matters

A 2.0.1 station that has not been commissioned cannot record a connector correctly. Where the tenant-wide catalogue holds no row with that `databaseId` - a new tenant, which is what the test sets up - its first `TransactionEventRequest` reaches:

```
SequelizeForeignKeyConstraintError: insert or update on table "Connectors"
violates foreign key constraint "Connectors_evseTypeConnectorId_fkey"
```

`createOrUpdateTransactionByTransactionEventAndStationId` runs inside a Sequelize transaction, so the whole event is rolled back.

Where the connector number *does* happen to be an `EvseTypes.databaseId`, the insert succeeds and the connector points at an unrelated catalogue row - typically one belonging to another station, since `EvseTypes` is tenant-wide.

## Fix

- `@ForeignKey(() => EvseType)` and `@BelongsTo(() => EvseType, 'evseTypeConnectorId')` removed. Nothing read the `evseTypeByConnector` navigation.
- `commissionEvseForOcpp16Connector` returns `1` instead of `EvseType.databaseId`. A 1.6 connector becomes its own single-connector EVSE, so its number within that EVSE is 1.
- Migration drops `Connectors_evseTypeConnectorId_fkey`.

`commissionEvseForOcpp16Connector` runs only for a station with no `Evse` rows, so rows written before this keep their old value; they are read only by the 2.0.1 paths, which never see a 1.6 station.

## Test

`packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts` - testcontainers-backed, real repositories.

Against the unpatched model:

```
× records the connector a 2.0.1 transaction names on an uncommissioned station
  → SequelizeForeignKeyConstraintError: insert or update on table "Connectors"
    violates foreign key constraint "Connectors_evseTypeConnectorId_fkey"
× commissions an OCPP 1.6 connector with a connector number, not a catalogue key
  → expected 3 to be 1
× does not tie the connector number to a device model catalogue row
  → expected [ Array(1) ] to have a length of +0 but got 1
```

After: 3 passed, and the full `packages/core` suite is green (75 files, 1390 tests).
