### PR TITLE
fix(types): let evseId be 0 in the OCPP 2.1 schemas that document it as the station

### DIFF
--- a/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleRequest.json
@@ -38,7 +38,7 @@
     "evseId": {
       "description": "The ID of the EVSE for which the schedule is requested. When evseid=0, the Charging Station will calculate the expected consumption for the grid connection.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "customData": {

--- a/packages/types/src/ocpp/model/2.1/schemas/ReportChargingProfilesRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/ReportChargingProfilesRequest.json
@@ -975,7 +975,7 @@
     "evseId": {
       "description": "The evse to which the charging profile applies. If evseId = 0, the message contains an overall limit for the Charging Station.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "customData": {

--- a/packages/types/src/ocpp/model/2.1/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/SetChargingProfileRequest.json
@@ -947,7 +947,7 @@
     "evseId": {
       "description": "For TxDefaultProfile an evseId=0 applies the profile to each individual evse. For ChargingStationMaxProfile and ChargingStationExternalConstraints an evseId=0 contains an overal limit for the whole Charging Station.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "chargingProfile": {


### PR DESCRIPTION
## The problem

Three OCPP 2.1 request schemas carry an `evseId` whose **own description** says `0` addresses the whole charging station, while the schema sets `minimum: 1` and makes that value unrepresentable:

| schema (2.1) | `minimum` | its own `description` |
| --- | --- | --- |
| `SetChargingProfileRequest` | `1` | "For ChargingStationMaxProfile and ChargingStationExternalConstraints an evseId=0 contains an overal limit for the whole Charging Station." |
| `GetCompositeScheduleRequest` | `1` | "When evseid=0, the Charging Station will calculate the expected consumption for the grid connection." |
| `ReportChargingProfilesRequest` | `1` | "If evseId = 0, the message contains an overall limit for the Charging Station." |

The same 2.1 schema set is not uniform about it, which is what rules out a blanket generation artefact:

- `GetChargingProfilesRequest.evseId` already has `minimum: 0`, and documents "If 0, only charging profiles installed on the Charging Station itself (the grid connection) SHALL be reported."
- `NotifyEVChargingNeedsRequest.evseId` has `minimum: 1`, and that is **correct** — its description says "EvseId may not be 0." This PR leaves it alone.

So the bound was decided per field, and three of those decisions contradict the field's documented meaning. The 2.0.1 copies of all three place no lower bound on `evseId`.

## What it breaks

Different things per message, and one of them is inbound:

- **`SetChargingProfile`** — a station-wide `ChargingStationMaxProfile` or `ChargingStationExternalConstraints` cannot be sent at all on a 2.1 connection. There is no other way to express a whole-station limit.
- **`GetCompositeSchedule`** — the grid-connection schedule (the whole-station forecast) cannot be requested.
- **`ReportChargingProfiles`** — this one travels charger → CSMS. A spec-compliant charger reporting a station-level profile is refused by inbound validation, which reads like a charger fault rather than a schema bound.

## The fix

`minimum: 0` on those three fields, nothing else. Three one-character changes.

## Verified

Found on a Titan DC charger that negotiates `ocpp2.1`: a `ChargingStationMaxProfile` with `evseId: 0` was rejected before it ever reached the station. With the bound corrected, the same profile is accepted end-to-end and the station applies it.

## A question for the maintainers

`ClearedChargingLimitRequest.evseId` is also `minimum: 1` in 2.1 with no lower bound in 2.0.1, but its description is only "EVSE Identifier." — nothing about `0`. I have left it unchanged rather than guess. If the intent there matches `NotifyEVChargingNeeds` (0 not allowed), it is already right; if it matches the three above, it belongs in this PR too.

Also worth saying plainly: if these files are vendored from the OCPP 2.1 release as published, the root defect is in the spec's own schemas and this PR is a deliberate deviation — necessary either way, since a station-wide limit is otherwise unexpressible, but you may want to raise it with the OCA as well.
