### PR TITLE
fix(core): accept a transaction started with a button

### DIFF
--- a/packages/core/src/modules/Transactions/src/module/TransactionService.ts
+++ b/packages/core/src/modules/Transactions/src/module/TransactionService.ts
@@ -97,6 +97,13 @@ export class TransactionService {
     messageContext: IMessageContext,
   ): Promise<OCPP2_response_types.TransactionEventResponse> {
     const idToken = transactionEvent.idToken!;
+
+    // C02.FR.02: a transaction started with a button carries a NoAuthorization idToken with an
+    // empty value, which is not backed by an Authorization and is accepted as it stands.
+    if (idToken.type === OCPP2_0_1.IdTokenEnumType.NoAuthorization) {
+      return { idTokenInfo: { status: OCPP2_0_1.AuthorizationStatusEnumType.Accepted } };
+    }
+
     const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
       idToken: idToken.idToken,
       type: idToken.type,
@@ -177,6 +184,13 @@ export class TransactionService {
     messageContext: IMessageContext,
   ): Promise<OCPP2_1.TransactionEventResponse> {
     const idToken = transactionEvent.idToken!;
+
+    // C02.FR.02: a transaction started with a button carries a NoAuthorization idToken with an
+    // empty value, which is not backed by an Authorization and is accepted as it stands.
+    if (idToken.type === OCPP2_1.IdTokenEnumType.NoAuthorization) {
+      return { idTokenInfo: { status: OCPP2_1.AuthorizationStatusEnumType.Accepted } };
+    }
+
     const authorizations = await this._authorizationRepository.readAllByQuerystring(tenantId, {
       idToken: idToken.idToken,
       type: idToken.type,

--- a/packages/core/test/modules/Transactions/module/TransactionService.test.ts
+++ b/packages/core/test/modules/Transactions/module/TransactionService.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { DEFAULT_TENANT_ID, IAuthorizer } from '@citrineos/base';
-import { AuthorizationStatusEnum, OCPP1_6, OCPP2_0_1 } from '@citrineos/types';
+import { AuthorizationStatusEnum, OCPP1_6, OCPP2_0_1, OCPP2_1 } from '@citrineos/types';
 import {
   IAuthorizationRepository,
   ILocationRepository,
@@ -69,6 +69,62 @@ describe('TransactionService', () => {
       ocppMessageRepository,
       realTimeAuthorizer,
       authorizers: [authorizer],
+    });
+  });
+
+  // C02.FR.02: "CSMS receives a TransactionEventRequest with an IdTokenType of type:
+  // NoAuthorization -> The CSMS SHALL respond with a TransactionEventResponse with
+  // IdTokenInfo.status set Accepted." C02.FR.01 has the station send this when a transaction is
+  // started with a button, so there is no Authorization row to find and none is expected.
+  describe('C02 - transaction started with a button', () => {
+    const noAuthorizationIdToken = anIdToken((token) => {
+      token.idToken = '';
+      token.type = OCPP2_0_1.IdTokenEnumType.NoAuthorization;
+    });
+
+    it('accepts a NoAuthorization idToken on OCPP 2.0.1', async () => {
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([]);
+      const transactionEventRequest = aTransactionEventRequest((item) => {
+        item.idToken = noAuthorizationIdToken;
+      });
+
+      const response = await transactionService.authorizeOcpp201IdToken(
+        DEFAULT_TENANT_ID,
+        transactionEventRequest,
+        aMessageContext(),
+      );
+
+      expect(response.idTokenInfo!.status).toBe(OCPP2_0_1.AuthorizationStatusEnumType.Accepted);
+    });
+
+    it('accepts a NoAuthorization idToken on OCPP 2.1', async () => {
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([]);
+      const transactionEventRequest = aTransactionEventRequest((item) => {
+        item.idToken = noAuthorizationIdToken;
+      });
+
+      const response = await transactionService.authorizeOcpp21IdToken(
+        DEFAULT_TENANT_ID,
+        transactionEventRequest,
+        aMessageContext(),
+      );
+
+      expect(response.idTokenInfo!.status).toBe(OCPP2_1.AuthorizationStatusEnumType.Accepted);
+    });
+
+    it('does not look the token up at all', async () => {
+      authorizationRepository.readAllByQuerystring.mockResolvedValue([]);
+      const transactionEventRequest = aTransactionEventRequest((item) => {
+        item.idToken = noAuthorizationIdToken;
+      });
+
+      await transactionService.authorizeOcpp201IdToken(
+        DEFAULT_TENANT_ID,
+        transactionEventRequest,
+        aMessageContext(),
+      );
+
+      expect(authorizationRepository.readAllByQuerystring).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
A transaction started with a button is refused. The station sends a `TransactionEventRequest` whose
`idToken` is `{ idToken: "", type: "NoAuthorization" }`, the CSMS answers
`idTokenInfo.status = Unknown`, and the station stops the session.

### The requirement

**C02 - Start Transaction options: Start transaction with a button**, in both versions:

> **C02.FR.01** When a transaction is started with a button → The Charging Station SHALL send
> TransactionEventRequest with an IdTokenType of type: NoAuthorization and the field idToken left
> empty (empty string).
>
> **C02.FR.02** CSMS receives a TransactionEventRequest with an IdTokenType of type:
> NoAuthorization → The CSMS SHALL respond with a TransactionEventResponse with IdTokenInfo.status
> set Accepted.

The whole point of the type is that there is nothing to look up. C02.FR.03 has the station refuse to
even cache the `IdTokenInfo` it gets back.

### What the code does

`AuthorizeRequestOcpp201Handler` and `AuthorizeRequestOcpp21Handler` both handle it:

```ts
if (message.payload.idToken.type === IdTokenEnum.NoAuthorization) {
  response = { ...response, idTokenInfo: { status: AuthorizationStatusEnum.Accepted } };
  await this._sendAuthorizeResult(message, response);
  return;
}
```

but C02.FR.01 puts the token on a **TransactionEventRequest**, not an `AuthorizeRequest`, and
`TransactionService.authorizeOcpp201IdToken` / `authorizeOcpp21IdToken` - the pair that serves that
path - has no such branch. It queries the authorization repository by `idToken` and `type`, finds
nothing, and takes the `authorizations.length !== 1` exit, which returns the `Unknown` the response
was seeded with.

There is no Authorization row to find: `SequelizeTransactionEventRepository` already skips the
lookup for this type when it persists the event -

```ts
if (value.idToken && value.idToken.type !== OCPP2_0_1.IdTokenEnumType.NoAuthorization) {
```

\- so the response path is the only place that treats it as an ordinary token.

Free-vend and button-start installations therefore cannot charge: E01/E02 have the station act on
`idTokenInfo.status`, and `Unknown` means deauthorize.

### The change

The same guard the Authorize handlers already carry, at the top of both TransactionEvent authorize
methods, before the repository is touched. Both versions, because C02 is identical in 2.0.1 Edition 4
and 2.1 Edition 2.

Spec references are to OCPP 2.0.1 Edition 4 (2025-12-03) Part 2, C02; the 2.1 Edition 2 wording of
C02.FR.01/02 is the same.

Full workspace suite green: 91 files, 1997 tests (the six testcontainers suites need Docker and were
not run locally).
