### PR TITLE
fix: pass redis password when cache configured via host/port

### DIFF
--- a/apps/ocpp-server/src/citrineOSServer.ts
+++ b/apps/ocpp-server/src/citrineOSServer.ts
@@ -273,6 +273,7 @@ export class CitrineOSServer {
                 host: this._config.util.cache.redis.host,
                 port: this._config.util.cache.redis.port,
               },
+              password: this._config.util.cache.redis.password,
             };
       return new RedisCache(redisClientOptions, this._logger);
     }

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -210,6 +210,7 @@ export const systemConfigInputSchema = z.object({
             z.object({
               host: z.string().default('localhost').optional(),
               port: z.number().int().min(1).default(6379).optional(),
+              password: z.string().optional(),
             }),
           ])
           .optional(),
@@ -526,6 +527,7 @@ export const systemConfigSchema = z
               z.object({
                 host: z.string(),
                 port: z.number().int().min(1),
+                password: z.string().optional(),
               }),
               z.object({
                 url: z.url().refine((v) => v.startsWith('redis://') || v.startsWith('rediss://'), {


### PR DESCRIPTION
## Problem

When the Redis cache is configured via separate `host`/`port` fields (rather than a single `url`) and the Redis/Valkey instance requires authentication, `CitrineOSServer` fails to authenticate. Every cache operation fails with:

```
NOAUTH Authentication required.
```

Because `ConnectedStationFilter.filter()` calls into the cache on every OCPP websocket upgrade, this blocks **all** charging station connections when a password-protected Redis is configured via host/port.

## Root cause

`CitrineOSServer.initCache()` only forwards `redis.password` into `RedisClientOptions` when the cache is configured via a single `url`:

```ts
const redisClientOptions: RedisClientOptions =
  'url' in this._config.util.cache.redis
    ? { url: this._config.util.cache.redis.url }
    : {
        socket: {
          host: this._config.util.cache.redis.host,
          port: this._config.util.cache.redis.port,
        },
      };
```

When configured via `host`/`port`, the password is silently dropped, so the client connects without credentials. Additionally, the `password` field was missing entirely from the `redis` host/port zod schema in `packages/types/src/config/types.ts`, so it would have been stripped by config validation even if wired through.

## Fix

- Add `password: z.string().optional()` to both host/port redis schema variants.
- Pass `this._config.util.cache.redis.password` through in `initCache()` for the host/port branch.

## Test plan

- Verified `pnpm --filter @citrineos/types --filter @citrineos/base --filter @citrineos/core --filter @citrineos/ocpp-server build` succeeds.
- Reproduced against a real deployment: a host/port-configured, password-protected Redis instance caused every websocket upgrade to fail with `NOAUTH Authentication required.`; after the fix, cache operations authenticate correctly.