### PR TITLE
fix(ocpp): omit company from VatNumberValidationResponse instead of sending null

### DIFF
--- a/packages/ocpp/src/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.ts
@@ -41,7 +41,7 @@ export class VatNumberValidationRequestOcpp21Handler extends AbstractHandler {
 
     const request = message.payload;
 
-    const company = this._vatProvider ? await this._vatProvider.getVat(request.vatNumber) : null;
+    const company = (await this._vatProvider?.getVat(request.vatNumber)) ?? undefined;
 
     const response: OCPP2_1.VatNumberValidationResponse = {
       vatNumber: request.vatNumber,

--- a/packages/ocpp/test/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.test.ts
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type IMessage,
+  type IVatProvider,
+  DEFAULT_TENANT_ID,
+  OCPPValidator,
+} from '@citrineos/base';
+import {
+  type OcppRequest,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import { VatNumberValidationRequestOcpp21Handler } from '@handlers/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
+
+function makeMessage<T extends OcppRequest>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.Transactions,
+    action: OCPP_CallAction.VatNumberValidation,
+    state: MessageState.Request,
+    protocol: OCPPVersion.OCPP2_1,
+  } as unknown as IMessage<T>;
+}
+
+describe('VatNumberValidationRequestOcpp21Handler', () => {
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+  let getVat: ReturnType<typeof vi.fn>;
+  let handler: VatNumberValidationRequestOcpp21Handler;
+
+  beforeEach(() => {
+    const { logger } = createTestContainer();
+    ocppSender = makeMockOcppSender();
+    getVat = vi.fn();
+    handler = new VatNumberValidationRequestOcpp21Handler({
+      logger,
+      ocppSender,
+      viesVatProvider: { getVat } as unknown as IVatProvider,
+    });
+  });
+
+  async function validate(
+    request: OCPP2_1.VatNumberValidationRequest,
+  ): Promise<OCPP2_1.VatNumberValidationResponse> {
+    await handler.handle(makeMessage(request));
+    return ocppSender.sendCallResultWithMessage.mock
+      .calls[0][1] as OCPP2_1.VatNumberValidationResponse;
+  }
+
+  // C18.FR.09: the CSMS responds Rejected when the VAT number is invalid, and MAY return the
+  // company address. company is an AddressType, so null is not a value it can carry.
+  it('omits company when the VAT number does not resolve', async () => {
+    getVat.mockResolvedValue(null);
+
+    const response = await validate({ vatNumber: 'GB000000000' });
+
+    expect(response.status).toBe(OCPP2_1.GenericStatusEnumType.Rejected);
+    expect(response).not.toHaveProperty('company');
+  });
+
+  it('produces a response the schema accepts when the VAT number does not resolve', async () => {
+    getVat.mockResolvedValue(null);
+
+    const response = await validate({ vatNumber: 'GB000000000' });
+
+    const { isValid, errors } = new OCPPValidator().validateOCPPResponse(
+      OCPP_CallAction.VatNumberValidation,
+      response,
+      OCPPVersion.OCPP2_1,
+    );
+    expect(errors ?? []).toEqual([]);
+    expect(isValid).toBe(true);
+  });
+
+  // C18.FR.10: the CSMS uses the same evseId in the response.
+  it('echoes the evseId the station asked about', async () => {
+    getVat.mockResolvedValue(null);
+
+    const response = await validate({ vatNumber: 'GB000000000', evseId: 2 });
+
+    expect(response.evseId).toBe(2);
+  });
+
+  it('returns the company when the VAT number resolves', async () => {
+    const company: OCPP2_1.AddressType = {
+      name: 'Example Ltd',
+      address1: '1 Example Street',
+      city: 'Example',
+      country: 'GB',
+    };
+    getVat.mockResolvedValue(company);
+
+    const response = await validate({ vatNumber: 'GB123456789' });
+
+    expect(response.status).toBe(OCPP2_1.GenericStatusEnumType.Accepted);
+    expect(response.company).toEqual(company);
+  });
+});

--- a/packages/ocpp/test/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/vat-number-validation-request-ocpp-21-handler.test.ts
@@ -62,15 +62,13 @@ describe('VatNumberValidationRequestOcpp21Handler', () => {
       .calls[0][1] as OCPP2_1.VatNumberValidationResponse;
   }
 
-  // C18.FR.09: the CSMS responds Rejected when the VAT number is invalid, and MAY return the
-  // company address. company is an AddressType, so null is not a value it can carry.
-  it('omits company when the VAT number does not resolve', async () => {
+  it('omits company from the sent response when the VAT number does not resolve', async () => {
     getVat.mockResolvedValue(null);
 
     const response = await validate({ vatNumber: 'GB000000000' });
 
     expect(response.status).toBe(OCPP2_1.GenericStatusEnumType.Rejected);
-    expect(response).not.toHaveProperty('company');
+    expect(JSON.parse(JSON.stringify(response))).not.toHaveProperty('company');
   });
 
   it('produces a response the schema accepts when the VAT number does not resolve', async () => {
@@ -87,7 +85,6 @@ describe('VatNumberValidationRequestOcpp21Handler', () => {
     expect(isValid).toBe(true);
   });
 
-  // C18.FR.10: the CSMS uses the same evseId in the response.
   it('echoes the evseId the station asked about', async () => {
     getVat.mockResolvedValue(null);
 


### PR DESCRIPTION
When a station asks the CSMS to check a VAT number and the number does not resolve, the
`VatNumberValidationResponse` CitrineOS sends fails its own schema.

`company` is an `AddressType`:

```json
"company": { "$ref": "#/definitions/AddressType" }
```

and `AddressType` is `"type": "object"`. The handler sets it unconditionally from whatever
`IVatProvider.getVat` returned, and `getVat` returns `null` for a VAT number that is permanently
invalid - which is the normal outcome of the check that C18.FR.09 describes:

> CSMS validates given VAT number and responds with VatNumberValidationResponse with status =
> Accepted if validated and Rejected when invalid. Optionally the company address can be returned in
> the company field.

So the Rejected answer goes out as `{"vatNumber": "...", "status": "Rejected", "company": null}`, and
a station that validates what it receives answers a CALLERROR rather than telling the driver the VAT
number was not accepted. Nothing catches it on this side: `sendCallResult` does not validate outgoing
messages.

The field is optional, so the fix is to leave it out.

`VatNumberValidationRequestOcpp21Handler.test.ts` is new - the handler had no coverage. One of its
cases runs the response back through `OCPPValidator`, so the shape is pinned against the schema
itself rather than against a hand-written expectation; against the previous commit it fails with
`/company must be object`. It also pins C18.FR.10 (the response carries the evseId the station
asked about), which the handler already gets right.

Full workspace suite green: 92 files, 1998 tests (the six testcontainers suites need Docker and were
not run locally).
