### PR TITLE
test(operator-ui): wait for the EVerest device model lock instead of failing on it

### DIFF
--- a/apps/operator-ui/tests/e2e/fixtures/everest.ts
+++ b/apps/operator-ui/tests/e2e/fixtures/everest.ts
@@ -48,6 +48,8 @@ const POLL_INTERVAL_MS = 2_000;
 // few seconds after `compose up`; this bounds the wait so a manager that never
 // boots fails fast into awaitStationOnline's diagnostics rather than hanging.
 const DB_READY_TIMEOUT_MS = 60_000;
+const SQLITE_BUSY_TIMEOUT_MS = 30_000;
+const SQLITE_PATCH_ATTEMPTS = 3;
 
 export interface EverestHandle {
   readonly ocppConnectionName: string;
@@ -319,24 +321,43 @@ async function patchEverestNetworkProfile(): Promise<void> {
   }
 
   const escaped = CORRECT_NETWORK_PROFILE_JSON.replace(/'/g, "''");
-  const sql = `UPDATE VARIABLE_ATTRIBUTE SET VALUE='${escaped}' WHERE VARIABLE_ID = (SELECT ID FROM VARIABLE WHERE NAME='NetworkConnectionProfiles');\n`;
+  // The manager holds the same database open, so the write waits for its lock rather than failing
+  // on the first SQLITE_BUSY. The retry covers a lock held for longer than the pragma waits.
+  const sql =
+    `PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS};` +
+    `UPDATE VARIABLE_ATTRIBUTE SET VALUE='${escaped}' WHERE VARIABLE_ID = (SELECT ID FROM VARIABLE WHERE NAME='NetworkConnectionProfiles');`;
   // Pipe SQL via stdin to avoid shell quoting hell with the embedded JSON.
-  await new Promise<void>((res, rej) => {
-    const proc = spawn(
-      process.platform === 'win32' ? 'docker.exe' : 'docker',
-      ['exec', '-i', 'everest-manager-1', 'sqlite3', EVEREST_DEVICE_MODEL_DB],
-      { stdio: ['pipe', 'pipe', 'pipe'], shell: false },
-    );
-    let stderr = '';
-    proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString()));
-    proc.on('exit', (code) => {
-      if (code === 0) res();
-      else rej(new Error(`SQLite patch failed (code ${code}): ${stderr}`));
-    });
-    proc.on('error', rej);
-    proc.stdin?.write(sql);
-    proc.stdin?.end();
-  });
+  let lastFailure: Error | undefined;
+  for (let attempt = 1; attempt <= SQLITE_PATCH_ATTEMPTS; attempt++) {
+    try {
+      await new Promise<void>((res, rej) => {
+        const proc = spawn(
+          process.platform === 'win32' ? 'docker.exe' : 'docker',
+          ['exec', '-i', 'everest-manager-1', 'sqlite3', EVEREST_DEVICE_MODEL_DB],
+          { stdio: ['pipe', 'pipe', 'pipe'], shell: false },
+        );
+        let stderr = '';
+        proc.stderr?.on('data', (c: Buffer) => (stderr += c.toString()));
+        proc.on('exit', (code) => {
+          if (code === 0) res();
+          else rej(new Error(`SQLite patch failed (code ${code}): ${stderr}`));
+        });
+        proc.on('error', rej);
+        proc.stdin?.write(sql);
+        proc.stdin?.end();
+      });
+      lastFailure = undefined;
+      break;
+    } catch (error) {
+      lastFailure = error as Error;
+      if (attempt < SQLITE_PATCH_ATTEMPTS) {
+        await delay(POLL_INTERVAL_MS);
+      }
+    }
+  }
+  if (lastFailure) {
+    throw lastFailure;
+  }
   await new Promise<void>((res) => {
     const proc = spawn(
       process.platform === 'win32' ? 'docker.exe' : 'docker',


### PR DESCRIPTION
## What

The `everest` fixture rewrites libocpp's network profile by shelling into the manager container and running `sqlite3` against its device-model database:

```ts
const proc = spawn('docker', ['exec', '-i', 'everest-manager-1', 'sqlite3', EVEREST_DEVICE_MODEL_DB], ...);
proc.on('exit', (code) => {
  if (code === 0) res();
  else rej(new Error(`SQLite patch failed (code ${code}): ${stderr}`));
});
```

The manager holds that same database open. SQLite returns `SQLITE_BUSY` while another connection holds the write lock, and with no `busy_timeout` set the CLI gives up immediately:

```
Error: SQLite patch failed (code 1): Runtime error near line 1: database is locked (5)
```

## Why it matters

`patchEverestNetworkProfile` runs before any spec, so when it loses the race the whole EVerest lane fails and reports it against whichever spec happened to be first. It has taken out unrelated pull requests on two different specs:

- `admin-toggles.spec.ts:11` E2E-056 - https://github.com/citrineos/citrineos-core/actions/runs/32517808208 and again on https://github.com/citrineos/citrineos-core/actions/runs/32517915657
- `charging-session.spec.ts:86` E2E-098 - same run, after the retries

The three Playwright retries do not help: the fixture has already thrown, and the lock is just as likely to be held on the next attempt.

## Fix

- `PRAGMA busy_timeout` on the same connection, so the write waits for the manager's lock instead of failing on the first `SQLITE_BUSY`.
- A bounded retry around the patch, for a lock held longer than the pragma waits.

Nothing else changes: the same statement runs, and a genuine failure still throws with the original message.

## Verification

`tsc --noEmit` clean on `apps/operator-ui`. I cannot reproduce the lock deterministically - it is a race with the manager's own writes - so the evidence is the two runs above plus the SQLite semantics: `busy_timeout` is the documented remedy for `SQLITE_BUSY` from a concurrent writer.