### PR TITLE
fix(core): compare charging profile validity as a window

### DIFF
--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -141,19 +141,35 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     const validFrom = chargingProfile.validFrom ? new Date(chargingProfile.validFrom) : null;
     const validTo = chargingProfile.validTo ? new Date(chargingProfile.validTo) : null;
 
-    if (validFrom && validFrom.getTime() > now) {
-      return {
-        success: false,
-        payload: `chargingProfile validFrom ${chargingProfile.validFrom} should not be in the future.`,
-      };
-    }
     if (validTo && validTo.getTime() <= now) {
       return {
         success: false,
         payload: `chargingProfile validTo ${chargingProfile.validTo} should be in the future.`,
       };
     }
+    if (validFrom && validTo && validFrom.getTime() >= validTo.getTime()) {
+      return {
+        success: false,
+        payload: `chargingProfile validFrom ${chargingProfile.validFrom} should be before validTo ${chargingProfile.validTo}.`,
+      };
+    }
     return undefined;
+  }
+
+  /**
+   * Two profiles are valid at the same time unless one window ends before the other begins. An
+   * absent validFrom means valid on receipt, and an absent validTo means valid until replaced.
+   */
+  private static _overlaps(
+    left: { validFrom?: string | null; validTo?: string | null },
+    right: { validFrom?: string | null; validTo?: string | null },
+    now: number,
+  ): boolean {
+    const from = (profile: { validFrom?: string | null }) =>
+      profile.validFrom ? new Date(profile.validFrom).getTime() : now;
+    const to = (profile: { validTo?: string | null }) =>
+      profile.validTo ? new Date(profile.validTo).getTime() : Number.POSITIVE_INFINITY;
+    return from(left) < to(right) && from(right) < to(left);
   }
 
   private async _rejectOnPurpose(
@@ -204,24 +220,17 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     this._logger.info(
       `Found existing charging profiles: ${JSON.stringify(existedChargingProfiles)}`,
     );
-    if (existedChargingProfiles.length === 0) {
-      return undefined;
-    }
-
-    const overlapping = {
-      success: false,
-      payload:
-        'No two charging profiles with the same stack level and purpose can be valid at the same time.',
-    };
-    const validTo = chargingProfile.validTo ? new Date(chargingProfile.validTo) : null;
-    if (!validTo) {
-      return overlapping;
-    }
-    for (const existedProfile of existedChargingProfiles) {
-      const existedValidTo = existedProfile.validTo ? new Date(existedProfile.validTo) : null;
-      if (!existedValidTo || existedValidTo.getTime() >= validTo.getTime()) {
-        return overlapping;
-      }
+    const now = Date.now();
+    if (
+      existedChargingProfiles.some((existedProfile) =>
+        SetChargingProfileEndpoint._overlaps(chargingProfile, existedProfile, now),
+      )
+    ) {
+      return {
+        success: false,
+        payload:
+          'No two charging profiles with the same stack level and purpose can be valid at the same time.',
+      };
     }
     return undefined;
   }

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -156,10 +156,6 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     return undefined;
   }
 
