### PR TITLE
fix(core): blacklist the OCPP 2.1 actions too while a boot is not Accepted

### DIFF
--- a/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
+++ b/packages/core/src/modules/Configuration/src/module/BootNotificationService.ts
@@ -10,6 +10,7 @@ import {
   BOOT_STATUS,
   OCPP1_6_CALL_SCHEMA_RECORD,
   OCPP2_0_1_CALL_SCHEMA_RECORD,
+  OCPP2_1_CALL_SCHEMA_RECORD,
 } from '@citrineos/base';
 import {
   type BootDto,
@@ -133,6 +134,20 @@ export class BootNotificationService {
   }
 
   /**
+   * Every action a station on OCPP 2.x can send. B01.FR.10, B02.FR.09 and B03.FR.07 answer anything
+   * other than BootNotification with SecurityError while the boot is Rejected or Pending, and this
+   * blacklist is what enforces that, so it has to cover 2.1's own actions as well as 2.0.1's - the
+   * same handler serves both versions. Blacklisting an action a 2.0.1 station will never send costs
+   * nothing.
+   */
+  private static readonly OCPP2_CHARGER_ACTIONS: readonly string[] = Array.from(
+    new Set([
+      ...Object.keys(OCPP2_0_1_CALL_SCHEMA_RECORD),
+      ...Object.keys(OCPP2_1_CALL_SCHEMA_RECORD),
+    ]),
+  );
+
+  /**
    * Determines whether to blacklist or whitelist charger actions based on its boot status.
    *
    * If the new boot is accepted and the charger actions were previously blacklisted, then whitelist the charger actions.
@@ -151,13 +166,11 @@ export class BootNotificationService {
     if (bootNotificationResponseStatus === OCPP2_0_1.RegistrationStatusEnumType.Accepted) {
       if (cachedBootStatus) {
         // Undo blacklisting of charger-originated actions
-        const promises = Array.from(Object.keys(OCPP2_0_1_CALL_SCHEMA_RECORD)).map(
-          async (action) => {
-            if (action !== OCPP_CallAction.BootNotification) {
-              return this._cache.remove(action, ocppConnectionName);
-            }
-          },
-        );
+        const promises = BootNotificationService.OCPP2_CHARGER_ACTIONS.map(async (action) => {
+          if (action !== OCPP_CallAction.BootNotification) {
+            return this._cache.remove(action, ocppConnectionName);
+          }
+        });
         await Promise.all(promises);
         // Remove cached boot status
         await this._cache.remove(BOOT_STATUS, ocppConnectionName);
@@ -169,7 +182,7 @@ export class BootNotificationService {
       // Blacklist all charger-originated actions except BootNotification
       // GetReport messages will need to un-blacklist NotifyReport
       // TriggerMessage will need to un-blacklist the message it triggers
-      const promises = Array.from(Object.keys(OCPP2_0_1_CALL_SCHEMA_RECORD)).map(async (action) => {
+      const promises = BootNotificationService.OCPP2_CHARGER_ACTIONS.map(async (action) => {
         if (action !== OCPP_CallAction.BootNotification) {
           return this._cache.set(action, 'blacklisted', ocppConnectionName);
         }

--- a/packages/core/test/modules/Configuration/module/BootNotificationService.test.ts
+++ b/packages/core/test/modules/Configuration/module/BootNotificationService.test.ts
@@ -4,7 +4,7 @@
 import { Boot, IBootRepository } from '@citrineos/core';
 import { BootNotificationService } from '@modules/Configuration/src/module/BootNotificationService.js';
 import { ICache } from '@citrineos/base';
-import { OCPP1_6, OCPP2_0_1, SystemConfig } from '@citrineos/types';
+import { OCPP1_6, OCPP2_0_1, OCPP_CallAction, SystemConfig } from '@citrineos/types';
 import { aValidBootConfig } from '../providers/BootConfigProvider.js';
 import { aMessageConfirmation, MOCK_REQUEST_ID } from '../providers/SendCall.js';
 import { afterEach, beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
@@ -169,6 +169,54 @@ describe('BootService', () => {
 
       expect(mockCache.remove).not.toHaveBeenCalled();
       expect(mockCache.set).not.toHaveBeenCalled();
+    });
+
+    // B01.FR.10 / B02.FR.09 / B03.FR.07: while a station's boot is Rejected or Pending, anything it
+    // sends other than BootNotification (or a triggered message) is answered SecurityError. The
+    // blacklist is what enforces that, so it has to cover every action the station can send -
+    // including the ones only OCPP 2.1 defines.
+    it.each([OCPP_CallAction.NotifySettlement, OCPP_CallAction.VatNumberValidation])(
+      'blacklists the OCPP 2.1 action %s',
+      async (action) => {
+        await bootService.cacheChargerActionsPermissions(
+          MOCK_STATION_ID,
+          null,
+          OCPP2_0_1.RegistrationStatusEnumType.Rejected,
+        );
+
+        expect(mockCache.set).toHaveBeenCalledWith(action, 'blacklisted', MOCK_STATION_ID);
+      },
+    );
+
+    it('whitelists the OCPP 2.1 actions again once the boot is accepted', async () => {
+      await bootService.cacheChargerActionsPermissions(
+        MOCK_STATION_ID,
+        OCPP2_0_1.RegistrationStatusEnumType.Pending,
+        OCPP2_0_1.RegistrationStatusEnumType.Accepted,
+      );
+
+      expect(mockCache.remove).toHaveBeenCalledWith(
+        OCPP_CallAction.NotifySettlement,
+        MOCK_STATION_ID,
+      );
+      expect(mockCache.remove).toHaveBeenCalledWith(
+        OCPP_CallAction.VatNumberValidation,
+        MOCK_STATION_ID,
+      );
+    });
+
+    it('never blacklists BootNotification itself', async () => {
+      await bootService.cacheChargerActionsPermissions(
+        MOCK_STATION_ID,
+        null,
+        OCPP2_0_1.RegistrationStatusEnumType.Rejected,
+      );
+
+      expect(mockCache.set).not.toHaveBeenCalledWith(
+        OCPP_CallAction.BootNotification,
+        'blacklisted',
+        MOCK_STATION_ID,
+      );
     });
   });
 


### PR DESCRIPTION
A charging station whose `BootNotification` was **Rejected** can still get CitrineOS to act on
`NotifySettlementRequest` and `VatNumberValidationRequest`, because the boot blacklist is built from
the OCPP 2.0.1 action list only and those two are 2.1's.

### The requirement

Three requirements say the same thing for the three boot states:

- **B01.FR.10** - status not Accepted, station sends a CALL that is not a BootNotification or a
  triggered message → *"The CSMS SHALL respond with RPC Framework: CALLERROR: SecurityError"*
- **B02.FR.09** - same for Pending
- **B03.FR.07** - same for Rejected, on top of **B03.FR.03**, *"The CSMS SHALL NOT initiate any
  messages"*

`OcppRouter._onCall` enforces them by asking `_onCallIsAllowed`, which is a lookup against what
`BootNotificationService.cacheChargerActionsPermissions` wrote into the cache.

### The gap

```ts
const promises = Array.from(Object.keys(OCPP2_0_1_CALL_SCHEMA_RECORD)).map(async (action) => {
  if (action !== OCPP_CallAction.BootNotification) {
    return this._cache.set(action, 'blacklisted', ocppConnectionName);
  }
});
```

`BootNotificationRequestOcpp2Handler` is registered for `OCPP_2_VER_LIST`, so it serves 2.1 stations
too, but the blacklist it builds only names 2.0.1's 64 actions. `OCPP2_1_CALL_SCHEMA_RECORD` adds
three - `NotifySettlement`, `SetDefaultTariff` and `VatNumberValidation` - and two of those are sent
by the station:

- `NotifySettlementRequest` is processed and written onto the transaction's `customData`, and can
  trigger a `SetDisplayMessageRequest` back to a station the CSMS has just refused - which is also
  what B03.FR.03 forbids;
- `VatNumberValidationRequest` makes the CSMS call out to the configured VAT provider on behalf of a
  station it has not accepted.

The whitelist side has the same hole in reverse, but it is harmless: an action that was never
blacklisted does not need removing.

### The change

One list, the union of the two records, used by both loops. Blacklisting an action a 2.0.1 station
will never send costs nothing, and it means the list does not have to be revisited every time a
version adds a message. `BootNotification` is still excluded, which the tests now pin explicitly.

### Overlap

This touches the same two loops as citrineos/citrineos-core#872, which changes the cache key those
lines use from the bare station name to the tenant-scoped identifier. The two changes are
independent - one changes what is iterated, the other what it is keyed under - but they will
conflict textually. Happy to rebase whichever lands second.

Full workspace suite green: 91 files, 1998 tests (the six testcontainers suites need Docker and were
not run locally).
