### PR TITLE
fix(core): give a 2.0.1 connector a station-wide number of its own

### DIFF
--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -6,9 +6,6 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
-// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
-// has been removed; this drops the constraint it left behind.
 const TABLE_NAME = 'Connectors';
 const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
 
@@ -31,8 +28,6 @@ export default {
     }
   },
 
-  // Restoring the constraint fails wherever a stored connector number does not happen to be an
-  // EvseType key, which is the state it was wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     if (!(await constraintExists(queryInterface))) {
       await queryInterface.sequelize.query(

--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
+// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
+// has been removed; this drops the constraint it left behind.
+const TABLE_NAME = 'Connectors';
+const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
+
+const constraintExists = async (queryInterface: QueryInterface): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name: CONSTRAINT_NAME }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    if (await constraintExists(queryInterface)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+
+  // Restoring the constraint fails wherever a stored connector number does not happen to be an
+  // EvseType key, which is the state it was wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    if (!(await constraintExists(queryInterface))) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}"
+           FOREIGN KEY ("evseTypeConnectorId") REFERENCES "EvseTypes" ("databaseId")
+           ON UPDATE CASCADE ON DELETE SET NULL`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+};

--- a/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
@@ -73,7 +73,6 @@ export class Connector extends Model implements ConnectorDto {
   })
   declare connectorId: number; // This is the serial int starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station.
 
-  @ForeignKey(() => EvseType)
   @Column({
     unique: 'evseId_evseTypeConnectorId',
     allowNull: false,
@@ -136,9 +135,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Evse, 'evseId')
   declare evse?: EvseDto;
-
-  @BelongsTo(() => EvseType, 'evseTypeConnectorId')
-  declare evseTypeByConnector?: EvseTypeDto;
 
   @HasMany(() => EvseType, 'connectorId')
   declare evseTypes?: EvseTypeDto[];

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -15,7 +15,6 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
-/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
 const OCPP_2_0_1_FIRST_CONNECTOR = 1;
 
 export class SequelizeLocationRepository
@@ -368,7 +367,6 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      // The EVSE holds this one connector, so its number within that EVSE is 1.
       return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -15,6 +15,9 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
+/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
+const OCPP_2_0_1_FIRST_CONNECTOR = 1;
+
 export class SequelizeLocationRepository
   extends SequelizeRepository<Location>
   implements ILocationRepository
@@ -355,7 +358,7 @@ export class SequelizeLocationRepository
       // is implicit (single-connector hardware abstraction). The Evse's
       // stationId FK is auto-resolved from ocppConnectionName by the
       // BeforeCreate hook on the Evse model.
-      const [evseType] = await EvseType.findOrCreate({
+      await EvseType.findOrCreate({
         where: { tenantId, id: connectorId, connectorId: null },
         defaults: { tenantId, id: connectorId, connectorId: null },
         transaction: sequelizeTransaction,
@@ -365,7 +368,8 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      return { evseId: evse.id, evseTypeConnectorId: evseType.databaseId };
+      // The EVSE holds this one connector, so its number within that EVSE is 1.
+      return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }
 

--- a/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
@@ -368,12 +368,6 @@ export class SequelizeTransactionEventRepository
     });
   }
 
-  /**
-   * OCPP 2.0.1 numbers a connector within its EVSE, so every EVSE of a station numbers its first
-   * connector 1. Connector.connectorId is the station-wide OCPP 1.6 numbering and is unique per
-   * station, so a connector the CSMS has not recorded before is given the next number free on that
-   * station rather than the one the EVSE calls it.
-   */
   private async _readOrCreateConnectorForEvse(
     tenantId: number,
     ocppConnectionName: string,

--- a/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/TransactionEvent.ts
@@ -144,15 +144,12 @@ export class SequelizeTransactionEventRepository
               evseTypeId: value.evse.id,
             },
           });
-          const [connector] = await this.connector.readOrCreateByQuery(tenantId, {
-            where: {
-              tenantId,
-              ocppConnectionName: ocppConnectionName,
-              evseId: evse.id,
-              evseTypeConnectorId: value.evse.connectorId,
-            },
-            include: [Tariff],
-          });
+          const connector = await this._readOrCreateConnectorForEvse(
+            tenantId,
+            ocppConnectionName,
+            evse.id,
+            value.evse.connectorId,
+          );
           connectorId = connector.id;
           tariffId = connector.tariff?.id;
         }
@@ -224,16 +221,12 @@ export class SequelizeTransactionEventRepository
           });
           newTransaction.set('evseId', evse.id);
           if (value.evse?.connectorId) {
-            const [connector] = await this.connector.readOrCreateByQuery(tenantId, {
-              where: {
-                tenantId,
-                ocppConnectionName: ocppConnectionName,
-                evseId: evse.id,
-                evseTypeConnectorId: value.evse.connectorId,
-              },
-              defaults: { connectorId: value.evse.connectorId },
-              include: [Tariff],
-            });
+            const connector = await this._readOrCreateConnectorForEvse(
+              tenantId,
+              ocppConnectionName,
+              evse.id,
+              value.evse.connectorId,
+            );
             newTransaction.set('connectorId', connector.id);
             if (infoTariffId) {
               const tariff = await Tariff.findOne({
@@ -373,6 +366,36 @@ export class SequelizeTransactionEventRepository
 
       return finalTransaction;
     });
+  }
+
+  /**
+   * OCPP 2.0.1 numbers a connector within its EVSE, so every EVSE of a station numbers its first
+   * connector 1. Connector.connectorId is the station-wide OCPP 1.6 numbering and is unique per
+   * station, so a connector the CSMS has not recorded before is given the next number free on that
+   * station rather than the one the EVSE calls it.
+   */
+  private async _readOrCreateConnectorForEvse(
+    tenantId: number,
+    ocppConnectionName: string,
+    evseDatabaseId: number,
+    ocpp201ConnectorId: number,
+  ): Promise<Connector> {
+    const [connector] = await this.connector.readOrCreateByQuery(tenantId, {
+      where: {
+        tenantId,
+        ocppConnectionName,
+        evseId: evseDatabaseId,
+        evseTypeConnectorId: ocpp201ConnectorId,
+      },
+      defaults: {
+        connectorId: await this.connector.readNextValue(tenantId, 'connectorId', {
+          where: { tenantId, ocppConnectionName },
+        }),
+        timestamp: new Date().toISOString(),
+      },
+      include: [Tariff],
+    });
+    return connector;
   }
 
   async readAllByStationIdAndTransactionId(

--- a/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1, type OCPP2_request_types } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  SequelizeLocationRepository,
+  SequelizeTransactionEventRepository,
+  Tenant,
+} from '@dal/index.js';
+
+/**
+ * Connector.evseTypeConnectorId holds the connector number within its EVSE, which is what an OCPP
+ * 2.0.1 station sends and what every 2.0.1 read compares against. Constraining it to
+ * EvseTypes.databaseId makes that number mean a row in the tenant-wide device model catalogue
+ * instead.
+ */
+const STATION = 'CS-CONNECTOR-REF-1';
+const OCPP_201_CONNECTOR_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let transactionEventRepository: SequelizeTransactionEventRepository;
+let locationRepository: SequelizeLocationRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+  transactionEventRepository = new SequelizeTransactionEventRepository(dependencies);
+  locationRepository = new SequelizeLocationRepository(dependencies);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aStartedEvent(): OCPP2_request_types.TransactionEventRequest {
+  return {
+    eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+    timestamp: new Date().toISOString(),
+    triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+    seqNo: 1,
+    transactionInfo: { transactionId: 'TX-CONNECTOR-REF' },
+    evse: { id: 1, connectorId: OCPP_201_CONNECTOR_NUMBER },
+  } as unknown as OCPP2_request_types.TransactionEventRequest;
+}
+
+describe('A connector number scoped to its EVSE', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('records the connector a 2.0.1 transaction names on an uncommissioned station', async () => {
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      aStartedEvent(),
+      STATION,
+    );
+
+    const connectors = await Connector.findAll();
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].evseTypeConnectorId).toBe(OCPP_201_CONNECTOR_NUMBER);
+  });
+
+  it('commissions an OCPP 1.6 connector with a connector number, not a catalogue key', async () => {
+    // Each 1.6 connector becomes its own single-connector EVSE, so its number within that EVSE is 1
+    // however many rows the tenant-wide EvseType catalogue already holds.
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 1);
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 2);
+
+    const commissioned = await locationRepository.commissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      STATION,
+      3,
+    );
+
+    expect(commissioned.evseTypeConnectorId).toBe(1);
+  });
+
+  it('does not tie the connector number to a device model catalogue row', async () => {
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'Connectors'
+          AND kcu.column_name = 'evseTypeConnectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+});

--- a/packages/core/test/dal/layers/sequelize/repository/MultiEvseTransactionConnector.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/MultiEvseTransactionConnector.integration.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1, type OCPP2_request_types } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  SequelizeTransactionEventRepository,
+  Tenant,
+} from '@dal/index.js';
+
+/**
+ * In OCPP 2.0.1 a connectorId is scoped to its EVSE, so every EVSE of a station numbers its first
+ * connector 1. Connector.connectorId holds the station-wide OCPP 1.6 numbering and is unique per
+ * station, so writing the EVSE-scoped number straight into it collides as soon as a second EVSE
+ * starts a transaction.
+ */
+const STATION = 'CS-MULTI-EVSE-1';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let transactionEventRepository: SequelizeTransactionEventRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  transactionEventRepository = new SequelizeTransactionEventRepository({
+    config,
+    logger: undefined,
+    sequelizeInstance,
+  } as never);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aStartedEvent(
+  transactionId: string,
+  evseId: number,
+  connectorId: number,
+): OCPP2_request_types.TransactionEventRequest {
+  return {
+    eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+    timestamp: new Date().toISOString(),
+    triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+    seqNo: 1,
+    transactionInfo: { transactionId },
+    evse: { id: evseId, connectorId },
+  } as unknown as OCPP2_request_types.TransactionEventRequest;
+}
+
+function anUpdatedEvent(
+  transactionId: string,
+  evseId: number,
+  connectorId: number,
+): OCPP2_request_types.TransactionEventRequest {
+  return {
+    eventType: OCPP2_0_1.TransactionEventEnumType.Updated,
+    timestamp: new Date().toISOString(),
+    triggerReason: OCPP2_0_1.TriggerReasonEnumType.MeterValuePeriodic,
+    seqNo: 2,
+    transactionInfo: { transactionId },
+    evse: { id: evseId, connectorId },
+  } as unknown as OCPP2_request_types.TransactionEventRequest;
+}
+
+describe('A station whose EVSEs each number their first connector 1', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('starts a transaction on a second EVSE', async () => {
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      aStartedEvent('TX-EVSE-1', 1, 1),
+      STATION,
+    );
+
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      aStartedEvent('TX-EVSE-2', 2, 1),
+      STATION,
+    );
+
+    const connectors = await Connector.findAll({ order: [['id', 'ASC']] });
+    expect(connectors).toHaveLength(2);
+    expect(connectors[0].connectorId).not.toBe(connectors[1].connectorId);
+    expect(() => JSON.stringify(connectors)).not.toThrow();
+  });
+
+  it('records a connector for a transaction whose first event named no connector', async () => {
+    // A station may send the connector only on a later event, which lands in the update branch.
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      {
+        eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+        timestamp: new Date().toISOString(),
+        triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+        seqNo: 1,
+        transactionInfo: { transactionId: 'TX-LATE-CONNECTOR' },
+      } as unknown as OCPP2_request_types.TransactionEventRequest,
+      STATION,
+    );
+
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      anUpdatedEvent('TX-LATE-CONNECTOR', 1, 1),
+      STATION,
+    );
+
+    const connectors = await Connector.findAll();
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].connectorId).not.toBeNull();
+  });
+});


### PR DESCRIPTION
> Stacked on #936, which removes the foreign key that this hits first. The diff against `next` therefore contains both commits; review the second one.

## What

`createOrUpdateTransactionByTransactionEventAndStationId` created a `Connector` from an OCPP 2.0.1 transaction event. An OCPP 2.0.1 `connectorId` is scoped to its EVSE, so every EVSE of a station numbers its first connector 1. `Connector.connectorId` is the station-wide OCPP 1.6 numbering and is unique per `(stationId, connectorId)`.

Two separate defects in the same method:

**Second EVSE collides.** The new-transaction branch wrote the EVSE-scoped number straight into the station-wide column:

```ts
defaults: { connectorId: value.evse.connectorId },
```

EVSE 1 connector 1 takes `connectorId = 1`. EVSE 2 connector 1 asks for `connectorId = 1` too:

```
SequelizeUniqueConstraintError: Validation error
```

The whole method runs inside `this.s.transaction(...)`, so the second EVSE's session cannot start at all.

**Existing-transaction branch inserted a null.** The branch that attaches a connector to a transaction already in flight passed no `defaults`:

```ts
const [connector] = await this.connector.readOrCreateByQuery(tenantId, {
  where: { tenantId, ocppConnectionName, evseId: evse.id,
           evseTypeConnectorId: value.evse.connectorId },
  include: [Tariff],
});
```

`Connector.connectorId` is `allowNull: false`:

```
SequelizeValidationError: notNull Violation: Connector.connectorId cannot be null
```

That is the path a station takes when it names the connector on a later event than the first.

## Fix

Both branches go through one helper. A connector the CSMS has not recorded before gets the next number free on its station, rather than the number its EVSE calls it. The lookup key is unchanged - `(ocppConnectionName, evseId, evseTypeConnectorId)` - so the allocation happens once per connector and later events find the same row.

The helper also sets `timestamp` on creation. `Connector.timestamp` has a column getter that calls `.toISOString()` unconditionally, so a row created without one throws as soon as anything reads it.

## Test

`packages/core/test/dal/layers/sequelize/repository/MultiEvseTransactionConnector.integration.test.ts` - testcontainers-backed, a station that has not been commissioned.

Against the unpatched repository (on top of #936):

```
× starts a transaction on a second EVSE
  → SequelizeUniqueConstraintError: Validation error
× records a connector for a transaction whose first event named no connector
  → notNull Violation: Connector.connectorId cannot be null
```

After: 2 passed, and the full `packages/core` suite is green (76 files, 1392 tests).