### PR TITLE
fix(types): truncate charging rates on the way out instead of rejecting them

### DIFF
--- a/packages/ocpp/src/modules/ocpp-router/router.ts
+++ b/packages/ocpp/src/modules/ocpp-router/router.ts
@@ -62,6 +62,7 @@ import { Logger } from 'tslog';
 import { v4 as uuidv4 } from 'uuid';
 import { type CallbackUrlNotifier } from './callback-url-notifier.js';
 import { buildConnectionEvent, buildFrameEvent, MessagesExchangeSink } from '@/transport/index.js';
+import { truncateChargingRates } from '@util/index.js';
 
 /**
  * Implementation of the ocpp router
@@ -416,7 +417,7 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
     const identifier = createIdentifier(tenantId, ocppConnectionName);
     const transactionNamespace = CacheNamespace.Transactions + identifier;
 
-    const message = new Call(correlationId, action, payload);
+    const message = new Call(correlationId, action, truncateChargingRates(payload, protocol));
     if (await this._sendCallIsAllowed(identifier, protocol, message)) {
       if (!(await this._cache.existsAnyInNamespace(transactionNamespace))) {
         const cacheTimestamp = new Date();

--- a/packages/ocpp/src/util/charging-rate-precision.ts
+++ b/packages/ocpp/src/util/charging-rate-precision.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { OCPPVersion, type OCPPVersionType } from '@citrineos/types';
+
+const CHARGING_RATE_FIELDS = new Set(['limit', 'minChargingRate']);
+
+const OCPP2_1_FRACTION_DIGITS = 6;
+const OCPP2_0_1_FRACTION_DIGITS = 1;
+
+export function maxChargingRateFractionDigits(protocol: OCPPVersionType): number {
+  return protocol === OCPPVersion.OCPP2_1 ? OCPP2_1_FRACTION_DIGITS : OCPP2_0_1_FRACTION_DIGITS;
+}
+
+export function truncateFractionDigits(value: number, digits: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  const text = value.toString();
+  const point = text.indexOf('.');
+  if (point < 0 || text.includes('e') || text.includes('E')) {
+    return value;
+  }
+  if (text.length - point - 1 <= digits) {
+    return value;
+  }
+  return Number(digits === 0 ? text.slice(0, point) : text.slice(0, point + 1 + digits));
+}
+
+export function truncateChargingRates<T>(payload: T, protocol: OCPPVersionType): T {
+  return truncate(payload, maxChargingRateFractionDigits(protocol)) as T;
+}
+
+function truncate(value: unknown, digits: number): unknown {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => truncate(item, digits));
+    return items.some((item, index) => item !== value[index]) ? items : value;
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  let changed = false;
+  const result: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    const next =
+      CHARGING_RATE_FIELDS.has(key) && typeof item === 'number'
+        ? truncateFractionDigits(item, digits)
+        : truncate(item, digits);
+    changed ||= next !== item;
+    result[key] = next;
+  }
+  return changed ? result : value;
+}

--- a/packages/ocpp/src/util/index.ts
+++ b/packages/ocpp/src/util/index.ts
@@ -28,6 +28,11 @@ export {
   type ChargingProfileTransactionContext,
   type ChargingProfileValidation,
 } from './validator.js';
+export {
+  maxChargingRateFractionDigits,
+  truncateChargingRates,
+  truncateFractionDigits,
+} from './charging-rate-precision.js';
 export { IdGenerator } from './id-generator.js';
 
 export {

--- a/packages/ocpp/src/util/validator.ts
+++ b/packages/ocpp/src/util/validator.ts
@@ -21,7 +21,6 @@ import { VariableAttribute } from '@citrineos/dal';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 import { calculateCheckDigit } from './emaid-check-digit-calculator.js';
-import { getNumberOfFractionDigit } from './parser.js';
 
 /**
  * Validate a language tag is an RFC-5646 tag, see: {@link https://tools.ietf.org/html/rfc5646},
@@ -133,14 +132,6 @@ export async function validateChargingProfileType(
     periodsPerSchedule = Number(periodsPerSchedules[0].value);
   }
   for (const chargingSchedule of chargingProfileType.chargingSchedule) {
-    if (
-      chargingSchedule.minChargingRate &&
-      getNumberOfFractionDigit(chargingSchedule.minChargingRate) > 1
-    ) {
-      throw new Error(
-        `chargingSchedule ${chargingSchedule.id}: minChargingRate accepts at most one digit fraction (e.g. 8.1).`,
-      );
-    }
     if (periodsPerSchedule && chargingSchedule.chargingSchedulePeriod.length > periodsPerSchedule) {
       throw new Error(
         `ChargingSchedule ${chargingSchedule.id}: The number of chargingSchedulePeriod SHALL not exceed ${periodsPerSchedule}.`,
@@ -148,12 +139,6 @@ export async function validateChargingProfileType(
     }
 
     for (const chargingSchedulePeriod of chargingSchedule.chargingSchedulePeriod) {
-      if (getNumberOfFractionDigit(chargingSchedulePeriod.limit ?? 0) > 1) {
-        throw new Error(
-          `ChargingSchedule ${chargingSchedule.id}: chargingSchedulePeriod limit accepts at most one digit fraction (e.g. 8.1).`,
-        );
-      }
-
       if (receivedChargingNeeds) {
         if (receivedChargingNeeds.acChargingParameters) {
           // EV AC charging

--- a/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
+++ b/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
@@ -1014,6 +1014,39 @@ describe('MessageRouterImpl', () => {
       expect(recorded(sink, 'frame').some((e: any) => e.direction === 'outbound')).toBe(true);
     });
 
+    it.each([
+      ['ocpp2.0.1', 8.1, 22.5],
+      ['ocpp2.1', 8.123456, 22.55],
+    ])('truncates a charging rate to what a %s station accepts', async (protocol, rate, limit) => {
+      cache.get.mockResolvedValue(null);
+      const setChargingProfile = {
+        evseId: 1,
+        chargingProfile: {
+          chargingSchedule: [
+            {
+              id: 1,
+              minChargingRate: 8.1234567,
+              chargingSchedulePeriod: [{ startPeriod: 0, limit: 22.55 }],
+            },
+          ],
+        },
+      } as unknown as OcppRequest;
+
+      await router.sendCall(
+        STATION_ID,
+        TENANT_ID,
+        protocol as typeof PROTOCOL,
+        OCPP_CallAction.SetChargingProfile,
+        setChargingProfile,
+        CORRELATION_ID,
+      );
+
+      const schedule = JSON.parse(networkHook.mock.calls[0][1])[3].chargingProfile
+        .chargingSchedule[0];
+      expect(schedule.minChargingRate).toBe(rate);
+      expect(schedule.chargingSchedulePeriod[0].limit).toBe(limit);
+    });
+
     it('should set cache entry with correlationId key and action@timestamp value', async () => {
       cache.get.mockResolvedValue(null);
 

--- a/packages/ocpp/test/util/charging-rate-precision.test.ts
+++ b/packages/ocpp/test/util/charging-rate-precision.test.ts
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPPVersion } from '@citrineos/types';
+import {
+  maxChargingRateFractionDigits,
+  truncateChargingRates,
+  truncateFractionDigits,
+} from '@util/index.js';
+
+describe('truncateFractionDigits', () => {
+  it.each([
+    [8.123, 1, 8.1],
+    [8.15, 1, 8.1],
+    [-8.15, 1, -8.1],
+    [8.1, 1, 8.1],
+    [0.3, 1, 0.3],
+    [8, 1, 8],
+    [1.2345678, 6, 1.234567],
+    [1.23456, 6, 1.23456],
+  ])('truncates %s to %s fraction digits as %s', (value, digits, expected) => {
+    expect(truncateFractionDigits(value, digits)).toBe(expected);
+  });
+
+  it('leaves a value in exponent notation alone', () => {
+    expect(truncateFractionDigits(1e-7, 6)).toBe(1e-7);
+  });
+});
+
+describe('maxChargingRateFractionDigits', () => {
+  it.each([
+    [OCPPVersion.OCPP1_6, 1],
+    [OCPPVersion.OCPP2_0_1, 1],
+    [OCPPVersion.OCPP2_1, 6],
+  ])('allows %s fraction digits on %s', (protocol, expected) => {
+    expect(maxChargingRateFractionDigits(protocol)).toBe(expected);
+  });
+});
+
+describe('truncateChargingRates', () => {
+  const aProfile = (minChargingRate: number, limit: number) => ({
+    chargingProfileId: 1,
+    chargingSchedule: [
+      {
+        id: 1,
+        minChargingRate,
+        chargingSchedulePeriod: [{ startPeriod: 0, limit }],
+      },
+    ],
+  });
+
+  it('truncates a charging rate to one fraction digit for a 2.0.1 station', () => {
+    const truncated = truncateChargingRates(aProfile(8.123, 22.55), OCPPVersion.OCPP2_0_1);
+
+    expect(truncated.chargingSchedule[0].minChargingRate).toBe(8.1);
+    expect(truncated.chargingSchedule[0].chargingSchedulePeriod[0].limit).toBe(22.5);
+  });
+
+  it('truncates a charging rate to six fraction digits for a 2.1 station', () => {
+    const truncated = truncateChargingRates(aProfile(8.1234567, 22.5), OCPPVersion.OCPP2_1);
+
+    expect(truncated.chargingSchedule[0].minChargingRate).toBe(8.123456);
+    expect(truncated.chargingSchedule[0].chargingSchedulePeriod[0].limit).toBe(22.5);
+  });
+
+  it('leaves the payload untouched when every rate already fits', () => {
+    const payload = aProfile(8.1, 22.5);
+
+    expect(truncateChargingRates(payload, OCPPVersion.OCPP2_0_1)).toBe(payload);
+  });
+
+  it('leaves fields that are not charging rates alone', () => {
+    const payload = { evseId: 1, totalCost: 12.3456, chargingSchedule: [] };
+
+    const truncated = truncateChargingRates(payload, OCPPVersion.OCPP2_0_1);
+
+    expect(truncated.totalCost).toBe(12.3456);
+  });
+});

--- a/packages/ocpp/test/util/validator.test.ts
+++ b/packages/ocpp/test/util/validator.test.ts
@@ -509,68 +509,15 @@ describe('validateChargingProfileType', () => {
   });
 
   describe('fraction digit validation', () => {
-    it('should throw error for minChargingRate with more than 1 fraction digit', async () => {
+    it('accepts a charging rate with more fraction digits than the station takes', async () => {
       const chargingProfile = aChargingProfileType({
         chargingSchedule: [
           aChargingSchedule({
             id: 1,
-            minChargingRate: 8.123, // More than 1 fraction digit
-          }),
-        ],
-      });
-
-      await expect(
-        validateChargingProfileType(
-          chargingProfile,
-          testTenantId,
-          testStationId,
-          mockDeviceModelRepo,
-          mockChargingProfileRepo,
-          mockTransactionEventRepo,
-          mockLogger,
-        ),
-      ).rejects.toThrow(
-        'chargingSchedule 1: minChargingRate accepts at most one digit fraction (e.g. 8.1).',
-      );
-    });
-
-    it('should throw error for chargingSchedulePeriod limit with more than 1 fraction digit', async () => {
-      const chargingProfile = aChargingProfileType({
-        chargingSchedule: [
-          aChargingSchedule({
-            id: 1,
+            minChargingRate: 8.123,
             chargingSchedulePeriod: [
               aChargingSchedulePeriod({
-                limit: 8.123, // More than 1 fraction digit
-              }),
-            ],
-          }),
-        ],
-      });
-
-      await expect(
-        validateChargingProfileType(
-          chargingProfile,
-          testTenantId,
-          testStationId,
-          mockDeviceModelRepo,
-          mockChargingProfileRepo,
-          mockTransactionEventRepo,
-          mockLogger,
-        ),
-      ).rejects.toThrow(
-        'ChargingSchedule 1: chargingSchedulePeriod limit accepts at most one digit fraction (e.g. 8.1).',
-      );
-    });
-
-    it('should not throw error for valid fraction digits', async () => {
-      const chargingProfile = aChargingProfileType({
-        chargingSchedule: [
-          aChargingSchedule({
-            minChargingRate: 8.1, // Valid: 1 fraction digit
-            chargingSchedulePeriod: [
-              aChargingSchedulePeriod({
-                limit: 22.5, // Valid: 1 fraction digit
+                limit: 8.123,
               }),
             ],
           }),

--- a/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleResponse.json
@@ -34,8 +34,7 @@
                 "type": "integer"
               },
               "limit": {
-                "type": "number",
-                "multipleOf": 0.1
+                "type": "number"
               },
               "numberPhases": {
                 "type": "integer"
@@ -46,8 +45,7 @@
           }
         },
         "minChargingRate": {
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         }
       },
       "additionalProperties": true,

--- a/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionRequest.json
@@ -60,8 +60,7 @@
                     "type": "integer"
                   },
                   "limit": {
-                    "type": "number",
-                    "multipleOf": 0.1
+                    "type": "number"
                   },
                   "numberPhases": {
                     "type": "integer"
@@ -72,8 +71,7 @@
               }
             },
             "minChargingRate": {
-              "type": "number",
-              "multipleOf": 0.1
+              "type": "number"
             }
           },
           "additionalProperties": true,

--- a/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileRequest.json
@@ -56,8 +56,7 @@
                     "type": "integer"
                   },
                   "limit": {
-                    "type": "number",
-                    "multipleOf": 0.1
+                    "type": "number"
                   },
                   "numberPhases": {
                     "type": "integer"
@@ -68,8 +67,7 @@
               }
             },
             "minChargingRate": {
-              "type": "number",
-              "multipleOf": 0.1
+              "type": "number"
             }
           },
           "additionalProperties": true,

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleResponse.json
@@ -47,8 +47,7 @@
         },
         "limit": {
           "description": "Charging_ Schedule_ Period. Limit. Measure\r\nurn:x-oca:ocpp:uid:1:569241\r\nCharging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes (A) or Watts (W). Accepts at most one digit fraction (e.g. 8.1).\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "numberPhases": {
           "description": "Charging_ Schedule_ Period. Number_ Phases. Counter\r\nurn:x-oca:ocpp:uid:1:569242\r\nThe number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.\r\n",

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitRequest.json
@@ -136,8 +136,7 @@
         },
         "minChargingRate": {
           "description": "Charging_ Schedule. Min_ Charging_ Rate. Numeric\r\nurn:x-oca:ocpp:uid:1:569239\r\nMinimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "salesTariff": {
           "$ref": "#/definitions/SalesTariffType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleRequest.json
@@ -108,8 +108,7 @@
         },
         "minChargingRate": {
           "description": "Charging_ Schedule. Min_ Charging_ Rate. Numeric\r\nurn:x-oca:ocpp:uid:1:569239\r\nMinimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "salesTariff": {
           "$ref": "#/definitions/SalesTariffType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesRequest.json
@@ -159,8 +159,7 @@
         },
         "limit": {
           "description": "Charging_ Schedule_ Period. Limit. Measure\r\nurn:x-oca:ocpp:uid:1:569241\r\nCharging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes (A) or Watts (W). Accepts at most one digit fraction (e.g. 8.1).\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "numberPhases": {
           "description": "Charging_ Schedule_ Period. Number_ Phases. Counter\r\nurn:x-oca:ocpp:uid:1:569242\r\nThe number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.\r\n",
@@ -218,8 +217,7 @@
         },
         "minChargingRate": {
           "description": "Charging_ Schedule. Min_ Charging_ Rate. Numeric\r\nurn:x-oca:ocpp:uid:1:569239\r\nMinimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "salesTariff": {
           "$ref": "#/definitions/SalesTariffType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
@@ -196,8 +196,7 @@
         },
         "limit": {
           "description": "Charging_ Schedule_ Period. Limit. Measure\r\nurn:x-oca:ocpp:uid:1:569241\r\nCharging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes (A) or Watts (W). Accepts at most one digit fraction (e.g. 8.1).\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "numberPhases": {
           "description": "Charging_ Schedule_ Period. Number_ Phases. Counter\r\nurn:x-oca:ocpp:uid:1:569242\r\nThe number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.\r\n",
@@ -254,8 +253,7 @@
         },
         "minChargingRate": {
           "description": "Charging_ Schedule. Min_ Charging_ Rate. Numeric\r\nurn:x-oca:ocpp:uid:1:569239\r\nMinimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "salesTariff": {
           "$ref": "#/definitions/SalesTariffType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileRequest.json
@@ -148,8 +148,7 @@
         },
         "limit": {
           "description": "Charging_ Schedule_ Period. Limit. Measure\r\nurn:x-oca:ocpp:uid:1:569241\r\nCharging rate limit during the schedule period, in the applicable chargingRateUnit, for example in Amperes (A) or Watts (W). Accepts at most one digit fraction (e.g. 8.1).\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "numberPhases": {
           "description": "Charging_ Schedule_ Period. Number_ Phases. Counter\r\nurn:x-oca:ocpp:uid:1:569242\r\nThe number of phases that can be used for charging. If a number of phases is needed, numberPhases=3 will be assumed unless another number is given.\r\n",
@@ -206,8 +205,7 @@
         },
         "minChargingRate": {
           "description": "Charging_ Schedule. Min_ Charging_ Rate. Numeric\r\nurn:x-oca:ocpp:uid:1:569239\r\nMinimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. Accepts at most one digit fraction (e.g. 8.1)\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "salesTariff": {
           "$ref": "#/definitions/SalesTariffType"

--- a/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleResponse.json
@@ -57,8 +57,7 @@
         },
         "limit": {
           "description": "Optional only when not required by the _operationMode_, as in CentralSetpoint, ExternalSetpoint, ExternalLimits, LocalFrequency,  LocalLoadBalancing. +\r\nCharging rate limit during the schedule period, in the applicable _chargingRateUnit_. \r\nThis SHOULD be a non-negative value; a negative value is only supported for backwards compatibility with older systems that use a negative value to specify a discharging limit.\r\nWhen using _chargingRateUnit_ = `W`, this field represents the sum of the power of all phases, unless values are provided for L2 and L3, in which case this field represents phase L1.\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "limit_L2": {
           "description": "*(2.1)* Charging rate limit on phase L2  in the applicable _chargingRateUnit_. \r\n",

--- a/packages/types/src/ocpp/model/2.1/schemas/NotifyChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/NotifyChargingLimitRequest.json
@@ -322,8 +322,7 @@
         },
         "minChargingRate": {
           "description": "Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. \r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "powerTolerance": {
           "description": "*(2.1)* Power tolerance when following EVPowerProfile.\r\n\r\n",

--- a/packages/types/src/ocpp/model/2.1/schemas/NotifyEVChargingScheduleRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/NotifyEVChargingScheduleRequest.json
@@ -297,8 +297,7 @@
         },
         "minChargingRate": {
           "description": "Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. \r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "powerTolerance": {
           "description": "*(2.1)* Power tolerance when following EVPowerProfile.\r\n\r\n",

--- a/packages/types/src/ocpp/model/2.1/schemas/ReportChargingProfilesRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/ReportChargingProfilesRequest.json
@@ -293,8 +293,7 @@
         },
         "limit": {
           "description": "Optional only when not required by the _operationMode_, as in CentralSetpoint, ExternalSetpoint, ExternalLimits, LocalFrequency,  LocalLoadBalancing. +\r\nCharging rate limit during the schedule period, in the applicable _chargingRateUnit_. \r\nThis SHOULD be a non-negative value; a negative value is only supported for backwards compatibility with older systems that use a negative value to specify a discharging limit.\r\nWhen using _chargingRateUnit_ = `W`, this field represents the sum of the power of all phases, unless values are provided for L2 and L3, in which case this field represents phase L1.\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "limit_L2": {
           "description": "*(2.1)* Charging rate limit on phase L2  in the applicable _chargingRateUnit_. \r\n",

--- a/packages/types/src/ocpp/model/2.1/schemas/RequestStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/RequestStartTransactionRequest.json
@@ -312,8 +312,7 @@
         },
         "limit": {
           "description": "Optional only when not required by the _operationMode_, as in CentralSetpoint, ExternalSetpoint, ExternalLimits, LocalFrequency,  LocalLoadBalancing. +\r\nCharging rate limit during the schedule period, in the applicable _chargingRateUnit_. \r\nThis SHOULD be a non-negative value; a negative value is only supported for backwards compatibility with older systems that use a negative value to specify a discharging limit.\r\nWhen using _chargingRateUnit_ = `W`, this field represents the sum of the power of all phases, unless values are provided for L2 and L3, in which case this field represents phase L1.\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "limit_L2": {
           "description": "*(2.1)* Charging rate limit on phase L2  in the applicable _chargingRateUnit_. \r\n",
@@ -443,8 +442,7 @@
         },
         "minChargingRate": {
           "description": "Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. \r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "powerTolerance": {
           "description": "*(2.1)* Power tolerance when following EVPowerProfile.\r\n\r\n",

--- a/packages/types/src/ocpp/model/2.1/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/SetChargingProfileRequest.json
@@ -290,8 +290,7 @@
         },
         "limit": {
           "description": "Optional only when not required by the _operationMode_, as in CentralSetpoint, ExternalSetpoint, ExternalLimits, LocalFrequency,  LocalLoadBalancing. +\r\nCharging rate limit during the schedule period, in the applicable _chargingRateUnit_. \r\nThis SHOULD be a non-negative value; a negative value is only supported for backwards compatibility with older systems that use a negative value to specify a discharging limit.\r\nWhen using _chargingRateUnit_ = `W`, this field represents the sum of the power of all phases, unless values are provided for L2 and L3, in which case this field represents phase L1.\r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "limit_L2": {
           "description": "*(2.1)* Charging rate limit on phase L2  in the applicable _chargingRateUnit_. \r\n",
@@ -421,8 +420,7 @@
         },
         "minChargingRate": {
           "description": "Minimum charging rate supported by the EV. The unit of measure is defined by the chargingRateUnit. This parameter is intended to be used by a local smart charging algorithm to optimize the power allocation for in the case a charging process is inefficient at lower charging rates. \r\n",
-          "type": "number",
-          "multipleOf": 0.1
+          "type": "number"
         },
         "powerTolerance": {
           "description": "*(2.1)* Power tolerance when following EVPowerProfile.\r\n\r\n",


### PR DESCRIPTION
A charging rate with more decimal places than the station's OCPP version allows was refused twice
over - by `multipleOf: 0.1` in the schemas, and by a throwing check in `validateChargingProfileType`.
Both refusals were wrong for a message the station sent, and neither stopped the CSMS from sending
one the station would refuse. This PR moves the rule to the one place it belongs: the CSMS to
Charging Station direction, at serialisation.

Reworked after review (see the thread with @thanaParis below); citrineos/citrineos-core#959 is
closed and folded in here.

### What the spec says

OCPP 2.0.1 restricts `ChargingSchedulePeriodType.limit` and `ChargingScheduleType.minChargingRate`
to one decimal place - *"Accepts at most one digit fraction (e.g. 8.1)"* - and 1.6 says the same of
the same two fields. OCPP 2.1 dropped the field-level restriction and replaced it with the general
rule for the `decimal` datatype, Part 2 §2.1.4:

> For data being reported by the Charging Station, the full resolution of the source data must be
> preserved. The decimal sent towards the Charging Station SHALL NOT have more than six decimal
> places.

So the constraint is on what the CSMS **sends**. What the station reports is to be kept as it came.

### What this repo had

- `multipleOf: 0.1` on `limit` and `minChargingRate` in the 1.6, 2.0.1 and 2.1 schemas - 23 sites
  across 15 files. The router validates inbound messages against those schemas, so a station
  reporting `16.25 A` in `ReportChargingProfiles`, `NotifyChargingLimit`,
  `NotifyEVChargingSchedule` or a `GetCompositeSchedule` result was answered with a CALLERROR. On
  2.1 that is a direct violation of §2.1.4; on 2.0.1 and 1.6 it is the CSMS policing the station's
  own resolution. Ajv also checks `multipleOf` by dividing in binary floating point, which is why
  `8.1` itself - the spec's example - was refused (citrineos/citrineos-core#959).
- `validateChargingProfileType` threw on more than one fraction digit, for every version, from the
  operator API handlers.

### The change

**Schemas.** `multipleOf: 0.1` removed from all 23 sites. Nothing a station sends is refused over
resolution any more.

**Validator.** The two fraction-digit throws in `validateChargingProfileType` are deleted, and with
them the last use of `getNumberOfFractionDigit` there.

**Router.** `MessageRouterImpl.sendCall` runs the payload through
`truncateChargingRates(payload, protocol)` before building the `Call`. `limit` and
`minChargingRate` are truncated to one fraction digit for a 1.6 or 2.0.1 station and six for a 2.1
station; everything else in the payload is untouched, and a payload that already fits is returned
as the same object. `sendCall` is the only path that carries a charging schedule from the CSMS to a
station (`SetChargingProfile`, `RequestStartTransaction` / `RemoteStartTransaction`, and 2.1's
`UpdateDynamicSchedule`), so that is the whole outbound surface.

Two judgement calls, both easy to change:

- **Truncate, not round.** `8.15` goes to `8.1`, not `8.2`. For a limit, rounding up would send the
  station a ceiling higher than the operator asked for. It is done on the decimal string, not by
  `Math.trunc(v * 10) / 10`, so `0.3` stays `0.3` rather than becoming `0.2`.
- **Scoped to `limit` and `minChargingRate`, not every decimal.** On 2.0.1 a blanket one-decimal
  truncation would corrupt `totalCost`, meter values and anything else in the payload; the one-digit
  restriction is specific to those two fields, which is exactly the set that carried
  `multipleOf: 0.1`. On 2.1 the §2.1.4 rule is general, so widening it there to every number in the
  payload would be defensible - say the word.

### Tests

- `packages/ocpp/test/util/charging-rate-precision.test.ts` - the truncation itself, including the
  `0.3` and negative cases, the per-version digit counts, and that a payload with nothing to change
  is returned unchanged.
- `message-router-impl.test.ts` - `sendCall` of a `SetChargingProfile` on a 2.0.1 and on a 2.1
  station, asserting what actually went over the network hook.
- `validator.test.ts` - the two tests that asserted the throw are replaced by one asserting a
  finer-resolution profile is accepted.

Verified on `c1bd4ca`: build clean, full suite green (327 files, 4384 passing / 8 skipped), lint
0 errors.
