### PR TITLE
fix(ocpp): build an OCSP request the responder can parse

### DIFF
--- a/packages/ocpp/src/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.ts
@@ -46,11 +46,13 @@ export class GetCertificateStatusRequestOcpp2Handler extends AbstractHandler {
 
     const reqData = message.payload.ocspRequestData;
     try {
-      const ocspRequest = createOcspRequest(reqData);
-      const ocspResult = await sendOCSPRequest(ocspRequest, reqData.responderURL);
+      const ocspResponseHex = await sendOCSPRequest(
+        createOcspRequest(reqData),
+        reqData.responderURL,
+      );
       const response: OCPP2_response_types.GetCertificateStatusResponse = {
         status: OCPP2_1.GetCertificateStatusEnumType.Accepted,
-        ocspResult,
+        ocspResult: Buffer.from(ocspResponseHex, 'hex').toString('base64'),
       };
       await this._ocppSender.sendCallResultWithMessage(message, response);
     } catch (error) {

--- a/packages/ocpp/src/services/certificate/certificate-util.ts
+++ b/packages/ocpp/src/services/certificate/certificate-util.ts
@@ -7,7 +7,7 @@ import { CertificationRequest } from 'pkijs';
 import * as asn1js from 'asn1js';
 import { fromBER } from 'asn1js';
 import { CountryNameEnumType, SignatureAlgorithmEnumType } from '@citrineos/dal';
-import type { CertificateCreate } from '@citrineos/types';
+import type { CertificateCreate, OCPP2_0_1, OCPP2_1 } from '@citrineos/types';
 import jsrsasign from 'jsrsasign';
 import { fromBase64, stringToArrayBuffer } from 'pvutils';
 import moment from 'moment';
@@ -15,7 +15,6 @@ import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import KJUR = jsrsasign.KJUR;
 import OCSPRequest = jsrsasign.KJUR.asn1.ocsp.OCSPRequest;
-import Request = jsrsasign.KJUR.asn1.ocsp.Request;
 import X509 = jsrsasign.X509;
 import KEYUTIL = jsrsasign.KEYUTIL;
 
@@ -290,24 +289,23 @@ interface OcspCertIdValueParams {
   sbjsn: string;
 }
 
-export function createOcspRequest(reqData: {
-  hashAlgorithm: string;
-  issuerNameHash: string;
-  issuerKeyHash: string;
-  serialNumber: string;
-}): Request {
-  const params: OcspCertIdValueParams = {
+export function createOcspRequest(
+  reqData: OCPP2_0_1.OCSPRequestDataType | OCPP2_1.OCSPRequestDataType,
+): OCSPRequest {
+  const certId: OcspCertIdValueParams = {
     alg: reqData.hashAlgorithm.toLowerCase(),
     issname: reqData.issuerNameHash,
     isskey: reqData.issuerKeyHash,
     sbjsn: reqData.serialNumber,
   };
 
-  return new Request(params as unknown as ConstructorParameters<typeof Request>[0]);
+  return new OCSPRequest({
+    reqList: [certId as unknown as jsrsasign.KJUR.asn1.ocsp.CertificateRequest],
+  });
 }
 
 export async function sendOCSPRequest(
-  ocspRequest: OCSPRequest | Request,
+  ocspRequest: OCSPRequest,
   responderURL: string,
 ): Promise<string> {
   const response = await fetch(responderURL, {
@@ -316,7 +314,7 @@ export async function sendOCSPRequest(
       'Content-Type': 'application/ocsp-request',
       Accept: 'application/ocsp-response',
     },
-    body: ocspRequest.getEncodedHex(),
+    body: Uint8Array.from(Buffer.from(ocspRequest.getEncodedHex(), 'hex')),
   });
 
   if (!response.ok) {
@@ -325,7 +323,7 @@ export async function sendOCSPRequest(
     );
   }
 
-  return await response.text();
+  return Buffer.from(await response.arrayBuffer()).toString('hex');
 }
 
 export function parseCSRForVerification(csrPem: string): CertificationRequest {

--- a/packages/ocpp/test/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.test.ts
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  EventGroup,
+  GetCertificateStatusEnum,
+  MessageOrigin,
+  MessageState,
+  OCPP2_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import { GetCertificateStatusRequestOcpp2Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
+
+const RESPONDER_URL = 'http://ocsp.example.test/responder';
+
+/**
+ * A short stand-in for the DER an OCSP responder returns. The handler is not expected to parse it,
+ * only to carry it through to the station, so any byte string that is not valid UTF-8 will do -
+ * 0x80 through 0x83 are continuation bytes with no lead byte, so a text decode mangles them.
+ */
+const RESPONDER_DER = Uint8Array.from([0x30, 0x03, 0x0a, 0x01, 0x00, 0x80, 0x81, 0x82, 0x83]);
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Certificates,
+    action: OCPP_CallAction.GetCertificateStatus,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_1,
+  } as unknown as IMessage<T>;
+}
+
+function aGetCertificateStatusRequest(): OCPP2_1.GetCertificateStatusRequest {
+  return {
+    ocspRequestData: {
+      hashAlgorithm: OCPP2_1.HashAlgorithmEnumType.SHA256,
+      issuerNameHash: 'aa'.repeat(32),
+      issuerKeyHash: 'bb'.repeat(32),
+      serialNumber: '0102030405',
+      responderURL: RESPONDER_URL,
+    },
+  };
+}
+
+describe('GetCertificateStatusRequestOcpp2Handler', () => {
+  let handler: GetCertificateStatusRequestOcpp2Handler;
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const { logger } = createTestContainer();
+    ocppSender = makeMockOcppSender();
+    handler = new GetCertificateStatusRequestOcpp2Handler({ logger, ocppSender });
+
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(RESPONDER_DER, {
+        status: 200,
+        headers: { 'Content-Type': 'application/ocsp-response' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function handleAndGetResponse(): Promise<OCPP2_1.GetCertificateStatusResponse> {
+    await handler.handle(makeMessage(aGetCertificateStatusRequest()));
+    return ocppSender.sendCallResultWithMessage.mock
+      .calls[0][1] as OCPP2_1.GetCertificateStatusResponse;
+  }
+
+  // M06.FR.02: the CSMS indicates success by setting status to Accepted.
+  it('reaches the responder and reports Accepted', async () => {
+    const response = await handleAndGetResponse();
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(response.status).toBe(GetCertificateStatusEnum.Accepted);
+  });
+
+  // M06.FR.08 / M06.FR.09: the request body is the DER of an RFC 6960 OCSPRequest.
+  it('posts the DER of an OCSPRequest, not its hex text', async () => {
+    await handleAndGetResponse();
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(RESPONDER_URL);
+    expect(init.body).toBeInstanceOf(Uint8Array);
+
+    const der = Buffer.from(init.body as Uint8Array);
+    // 0x30 is the SEQUENCE tag every DER OCSPRequest starts with.
+    expect(der[0]).toBe(0x30);
+
+    const { KJUR } = await import('jsrsasign');
+    const parsed = new KJUR.asn1.ocsp.OCSPParser().getOCSPRequest(der.toString('hex'));
+    expect(parsed.array).toEqual([
+      {
+        alg: 'sha256',
+        issname: 'aa'.repeat(32),
+        isskey: 'bb'.repeat(32),
+        sbjsn: '0102030405',
+      },
+    ]);
+  });
+
+  // M06.FR.03: the OCSP response data goes back in ocspResult, base64 of the DER.
+  it('returns the responder DER in ocspResult, base64 encoded', async () => {
+    const response = await handleAndGetResponse();
+
+    expect(response.ocspResult).toBe(Buffer.from(RESPONDER_DER).toString('base64'));
+  });
+
+  // M06.FR.04: the CSMS says Failed when it could not retrieve the status.
+  it('reports Failed when the responder refuses', async () => {
+    fetchMock.mockResolvedValue(new Response('no', { status: 500 }));
+
+    const response = await handleAndGetResponse();
+
+    expect(response.status).toBe(GetCertificateStatusEnum.Failed);
+    expect(response.ocspResult).toBeUndefined();
+  });
+});

--- a/packages/ocpp/test/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.test.ts
@@ -16,14 +16,10 @@ import {
 } from '@citrineos/types';
 import { GetCertificateStatusRequestOcpp2Handler } from '@handlers/index.js';
 import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
+import { parseOcspRequestHex } from '../../../utils/ocsp-request-parser.js';
 
 const RESPONDER_URL = 'http://ocsp.example.test/responder';
 
-/**
- * A short stand-in for the DER an OCSP responder returns. The handler is not expected to parse it,
- * only to carry it through to the station, so any byte string that is not valid UTF-8 will do -
- * 0x80 through 0x83 are continuation bytes with no lead byte, so a text decode mangles them.
- */
 const RESPONDER_DER = Uint8Array.from([0x30, 0x03, 0x0a, 0x01, 0x00, 0x80, 0x81, 0x82, 0x83]);
 
 function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
@@ -84,7 +80,6 @@ describe('GetCertificateStatusRequestOcpp2Handler', () => {
       .calls[0][1] as OCPP2_1.GetCertificateStatusResponse;
   }
 
-  // M06.FR.02: the CSMS indicates success by setting status to Accepted.
   it('reaches the responder and reports Accepted', async () => {
     const response = await handleAndGetResponse();
 
@@ -92,7 +87,6 @@ describe('GetCertificateStatusRequestOcpp2Handler', () => {
     expect(response.status).toBe(GetCertificateStatusEnum.Accepted);
   });
 
-  // M06.FR.08 / M06.FR.09: the request body is the DER of an RFC 6960 OCSPRequest.
   it('posts the DER of an OCSPRequest, not its hex text', async () => {
     await handleAndGetResponse();
 
@@ -101,12 +95,9 @@ describe('GetCertificateStatusRequestOcpp2Handler', () => {
     expect(init.body).toBeInstanceOf(Uint8Array);
 
     const der = Buffer.from(init.body as Uint8Array);
-    // 0x30 is the SEQUENCE tag every DER OCSPRequest starts with.
     expect(der[0]).toBe(0x30);
 
-    const { KJUR } = await import('jsrsasign');
-    const parsed = new KJUR.asn1.ocsp.OCSPParser().getOCSPRequest(der.toString('hex'));
-    expect(parsed.array).toEqual([
+    expect(parseOcspRequestHex(der.toString('hex'))).toEqual([
       {
         alg: 'sha256',
         issname: 'aa'.repeat(32),
@@ -116,14 +107,12 @@ describe('GetCertificateStatusRequestOcpp2Handler', () => {
     ]);
   });
 
-  // M06.FR.03: the OCSP response data goes back in ocspResult, base64 of the DER.
   it('returns the responder DER in ocspResult, base64 encoded', async () => {
     const response = await handleAndGetResponse();
 
     expect(response.ocspResult).toBe(Buffer.from(RESPONDER_DER).toString('base64'));
   });
 
-  // M06.FR.04: the CSMS says Failed when it could not retrieve the status.
   it('reports Failed when the responder refuses', async () => {
     fetchMock.mockResolvedValue(new Response('no', { status: 500 }));
 

--- a/packages/ocpp/test/services/certificate/certificate-authority.test.ts
+++ b/packages/ocpp/test/services/certificate/certificate-authority.test.ts
@@ -18,6 +18,7 @@ import {
   aValidSignedCertificateWithOCSPInfo,
 } from '../../providers/certificate-authority.js';
 import { readFile } from '../../utils/file-util.js';
+import { parseOcspRequestHex } from '../../utils/ocsp-request-parser.js';
 
 vi.mock('@services/certificate/certificate-util.js');
 vi.spyOn(KJUR.asn1.ocsp.OCSPUtil, 'getOCSPResponseInfo').mockImplementation(() => {
@@ -61,7 +62,6 @@ describe('CertificateAuthorityService', () => {
     } as unknown as Mocked<IChargingStationCertificateAuthorityClient>;
 
     mockCertUtil = CertificateUtil as Mocked<typeof CertificateUtil>;
-
     type WithFactoryHooks = typeof CertificateAuthorityService & {
       _instantiateV2GClient: (...args: unknown[]) => IV2GCertificateAuthorityClient;
       _instantiateChargingStationClient: (
@@ -298,7 +298,7 @@ describe('CertificateAuthorityService', () => {
       ]);
 
       expect(mockCertUtil.sendOCSPRequest).toHaveBeenCalledWith(
-        expect.any(KJUR.asn1.ocsp.Request),
+        expect.any(KJUR.asn1.ocsp.OCSPRequest),
         givenResponderURL,
       );
       const capturedRequest = mockCertUtil.sendOCSPRequest.mock.calls.find(
@@ -308,6 +308,29 @@ describe('CertificateAuthorityService', () => {
       expect(capturedRequest.getEncodedHex()).toMatch(/^[0-9a-f]+$/i);
       expect(KJUR.asn1.ocsp.OCSPUtil.getOCSPResponseInfo).toHaveBeenCalledWith(mockOCSPResponse);
       expect(actualResult).toBe(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted);
+    });
+
+    it('sends hash data the responder can parse back', async () => {
+      mockCertUtil.sendOCSPRequest.mockReturnValue(Promise.resolve(faker.lorem.word()));
+
+      const givenOCSPRequest = {
+        hashAlgorithm: OCPP2_0_1.HashAlgorithmEnumType.SHA256,
+        issuerNameHash: 'aa'.repeat(32),
+        issuerKeyHash: 'bb'.repeat(32),
+        serialNumber: '0102030405',
+        responderURL: faker.internet.url(),
+      } as OCPP2_0_1.OCSPRequestDataType;
+      await certificateAuthorityService.validateCertificateHashData([givenOCSPRequest]);
+
+      const [sentRequest] = mockCertUtil.sendOCSPRequest.mock.lastCall!;
+      expect(parseOcspRequestHex(sentRequest.getEncodedHex())).toEqual([
+        {
+          alg: 'sha256',
+          issname: givenOCSPRequest.issuerNameHash,
+          isskey: givenOCSPRequest.issuerKeyHash,
+          sbjsn: givenOCSPRequest.serialNumber,
+        },
+      ]);
     });
   });
 });

--- a/packages/ocpp/test/services/certificate/certificate-util.test.ts
+++ b/packages/ocpp/test/services/certificate/certificate-util.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { faker } from '@faker-js/faker';
 import {
+  createOcspRequest,
   createPemBlock,
   createSignedCertificateFromCSR,
   extractCertificateArrayFromEncodedString,
@@ -11,8 +12,10 @@ import {
   parseCertificateChainPem,
   sendOCSPRequest,
 } from '@services/index.js';
+import { OCPP2_1 } from '@citrineos/types';
 import jsrsasign from 'jsrsasign';
 import { readFile } from '../../utils/file-util.js';
+import { parseOcspRequestHex } from '../../utils/ocsp-request-parser.js';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 import X509 = jsrsasign.X509;
 import OCSPRequest = jsrsasign.KJUR.asn1.ocsp.OCSPRequest;
@@ -77,6 +80,39 @@ describe('CertificateUtil', () => {
     });
   });
 
+  describe('createOcspRequest', () => {
+    const givenOcspRequestData: OCPP2_1.OCSPRequestDataType = {
+      hashAlgorithm: OCPP2_1.HashAlgorithmEnumType.SHA256,
+      issuerNameHash: 'aa'.repeat(32),
+      issuerKeyHash: 'bb'.repeat(32),
+      serialNumber: '0102030405',
+      responderURL: 'http://ocsp.example.test/responder',
+    };
+
+    it('encodes the hash data the station reported', () => {
+      const hex = createOcspRequest(givenOcspRequestData).getEncodedHex();
+
+      expect(parseOcspRequestHex(hex)).toEqual([
+        {
+          alg: 'sha256',
+          issname: givenOcspRequestData.issuerNameHash,
+          isskey: givenOcspRequestData.issuerKeyHash,
+          sbjsn: givenOcspRequestData.serialNumber,
+        },
+      ]);
+    });
+
+    it.each([
+      OCPP2_1.HashAlgorithmEnumType.SHA256,
+      OCPP2_1.HashAlgorithmEnumType.SHA384,
+      OCPP2_1.HashAlgorithmEnumType.SHA512,
+    ])('encodes with hash algorithm %s', (hashAlgorithm) => {
+      const hex = createOcspRequest({ ...givenOcspRequestData, hashAlgorithm }).getEncodedHex();
+
+      expect(parseOcspRequestHex(hex)[0].alg).toBe(hashAlgorithm.toLowerCase());
+    });
+  });
+
   describe('sendOCSPRequest', () => {
     global.fetch = vi.fn();
 
@@ -93,24 +129,24 @@ describe('CertificateUtil', () => {
     const givenResponderURL = faker.internet.url();
 
     it('success', async () => {
-      const mockResult = faker.lorem.word();
+      const responderDer = Uint8Array.from([0x30, 0x03, 0x0a, 0x01, 0x00, 0x80, 0x81]);
       (fetch as Mock).mockReturnValueOnce(
         Promise.resolve({
           ok: true,
-          text: () => mockResult,
+          arrayBuffer: () => Promise.resolve(responderDer.buffer),
         }),
       );
 
       const actualResult = await sendOCSPRequest(givenRequest, givenResponderURL);
 
-      expect(actualResult).toBe(mockResult);
+      expect(actualResult).toBe(Buffer.from(responderDer).toString('hex'));
       const expectedInit: RequestInit = {
         method: 'POST',
         headers: {
           'Content-Type': 'application/ocsp-request',
           Accept: 'application/ocsp-response',
         },
-        body: givenRequest.getEncodedHex(),
+        body: Uint8Array.from(Buffer.from(givenRequest.getEncodedHex(), 'hex')),
       };
       expect(fetch).toHaveBeenCalledWith(givenResponderURL, expectedInit);
     });

--- a/packages/ocpp/test/utils/ocsp-request-parser.ts
+++ b/packages/ocpp/test/utils/ocsp-request-parser.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import jsrsasign from 'jsrsasign';
+
+export interface ParsedOcspCertId {
+  alg: string;
+  issname: string;
+  isskey: string;
+  sbjsn: string;
+}
+
+// @types/jsrsasign does not declare OCSPParser, which jsrsasign 11 ships.
+const { OCSPParser } = jsrsasign.KJUR.asn1.ocsp as unknown as {
+  OCSPParser: new () => { getOCSPRequest(hex: string): { array: ParsedOcspCertId[] } };
+};
+
+export function parseOcspRequestHex(hex: string): ParsedOcspCertId[] {
+  return new OCSPParser().getOCSPRequest(hex).array;
+}


### PR DESCRIPTION
`GetCertificateStatus` has never reached an OCSP responder. The request the CSMS builds cannot be
encoded, so every call falls into the handler's `catch` and answers `Failed`. The same construction
sits behind the contract-certificate check, where it makes `validateCertificateHashData` return
`NoCertificateAvailable` for every set of hash data a station sends - so Plug and Charge never gets
a real revocation answer either.

### What breaks

`jsrsasign.KJUR.asn1.ocsp.CertID` reads a value-based CertID from `issname` / `isskey` / `sbjsn`.
Both call sites pass `namehash` / `keyhash` / `serial`, so `CertID.tohex()` takes its last branch:

```js
} else { throw new Error("required param members not defined") }
```

Those were jsrsasign 10's names. `@types/jsrsasign` is still pinned at 10.5.15 and still documents
them - its `CertID` constructor type literally lists `{ namehash, keyhash, serial, alg }` - so
TypeScript accepted the call that the installed jsrsasign 11.1.3 rejects, and it will not accept the
correct member names at all. That is why the fix carries one cast.

Three more sit behind that one:

- `alg` is passed through as the OCPP `HashAlgorithmEnumType` value. jsrsasign resolves the digest
  name against an OID table that only holds lower-case entries, so `"SHA256"` throws
  `Name of ObjectIdentifier not defined: SHA256`. Fixing only the member names is not enough.
- Both sites build a bare `Request`, which encodes one `Request` SEQUENCE. RFC 6960 §4.1.1 wants
  `OCSPRequest ::= SEQUENCE { tbsRequest TBSRequest }` with `TBSRequest.requestList` a
  `SEQUENCE OF Request` - two levels further out.
- `sendOCSPRequest` puts `getEncodedHex()` in the body, i.e. the ASCII hex text rather than the DER
  that RFC 6960 Appendix A.1 specifies for `Content-Type: application/ocsp-request`, and reads the
  answer with `response.text()`, which UTF-8-decodes binary DER before `getOCSPResponseInfo` tries
  to read it as hex.

And the response the handler builds sets `ocspResponse`. The field is `ocspResult`
(**M06.FR.03**: *"The CSMS SHALL include the OCSP response data in the OCSPResult field"*), and
**M06.FR.09** requires it DER encoded - the schema then carries it base64 encoded. So even a
successful lookup returned nothing usable, and `additionalProperties: false` means a conformant
station rejects the message outright.

### The fix

`createOcspRequest` in `CertificateUtil`, used by both call sites, that maps the OCPP
`OCSPRequestDataType` onto jsrsasign's CertID members and folds the algorithm name. `sendOCSPRequest`
now posts the DER and returns the responder's DER as hex, which is what
`KJUR.asn1.ocsp.OCSPUtil.getOCSPResponseInfo` expects. The handler base64-encodes that DER into
`ocspResult`.

### Why the existing tests did not catch it

`CertificateAuthority.test.ts` mocks the whole `CertificateUtil` module, so `getEncodedHex()` never
ran and `expect.any(KJUR.asn1.ocsp.Request)` passed on an object that could not be serialised. That test now keeps `createOcspRequest` real and parses the request back with jsrsasign's `OCSPParser`
(through `packages/ocpp/test/utils/ocsp-request-parser.ts`, since `@types/jsrsasign` does not
declare it), so the hash data has to survive a round trip.

`packages/ocpp/test/handlers/requests/2/get-certificate-status-request-ocpp-2-handler.test.ts` is new - the
handler had no coverage at all. It stubs `fetch`, so the whole path from `ocspRequestData` to the
bytes on the wire and back into `ocspResult` runs for real. Against the previous commit it fails with
`expected undefined to be 'MAMKAQCAgYKD'` and a `Failed` status.

Spec references are to OCPP 2.1 Edition 2 (2025-12-03) Part 2, M06 - *Get Certificate Status*; the
2.0.1 wording of M06.FR.03 is the same, and the defect affects both protocol versions.

Full workspace suite green: 92 files, 2003 tests (the six testcontainers suites need Docker and were
not run locally).


