### PR TITLE
fix(types): restore the OCPP 2.0.1 idToken length

### DIFF
--- a/packages/base/test/modules/ocpp201IdTokenLength.test.ts
+++ b/packages/base/test/modules/ocpp201IdTokenLength.test.ts
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPP2_0_1_CALL_SCHEMA_RECORD } from '../../index.js';
+import { OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import { OCPPValidator } from '@interfaces/modules/OCPPValidator.js';
+
+/**
+ * OCPP 2.0.1 types IdTokenType.idToken as identifierString[0..36]. OCPP 2.1 widened the same field
+ * to identifierString[0..255]; 2.0.1 did not, and a 2.0.1 station's own schema still stops at 36.
+ */
+const MAX_2_0_1_ID_TOKEN = 36;
+
+describe('OCPP 2.0.1 idToken length', () => {
+  const validator = new OCPPValidator();
+
+  function validateAuthorize(idToken: string) {
+    return validator.validateOCPPRequest(
+      OCPP_CallAction.Authorize,
+      { idToken: { idToken, type: 'Central' } },
+      OCPPVersion.OCPP2_0_1,
+    );
+  }
+
+  it('accepts the longest idToken 2.0.1 allows', () => {
+    expect(validateAuthorize('a'.repeat(MAX_2_0_1_ID_TOKEN)).isValid).toBe(true);
+  });
+
+  it('refuses one character more', () => {
+    expect(validateAuthorize('a'.repeat(MAX_2_0_1_ID_TOKEN + 1)).isValid).toBe(false);
+  });
+
+  it('refuses an idToken of the length OCPP 2.1 allows', () => {
+    expect(validateAuthorize('a'.repeat(255)).isValid).toBe(false);
+  });
+
+  // The CSMS also sends idTokens to the station, so the same bound has to hold on the messages the
+  // operator API validates before forwarding.
+  it.each([
+    OCPP_CallAction.RequestStartTransaction,
+    OCPP_CallAction.SendLocalList,
+    OCPP_CallAction.ReserveNow,
+    OCPP_CallAction.CustomerInformation,
+    OCPP_CallAction.TransactionEvent,
+  ])('declares the 2.0.1 bound in the %s schema', (action) => {
+    const schema = OCPP2_0_1_CALL_SCHEMA_RECORD[action] as {
+      definitions: { IdTokenType: { properties: { idToken: { maxLength: number } } } };
+    };
+
+    expect(schema.definitions.IdTokenType.properties.idToken.maxLength).toBe(MAX_2_0_1_ID_TOKEN);
+  });
+});

--- a/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeRequest.json
@@ -91,7 +91,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255,
+          "maxLength": 36,
           "pattern": "^[a-zA-Z0-9*\\-_=:+|@.]*$"
         },
         "type": {

--- a/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeResponse.json
@@ -197,7 +197,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationRequest.json
@@ -119,7 +119,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
@@ -331,7 +331,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowRequest.json
@@ -136,7 +136,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListRequest.json
@@ -199,7 +199,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventRequest.json
@@ -328,7 +328,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255,
+          "maxLength": 36,
           "pattern": "^[a-zA-Z0-9*\\-_=:+|@.]*$"
         },
         "type": {

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventResponse.json
@@ -173,7 +173,7 @@
         "idToken": {
           "description": "IdToken is case insensitive. Might hold the hidden id of an RFID tag, but can for example also contain a UUID.\r\n",
           "type": "string",
-          "maxLength": 255
+          "maxLength": 36
         },
         "type": {
           "$ref": "#/definitions/IdTokenEnumType"


### PR DESCRIPTION
The OCPP 2.0.1 schemas in this repo allow a 255-character `idToken`. That is OCPP 2.1's bound;
2.0.1 stops at 36, and a 2.0.1 station's own schema stops there too.

### The bound

OCPP 2.0.1 Edition 4 Part 2 types `IdTokenType.idToken` as **`identifierString[0..36]`**, and the
published Part 3 schema says `"maxLength": 36` in all eight places it defines `IdTokenType`.

OCPP 2.1 Edition 2 widened the same field to `identifierString[0..255]`, along with
`AdditionalInfoType.additionalIdToken`. The repo's 2.1 schemas correctly say 255.

The repo's 2.0.1 schemas say 255 as well - but only for `idToken`. `additionalIdToken` in the same
files is still 36, which is what 2.0.1 says, so this is an isolated edit rather than a decision to
run 2.0.1 on 2.1's lengths.

### What it costs

The CSMS does not only receive idTokens, it sends them. `RequestStartTransactionRequest`,
`SendLocalListRequest`, `ReserveNowRequest` and `CustomerInformationRequest` all carry one, and
`AuthorizeResponse` / `TransactionEventResponse` carry `idTokenInfo.groupIdToken`. Those bodies are
validated against this schema at the operator API before being forwarded.

So an operator can create an authorization with a 40-character token, or a group token, and every
message carrying it to a 2.0.1 station is refused by the station with a `FormatViolation` - a remote
start that never starts, or a local authorization list that never installs. Nothing on the CSMS side
reports the cause, because as far as CitrineOS is concerned the token was fine.

Inbound is the milder half: a conformant 2.0.1 station will not send one, but if something does, the
CSMS stores it and then cannot send it back.

### The change

`maxLength` back to 36, in the eight 2.0.1 schemas that define `IdTokenType`, and nothing else - the
diff is eight single-line edits. `additionalIdToken` is already correct and is untouched.

The test asserts the behaviour through `OCPPValidator` (36 accepted, 37 refused, 255 refused) rather
than only the constant, and pins the bound in the five request schemas the CSMS sends.

Spec reference is to OCPP 2.0.1 Edition 4 (2025-12-03) Part 2 and the published Part 3 JSON schemas.

Full workspace suite green: 92 files, 2002 tests (the six testcontainers suites need Docker and were
not run locally).
