### PR TITLE
fix(core): record the connected server on a station's first connection

### DIFF
--- a/packages/core/src/dal/layers/sequelize/repository/Location.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/Location.ts
@@ -97,6 +97,7 @@ export class SequelizeLocationRepository
         tenantId,
         isOnline,
         protocol: ocppVersion,
+        connectedWebsocketServerConfigId: connectedWebsocketServerConfigId ?? null,
       });
     }
 


### PR DESCRIPTION
## The problem

A station admitted by `allowUnknownChargingStations` has no record of which server accepted it for the whole of its first session.

`setChargingStationIsOnlineAndOCPPVersion` creates the row on that first connection, and the create branch omits the one field the caller passed in for exactly this purpose:

```ts
if (!station) {
  ...
  return await ChargingStation.create({
    ocppConnectionName,
    tenantId,
    isOnline,
    protocol: ocppVersion,
    // connectedWebsocketServerConfigId is dropped here
  });
}

await station.update({
  isOnline,
  protocol: ocppVersion,
  connectedWebsocketServerConfigId: connectedWebsocketServerConfigId ?? null,  // set here
});
```

Anything derived from that server config is therefore unavailable for the first session. In the operator UI the charging station's **Security Profile** and **Server ID** are blank until the station reconnects and takes the update branch.

## Reproduction

Against a security-profile-0 listener with `allowUnknownChargingStations: true`:

1. Connect a station id that does not exist yet and send a `BootNotification`.
2. While it is still connected, read the station:

```sql
SELECT "connectedWebsocketServerConfigId" FROM "ChargingStations"
 WHERE "ocppConnectionName" = 'NEW-STATION-1';
-- NULL
```

3. Disconnect and connect again, then read the same column while connected — now it holds the server config id, and the UI fills in.

Observed on 2.0.0-beta3: `NULL` on the first connection, still `NULL` two seconds later while connected, correct on the second connection, cleared on disconnect. `next` at `cb5264c0a` carries the same omission.

## The fix

Pass the field on the create branch too, so a station records its server from its first connection rather than its second.

## Note for anyone testing this

The column is written after the upgrade completes, so a single read taken immediately after `BootNotification` races it — poll briefly instead. That is easy to mistake for this bug and it is not the same thing.
