### PR TITLE
fix(ocpi): command an OCPP 2.1 station instead of failing it

### DIFF
--- a/apps/ocpi-server/src/config/envs/docker.ts
+++ b/apps/ocpi-server/src/config/envs/docker.ts
@@ -92,6 +92,17 @@ export function createDockerOcpiConfig(): OcpiConfigInput {
           process.env.COMMANDS_OCPP2_0_1_UNLOCK_CONNECTOR_REQUEST_URL ||
           'http://citrine:8080/ocpp/2.0.1/evdriver/unlockConnector',
       },
+      ocpp2_1: {
+        requestStartTransactionRequestUrl:
+          process.env.COMMANDS_OCPP2_1_REQUEST_START_TRANSACTION_REQUEST_URL ||
+          'http://citrine:8080/ocpp/2.1/evdriver/requestStartTransaction',
+        requestStopTransactionRequestUrl:
+          process.env.COMMANDS_OCPP2_1_REQUEST_STOP_TRANSACTION_REQUEST_URL ||
+          'http://citrine:8080/ocpp/2.1/evdriver/requestStopTransaction',
+        unlockConnectorRequestUrl:
+          process.env.COMMANDS_OCPP2_1_UNLOCK_CONNECTOR_REQUEST_URL ||
+          'http://citrine:8080/ocpp/2.1/evdriver/unlockConnector',
+      },
     },
 
     messageBroker: {

--- a/apps/ocpi-server/src/config/envs/local.ts
+++ b/apps/ocpi-server/src/config/envs/local.ts
@@ -85,6 +85,17 @@ export function createLocalOcpiConfig(): OcpiConfigInput {
           process.env.COMMANDS_OCPP2_0_1_UNLOCK_CONNECTOR_REQUEST_URL ||
           'http://localhost:8080/ocpp/2.0.1/evdriver/unlockConnector',
       },
+      ocpp2_1: {
+        requestStartTransactionRequestUrl:
+          process.env.COMMANDS_OCPP2_1_REQUEST_START_TRANSACTION_REQUEST_URL ||
+          'http://localhost:8080/ocpp/2.1/evdriver/requestStartTransaction',
+        requestStopTransactionRequestUrl:
+          process.env.COMMANDS_OCPP2_1_REQUEST_STOP_TRANSACTION_REQUEST_URL ||
+          'http://localhost:8080/ocpp/2.1/evdriver/requestStopTransaction',
+        unlockConnectorRequestUrl:
+          process.env.COMMANDS_OCPP2_1_UNLOCK_CONNECTOR_REQUEST_URL ||
+          'http://localhost:8080/ocpp/2.1/evdriver/unlockConnector',
+      },
     },
 
     messageBroker: {

--- a/packages/ocpi-base/src/config/ocpi.types.ts
+++ b/packages/ocpi-base/src/config/ocpi.types.ts
@@ -165,6 +165,11 @@ export const ocpiConfigInputSchema = z.object({
       requestStopTransactionRequestUrl: z.string(),
       unlockConnectorRequestUrl: z.string(),
     }),
+    ocpp2_1: z.object({
+      requestStartTransactionRequestUrl: z.string(),
+      requestStopTransactionRequestUrl: z.string(),
+      unlockConnectorRequestUrl: z.string(),
+    }),
   }),
 
   // OCPI-specific settings
