### PR TITLE
fix(ocpi): let the station choose when StartSession names no EVSE

### DIFF
--- a/packages/ocpi-base/src/util/ocpp-command-handlers/ocpp-201-command-handler.ts
+++ b/packages/ocpi-base/src/util/ocpp-command-handlers/ocpp-201-command-handler.ts
@@ -98,6 +98,15 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
         });
       });
 
+    let evseId: number | undefined;
+    if (startSession.evse_uid !== null && startSession.evse_uid !== undefined) {
+      evseId = Number(EXTRACT_EVSE_ID(startSession.evse_uid));
+      if (!Number.isInteger(evseId) || evseId <= 0) {
+        this.reportEvseNotFound(startSession, tenantPartner, startSession.response_url, commandId);
+        return;
+      }
+    }
+
     const requestStartTransactionRequest: OCPP2_0_1.RequestStartTransactionRequest = {
       remoteStartId,
       idToken: {
@@ -106,7 +115,7 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
           this.tokensMapper.mapOcpiTokenTypeToOcppIdTokenType(startSession.token.type),
         ),
       },
-      evseId: Number(EXTRACT_EVSE_ID(startSession.evse_uid!)),
+      ...(evseId !== undefined ? { evseId } : {}),
     };
     await this.sendOCPPMessage(
       this.commandUrls.requestStartTransactionRequestUrl,
@@ -412,5 +421,30 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
           commandId,
         );
     }
+  }
+
+  private reportEvseNotFound(
+    startSession: StartSession,
+    tenantPartner: TenantPartnerDto,
+    responseUrl: string,
+    commandId: string,
+  ): void {
+    this.logger.error('StartSession failed, EVSE not found', startSession);
+    this.commandsClientApi
+      .postCommandResult(
+        tenantPartner,
+        responseUrl,
+        {
+          result: CommandResultType.FAILED,
+          message: {
+            language: 'en',
+            text: 'EVSE not found on charging station',
+          },
+        },
+        commandId,
+      )
+      .catch((error) => {
+        this.logger.error('Failed to post command result', { error });
+      });
   }
 }

--- a/packages/ocpi-base/test/util/ocpp-command-handlers/ocpp-201-command-handler.test.ts
+++ b/packages/ocpi-base/test/util/ocpp-command-handlers/ocpp-201-command-handler.test.ts
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import 'reflect-metadata';
+import { describe, expect, it, vi } from 'vitest';
+import { Logger } from 'tslog';
+
+// The package barrel re-exports the handler index, which defines OCPP2_1_CommandHandler as a
+// subclass of the class under test - so importing the handler through it leaves the base class
+// undefined. Stub the barrel down to the three values the handler and its base read from it.
+vi.mock('../../../src/index.js', async () => {
+  const { CommandResultType } = await import('../../../src/model/command-result.js');
+  const { CommandType } = await import('../../../src/model/command-type.js');
+  const { ModuleId } = await import('../../../src/model/module-id.js');
+  return { CommandResultType, CommandType, ModuleId };
+});
+
+import { OCPP2_0_1_CommandHandler } from '../../../src/util/ocpp-command-handlers/ocpp-201-command-handler.js';
+import { CommandResultType } from '../../../src/model/command-result.js';
+import { uidDelimiter } from '../../../src/model/dto/evse-dto.js';
+
+/**
+ * OCPI addresses an EVSE by a uid built as `<stationId><delimiter><evseId>`, and evse_uid is
+ * optional on StartSession. OCPP 2.0.1 addresses it by the EVSE number, which is optional on
+ * RequestStartTransaction - an absent one leaves the choice to the station.
+ */
+const STATION = 'CS001';
+const OCPP_EVSE_NUMBER = 3;
+
+const chargingStation = { id: 5, ocppConnectionName: STATION } as never;
+
+const tenantPartner = {
+  id: 3,
+  countryCode: 'GB',
+  partyId: 'MSP',
+  partnerProfileOCPI: {},
+  tenant: { id: 1, countryCode: 'GB', partyId: 'VLT' },
+} as never;
+
+/** Capture the OCPP payload the handler builds instead of putting it on the wire. */
+function aHandler() {
+  const sent: { url: string; payload: any }[] = [];
+  const postCommandResult = vi.fn().mockResolvedValue(undefined);
+
+  const handler = new OCPP2_0_1_CommandHandler({
+    ajv: {} as never,
+    logger: new Logger({ type: 'hidden' }),
+    commandsClientApi: { postCommandResult } as never,
+    ocpiGraphqlClient: {
+      request: vi.fn().mockResolvedValue({ ChargingStationSequences: [] }),
+    } as never,
+    tokensMapper: {
+      mapOcpiTokenTypeToOcppIdTokenType: () => 'ISO14443',
+    } as never,
+    config: {
+      commands: {
+        coreHeaders: {},
+        ocpiBaseUrl: 'http://ocpi.test',
+        ocpp2_0_1: {
+          requestStartTransactionRequestUrl: 'http://core.test/remoteStart',
+        },
+      },
+    } as never,
+  });
+
+  (handler as never as { sendOCPPMessage: unknown }).sendOCPPMessage = async (
+    url: string,
+    payload: any,
+  ) => {
+    sent.push({ url, payload });
+  };
+
+  return { handler, sent, postCommandResult };
+}
+
+const aStartSession = (evseUid?: string | null) =>
+  ({
+    evse_uid: evseUid,
+    token: { uid: 'TAG001', type: 'RFID' },
+    response_url: 'http://msp.test/commands/START_SESSION/1',
+  }) as never;
+
+describe('An OCPI StartSession sent to an OCPP 2.0.1 station', () => {
+  it('sends the EVSE the command names', async () => {
+    const { handler, sent } = aHandler();
+
+    await handler.sendStartSessionCommand(
+      aStartSession(`${STATION}${uidDelimiter}${OCPP_EVSE_NUMBER}`),
+      tenantPartner,
+      chargingStation,
+      'command-1',
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].payload).toMatchObject({ evseId: OCPP_EVSE_NUMBER });
+  });
+
+  it('leaves the EVSE to the station when the command names none', async () => {
+    const { handler, sent } = aHandler();
+
+    await handler.sendStartSessionCommand(
+      aStartSession(undefined),
+      tenantPartner,
+      chargingStation,
+      'command-1',
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0].payload).not.toHaveProperty('evseId');
+  });
+
+  it('reports a failure for an EVSE uid it cannot read', async () => {
+    const { handler, sent, postCommandResult } = aHandler();
+
+    await handler.sendStartSessionCommand(
+      aStartSession('not-an-evse-uid'),
+      tenantPartner,
+      chargingStation,
+      'command-1',
+    );
+
+    expect(sent).toHaveLength(0);
+    expect(postCommandResult).toHaveBeenCalled();
+    expect(postCommandResult.mock.calls[0][2]).toMatchObject({
+      result: CommandResultType.FAILED,
+    });
+  });
+});


