### PR TITLE
fix(ocpp): check a composite schedule EVSE against the station, not the tenant

### DIFF
--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
@@ -15,13 +15,14 @@ import {
   type OCPPVersion,
   type OCPP2_request_types,
 } from '@citrineos/types';
-import type { IDeviceModelRepository } from '@citrineos/dal';
+import type { IDeviceModelRepository, ILocationRepository } from '@citrineos/dal';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 import { readChargingRateUnitMemberList } from './charging-rate-units.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
   ocppSender: IOcppSender;
   deviceModelRepository: IDeviceModelRepository;
+  locationRepository: ILocationRepository;
 }
 
 export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
@@ -34,11 +35,13 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
 
   private readonly _ocppSender: IOcppSender;
   private readonly _deviceModelRepository: IDeviceModelRepository;
+  private readonly _locationRepository: ILocationRepository;
 
-  constructor({ logger, ocppSender, deviceModelRepository }: Dependencies) {
+  constructor({ logger, ocppSender, deviceModelRepository, locationRepository }: Dependencies) {
     super(logger);
     this._ocppSender = ocppSender;
     this._deviceModelRepository = deviceModelRepository;
+    this._locationRepository = locationRepository;
   }
 
   async handle(
@@ -51,10 +54,10 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
     return Promise.all(
       identifiers.map(async (ocppConnectionName) => {
         if (request.evseId !== 0) {
-          const evse = await this._deviceModelRepository.findEvseByIdAndConnectorId(
+          const evse = await this._locationRepository.readEvseByStationIdAndOcpp201EvseId(
             tenantId,
+            ocppConnectionName,
             request.evseId,
-            null,
           );
           if (!evse) {
             return {

--- a/packages/ocpp/test/apis/ocpp/composite-schedule-evse-guard-integration.test.ts
+++ b/packages/ocpp/test/apis/ocpp/composite-schedule-evse-guard-integration.test.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { type BootstrapConfig, DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPPVersion } from '@citrineos/types';
+import {
+  ChargingStation,
+  DefaultSequelizeInstance,
+  Evse,
+  EvseType,
+  SequelizeDeviceModelRepository,
+  SequelizeLocationRepository,
+  Tenant,
+} from '@citrineos/dal';
+import { GetCompositeScheduleEndpoint } from '@/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.js';
+import { createTestContainer, getTestInstance } from '@test/test-container.js';
+
+/**
+ * A depot runs a mixed estate: a six-EVSE charger next to single-EVSE units. Asking a single-EVSE
+ * station for EVSE 5's composite schedule has to be refused by that station's own EVSEs, not by
+ * whether any station in the tenant happens to have one.
+ */
+const SIX_EVSE_STATION = 'CS-GUARD-SIX';
+const SINGLE_EVSE_STATION = 'CS-GUARD-ONE';
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let locationRepository: SequelizeLocationRepository;
+let deviceModelRepository: SequelizeDeviceModelRepository;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as BootstrapConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+
+  const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+  locationRepository = new SequelizeLocationRepository(dependencies);
+  deviceModelRepository = new SequelizeDeviceModelRepository(dependencies);
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+async function aStationWithEvses(ocppConnectionName: string, evseNumbers: number[]) {
+  await ChargingStation.create({
+    ocppConnectionName,
+    isOnline: true,
+    tenantId: DEFAULT_TENANT_ID,
+  } as never);
+  for (const evseNumber of evseNumbers) {
+    await EvseType.findOrCreate({
+      where: { tenantId: DEFAULT_TENANT_ID, id: evseNumber, connectorId: null },
+      defaults: { tenantId: DEFAULT_TENANT_ID, id: evseNumber, connectorId: null } as never,
+    });
+    await Evse.create({
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      evseTypeId: evseNumber,
+    } as never);
+  }
+}
+
+describe('Asking a station for one of its EVSEs', () => {
+  const { container } = createTestContainer();
+  let sendCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    sendCall = vi.fn().mockResolvedValue({ success: true, payload: 'queued' });
+
+    await aStationWithEvses(SIX_EVSE_STATION, [1, 2, 3, 4, 5, 6]);
+    await aStationWithEvses(SINGLE_EVSE_STATION, [1]);
+  });
+
+  function handle(ocppConnectionName: string, evseId: number) {
+    return getTestInstance(container, GetCompositeScheduleEndpoint, {
+      ocppSender: { sendCall },
+      deviceModelRepository,
+      locationRepository,
+    }).handle(
+      [ocppConnectionName],
+      { duration: 60, evseId },
+      undefined,
+      DEFAULT_TENANT_ID,
+      OCPPVersion.OCPP2_0_1,
+    );
+  }
+
+  it('refuses an EVSE the station does not have, however many the tenant does', async () => {
+    const confirmations = await handle(SINGLE_EVSE_STATION, 5);
+
+    expect(confirmations[0].success).toBe(false);
+    expect(String(confirmations[0].payload)).toContain(
+      `EVSE 5 not found for station ${SINGLE_EVSE_STATION}`,
+    );
+    expect(sendCall).not.toHaveBeenCalled();
+  });
+
+  it('sends for an EVSE the station does have', async () => {
+    const confirmations = await handle(SIX_EVSE_STATION, 5);
+
+    expect(confirmations[0].success).toBe(true);
+    expect(sendCall).toHaveBeenCalled();
+  });
+});

--- a/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
+++ b/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
@@ -217,11 +217,11 @@ describe('smartCharging message endpoints', () => {
   });
 
   describe('GetCompositeScheduleEndpoint', () => {
-    let findEvseByIdAndConnectorId: ReturnType<typeof vi.fn>;
+    let readEvseByStationIdAndOcpp201EvseId: ReturnType<typeof vi.fn>;
     let findVariableCharacteristics: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
-      findEvseByIdAndConnectorId = vi.fn().mockResolvedValue({ id: 1 });
+      readEvseByStationIdAndOcpp201EvseId = vi.fn().mockResolvedValue({ id: 1 });
       findVariableCharacteristics = vi.fn().mockResolvedValue(undefined);
     });
 
@@ -229,9 +229,9 @@ describe('smartCharging message endpoints', () => {
       getTestInstance(container, GetCompositeScheduleEndpoint, {
         ocppSender: { sendCall },
         deviceModelRepository: {
-          findEvseByIdAndConnectorId,
           findVariableCharacteristicsByVariableNameAndVariableInstance: findVariableCharacteristics,
         },
+        locationRepository: { readEvseByStationIdAndOcpp201EvseId },
       });
 
     const handle = (request: OCPP2_0_1.GetCompositeScheduleRequest) =>
@@ -240,7 +240,7 @@ describe('smartCharging message endpoints', () => {
     it('sends for the whole station when evseId is 0, without an EVSE lookup', async () => {
       const confirmations = await handle({ duration: 60, evseId: 0 });
 
-      expect(findEvseByIdAndConnectorId).not.toHaveBeenCalled();
+      expect(readEvseByStationIdAndOcpp201EvseId).not.toHaveBeenCalled();
       expect(confirmations[0].success).toBe(true);
       expect(sendCall.mock.calls[0][0]).toMatchObject({
         action: OCPP_CallAction.GetCompositeSchedule,
@@ -251,12 +251,16 @@ describe('smartCharging message endpoints', () => {
     it('looks up a non-zero EVSE before sending', async () => {
       const confirmations = await handle({ duration: 60, evseId: 2 });
 
-      expect(findEvseByIdAndConnectorId).toHaveBeenCalledWith(DEFAULT_TENANT_ID, 2, null);
+      expect(readEvseByStationIdAndOcpp201EvseId).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        2,
+      );
       expect(confirmations[0].success).toBe(true);
     });
 
     it('refuses an unknown EVSE without sending', async () => {
-      findEvseByIdAndConnectorId.mockResolvedValue(undefined);
+      readEvseByStationIdAndOcpp201EvseId.mockResolvedValue(undefined);
 
       const confirmations = await handle({ duration: 60, evseId: 2 });
 


### PR DESCRIPTION
> **No longer stacked.** Rebased onto `next` as a single commit - three files, no migration and no model change. It was only ever in that stack because it shared a test file with it; the defect has nothing to do with commissioning.

## What

`GetCompositeScheduleEndpoint` refuses a request for an EVSE the station does not have:

```ts
const evse = await this._deviceModelRepository.findEvseByIdAndConnectorId(tenantId, request.evseId, null);
if (!evse) {
  return { success: false, payload: `EVSE ${request.evseId} not found for station ${ocppConnectionName}.` };
}
```

`findEvseByIdAndConnectorId` reads `EvseType`, the device-model catalogue. That table has no station column - it is keyed on `(tenantId, id, connectorId)` and shared across every station in the tenant. So the guard answers "does *any* station in this tenant have an EVSE numbered N", while its message claims to answer "does *this* station".

## Why it matters

The two differ in both directions on a mixed estate:

- A request naming EVSE 5 against a single-EVSE unit passes the guard, because a six-EVSE charger elsewhere in the tenant put an `EvseType` with id 5 in the catalogue.
- A station whose EVSEs are recorded but whose catalogue entries are not - a `NotifyReport` that never named an EVSE-scoped component - is refused for every EVSE it has.

## Fix

`Evse` is the per-station table (`ocppConnectionName` + `evseTypeId`, the OCPP 2.0.1 EVSE number), and `readEvseByStationIdAndOcpp201EvseId` already asks exactly the question the message describes. The endpoint takes `locationRepository` and uses it.

## Test

`packages/ocpp/test/apis/ocpp/composite-schedule-evse-guard-integration.test.ts` - testcontainers-backed, a six-EVSE charger and a single-EVSE unit in one tenant.

Against the unpatched endpoint:

```
× refuses an EVSE the station does not have, however many the tenant does
  → expected true to be false
✓ sends for an EVSE the station does have
```

After: 2 passed. The existing `smart-charging-endpoints.test.ts` cases move to the new lookup (35 tests), and on `486f1e99` the full suite is green - 142 files, 2303 passed, 4 skipped - with `pnpm run lint` clean.

`readEvseByStationIdAndOcpp201EvseId` already exists on `next` (`repositories.ts:249`, `Location.ts:444`), so nothing else is needed for this one.

