### PR TITLE
fix(base): stop the schema validator refusing decimals OCPP allows

### DIFF
--- a/packages/base/src/interfaces/modules/ocpp-validator.ts
+++ b/packages/base/src/interfaces/modules/ocpp-validator.ts
@@ -22,6 +22,17 @@ import {
 } from '@citrineos/types';
 import { OcppError } from '@ocpp/rpc/message.js';
 
+/**
+ * OCPP states its decimal step constraints as multipleOf: 0.1. Ajv checks those by dividing in
+ * binary floating point, where 8.1 / 0.1 is 81.00000000000001 rather than 81, so an unqualified
+ * check refuses about a third of the one-decimal values the spec allows - including 8.1, which
+ * OCPP 2.0.1 gives as its own example of an accepted charging limit. multipleOfPrecision rounds the
+ * quotient to this many significant digits before testing it for integrality; six is far above the
+ * one decimal place the constraint is expressing and far below the point at which a genuinely
+ * two-decimal value would start to pass.
+ */
+const MULTIPLE_OF_PRECISION = 6;
+
 export class OCPPValidator {
   protected _ajv: Ajv;
   protected readonly _logger: Logger<ILogObj>;
@@ -50,6 +61,7 @@ export class OCPPValidator {
         coerceTypes: true, // HTTP query/path params arrive as strings and need coercion
         strict: false,
         allErrors: true,
+        multipleOfPrecision: MULTIPLE_OF_PRECISION,
       });
 
     OCPPValidator.addFormats(ajvInstance);
@@ -76,6 +88,7 @@ export class OCPPValidator {
         strictNumbers: true, // Reject numeric strings where a number is required
         validateFormats: true,
         allErrors: true,
+        multipleOfPrecision: MULTIPLE_OF_PRECISION,
       });
 
     OCPPValidator.addOcppKeywords(ajvInstance);

--- a/packages/base/test/modules/ocpp-validator.test.ts
+++ b/packages/base/test/modules/ocpp-validator.test.ts
@@ -127,6 +127,57 @@ describe('OCPPValidator', () => {
     });
   });
 
+  describe('decimal fields constrained by multipleOf', () => {
+    /**
+     * OCPP 2.0.1 constrains a charging limit to one decimal place and gives 8.1 as its own example
+     * of an accepted value. The schema states that as multipleOf: 0.1, which Ajv checks by dividing
+     * in binary floating point: 8.1 / 0.1 is 81.00000000000001, so without a precision the check
+     * refuses roughly a third of the values it is meant to allow.
+     */
+    function aSetChargingProfileRequest(limit: number) {
+      return {
+        evseId: 1,
+        chargingProfile: {
+          id: 1,
+          stackLevel: 0,
+          chargingProfilePurpose: 'TxDefaultProfile',
+          chargingProfileKind: 'Relative',
+          chargingSchedule: [
+            {
+              id: 1,
+              chargingRateUnit: 'A',
+              chargingSchedulePeriod: [{ startPeriod: 0, limit }],
+            },
+          ],
+        },
+      };
+    }
+
+    function validateLimit(limit: number) {
+      return validator.validateOCPPRequest(
+        OCPP_CallAction.SetChargingProfile,
+        aSetChargingProfileRequest(limit),
+        OCPPVersion.OCPP2_0_1,
+      );
+    }
+
+    it('accepts the one decimal place the spec gives as its example', () => {
+      expect(validateLimit(8.1).isValid).toBe(true);
+    });
+
+    it('accepts every one decimal place limit up to 40 A', () => {
+      const refused = Array.from({ length: 401 }, (_, i) => i / 10).filter(
+        (limit) => !validateLimit(limit).isValid,
+      );
+
+      expect(refused).toEqual([]);
+    });
+
+    it('still refuses a second decimal place', () => {
+      expect(validateLimit(6.25).isValid).toBe(false);
+    });
+  });
+
   describe('validateOCPPRequest', () => {
     describe('OCPP 1.6', () => {
       it('should validate a valid BootNotification request', () => {


### PR DESCRIPTION
A charging limit of **8.1 A** is refused with `FormatViolation`. That is the value OCPP 2.0.1 gives
as its own example of an accepted limit - `ChargingSchedulePeriodType.limit`, *"Accepts at most one
digit fraction (e.g. 8.1)"* - and 134 of the 401 one-decimal limits between 0 and 40 A go the same
way.

### Why

OCPP states the one-decimal constraint as `"multipleOf": 0.1`, and there are 23 of those across the
1.6, 2.0.1 and 2.1 schemas. Ajv checks `multipleOf` by dividing and testing the quotient for
integrality, in binary floating point:

```
8.1 / 0.1 === 81.00000000000001
```

so the check fails. Neither Ajv instance in `OCPPValidator` sets `multipleOfPrecision`, which is
exactly the option Ajv provides for this: it rounds the quotient to N significant digits before
testing it. Six is far above the one decimal place the constraint expresses, and far below the point
at which a genuinely two-decimal value would start to slip through.

Measured against `next`, over `0.0` to `40.0` in steps of `0.1`:

| | one-decimal limits refused | 8.1 | 6.25 (must be refused) |
|---|---|---|---|
| `next` | 134 / 401 | refused | refused |
| with `multipleOfPrecision: 6` | 0 / 401 | accepted | refused |

### What it costs today

`OcppRouter._onCall` and `_onCallResult` validate every inbound message against these schemas and
throw `FormatViolation` on failure, so this is not confined to the CSMS-initiated side:

- a station's `ReportChargingProfilesRequest` or `NotifyChargingLimitRequest` carrying an affected
  limit is answered with a CALLERROR;
- a `GetCompositeScheduleResponse` with one is rejected as a CallResult, and the composite schedule
  is dropped;
- `SetChargingProfile` and `RequestStartTransaction` from the operator API are refused by the
  endpoint's body schema.

Which limits are affected is not predictable from the value - `16.3` passes, `8.1` does not - so the
symptom looks intermittent.

### Scope

One option on each of the two Ajv instances `OCPPValidator` builds. It changes nothing for a value
that genuinely violates a `multipleOf`; the test pins `6.25` staying refused alongside every
one-decimal value being accepted.

The Ajv instance in `packages/ocpi-base` is left alone: it validates OCPI DTOs, which carry no
`multipleOf`.

Note that OCPP 2.1 dropped the one-decimal restriction from `limit` and `minChargingRate`
altogether - Part 2 §2.1.4 now allows six decimal places towards the Charging Station - but the 2.1
schemas in this repo still carry `multipleOf: 0.1`, copied across from 2.0.1. That is a separate
defect and a separate PR; this one fixes the constraint for the versions that do impose it.

Full workspace suite green: 91 files, 1997 tests (the six testcontainers suites need Docker and were
not run locally).