-  /**
-   * Two profiles are valid at the same time unless one window ends before the other begins. An
-   * absent validFrom means valid on receipt, and an absent validTo means valid until replaced.
-   */
   private static _overlaps(
     left: { validFrom?: string | null; validTo?: string | null },
     right: { validFrom?: string | null; validTo?: string | null },

--- a/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
+++ b/packages/core/src/modules/Api/src/module/endpoints/ocpp/2/smartCharging/SetChargingProfileEndpoint.ts
@@ -162,7 +162,7 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     now: number,
   ): boolean {
     const from = (profile: { validFrom?: string | null }) =>
-      profile.validFrom ? new Date(profile.validFrom).getTime() : now;
+      Math.max(profile.validFrom ? new Date(profile.validFrom).getTime() : now, now);
     const to = (profile: { validTo?: string | null }) =>
       profile.validTo ? new Date(profile.validTo).getTime() : Number.POSITIVE_INFINITY;
     return from(left) < to(right) && from(right) < to(left);
@@ -218,8 +218,10 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     );
     const now = Date.now();
     if (
-      existedChargingProfiles.some((existedProfile) =>
-        SetChargingProfileEndpoint._overlaps(chargingProfile, existedProfile, now),
+      existedChargingProfiles.some(
+        (existedProfile) =>
+          existedProfile.id !== chargingProfile.id &&
+          SetChargingProfileEndpoint._overlaps(chargingProfile, existedProfile, now),
       )
     ) {
       return {

--- a/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
@@ -267,17 +267,24 @@ describe('smartCharging message endpoints', () => {
   describe('SetChargingProfileEndpoint', () => {
     let readAllByQuerystring: ReturnType<typeof vi.fn>;
     let createOrUpdateChargingProfile: ReturnType<typeof vi.fn>;
+    let readAllByQuery: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
       readAllByQuerystring = vi.fn().mockResolvedValue([]);
       createOrUpdateChargingProfile = vi.fn().mockResolvedValue({ id: 1 });
+      readAllByQuery = vi.fn().mockResolvedValue([]);
     });
 
     const build = () =>
       getTestInstance(container, SetChargingProfileEndpoint, {
         ocppSender: { sendCall },
-        deviceModelRepository: { readAllByQuerystring },
-        chargingProfileRepository: { createOrUpdateChargingProfile },
+        deviceModelRepository: {
+          readAllByQuerystring,
+          findVariableCharacteristicsByVariableNameAndVariableInstance: vi
+            .fn()
+            .mockResolvedValue(undefined),
+        },
+        chargingProfileRepository: { createOrUpdateChargingProfile, readAllByQuery },
         transactionEventRepository: {},
       });
 
@@ -305,14 +312,14 @@ describe('smartCharging message endpoints', () => {
       expect(createOrUpdateChargingProfile).not.toHaveBeenCalled();
     });
 
-    it('refuses a profile whose validFrom is in the future', async () => {
-      const validFrom = new Date(Date.now() + 60_000).toISOString();
+    it('sends a profile scheduled to start later', async () => {
+      const validFrom = new Date(Date.now() + 60 * 60_000).toISOString();
+      const validTo = new Date(Date.now() + 120 * 60_000).toISOString();
 
-      const confirmations = await handle(aProfile({ validFrom }));
+      const confirmations = await handle(aProfile({ validFrom, validTo }));
 
-      expect(confirmations[0].success).toBe(false);
-      expect(String(confirmations[0].payload)).toContain('should not be in the future');
-      expect(sendCall).not.toHaveBeenCalled();
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalled();
     });
 
     it('refuses a profile that has already expired', async () => {
@@ -323,6 +330,59 @@ describe('smartCharging message endpoints', () => {
       expect(confirmations[0].success).toBe(false);
       expect(String(confirmations[0].payload)).toContain('should be in the future');
       expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    it('refuses a window that ends before it begins', async () => {
+      const validFrom = new Date(Date.now() + 120 * 60_000).toISOString();
+      const validTo = new Date(Date.now() + 60 * 60_000).toISOString();
+
+      const confirmations = await handle(aProfile({ validFrom, validTo }));
+
+      expect(confirmations[0].success).toBe(false);
+      expect(String(confirmations[0].payload)).toContain('should be before validTo');
+      expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    it('refuses a profile whose window overlaps one already active', async () => {
+      // Both are valid from now, so they are valid at the same time however they end.
+      readAllByQuery.mockResolvedValue([
+        { validTo: new Date(Date.now() + 60 * 60_000).toISOString() },
+      ]);
+
+      const confirmations = await handle(
+        aProfile({ validTo: new Date(Date.now() + 120 * 60_000).toISOString() }),
+      );
+
+      expect(confirmations[0].success).toBe(false);
+      expect(String(confirmations[0].payload)).toContain('valid at the same time');
+      expect(sendCall).not.toHaveBeenCalled();
+    });
+
+    it('sends a profile whose window begins after the active one ends', async () => {
+      readAllByQuery.mockResolvedValue([
+        { validTo: new Date(Date.now() + 60 * 60_000).toISOString() },
+      ]);
+
+      const confirmations = await handle(
+        aProfile({
+          validFrom: new Date(Date.now() + 120 * 60_000).toISOString(),
+          validTo: new Date(Date.now() + 180 * 60_000).toISOString(),
+        }),
+      );
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalled();
+    });
+
+    it('sends a profile when the one already stored has expired', async () => {
+      readAllByQuery.mockResolvedValue([{ validTo: new Date(Date.now() - 60_000).toISOString() }]);
+
+      const confirmations = await handle(
+        aProfile({ validTo: new Date(Date.now() + 60 * 60_000).toISOString() }),
+      );
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
+++ b/packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts
@@ -384,5 +384,36 @@ describe('smartCharging message endpoints', () => {
       expect(confirmations[0].success).toBe(true);
       expect(sendCall).toHaveBeenCalled();
     });
+
+    it('sends a profile whose window only met the stored one before now', async () => {
+      readAllByQuery.mockResolvedValue([
+        { validTo: new Date(Date.now() - 60 * 60_000).toISOString() },
+      ]);
+
+      const confirmations = await handle(
+        aProfile({
+          validFrom: new Date(Date.now() - 120 * 60_000).toISOString(),
+          validTo: new Date(Date.now() + 60 * 60_000).toISOString(),
+        }),
+      );
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalled();
+    });
+
+    it('sends an update to the profile already stored under the same id', async () => {
+      // Re-sending an id the station already holds replaces that profile, so its stored copy is
+      // not a second profile to be valid at the same time as itself.
+      readAllByQuery.mockResolvedValue([
+        { id: 1, validTo: new Date(Date.now() + 60 * 60_000).toISOString() },
+      ]);
+
+      const confirmations = await handle(
+        aProfile({ id: 1, validTo: new Date(Date.now() + 120 * 60_000).toISOString() }),
+      );
+
+      expect(confirmations[0].success).toBe(true);
+      expect(sendCall).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What

Two checks in `SetChargingProfileEndpoint` disagreed about what a validity window is.

**A future `validFrom` was refused.**

```ts
if (validFrom && validFrom.getTime() > now) {
  return { success: false,
           payload: `chargingProfile validFrom ${chargingProfile.validFrom} should not be in the future.` };
}
```

The spec defines the field as *"Point in time at which the profile starts to be valid. If absent, the profile is valid as soon as it is received by the Charging Station."* (carried in `SetChargingProfileRequest.ts` for both 2.0.1 and 2.1). The only `validFrom` this check allowed is one at or before now - which is what omitting the field already means. So the field could never do the one thing it is for: send a profile ahead of the period it covers. For an overnight tariff window or a scheduled site limit that is the whole point.

**The overlap check compared `validTo` alone.**

```ts
const validTo = chargingProfile.validTo ? new Date(chargingProfile.validTo) : null;
if (!validTo) return overlapping;
for (const existedProfile of existedChargingProfiles) {
  const existedValidTo = existedProfile.validTo ? new Date(existedProfile.validTo) : null;
  if (!existedValidTo || existedValidTo.getTime() >= validTo.getTime()) return overlapping;
}
return undefined;
```

`validFrom` is never read. An active profile ending in an hour and a new one ending in two hours take the `false` branch and the new profile is accepted - but both are valid right now, which is exactly what the rejection message forbids: *"No two charging profiles with the same stack level and purpose can be valid at the same time."*

The reverse also happens once profiles can be scheduled: a profile whose window opens after the active one closes would be refused, because only the end times are compared.

## Fix

- `_rejectOnValidity` keeps the "already expired" check and swaps the future-`validFrom` rejection for the constraint that actually has to hold: `validFrom` before `validTo`, so the window can be valid at all.
- `_rejectOnPurpose` compares the two windows. They overlap unless one ends before the other begins, with an absent `validFrom` meaning valid on receipt and an absent `validTo` meaning valid until replaced. A stored profile whose window has already closed no longer blocks a new one.

## Test

`packages/core/test/modules/Api/endpoints/ocpp/smartChargingEndpoints.test.ts`. The case that asserted the old premise - *"refuses a profile whose validFrom is in the future"* - is replaced.

Against the unpatched endpoint:

```
× sends a profile scheduled to start later
  → expected false to be true
× refuses a window that ends before it begins
  → expected 'chargingProfile validFrom 2026-08-21T…' to contain 'should be before validTo'
× refuses a profile whose window overlaps one already active
  → expected true to be false
× sends a profile whose window begins after the active one ends
  → expected false to be true
```

After: 25 passed in that file, and the full `packages/core` suite is green (77 files, 1391 tests).