### PR TITLE
fix(core): read a device model boolean as a boolean, not as a string

### DIFF
--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp201Handler.ts
@@ -297,10 +297,12 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
           type: AttributeEnum.Actual,
         });
 
-      // only send the tariff information if the Charging Station supports the tariff or DisplayMessage functionality
+      // I01.FR.02: only send the tariff information if the Charging Station supports the tariff or
+      // DisplayMessage functionality. A device model boolean arrives as the string "false" or
+      // "true" (Part 2 §2.1.4), so it has to be compared, not coerced.
       if (
-        (tariffAvailable.length > 0 && Boolean(tariffAvailable[0].value)) ||
-        (displayMessageAvailable.length > 0 && Boolean(displayMessageAvailable[0].value))
+        tariffAvailable[0]?.value?.toLowerCase() === 'true' ||
+        displayMessageAvailable[0]?.value?.toLowerCase() === 'true'
       ) {
         // TODO: The OCPP 2.0.1 Authorize request pricing message requires EV Driver specific pricing, which is not yet supported.
       }

--- a/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
+++ b/packages/core/src/handlers/requests/2/AuthorizeRequestOcpp21Handler.ts
@@ -304,7 +304,9 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
           type: AttributeEnum.Actual,
         });
 
-      if (tariffEnabled.length > 0 && Boolean(tariffEnabled[0].value)) {
+      // A device model boolean arrives as the string "false" or "true" (Part 2 §2.1.4), so it
+      // has to be compared, not coerced.
+      if (tariffEnabled[0]?.value?.toLowerCase() === 'true') {
         if (authorization.tariffId != null) {
           const tariff = await this._tariffRepository.readByKey(
             context.tenantId,

--- a/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
+++ b/packages/core/src/handlers/requests/2/TransactionEventRequestOcpp2Handler.ts
@@ -463,8 +463,10 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
             variable_name: 'Available',
             type: AttributeEnum.Actual,
           });
+        // A device model boolean arrives as the string "false" or "true" (Part 2 §2.1.4), so it
+        // has to be compared, not coerced.
         const supportTariff: boolean =
-          tariffAvailableAttributes.length !== 0 && Boolean(tariffAvailableAttributes[0].value);
+          tariffAvailableAttributes[0]?.value?.toLowerCase() === 'true';
 
         if (supportTariff && transaction && transaction.isActive) {
           this._logger.debug(
@@ -576,8 +578,11 @@ export class TransactionEventRequestOcpp2Handler extends AbstractHandler {
             variable_instance: 'Tariff',
             type: AttributeEnum.Actual,
           });
-        // C20.FR.03
-        if (tariffEnabled.length == 0 || !tariffEnabled[0].value) {
+        // C20.FR.03: central cost calculation is what applies when the station is not doing it
+        // itself, i.e. TariffCostCtrlr.Enabled[Tariff] is false or was never reported. A device
+        // model boolean arrives as the string "false" or "true" (Part 2 §2.1.4).
+        const localCostCalculation = tariffEnabled[0]?.value?.toLowerCase() === 'true';
+        if (!localCostCalculation) {
           this._logger.info(`Central cost calculation is used for transaction ${transactionId}`);
           response.totalCost = 0;
         }

--- a/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp21Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/AuthorizeRequestOcpp21Handler.test.ts
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  AuthorizationStatusEnum,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type {
+  IAuthorizationRepository,
+  IDeviceModelRepository,
+  ITariffRepository,
+} from '@dal/interfaces/repositories.js';
+import { AuthorizeRequestOcpp21Handler } from '@handlers/index.js';
+import type { CertificateAuthorityService } from '@util/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/testContainer.js';
+
+const TARIFF_ID = 7;
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.Authorize,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_1,
+  } as unknown as IMessage<T>;
+}
+
+function anAuthorizeRequest(): OCPP2_1.AuthorizeRequest {
+  return {
+    idToken: { idToken: 'TOKEN01', type: OCPP2_1.IdTokenEnumType.Central },
+  } as OCPP2_1.AuthorizeRequest;
+}
+
+describe('AuthorizeRequestOcpp21Handler', () => {
+  /**
+   * I08.FR.01 lets the CSMS answer with a driver-specific tariff, but a station that does not do
+   * local cost calculation cannot use one - TariffCostCtrlr.Enabled[Tariff] is what says whether it
+   * does (Part 2, Tariff and Cost, Configuration Settings). Device model values arrive as strings,
+   * and OCPP spells a boolean "false" (Part 2 §2.1.4), which is truthy.
+   */
+  describe('driver tariff in the AuthorizeResponse', () => {
+    let ocppSender: ReturnType<typeof makeMockOcppSender>;
+    let deviceModelRepository: { readAllByQuerystring: ReturnType<typeof vi.fn> };
+    let handler: AuthorizeRequestOcpp21Handler;
+
+    function makeHandler(tariffEnabled: string | null | undefined) {
+      const { logger } = createTestContainer();
+      ocppSender = makeMockOcppSender();
+
+      deviceModelRepository = {
+        readAllByQuerystring: vi.fn().mockImplementation(async (_tenantId, query) => {
+          if (query.component_name === 'TariffCostCtrlr' && query.variable_name === 'Enabled') {
+            return tariffEnabled === undefined ? [] : [{ value: tariffEnabled }];
+          }
+          return [];
+        }),
+      };
+
+      const authorizationRepository = {
+        readOnlyOneByQuerystring: vi.fn().mockResolvedValue({
+          idToken: 'TOKEN01',
+          status: AuthorizationStatusEnum.Accepted,
+          tariffId: TARIFF_ID,
+        }),
+      };
+
+      const tariffRepository = {
+        readByKey: vi.fn().mockResolvedValue({
+          id: TARIFF_ID,
+          tariffId: 'DriverTariff01',
+          currency: 'EUR',
+          validFrom: '2026-01-01T00:00:00Z',
+        }),
+      };
+
+      return new AuthorizeRequestOcpp21Handler({
+        logger,
+        ocppSender,
+        certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+        authorizers: [],
+        authorizationRepository: authorizationRepository as unknown as IAuthorizationRepository,
+        deviceModelRepository: deviceModelRepository as unknown as IDeviceModelRepository,
+        tariffRepository: tariffRepository as unknown as ITariffRepository,
+      });
+    }
+
+    async function authorizeWithTariffEnabled(tariffEnabled: string | null | undefined) {
+      handler = makeHandler(tariffEnabled);
+      await handler.handle(makeMessage(anAuthorizeRequest()));
+      return ocppSender.sendCallResultWithMessage.mock.calls[0][1] as OCPP2_1.AuthorizeResponse;
+    }
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('does not send a tariff to a station that reports local cost calculation off', async () => {
+      const response = await authorizeWithTariffEnabled('false');
+
+      expect(response.idTokenInfo?.status).toBe(AuthorizationStatusEnum.Accepted);
+      expect(response.tariff).toBeUndefined();
+    });
+
+    it('does not send a tariff to a station that never reported the variable', async () => {
+      const response = await authorizeWithTariffEnabled(undefined);
+
+      expect(response.tariff).toBeUndefined();
+    });
+
+    it('sends the driver tariff when the station does calculate cost locally', async () => {
+      const response = await authorizeWithTariffEnabled('true');
+
+      expect(response.tariff?.tariffId).toBe('DriverTariff01');
+    });
+
+    // I08.FR.09: driver-specific tariffs have no validFrom date.
+    it('strips validFrom from the tariff it sends', async () => {
+      const response = await authorizeWithTariffEnabled('true');
+
+      expect(response.tariff).toBeDefined();
+      expect(response.tariff).not.toHaveProperty('validFrom');
+    });
+  });
+});

--- a/packages/core/test/handlers/requests/2/TransactionEventRequestOcpp2Handler.test.ts
+++ b/packages/core/test/handlers/requests/2/TransactionEventRequestOcpp2Handler.test.ts
@@ -64,6 +64,7 @@ function makeHandler(
     cache?: Partial<ICache>;
     transactionService?: Record<string, unknown>;
     config?: BootstrapConfig & SystemConfig;
+    deviceModelVariables?: Record<string, { value: string | null }[]>;
   } = {},
 ) {
   const { logger } = createTestContainer();
@@ -98,7 +99,15 @@ function makeHandler(
   };
 
   const chargingProfileRepository = { readAllByQuery: vi.fn().mockResolvedValue([]) };
-  const deviceModelRepository = { readAllByQuerystring: vi.fn().mockResolvedValue([]) };
+  const deviceModelVariables = overrides.deviceModelVariables ?? {};
+  const deviceModelRepository = {
+    readAllByQuerystring: vi.fn().mockImplementation(async (_tenantId, query) => {
+      const key = [query.component_name, query.variable_name, query.variable_instance]
+        .filter(Boolean)
+        .join('.');
+      return deviceModelVariables[key] ?? [];
+    }),
+  };
   const signedMeterValuesUtil = { validateMeterValues: vi.fn().mockResolvedValue(true) };
   const costCalculator = { calculateTotalCost: vi.fn().mockResolvedValue(0) };
   const costNotifier = { notifyWhileActive: vi.fn() };
@@ -118,10 +127,63 @@ function makeHandler(
     transactionService: transactionService as any,
   });
 
-  return { handler, ocppSender, transactionEventRepository, cache, transactionService };
+  return {
+    handler,
+    ocppSender,
+    transactionEventRepository,
+    cache,
+    transactionService,
+    deviceModelRepository,
+  };
 }
 
 describe('TransactionEventRequestOcpp2Handler', () => {
+  // C20.FR.03: when a transaction ends before any cost is incurred and central cost calculation is
+  // used, the CSMS answers with totalCost = 0. Central calculation is what applies when the station
+  // is not doing it itself, i.e. TariffCostCtrlr.Enabled[Tariff] is false or absent - and a device
+  // model boolean arrives as the string "false", which is truthy.
+  describe('C20 - cancelled before any cost was incurred', () => {
+    function anEndedTransactionEvent(): OCPP2_1.TransactionEventRequest {
+      return {
+        eventType: OCPP2_1.TransactionEventEnumType.Ended,
+        triggerReason: OCPP2_1.TriggerReasonEnumType.StopAuthorized,
+        timestamp: new Date().toISOString(),
+        seqNo: 2,
+        transactionInfo: { transactionId: 'txn-001' },
+      } as OCPP2_1.TransactionEventRequest;
+    }
+
+    async function handleWithTariffEnabled(value: string | null | undefined) {
+      const { handler, ocppSender } = makeHandler({
+        deviceModelVariables:
+          value === undefined ? {} : { 'TariffCostCtrlr.Enabled.Tariff': [{ value }] },
+      });
+
+      await handler.handle(makeMessage(anEndedTransactionEvent(), OCPPVersion.OCPP2_1));
+
+      return ocppSender.sendCallResultWithMessage.mock
+        .calls[0][1] as OCPP2_1.TransactionEventResponse;
+    }
+
+    it('answers totalCost 0 when the station reports local cost calculation off', async () => {
+      const response = await handleWithTariffEnabled('false');
+
+      expect(response.totalCost).toBe(0);
+    });
+
+    it('answers totalCost 0 when the station has never reported the variable', async () => {
+      const response = await handleWithTariffEnabled(undefined);
+
+      expect(response.totalCost).toBe(0);
+    });
+
+    it('leaves totalCost alone when the station calculates cost itself', async () => {
+      const response = await handleWithTariffEnabled('true');
+
+      expect(response.totalCost).toBeUndefined();
+    });
+  });
+
   describe('deactivateOtherActiveTransactionsAtEvse201', () => {
     it('calls deactivateOtherActiveTransactionsAtEvse when eventType=Started and evse is defined', async () => {
       const { handler, transactionService } = makeHandler();


### PR DESCRIPTION
Four device model booleans are read with `Boolean(value)` or `!value`. The value is a string, and
OCPP spells a boolean as the word - Part 2 §2.1.4, `boolean`: *"Only allowed values: "false" and
"true"."* - so `"false"` reads as true and the checks are the opposite of what they were written to
be.

Two of the four decide behaviour today:

### A station that does not calculate cost is sent a driver tariff

`AuthorizeRequestOcpp21Handler` gates the driver-specific tariff on
`TariffCostCtrlr.Enabled[Tariff]`, which is what says whether a station does local cost calculation
at all (Part 2, *Tariff and Cost*, §1.1 Configuration Settings: *"Local cost calculation is enabled
by setting TariffCostCtrlr.Enabled[Tariff] to true"*).

```ts
if (tariffEnabled.length > 0 && Boolean(tariffEnabled[0].value)) {
```

A station reporting `Enabled[Tariff] = false` has a row whose value is the string `"false"`, so the
branch is taken and the tariff goes out anyway. Per **I08.FR.30** the station then sets
`TariffCostCtrlr.Problem` and, depending on `HandleFailedTariff`, may refuse to authorise the driver
at all (**I08.FR.31**).

### The zero-cost answer for a cancelled transaction never fires

`TransactionEventRequestOcpp2Handler` implements **C20.FR.03** - *"( C20.FR.01 OR C20.FR.02 ) AND
central cost calculation is used → CSMS SHALL respond with a TransactionEventResponse with
totalCost = 0"*:

```ts
// C20.FR.03
if (tariffEnabled.length == 0 || !tariffEnabled[0].value) {
  response.totalCost = 0;
}
```

Central cost calculation is what applies when the station is *not* doing it, i.e.
`Enabled[Tariff]` is false or absent. `!("false")` is `false`, so the only station that gets
`totalCost = 0` is one that has never reported the variable. A station that reports it - either way -
gets no `totalCost` at all, and the driver's screen falls back to the `TotalCostFallbackMessage`
instead of showing that the cancelled session was free.

### The other two

`AuthorizeRequestOcpp201Handler` reads `TariffCostCtrlr.Available[Tariff]` and
`DisplayMessageCtrlr.Available` for **I01.FR.02**, and `TransactionEventRequestOcpp2Handler` reads
`Available[Tariff]` for **I06**. Both guard blocks that are still a `TODO`, so neither changes
behaviour today - they are in this PR because they are the same idiom, and leaving them is an
invitation to copy the wrong one.

### The fix

All four now compare, the way two sites in the same files already do -
`NotifySettlementRequestOcpp21Handler` for `PaymentCtrlr.ReceiptByCSMS`,
`TransactionEventRequestOcpp2Handler` for `PaymentCtrlr.SettlementByCSMS`, and
`RequestStartTransactionEndpoint` for `SmartChargingCtrlr.Enabled`:

```ts
attributes[0]?.value?.toLowerCase() === 'true'
```

The C20 check keeps its "false or absent" meaning by naming the positive first and negating it, so
the absent case still yields `totalCost = 0`.

`AuthorizeRequestOcpp21Handler.test.ts` is new - the handler had no coverage. It also pins
**I08.FR.09** (no `validFrom` in a tariff in an AuthorizeResponse), which the handler already gets
right.

Full workspace suite green: 92 files, 2001 tests (the six testcontainers suites need Docker and were
not run locally).