### PR DESCRIPTION
> **No longer stacked.** #908 replaced typedi property injection in `packages/ocpi-base` with explicit constructor dependencies, which is what #913 was working around, so this is now a single commit on `next` - two files. The test constructs the handler through `Ocpp201CommandHandlerDependencies` and stubs the package barrel, which is the same shape `OCPP1_6_CommandHandler.test.ts` already uses.

## What

`OCPP2_0_1_CommandHandler.sendStartSessionCommand` read the EVSE unconditionally:

```ts
const requestStartTransactionRequest: OCPP2_0_1.RequestStartTransactionRequest = {
  remoteStartId,
  idToken: { ... },
  evseId: Number(EXTRACT_EVSE_ID(startSession.evse_uid!)),
};
```

`evse_uid` is optional on OCPI `StartSession` - `z.string().max(36).nullable().optional()` in `StartSession.ts`, matching OCPI 2.2.1 - and `evseId` is optional on OCPP 2.0.1 `RequestStartTransaction`. So an omitted EVSE is a valid command that leaves the choice to the station.

## Why it matters

Two failures:

- **`evse_uid` omitted.** The non-null assertion silences the compiler, and `EXTRACT_EVSE_ID(undefined)` reaches `undefined.split(...)`:
  `TypeError: Cannot read properties of undefined (reading 'split')`. The throw happens before `sendOCPPMessage`, so the station is never told and no command result is posted either. The partner's `StartSession` gets no answer at all.
- **`evse_uid` that does not carry an EVSE number.** `EXTRACT_EVSE_ID` returns `''` when the uid has no delimiter, `Number('')` is `0`, and OCPP 2.0.1 says `evseId SHALL be > 0`. That was sent to the station as though it were a real EVSE.

## Fix

Mirrors what the 1.6 handler does for `connector_id`: an omitted EVSE is passed on as omitted; a uid that was given and does not name an EVSE reports `FAILED` to the partner rather than reaching the station.

## Test

`packages/ocpi-base/test/util/ocppCommandHandlers/OCPP2_0_1_CommandHandler.test.ts`.

Against the unpatched handler:

```
✓ sends the EVSE the command names
× leaves the EVSE to the station when the command names none
  → Cannot read properties of undefined (reading 'split')
× reports a failure for an EVSE uid it cannot read
  → expected [ { …(2) } ] to have a length of +0 but got 1
```

After: 3 passed, and the full `packages/ocpi-base` suite is green - 16 files, 69 tests - with `pnpm --filter @citrineos/ocpi-base run lint` at 0 errors (the 11 warnings are pre-existing and in files this does not touch).
