### PR TITLE
fix(ocpp): keep key codes out of the log

### DIFF
--- a/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-201-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-201-handler.ts
@@ -29,7 +29,7 @@ import {
   OCPP2_response_types,
 } from '@citrineos/types';
 import { CertificateAuthorityService } from '@services/index.js';
-import { validateIdToken } from '@util/index.js';
+import { redactKeyCode, redactKeyCodeInMessage, validateIdToken } from '@util/index.js';
 import {
   type IAuthorizationRepository,
   type IDeviceModelRepository,
@@ -71,7 +71,11 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
     message: IMessage<OCPP2_request_types.AuthorizeRequest>,
     props?: HandlerProperties,
   ): Promise<void> {
-    this._logger.info(this.createHandlerReceivedMessageLog('AuthorizeRequest'), message, props);
+    this._logger.info(
+      this.createHandlerReceivedMessageLog('AuthorizeRequest'),
+      redactKeyCodeInMessage(message),
+      props,
+    );
 
     const request = message.payload as OCPP2_0_1.AuthorizeRequest;
     const context = message.context;
@@ -88,7 +92,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
     if (!tokenValidation.isValid) {
       this._logger.warn(`Invalid ID token format`, {
         type: request.idToken.type,
-        token: request.idToken.idToken,
+        token: redactKeyCode(request.idToken.type, request.idToken.idToken),
         error: tokenValidation.errorMessage,
       });
       const messageId = message.context.correlationId;

--- a/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-21-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-21-handler.ts
@@ -29,7 +29,7 @@ import {
   OCPP2_response_types,
 } from '@citrineos/types';
 import { CertificateAuthorityService } from '@services/index.js';
-import { validateOcpp21IdToken } from '@util/index.js';
+import { redactKeyCode, redactKeyCodeInMessage, validateOcpp21IdToken } from '@util/index.js';
 import {
   type IAuthorizationRepository,
   type IDeviceModelRepository,
@@ -75,7 +75,11 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
     message: IMessage<OCPP2_request_types.AuthorizeRequest>,
     props?: HandlerProperties,
   ): Promise<void> {
-    this._logger.info(this.createHandlerReceivedMessageLog('AuthorizeRequest'), message, props);
+    this._logger.info(
+      this.createHandlerReceivedMessageLog('AuthorizeRequest'),
+      redactKeyCodeInMessage(message),
+      props,
+    );
 
     const request: OCPP2_request_types.AuthorizeRequest = message.payload;
     const context = message.context;
@@ -91,7 +95,7 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
     if (!tokenValidation.isValid) {
       this._logger.warn(`Invalid ID token format`, {
         type: request.idToken.type,
-        token: request.idToken.idToken,
+        token: redactKeyCode(request.idToken.type, request.idToken.idToken),
         error: tokenValidation.errorMessage,
       });
       const messageId = message.context.correlationId;

--- a/packages/ocpp/src/util/index.ts
+++ b/packages/ocpp/src/util/index.ts
@@ -28,6 +28,12 @@ export {
   type ChargingProfileTransactionContext,
   type ChargingProfileValidation,
 } from './validator.js';
+export {
+  isKeyCode,
+  redactKeyCode,
+  redactKeyCodeInMessage,
+  REDACTED_KEY_CODE,
+} from './key-code-redaction.js';
 export { IdGenerator } from './id-generator.js';
 
 export {

--- a/packages/ocpp/src/util/key-code-redaction.ts
+++ b/packages/ocpp/src/util/key-code-redaction.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { IdTokenEnum, type IdTokenEnumType } from '@citrineos/types';
+
+export const REDACTED_KEY_CODE = '[redacted key code]';
+
+export function isKeyCode(type: IdTokenEnumType | string | undefined): boolean {
+  return type === IdTokenEnum.KeyCode;
+}
+
+export function redactKeyCode(type: IdTokenEnumType | string | undefined, idToken: string): string {
+  return isKeyCode(type) ? REDACTED_KEY_CODE : idToken;
+}
+
+export function redactKeyCodeInMessage<T>(message: T): T {
+  const payload = (message as { payload?: { idToken?: { idToken?: string; type?: string } } })
+    ?.payload;
+  const idToken = payload?.idToken;
+  if (!idToken || !isKeyCode(idToken.type)) {
+    return message;
+  }
+  return {
+    ...message,
+    payload: { ...payload, idToken: { ...idToken, idToken: REDACTED_KEY_CODE } },
+  } as T;
+}

--- a/packages/ocpp/test/handlers/requests/2/authorize-id-token-logging.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/authorize-id-token-logging.test.ts
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppRequest,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP2_0_1,
+  OCPP2_1,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type {
+  IAuthorizationRepository,
+  IDeviceModelRepository,
+  ITariffRepository,
+} from '@citrineos/dal';
+import {
+  AuthorizeRequestOcpp201Handler,
+  AuthorizeRequestOcpp21Handler,
+} from '@handlers/index.js';
+import type { CertificateAuthorityService } from '@/services/index.js';
+import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
+
+/**
+ * C04.FR.04: "If an idToken of type keyCode is used -> The Charging Station or CSMS SHALL NOT show
+ * the IdToken in any logging. key codes should never appear in logs."
+ *
+ * A key code is a PIN the driver typed at the Charging Station, and a mistyped one is exactly the
+ * case that reaches the invalid-format branch.
+ */
+const KEY_CODE = 'PIN#1234';
+
+function makeMessage<T extends OcppRequest>(
+  payload: T,
+  protocol: OCPPVersion,
+): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.EVDriver,
+    action: OCPP_CallAction.Authorize,
+    state: MessageState.Request,
+    protocol,
+  } as unknown as IMessage<T>;
+}
+
+function everythingLogged(logger: {
+  debug: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+}): string {
+  return [logger.debug, logger.info, logger.warn, logger.error]
+    .flatMap((fn) => fn.mock.calls)
+    .map((call) => JSON.stringify(call))
+    .join('\n');
+}
+
+describe('C04.FR.04 - a key code never reaches the log', () => {
+  let container: ReturnType<typeof createTestContainer>['container'];
+  let logger: ReturnType<typeof createTestContainer>['logger'];
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+
+  beforeEach(() => {
+    ({ container, logger } = createTestContainer());
+    void container;
+    ocppSender = makeMockOcppSender();
+  });
+
+  it('OCPP 2.0.1: refuses the malformed key code without logging it', async () => {
+    const handler = new AuthorizeRequestOcpp201Handler({
+      logger,
+      ocppSender,
+      certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+      authorizers: [],
+      authorizationRepository: {
+        readOnlyOneByQuerystring: vi.fn().mockResolvedValue(null),
+      } as unknown as IAuthorizationRepository,
+      deviceModelRepository: {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as IDeviceModelRepository,
+    });
+
+    await handler.handle(
+      makeMessage(
+        {
+          idToken: { idToken: KEY_CODE, type: OCPP2_0_1.IdTokenEnumType.KeyCode },
+        } as OCPP2_0_1.AuthorizeRequest,
+        OCPPVersion.OCPP2_0_1,
+      ),
+    );
+
+    expect(ocppSender.sendCallErrorWithMessage).toHaveBeenCalledOnce();
+    expect(everythingLogged(logger)).not.toContain(KEY_CODE);
+  });
+
+  it('OCPP 2.1: refuses the malformed key code without logging it', async () => {
+    const handler = new AuthorizeRequestOcpp21Handler({
+      logger,
+      ocppSender,
+      certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+      authorizers: [],
+      authorizationRepository: {
+        readOnlyOneByQuerystring: vi.fn().mockResolvedValue(null),
+      } as unknown as IAuthorizationRepository,
+      deviceModelRepository: {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as IDeviceModelRepository,
+      tariffRepository: { readByKey: vi.fn() } as unknown as ITariffRepository,
+    });
+
+    await handler.handle(
+      makeMessage(
+        {
+          idToken: { idToken: KEY_CODE, type: OCPP2_1.IdTokenEnumType.KeyCode },
+        } as OCPP2_1.AuthorizeRequest,
+        OCPPVersion.OCPP2_1,
+      ),
+    );
+
+    expect(ocppSender.sendCallErrorWithMessage).toHaveBeenCalledOnce();
+    expect(everythingLogged(logger)).not.toContain(KEY_CODE);
+  });
+
+  it('still says what was wrong with it', async () => {
+    const handler = new AuthorizeRequestOcpp21Handler({
+      logger,
+      ocppSender,
+      certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+      authorizers: [],
+      authorizationRepository: {
+        readOnlyOneByQuerystring: vi.fn().mockResolvedValue(null),
+      } as unknown as IAuthorizationRepository,
+      deviceModelRepository: {
+        readAllByQuerystring: vi.fn().mockResolvedValue([]),
+      } as unknown as IDeviceModelRepository,
+      tariffRepository: { readByKey: vi.fn() } as unknown as ITariffRepository,
+    });
+
+    await handler.handle(
+      makeMessage(
+        {
+          idToken: { idToken: KEY_CODE, type: OCPP2_1.IdTokenEnumType.KeyCode },
+        } as OCPP2_1.AuthorizeRequest,
+        OCPPVersion.OCPP2_1,
+      ),
+    );
+
+    const logged = everythingLogged(logger);
+    expect(logged).toContain('KeyCode');
+    expect(logged).toContain('KeyCode tokens must contain only letters');
+  });
+});

--- a/packages/ocpp/test/handlers/requests/2/authorize-id-token-logging.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/authorize-id-token-logging.test.ts
@@ -19,26 +19,13 @@ import type {
   IDeviceModelRepository,
   ITariffRepository,
 } from '@citrineos/dal';
-import {
-  AuthorizeRequestOcpp201Handler,
-  AuthorizeRequestOcpp21Handler,
-} from '@handlers/index.js';
+import { AuthorizeRequestOcpp201Handler, AuthorizeRequestOcpp21Handler } from '@handlers/index.js';
 import type { CertificateAuthorityService } from '@/services/index.js';
 import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
 
-/**
- * C04.FR.04: "If an idToken of type keyCode is used -> The Charging Station or CSMS SHALL NOT show
- * the IdToken in any logging. key codes should never appear in logs."
- *
- * A key code is a PIN the driver typed at the Charging Station, and a mistyped one is exactly the
- * case that reaches the invalid-format branch.
- */
 const KEY_CODE = 'PIN#1234';
 
-function makeMessage<T extends OcppRequest>(
-  payload: T,
-  protocol: OCPPVersion,
-): IMessage<T> {
+function makeMessage<T extends OcppRequest>(payload: T, protocol: OCPPVersion): IMessage<T> {
   return {
     context: {
       tenantId: DEFAULT_TENANT_ID,


### PR DESCRIPTION
A key code is a PIN the driver typed on the Charging Station's keypad. OCPP singles it out:

> **C04.FR.04** If an idToken of type keyCode is used → The Charging Station or CSMS SHALL NOT show
> the IdToken in any logging. *key codes should never appear in logs.*

Both OCPP 2.x Authorize handlers write it out twice.

### Where

```ts
this._logger.info(this.createHandlerReceivedMessageLog('AuthorizeRequest'), message, props);
```

The whole inbound message, at **info**, on every `AuthorizeRequest` - so every key code a driver
enters is in the log, valid or not, at a level that is on by default.

```ts
this._logger.warn(`Invalid ID token format`, {
  type: request.idToken.type,
  token: request.idToken.idToken,
  error: tokenValidation.errorMessage,
});
```

And again, explicitly, when the token fails format validation - which for a key code is the mistyped
PIN, the value most worth not keeping. `validateIdToken` reaches this branch for a `KeyCode` carrying
any character outside the identifierString set, so a keypad that offers `#` or `*` in a way the
driver misuses lands here.

### The change

A small `keyCodeRedaction` helper, and both handlers routed through it: the received-message log gets
a copy with the key code replaced, and the invalid-format log gets a placeholder instead of the
value. Nothing else about the logging changes - the test pins that the type and the reason are still
there, so the message stays diagnosable:

```
Invalid ID token format { type: 'KeyCode', token: '[redacted key code]',
  error: 'KeyCode tokens must contain only letters, numbers, and characters: * - _ = : + | @ .' }
```

Only `KeyCode` is redacted. The other types are not what C04.FR.04 is about, and quietly hiding them
would cost real diagnostics.

### Two related places, deliberately not in this PR

- `OcppRouter._onCall` logs every inbound message, payload included, at **debug**. Same exposure,
  but redacting there means a general hook rather than a two-line change, and it is a decision about
  how the router logs rather than a defect in a handler.
- `WebhookDispatcher` persists every message to `OCPPMessage.payload` (JSONB), so key codes are in
  the database as well as the log. Whether an archive counts as "logging" is arguable, but a CPO
  that reads C04.FR.04 strictly will want that column redacted or the messages not stored, and that
  is a schema and retention decision.

Happy to take either on if you want them, but they are not bugfixes and did not belong in the same
change.

Spec reference is to OCPP 2.0.1 Edition 4 (2025-12-03) Part 2, C04 - *Authorization using a
PIN-code*; OCPP 2.1 Edition 2 carries C04.FR.04 unchanged, and both handlers are fixed.

Full workspace suite green: 92 files, 1997 tests (the six testcontainers suites need Docker and were
not run locally).
