### PR TITLE
fix(core): commission an OCPP 2.0.1 EVSE and connector on first sight

### DIFF
--- a/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
+++ b/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Both columns hold a connector number reported by a charging station, not a reference to a
+// Connector row. The associations that made them foreign keys have been removed; these drop the
+// constraints they left behind.
+const CONSTRAINTS: { table: string; name: string; columns: string }[] = [
+  {
+    table: 'StatusNotifications',
+    name: 'StatusNotifications_connectorId_fkey',
+    columns: '"connectorId"',
+  },
+  { table: 'EvseTypes', name: 'EvseTypes_connectorId_fkey', columns: '"connectorId"' },
+];
+
+const constraintExists = async (
+  queryInterface: QueryInterface,
+  table: string,
+  name: string,
+): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table, name }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    for (const { table, name } of CONSTRAINTS) {
+      if (await constraintExists(queryInterface, table, name)) {
+        await queryInterface.sequelize.query(`ALTER TABLE "${table}" DROP CONSTRAINT "${name}"`, {
+          type: QueryTypes.RAW,
+        });
+      }
+    }
+  },
+
+  // Restoring the constraints fails wherever a stored connector number does not happen to be a
+  // Connector id, which is the state they were wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    for (const { table, name, columns } of CONSTRAINTS) {
+      if (!(await constraintExists(queryInterface, table, name))) {
+        await queryInterface.sequelize.query(
+          `ALTER TABLE "${table}" ADD CONSTRAINT "${name}" FOREIGN KEY (${columns})
+             REFERENCES "Connectors" ("id") ON UPDATE CASCADE ON DELETE SET NULL`,
+          { type: QueryTypes.RAW },
+        );
+      }
+    }
+  },
+};