@@ -312,6 +317,11 @@ export const ocpiConfigSchema = z.object({
       unlockConnectorRequestUrl: z.string(),
     }),
     ocpp2_0_1: z.object({
+      requestStartTransactionRequestUrl: z.string(),
+      requestStopTransactionRequestUrl: z.string(),
+      unlockConnectorRequestUrl: z.string(),
+    }),
+    ocpp2_1: z.object({
       requestStartTransactionRequestUrl: z.string(),
       requestStopTransactionRequestUrl: z.string(),
       unlockConnectorRequestUrl: z.string(),

--- a/packages/ocpi-base/src/index.ts
+++ b/packages/ocpi-base/src/index.ts
@@ -52,6 +52,7 @@ export {
   OCPPCommandHandler,
   OCPP1_6_CommandHandler,
   OCPP2_0_1_CommandHandler,
+  OCPP2_1_CommandHandler,
 } from './util/ocppCommandHandlers/index.js';
 export type { ChargingPreferencesResponse } from './model/ChargingPreferencesResponse.js';
 export {

--- a/packages/ocpi-base/src/util/ocppCommandHandlers/OCPP2_0_1_CommandHandler.ts
+++ b/packages/ocpi-base/src/util/ocppCommandHandlers/OCPP2_0_1_CommandHandler.ts
@@ -31,7 +31,16 @@ import { OCPP_COMMAND_HANDLER, OCPPCommandHandler } from './base.js';
 
 @Service({ id: OCPP_COMMAND_HANDLER, multiple: true })
 export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
-  public readonly supportedVersion = OCPPVersion.OCPP2_0_1;
+  public readonly supportedVersion: OCPPVersion = OCPPVersion.OCPP2_0_1;
+
+  /**
+   * The core routes commands are posted to. OCPP 2.1 speaks the same three
+   * messages on its own version-namespaced routes, so a subclass only needs to
+   * point at those - see OCPP2_1_CommandHandler.
+   */
+  protected get commandUrls() {
+    return this.config.commands.ocpp2_0_1;
+  }
 
   public async sendStartSessionCommand(
     startSession: StartSession,
@@ -90,7 +99,7 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
       evseId: Number(EXTRACT_EVSE_ID(startSession.evse_uid!)),
     };
     await this.sendOCPPMessage(
-      this.config.commands.ocpp2_0_1.requestStartTransactionRequestUrl,
+      this.commandUrls.requestStartTransactionRequestUrl,
       requestStartTransactionRequest,
       options,
       tenantPartner,
@@ -122,7 +131,7 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
       transactionId: stopSession.session_id,
     };
     await this.sendOCPPMessage(
-      this.config.commands.ocpp2_0_1.requestStopTransactionRequestUrl,
+      this.commandUrls.requestStopTransactionRequestUrl,
       requestStopTransactionRequest,
       options,
       tenantPartner,
@@ -187,7 +196,7 @@ export class OCPP2_0_1_CommandHandler extends OCPPCommandHandler {
       connectorId: evseTypeConnectorId,
     };
     await this.sendOCPPMessage(
-      this.config.commands.ocpp2_0_1.unlockConnectorRequestUrl,
+      this.commandUrls.unlockConnectorRequestUrl,
       unlockConnectorRequest,
       options,
       tenantPartner,

--- a/packages/ocpi-base/src/util/ocppCommandHandlers/OCPP2_1_CommandHandler.ts
+++ b/packages/ocpi-base/src/util/ocppCommandHandlers/OCPP2_1_CommandHandler.ts
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { OCPPVersion } from '@citrineos/types';
+import { Service } from 'typedi';
+import { OCPP_COMMAND_HANDLER } from './base.js';
+import { OCPP2_0_1_CommandHandler } from './OCPP2_0_1_CommandHandler.js';
+
+/**
+ * OCPP 2.1 stations take the same three commands as 2.0.1 — the request and
+ * response payloads are identical, and 2.1 only widens idToken.type from an
+ * enum to a string — so the flow is inherited. What must differ is the route:
+ * OcppSender rejects a call whose requested protocol is not the one the
+ * station's websocket negotiated, so the command has to be posted to the
+ * /ocpp/2.1/ endpoints rather than the 2.0.1 ones.
+ */
+@Service({ id: OCPP_COMMAND_HANDLER, multiple: true })
+export class OCPP2_1_CommandHandler extends OCPP2_0_1_CommandHandler {
+  public readonly supportedVersion: OCPPVersion = OCPPVersion.OCPP2_1;
+
+  protected override get commandUrls() {
+    return this.config.commands.ocpp2_1;
+  }
+}

--- a/packages/ocpi-base/src/util/ocppCommandHandlers/index.ts
+++ b/packages/ocpi-base/src/util/ocppCommandHandlers/index.ts
@@ -7,7 +7,9 @@
  */
 import './OCPP1_6_CommandHandler.js';
 import './OCPP2_0_1_CommandHandler.js';
+import './OCPP2_1_CommandHandler.js';
 
 export { OCPP1_6_CommandHandler } from './OCPP1_6_CommandHandler.js';
 export { OCPP2_0_1_CommandHandler } from './OCPP2_0_1_CommandHandler.js';
+export { OCPP2_1_CommandHandler } from './OCPP2_1_CommandHandler.js';
 export { OCPP_COMMAND_HANDLER, OCPPCommandHandler } from './base.js';

--- a/packages/ocpi-base/test/util/ocppCommandHandlers.test.ts
+++ b/packages/ocpi-base/test/util/ocppCommandHandlers.test.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { OCPP_VERSION_LIST } from '@citrineos/types';
+import { describe, expect, it } from 'vitest';
+import { ocpiConfigSchema } from '../../src/config/ocpi.types.js';
+
+// The handler classes cannot be imported here: they are typedi @Service classes
+// and vitest's transform does not emit decorator metadata, so importing one
+// throws CannotInjectValueError. Their source is read instead.
+const HANDLER_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../src/util/ocppCommandHandlers',
+);
+
+function handlerSources(): string[] {
+  return readdirSync(HANDLER_DIR)
+    .filter((f) => f.endsWith('_CommandHandler.ts'))
+    .map((f) => readFileSync(join(HANDLER_DIR, f), 'utf-8'));
+}
+
+/**
+ * CommandExecutor keys its handler registry by ChargingStations.protocol, which
+ * is whatever subprotocol the station's websocket negotiated. Core offers all
+ * of OCPP_VERSION_LIST and prefers the newest, so a charger that speaks 2.1 is
+ * recorded as ocpp2.1 — and with no handler for that version every OCPI command
+ * was answered with a CommandResult of FAILED ("Charging station communication
+ * failed") without a message ever reaching the station.
+ */
+describe('OCPP command handlers', () => {
+  it('one exists for every OCPP version core can negotiate', () => {
+    const sources = handlerSources();
+
+    for (const version of OCPP_VERSION_LIST) {
+      const member = `OCPPVersion.${version.replace('ocpp', 'OCPP').replace(/\./g, '_')}`;
+      const handler = sources.filter((src) => src.includes(`= ${member};`));
+      expect(handler, `no command handler declares ${member}`).toHaveLength(1);
+    }
+  });
+
+  /**
+   * OcppSender refuses a call whose requested protocol is not the one the
+   * connection negotiated, so a 2.1 station has to be commanded through core's
+   * 2.1 routes — pointing the 2.1 handler at the 2.0.1 URLs would fail just as
+   * surely, only with a different message.
+   */
+  it('the 2.1 handler reads its own urls, not the 2.0.1 ones', () => {
+    const src = readFileSync(join(HANDLER_DIR, 'OCPP2_1_CommandHandler.ts'), 'utf-8');
+
+    expect(src).toContain('this.config.commands.ocpp2_1');
+    expect(src).not.toContain('commands.ocpp2_0_1');
+  });
+
+  it('the config carries a url per command for every 2.x version', () => {
+    const commands = ocpiConfigSchema.shape.commands;
+    const perVersion = ['ocpp2_0_1', 'ocpp2_1'] as const;
+
+    for (const version of perVersion) {
+      expect(Object.keys(commands.shape[version].shape).sort()).toEqual([
+        'requestStartTransactionRequestUrl',
+        'requestStopTransactionRequestUrl',
+        'unlockConnectorRequestUrl',
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
found this while setting up CI for the mock msp .. a station that connects as ocpp2.1 cant receive ANY ocpi command right now.

core advertises OCPP_VERSION_LIST on :8081 and prefers the newest, so a charger that speaks 2.1 gets stored as `ocpp2.1`. but CommandExecutor only had handlers for ocpp1.6 and ocpp2.0.1, so getCommandHandler misses and it posts back FAILED "Charging station communication failed" without ever sending anything to the station. the message is misleading too .. it reads like a network issue but its a version one.

saw it with everest on the ocpi stack: START_SESSION came back sync ACCEPTED then async FAILED every time, while the station was online and the connector Occupied.

core side is already fine (the evdriver endpoints declare OCPP2_PROTOCOLS and /ocpp/2.1/... is in rbac-rules.json), so this is only the ocpi side:

- new `OCPP2_1_CommandHandler` .. extends the 2.0.1 one bec the three messages are identical in 2.1 (idToken.type just widens from an enum to a string), only the urls differ
- `commands.ocpp2_1` url block in the config + both env files
- moved the three urls in the 2.0.1 handler behind one getter so the subclass can override them .. no behaviour change for 2.0.1

one thing worth knowing: u cant just map 2.1 onto the existing 2.0.1 handler, OcppSender rejects a call when the requested protocol != the connection protocol, so it has to go to the version matched route.

checked against the built output: 3 handlers resolve from the container now with distinct versions, and the 2.1 one reads the 2.1 urls while 2.0.1 stays where it was.