--- a/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
+++ b/apps/ocpp-server/migrations/20260821140000-drop-connector-number-foreign-keys.ts
@@ -6,9 +6,6 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// Both columns hold a connector number reported by a charging station, not a reference to a
-// Connector row. The associations that made them foreign keys have been removed; these drop the
-// constraints they left behind.
 const CONSTRAINTS: { table: string; name: string; columns: string }[] = [
   {
     table: 'StatusNotifications',
@@ -42,8 +39,6 @@ export default {
     }
   },
 
-  // Restoring the constraints fails wherever a stored connector number does not happen to be a
-  // Connector id, which is the state they were wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     for (const { table, name, columns } of CONSTRAINTS) {
       if (!(await constraintExists(queryInterface, table, name))) {

--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -6,9 +6,6 @@
 /** @type {import('sequelize-cli').Migration} */
 import { QueryInterface, QueryTypes } from 'sequelize';
 
-// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
-// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
-// has been removed; this drops the constraint it left behind.
 const TABLE_NAME = 'Connectors';
 const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
 
@@ -31,8 +28,6 @@ export default {
     }
   },
 
-  // Restoring the constraint fails wherever a stored connector number does not happen to be an
-  // EvseType key, which is the state it was wrong about in the first place.
   down: async (queryInterface: QueryInterface) => {
     if (!(await constraintExists(queryInterface))) {
       await queryInterface.sequelize.query(

--- a/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
+++ b/apps/ocpp-server/migrations/20260822110000-drop-connector-evse-type-foreign-key.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+// Connectors.evseTypeConnectorId holds the connector's number within its EVSE, which is what an OCPP
+// 2.0.1 station sends. It is not a reference to an EvseType row, and the association that made it one
+// has been removed; this drops the constraint it left behind.
+const TABLE_NAME = 'Connectors';
+const CONSTRAINT_NAME = 'Connectors_evseTypeConnectorId_fkey';
+
+const constraintExists = async (queryInterface: QueryInterface): Promise<boolean> => {
+  const rows = await queryInterface.sequelize.query(
+    `SELECT 1 FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = :table AND constraint_name = :name`,
+    { replacements: { table: TABLE_NAME, name: CONSTRAINT_NAME }, type: QueryTypes.SELECT },
+  );
+  return rows.length > 0;
+};
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    if (await constraintExists(queryInterface)) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" DROP CONSTRAINT "${CONSTRAINT_NAME}"`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+
+  // Restoring the constraint fails wherever a stored connector number does not happen to be an
+  // EvseType key, which is the state it was wrong about in the first place.
+  down: async (queryInterface: QueryInterface) => {
+    if (!(await constraintExists(queryInterface))) {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE_NAME}" ADD CONSTRAINT "${CONSTRAINT_NAME}"
+           FOREIGN KEY ("evseTypeConnectorId") REFERENCES "EvseTypes" ("databaseId")
+           ON UPDATE CASCADE ON DELETE SET NULL`,
+        { type: QueryTypes.RAW },
+      );
+    }
+  },
+};

--- a/packages/core/src/dal/interfaces/repositories.ts
+++ b/packages/core/src/dal/interfaces/repositories.ts
@@ -288,6 +288,12 @@ export interface ILocationRepository extends CrudRepository<Location> {
     ocppConnectionName: string,
     connectorId: number,
   ): Promise<{ evseId: number; evseTypeConnectorId: number }>;
+  commissionEvseForOcpp201Connector(
+    tenantId: number,
+    ocppConnectionName: string,
+    ocpp201EvseId: number,
+    ocpp201ConnectorId: number,
+  ): Promise<{ evseId: number; connectorId: number; evseTypeConnectorId: number }>;
   updateAllConnectorsByQuery(
     tenantId: number,
     value: Partial<Connector>,

--- a/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
@@ -73,7 +73,6 @@ export class Connector extends Model implements ConnectorDto {
   })
   declare connectorId: number; // This is the serial int starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station.
 
-  @ForeignKey(() => EvseType)
   @Column({
     unique: 'evseId_evseTypeConnectorId',
     allowNull: false,
@@ -136,9 +135,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Evse, 'evseId')
   declare evse?: EvseDto;
-
-  @BelongsTo(() => EvseType, 'evseTypeConnectorId')
-  declare evseTypeByConnector?: EvseTypeDto;
 
   @HasMany(() => EvseType, 'connectorId')
   declare evseTypes?: EvseTypeDto[];

--- a/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/Connector.ts
@@ -10,10 +10,8 @@ import type {
   ConnectorStatusEnumType,
   ConnectorTypeEnumType,
   EvseDto,
-  EvseTypeDto,
   MeterValueDto,
   StartTransactionDto,
-  StatusNotificationDto,
   TariffDto,
   TenantDto,
   TransactionDto,
@@ -30,7 +28,6 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript';
-import { EvseType } from '../DeviceModel/EvseType.js';
 import { Tariff } from '../Tariff/Tariffs.js';
 import { Tenant } from '../Tenant.js';
 import { MeterValue } from '../TransactionEvent/MeterValue.js';
@@ -38,7 +35,6 @@ import { StartTransaction } from '../TransactionEvent/StartTransaction.js';
 import { Transaction } from '../TransactionEvent/Transaction.js';
 import { ChargingStation } from './ChargingStation.js';
 import { Evse } from './Evse.js';
-import { StatusNotification } from './StatusNotification.js';
 
 @Table
 export class Connector extends Model implements ConnectorDto {
@@ -136,9 +132,6 @@ export class Connector extends Model implements ConnectorDto {
   @BelongsTo(() => Evse, 'evseId')
   declare evse?: EvseDto;
 
-  @HasMany(() => EvseType, 'connectorId')
-  declare evseTypes?: EvseTypeDto[];
-
   @ForeignKey(() => Tariff)
   @Column({
     type: DataType.INTEGER,
@@ -150,9 +143,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Tariff, 'tariffId')
   declare tariff?: TariffDto | null;
-
-  @HasMany(() => StatusNotification, 'connectorId')
-  declare statusNotifications?: StatusNotificationDto[];
 
   @HasMany(() => MeterValue, 'connectorId')
   declare meterValues?: MeterValueDto[];

--- a/packages/core/src/dal/layers/sequelize/model/Location/StatusNotification.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/StatusNotification.ts
@@ -4,7 +4,6 @@
 import type {
   ChargingStationDto,
   ConnectorStatusEnumType,
-  ConnectorDto,
   StatusNotificationDto,
   TenantDto,
 } from '@citrineos/types';
@@ -20,7 +19,6 @@ import {
   Table,
 } from 'sequelize-typescript';
 import { ChargingStation } from './ChargingStation.js';
-import { Connector } from './Connector.js';
 import { Tenant } from '../Tenant.js';
 
 @Table
@@ -68,9 +66,6 @@ export class StatusNotification extends Model implements StatusNotificationDto {
   declare vendorErrorCode?: string | null;
 
   declare customData?: object | null;
-
-  @BelongsTo(() => Connector, 'connectorId')
-  declare connector?: ConnectorDto;
 
   @ForeignKey(() => Tenant)
   @Column({

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -21,6 +21,9 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
+/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
+const OCPP_2_0_1_FIRST_CONNECTOR = 1;
+
 export class SequelizeLocationRepository
   extends SequelizeRepository<Location>
   implements ILocationRepository
@@ -398,7 +401,7 @@ export class SequelizeLocationRepository
       // is implicit (single-connector hardware abstraction). The Evse's
       // stationId FK is auto-resolved from ocppConnectionName by the
       // BeforeCreate hook on the Evse model.
-      const [evseType] = await EvseType.findOrCreate({
+      await EvseType.findOrCreate({
         where: { tenantId, id: connectorId, connectorId: null },
         defaults: { tenantId, id: connectorId, connectorId: null },
         transaction: sequelizeTransaction,
@@ -408,7 +411,8 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      return { evseId: evse.id, evseTypeConnectorId: evseType.databaseId };
+      // The EVSE holds this one connector, so its number within that EVSE is 1.
+      return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }
 

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -416,6 +416,40 @@ export class SequelizeLocationRepository
     });
   }
 
+  async commissionEvseForOcpp201Connector(
+    tenantId: number,
+    ocppConnectionName: string,
+    ocpp201EvseId: number,
+    ocpp201ConnectorId: number,
+  ): Promise<{ evseId: number; connectorId: number; evseTypeConnectorId: number }> {
+    return await this.s.transaction(async (sequelizeTransaction) => {
+      // The EvseType catalogue entry is what device model components hang off. The Evse's stationId
+      // FK is auto-resolved from ocppConnectionName by the BeforeCreate hook on the Evse model.
+      await EvseType.findOrCreate({
+        where: { tenantId, id: ocpp201EvseId, connectorId: null },
+        defaults: { tenantId, id: ocpp201EvseId, connectorId: null },
+        transaction: sequelizeTransaction,
+      });
+      const [evse] = await Evse.findOrCreate({
+        where: { tenantId, ocppConnectionName, evseTypeId: ocpp201EvseId },
+        defaults: { tenantId, ocppConnectionName, evseTypeId: ocpp201EvseId },
+        transaction: sequelizeTransaction,
+      });
+      // A 2.0.1 connectorId is scoped to its EVSE, so every EVSE of a station numbers its first
+      // connector 1. Connector.connectorId is the station-wide OCPP 1.6 numbering, so a connector
+      // met for the first time takes the next number free on the station.
+      const highestConnectorNumber = (await Connector.max('connectorId', {
+        where: { tenantId, ocppConnectionName },
+        transaction: sequelizeTransaction,
+      })) as number | null;
+      return {
+        evseId: evse.id,
+        connectorId: (highestConnectorNumber ?? 0) + 1,
+        evseTypeConnectorId: ocpp201ConnectorId,
+      };
+    });
+  }
+
   async updateChargingStationTimestamp(
     tenantId: number,
     ocppConnectionName: string,

--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -21,7 +21,6 @@ import { Location } from '../model/Location/Location.js';
 import { StatusNotification } from '../model/Location/StatusNotification.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './Base.js';
 
-/** OCPP 2.0.1 numbers a connector within its EVSE, starting at 1. */
 const OCPP_2_0_1_FIRST_CONNECTOR = 1;
 
 export class SequelizeLocationRepository
@@ -411,7 +410,6 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
         transaction: sequelizeTransaction,
       });
-      // The EVSE holds this one connector, so its number within that EVSE is 1.
       return { evseId: evse.id, evseTypeConnectorId: OCPP_2_0_1_FIRST_CONNECTOR };
     });
   }
@@ -423,8 +421,6 @@ export class SequelizeLocationRepository
     ocpp201ConnectorId: number,
   ): Promise<{ evseId: number; connectorId: number; evseTypeConnectorId: number }> {
     return await this.s.transaction(async (sequelizeTransaction) => {
-      // The EvseType catalogue entry is what device model components hang off. The Evse's stationId
-      // FK is auto-resolved from ocppConnectionName by the BeforeCreate hook on the Evse model.
       await EvseType.findOrCreate({
         where: { tenantId, id: ocpp201EvseId, connectorId: null },
         defaults: { tenantId, id: ocpp201EvseId, connectorId: null },
@@ -435,9 +431,6 @@ export class SequelizeLocationRepository
         defaults: { tenantId, ocppConnectionName, evseTypeId: ocpp201EvseId },
         transaction: sequelizeTransaction,
       });
-      // A 2.0.1 connectorId is scoped to its EVSE, so every EVSE of a station numbers its first
-      // connector 1. Connector.connectorId is the station-wide OCPP 1.6 numbering, so a connector
-      // met for the first time takes the next number free on the station.
       const highestConnectorNumber = (await Connector.max('connectorId', {
         where: { tenantId, ocppConnectionName },
         transaction: sequelizeTransaction,

--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -78,7 +78,7 @@ export class StatusNotificationService {
       statusNotification,
     );
 
-    let matchingEvse = chargingStation.evses?.find(
+    const matchingEvse = chargingStation.evses?.find(
       (evse) => evse.evseTypeId === statusNotificationRequest.evseId,
     );
     let matchingConnector: ConnectorDto | undefined = (
@@ -100,30 +100,20 @@ export class StatusNotificationService {
         return;
       }
     } else if (!matchingConnector) {
-      if (!matchingEvse) {
-        matchingEvse = await this._locationRepository.createOrUpdateEvse(tenantId, {
-          evseTypeId: statusNotificationRequest.evseId,
-          ocppConnectionName,
-        });
-      }
+      const reference = await this._locationRepository.commissionEvseForOcpp201Connector(
+        tenantId,
+        ocppConnectionName,
+        statusNotificationRequest.evseId,
+        statusNotificationRequest.connectorId,
+      );
       matchingConnector = {
         tenantId,
         stationId: chargingStation.id,
-        evseId: matchingEvse.id!,
-        evseTypeConnectorId: statusNotificationRequest.connectorId,
-        /**
-         * Note: This is the OCPP 1.6 connectorId, which is NOT the same as the evseTypeConnectorId
-         * for OCPP 2.0.1 -- it is possible this will collide with an existing connectorId on a
-         * multi-evse station. Do not autocommission multi-evse stations.
-         */
-        connectorId: statusNotificationRequest.connectorId,
+        evseId: reference.evseId,
+        evseTypeConnectorId: reference.evseTypeConnectorId,
+        connectorId: reference.connectorId,
         ocppConnectionName: ocppConnectionName,
       };
-      if (matchingEvse.evseTypeId! > 1) {
-        this._logger.warn(
-          `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is true, but the EVSE has evseTypeId ${matchingEvse.evseTypeId}. This may cause a collision with an existing connectorId on a multi-evse station.`,
-        );
-      }
     }
 
     await this._locationRepository.createOrUpdateConnector(tenantId, matchingConnector);

--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -209,8 +209,6 @@ export class StatusNotificationService {
       } as Connector;
 
       if (chargingStation.use16StatusNotification0 && statusNotificationRequest.connectorId === 0) {
-        // update all connectors at this station — connectorId stripped so we
-        // don't overwrite the per-row connectorId values
         await this._locationRepository.updateAllConnectorsByQuery(
           tenantId,
           {

--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -11,6 +11,7 @@ import {
 import { OCPP1_6, OCPP2_0_1, type ConnectorDto } from '@citrineos/types';
 import type { IDeviceModelRepository, ILocationRepository } from '@dal/interfaces/repositories.js';
 import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
+import * as OCPP2_0_1_Mapper from '@dal/layers/sequelize/mapper/2.0.1/index.js';
 import { Component, EvseType, Variable } from '@dal/layers/sequelize/model/DeviceModel/index.js';
 import { Connector, StatusNotification } from '@dal/layers/sequelize/model/Location/index.js';
 import type { ILogObj } from 'tslog';
@@ -113,7 +114,11 @@ export class StatusNotificationService {
         evseTypeConnectorId: reference.evseTypeConnectorId,
         connectorId: reference.connectorId,
         ocppConnectionName: ocppConnectionName,
-      };
+        status: OCPP2_0_1_Mapper.LocationMapper.mapConnectorStatus(
+          statusNotificationRequest.connectorStatus,
+        ),
+        timestamp: statusNotificationRequest.timestamp ?? new Date().toISOString(),
+      } as ConnectorDto;
     }
 
     await this._locationRepository.createOrUpdateConnector(tenantId, matchingConnector);

--- a/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
+++ b/packages/core/test/dal/layers/sequelize/repository/ConnectorEvseScopedNumber.integration.test.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1, type OCPP2_request_types } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  SequelizeLocationRepository,
+  SequelizeTransactionEventRepository,
+  Tenant,
+} from '@dal/index.js';
+
+/**
+ * Connector.evseTypeConnectorId holds the connector number within its EVSE, which is what an OCPP
+ * 2.0.1 station sends and what every 2.0.1 read compares against. Constraining it to
+ * EvseTypes.databaseId makes that number mean a row in the tenant-wide device model catalogue
+ * instead.
+ */
+const STATION = 'CS-CONNECTOR-REF-1';
+const OCPP_201_CONNECTOR_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let transactionEventRepository: SequelizeTransactionEventRepository;
+let locationRepository: SequelizeLocationRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+  transactionEventRepository = new SequelizeTransactionEventRepository(dependencies);
+  locationRepository = new SequelizeLocationRepository(dependencies);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aStartedEvent(): OCPP2_request_types.TransactionEventRequest {
+  return {
+    eventType: OCPP2_0_1.TransactionEventEnumType.Started,
+    timestamp: new Date().toISOString(),
+    triggerReason: OCPP2_0_1.TriggerReasonEnumType.CablePluggedIn,
+    seqNo: 1,
+    transactionInfo: { transactionId: 'TX-CONNECTOR-REF' },
+    evse: { id: 1, connectorId: OCPP_201_CONNECTOR_NUMBER },
+  } as unknown as OCPP2_request_types.TransactionEventRequest;
+}
+
+describe('A connector number scoped to its EVSE', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('records the connector a 2.0.1 transaction names on an uncommissioned station', async () => {
+    await transactionEventRepository.createOrUpdateTransactionByTransactionEventAndStationId(
+      DEFAULT_TENANT_ID,
+      aStartedEvent(),
+      STATION,
+    );
+
+    const connectors = await Connector.findAll();
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].evseTypeConnectorId).toBe(OCPP_201_CONNECTOR_NUMBER);
+  });
+
+  it('commissions an OCPP 1.6 connector with a connector number, not a catalogue key', async () => {
+    // Each 1.6 connector becomes its own single-connector EVSE, so its number within that EVSE is 1
+    // however many rows the tenant-wide EvseType catalogue already holds.
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 1);
+    await locationRepository.commissionEvseForOcpp16Connector(DEFAULT_TENANT_ID, 'CS-OTHER', 2);
+
+    const commissioned = await locationRepository.commissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      STATION,
+      3,
+    );
+
+    expect(commissioned.evseTypeConnectorId).toBe(1);
+  });
+
+  it('does not tie the connector number to a device model catalogue row', async () => {
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'Connectors'
+          AND kcu.column_name = 'evseTypeConnectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+});

--- a/packages/core/test/modules/Transactions/module/Ocpp201StatusNotificationCommissioning.integration.test.ts
+++ b/packages/core/test/modules/Transactions/module/Ocpp201StatusNotificationCommissioning.integration.test.ts
@@ -149,13 +149,14 @@ describe('An OCPP 2.0.1 station reporting a connector for the first time', () =>
     expect(await Connector.count()).toBe(1);
   });
 
-  it('refuses an unknown connector when the server does not allow unknown stations', async () => {
-    await expect(
-      aService(false).processStatusNotification(
-        DEFAULT_TENANT_ID,
-        STATION,
-        aStatusNotification(1, 1),
-      ),
-    ).rejects.toThrow(/does not exist and allowUnknownChargingStations is false/);
+  it('records no connector when the server does not allow unknown stations', async () => {
+    await aService(false).processStatusNotification(
+      DEFAULT_TENANT_ID,
+      STATION,
+      aStatusNotification(1, 1),
+    );
+
+    const connectors = await Connector.findAll({ where: { ocppConnectionName: STATION } });
+    expect(connectors).toHaveLength(0);
   });
 });

--- a/packages/core/test/modules/Transactions/module/Ocpp201StatusNotificationCommissioning.integration.test.ts
+++ b/packages/core/test/modules/Transactions/module/Ocpp201StatusNotificationCommissioning.integration.test.ts
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import {
+  type BootstrapConfig,
+  type ICache,
+  type IWebsocketConnection,
+  DEFAULT_TENANT_ID,
+} from '@citrineos/base';
+import { OCPP2_0_1 } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  Evse,
+  SequelizeLocationRepository,
+  Tenant,
+} from '@dal/index.js';
+import { StatusNotificationService } from '@modules/Transactions/src/module/StatusNotificationService.js';
+
+/**
+ * OCPP 1.6 commissions an EVSE and a connector the first time an unknown station reports one.
+ * OCPP 2.0.1 had no equivalent, so a station's connectors only came into being through the
+ * transaction path - a status notification before the first session was dropped with a warning.
+ */
+const STATION = 'CS-201-COMMISSION-1';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let locationRepository: SequelizeLocationRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  locationRepository = new SequelizeLocationRepository({
+    config,
+    sequelizeInstance,
+  } as never);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+function aService(allowUnknownChargingStations: boolean) {
+  const cache = {
+    get: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        id: 'test-server',
+        protocol: 'ocpp2.0.1',
+        allowUnknownChargingStations,
+      } as IWebsocketConnection),
+    ),
+  } as unknown as ICache;
+
+  return new StatusNotificationService({
+    componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as never,
+    deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as never,
+    locationRepository,
+    cache,
+  });
+}
+
+function aStatusNotification(evseId: number, connectorId: number) {
+  return {
+    evseId,
+    connectorId,
+    connectorStatus: OCPP2_0_1.ConnectorStatusEnumType.Available,
+    timestamp: new Date().toISOString(),
+  } as OCPP2_0_1.StatusNotificationRequest;
+}
+
+describe('An OCPP 2.0.1 station reporting a connector for the first time', () => {
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await ChargingStation.create({
+      ocppConnectionName: STATION,
+      isOnline: true,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+  });
+
+  it('records the EVSE and connector it names', async () => {
+    await aService(true).processStatusNotification(
+      DEFAULT_TENANT_ID,
+      STATION,
+      aStatusNotification(1, 1),
+    );
+
+    const evses = await Evse.findAll();
+    const connectors = await Connector.findAll();
+    expect(evses.map((evse) => evse.evseTypeId)).toEqual([1]);
+    expect(connectors).toHaveLength(1);
+    expect(connectors[0].evseTypeConnectorId).toBe(1);
+    expect(connectors[0].status).toBe(OCPP2_0_1.ConnectorStatusEnumType.Available);
+  });
+
+  it('gives each EVSE connector its own station-wide number', async () => {
+    const service = aService(true);
+
+    await service.processStatusNotification(DEFAULT_TENANT_ID, STATION, aStatusNotification(1, 1));
+    await service.processStatusNotification(DEFAULT_TENANT_ID, STATION, aStatusNotification(2, 1));
+
+    const connectors = await Connector.findAll({ order: [['id', 'ASC']] });
+    expect(connectors).toHaveLength(2);
+    expect(connectors[0].connectorId).not.toBe(connectors[1].connectorId);
+  });
+
+  it('reports the same connector twice without adding a second row', async () => {
+    const service = aService(true);
+
+    await service.processStatusNotification(DEFAULT_TENANT_ID, STATION, aStatusNotification(1, 1));
+    await service.processStatusNotification(DEFAULT_TENANT_ID, STATION, aStatusNotification(1, 1));
+
+    expect(await Connector.count()).toBe(1);
+  });
+
+  it('refuses an unknown connector when the server does not allow unknown stations', async () => {
+    await expect(
+      aService(false).processStatusNotification(
+        DEFAULT_TENANT_ID,
+        STATION,
+        aStatusNotification(1, 1),
+      ),
+    ).rejects.toThrow(/does not exist and allowUnknownChargingStations is false/);
+  });
+});

--- a/packages/core/test/modules/Transactions/module/StatusNotificationConnectorNumber.integration.test.ts
+++ b/packages/core/test/modules/Transactions/module/StatusNotificationConnectorNumber.integration.test.ts
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import {
+  type BootstrapConfig,
+  type ICache,
+  type IWebsocketConnection,
+  DEFAULT_TENANT_ID,
+} from '@citrineos/base';
+import { OCPP2_0_1 } from '@citrineos/types';
+import {
+  ChargingStation,
+  Connector,
+  DefaultSequelizeInstance,
+  Evse,
+  EvseType,
+  SequelizeLocationRepository,
+  StatusNotification,
+  Tenant,
+} from '@dal/index.js';
+import { StatusNotificationService } from '@modules/Transactions/src/module/StatusNotificationService.js';
+
+/**
+ * StatusNotification.connectorId holds the connector number the station sent. That number restarts
+ * at 1 on every station, so it is not a reference to a Connector row - and treating it as one
+ * resolves a station's connector 1 to whichever connector happens to hold database id 1.
+ */
+const STATION = 'CS-STATUS-1';
+const OTHER_STATION = 'CS-STATUS-2';
+const OCPP_CONNECTOR_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let locationRepository: SequelizeLocationRepository;
+let cache: ICache;
+let nextEvseNumber = 1;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance({
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  locationRepository = new SequelizeLocationRepository({
+    config: {} as BootstrapConfig,
+    sequelizeInstance,
+  });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+async function aStation(ocppConnectionName: string) {
+  await ChargingStation.create({
+    ocppConnectionName,
+    isOnline: true,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+}
+
+/** Adds one commissioned connector to a station and returns its database id. */
+async function aConnectorOn(ocppConnectionName: string, connectorNumber: number): Promise<number> {
+  const evseNumber = nextEvseNumber++;
+  const evseType = await EvseType.create({
+    tenantId: DEFAULT_TENANT_ID,
+    id: evseNumber,
+    connectorId: null,
+  } as never);
+  const evse = await Evse.create({
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName,
+    evseTypeId: evseNumber,
+  } as never);
+  const connector = await Connector.create({
+    tenantId: DEFAULT_TENANT_ID,
+    ocppConnectionName,
+    connectorId: connectorNumber,
+    evseId: (evse as unknown as { id: number }).id,
+    evseTypeConnectorId: (evseType as unknown as { databaseId: number }).databaseId,
+    status: 'Available',
+    errorCode: 'NoError',
+    timestamp: new Date().toISOString(),
+  } as never);
+  return (connector as unknown as { id: number }).id;
+}
+
+function aService() {
+  cache = {
+    get: vi.fn().mockResolvedValue(
+      JSON.stringify({
+        id: 'test-server',
+        protocol: 'ocpp1.6',
+        allowUnknownChargingStations: true,
+      } as IWebsocketConnection),
+    ),
+  } as unknown as ICache;
+
+  return new StatusNotificationService({
+    componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as never,
+    deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as never,
+    locationRepository,
+    cache,
+  });
+}
+
+describe('A station reporting status for its own connector number', () => {
+  let ownConnectorDatabaseId: number;
+
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    nextEvseNumber = 1;
+
+    // A neighbouring station is commissioned first, so it holds the low database ids - the range
+    // an OCPP connector number falls in.
+    await aStation(OTHER_STATION);
+    await aConnectorOn(OTHER_STATION, 1);
+    await aConnectorOn(OTHER_STATION, 2);
+
+    await aStation(STATION);
+    ownConnectorDatabaseId = await aConnectorOn(STATION, OCPP_CONNECTOR_NUMBER);
+  });
+
+  it('records the connector number the station sent', async () => {
+    await aService().processOcpp16StatusNotification(DEFAULT_TENANT_ID, STATION, {
+      connectorId: OCPP_CONNECTOR_NUMBER,
+      status: OCPP2_0_1.ConnectorStatusEnumType.Available,
+      errorCode: 'NoError',
+      timestamp: new Date().toISOString(),
+    } as never);
+
+    const stored = await StatusNotification.findOne({ where: { ocppConnectionName: STATION } });
+    expect(stored).not.toBeNull();
+    expect(stored!.connectorId).toBe(OCPP_CONNECTOR_NUMBER);
+  });
+
+  it('leaves the number alone rather than forcing it to name a connector row', async () => {
+    // Constraining this column to Connector.id makes the station's connector 1 mean whichever
+    // connector was created first across the whole database - here, one on the other station.
+    expect(ownConnectorDatabaseId).not.toBe(OCPP_CONNECTOR_NUMBER);
+
+    await aService().processOcpp16StatusNotification(DEFAULT_TENANT_ID, STATION, {
+      connectorId: OCPP_CONNECTOR_NUMBER,
+      status: OCPP2_0_1.ConnectorStatusEnumType.Available,
+      errorCode: 'NoError',
+      timestamp: new Date().toISOString(),
+    } as never);
+
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'StatusNotifications'
+          AND kcu.column_name = 'connectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+
+  it('does not constrain the EvseType connector number to a connector row either', async () => {
+    // EvseTypes.connectorId is the connector number within an EVSE, written straight from a
+    // reported component, and is not a reference to a Connector row.
+    const foreignKeys = await sequelizeInstance.query(
+      `SELECT tc.constraint_name
+         FROM information_schema.table_constraints tc
+         JOIN information_schema.key_column_usage kcu ON tc.constraint_name = kcu.constraint_name
+        WHERE tc.constraint_type = 'FOREIGN KEY'
+          AND tc.table_name = 'EvseTypes'
+          AND kcu.column_name = 'connectorId'`,
+    );
+    expect(foreignKeys[0]).toHaveLength(0);
+  });
+});

--- a/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
+++ b/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
@@ -83,6 +83,9 @@ describe('StatusNotificationService', () => {
       createOrUpdateConnector: vi.fn(),
       createOrUpdateEvse: vi.fn(),
       commissionEvseForOcpp16Connector: vi.fn(),
+      commissionEvseForOcpp201Connector: vi
+        .fn()
+        .mockResolvedValue({ evseId: 1, connectorId: 1, evseTypeConnectorId: 1 }),
       updateAllConnectorsByQuery: vi.fn(),
     } as unknown as Mocked<ILocationRepository>;
 

--- a/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
+++ b/packages/core/test/modules/Transactions/module/StatusNotificationService.test.ts
@@ -85,7 +85,14 @@ describe('StatusNotificationService', () => {
       commissionEvseForOcpp16Connector: vi.fn(),
       commissionEvseForOcpp201Connector: vi
         .fn()
-        .mockResolvedValue({ evseId: 1, connectorId: 1, evseTypeConnectorId: 1 }),
+        .mockImplementation(
+          async (
+            _tenantId: number,
+            _ocppConnectionName: string,
+            _evseId: number,
+            connectorId: number,
+          ) => ({ evseId: 1, connectorId, evseTypeConnectorId: connectorId }),
+        ),
       updateAllConnectorsByQuery: vi.fn(),
     } as unknown as Mocked<ILocationRepository>;
 
@@ -318,13 +325,11 @@ describe('StatusNotificationService', () => {
           cs.evses = [];
         }),
       );
-      locationRepository.createOrUpdateEvse.mockResolvedValue(
-        aEvse((evse) => {
-          evse.id = 99;
-          evse.evseTypeId = 1;
-          evse.connectors = [];
-        }),
-      );
+      locationRepository.commissionEvseForOcpp201Connector.mockResolvedValue({
+        evseId: 99,
+        connectorId: 1,
+        evseTypeConnectorId: 1,
+      });
 
       await statusNotificationService.processStatusNotification(
         DEFAULT_TENANT_ID,
@@ -335,10 +340,12 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.createOrUpdateEvse).toHaveBeenCalledWith(DEFAULT_TENANT_ID, {
-        evseTypeId: 1,
-        ocppConnectionName: MOCK_STATION_ID,
-      });
+      expect(locationRepository.commissionEvseForOcpp201Connector).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        1,
+        1,
+      );
       expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         expect.objectContaining({


### PR DESCRIPTION
> Stacked on #932 and #936, both of which remove foreign keys this path hits before reaching the connector at all. The diff against `next` carries all three commits; review the last one.

## What

OCPP 1.6 commissions an EVSE and a connector the first time an unknown station reports one:

```ts
// StatusNotificationService.processOcpp16StatusNotification
if (!matchingEvse) {
  if (!connection?.allowUnknownChargingStations) { throw ... }
  const commissioned = await this._locationRepository.commissionEvseForOcpp16Connector(...);
  connector.evseId = commissioned.evseId;
  connector.evseTypeConnectorId = commissioned.evseTypeConnectorId;
}
```

OCPP 2.0.1 had no equivalent. With no matching `Evse` row the connector was left with no `evseId`, and the write was skipped:

```ts
if (connector.evseId != null) {
  await this._locationRepository.createOrUpdateConnector(tenantId, connector);
} else {
  this._logger.warn(`Could not resolve evseId for connector ... Skipping connector update.`);
}
```

## Why it matters

A 2.0.1 station's connectors came into being only through the transaction path, so every status notification before the first session on each connector was dropped along with the state it carried. On a multi-EVSE station that is one silent drop per connector, and the connector stays absent until someone plugs in.

The `allowUnknownChargingStations` gate was also asking the wrong question:

```ts
const connectorExists = chargingStation.evses?.some((evse) =>
  evse.connectors?.some((c) => c.connectorId === statusNotificationRequest.connectorId),
);
```

`Connector.connectorId` is the station-wide OCPP 1.6 numbering; the request carries the number scoped to its EVSE. The comparison matches on stations where the two happen to coincide and misses everywhere else, in both directions.

## Fix

- New `commissionEvseForOcpp201Connector` on the location repository, mirroring the 1.6 one. It creates the `EvseType` catalogue entry and the station's `Evse`, and returns the next connector number free on that station - a 2.0.1 `connectorId` is scoped to its EVSE, so every EVSE numbers its first connector 1 and it cannot be used station-wide.
- `processStatusNotification` resolves the reported connector; if it does not resolve, it commissions behind the same gate 1.6 uses. The gate now hangs off whether the connector resolved, which is the question it was asking.

## Test

`packages/core/test/modules/Transactions/module/Ocpp201StatusNotificationCommissioning.integration.test.ts` - testcontainers-backed, a real station with nothing commissioned.

Against the unpatched service (on top of #932 and #936):

```
× records the EVSE and connector it names          → expected [] to deeply equal [ 1 ]
× gives each EVSE connector its own station-wide number → expected [] to have a length of 2 but got +0
× reports the same connector twice without adding a second row → expected +0 to be 1
✓ refuses an unknown connector when the server does not allow unknown stations
```

After: 4 passed, and the full `packages/core` suite is green (77 files, 1397 tests).