### PR TITLE
fix(types): close the OCPP 2.0.1 schema classes

### DIFF
--- a/packages/base/test/modules/ocpp201AdditionalProperties.test.ts
+++ b/packages/base/test/modules/ocpp201AdditionalProperties.test.ts
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPP2_0_1_CALL_RESULT_SCHEMA_RECORD, OCPP2_0_1_CALL_SCHEMA_RECORD } from '../../index.js';
+import { OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import { OCPPValidator } from '@interfaces/modules/OCPPValidator.js';
+
+/**
+ * OCPP 2.0.1 Edition 4, Part 4 - JSON over WebSockets, Chapter 9 CustomData Extension:
+ *
+ *   "In the JSON schema files all classes have the attribute additionalProperties set to false,
+ *    such that a JSON parser will not accept any other properties in the message. In order to allow
+ *    for some flexibility to create non-standard extensions for experimentation purposes, every
+ *    JSON class has been extended with a "customData" property. This property is of type
+ *    "CustomDataType", which has only one required property: "vendorId" ... However, since it does
+ *    not have additionalProperties set to false it can be freely extended with new properties."
+ *
+ * So every class is closed and customData is the one way in. CustomDataType itself is the single
+ * exception, and it carries no additionalProperties at all.
+ */
+type Schema = Record<string, unknown>;
+
+function walk(node: unknown, path: string, visit: (node: Schema, path: string) => void): void {
+  if (Array.isArray(node)) {
+    node.forEach((child, i) => walk(child, `${path}[${i}]`, visit));
+    return;
+  }
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  const schema = node as Schema;
+  if (schema.type === 'object') {
+    visit(schema, path);
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    walk(value, `${path}.${key}`, visit);
+  }
+}
+
+function openObjects(schema: Schema, name: string): string[] {
+  const open: string[] = [];
+  walk(schema, name, (node, path) => {
+    // CustomDataType is deliberately open; it is the extension point the chapter describes.
+    if (path.endsWith('.CustomDataType')) {
+      return;
+    }
+    if (node.additionalProperties !== false) {
+      open.push(`${path} (additionalProperties: ${JSON.stringify(node.additionalProperties)})`);
+    }
+  });
+  return open;
+}
+
+describe('OCPP 2.0.1 schemas are closed', () => {
+  const records: [string, Record<string, object>][] = [
+    ['call', OCPP2_0_1_CALL_SCHEMA_RECORD],
+    ['call result', OCPP2_0_1_CALL_RESULT_SCHEMA_RECORD],
+  ];
+
+  for (const [label, record] of records) {
+    it(`every ${label} schema closes every class except CustomDataType`, () => {
+      const open = Object.entries(record).flatMap(([action, schema]) =>
+        openObjects(schema as Schema, action),
+      );
+
+      expect(open).toEqual([]);
+    });
+  }
+
+  it('refuses a property the message definition does not have', () => {
+    const result = new OCPPValidator().validateOCPPRequest(
+      OCPP_CallAction.Heartbeat,
+      { notAField: 1 },
+      OCPPVersion.OCPP2_0_1,
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  it('still accepts a vendor extension under customData', () => {
+    const result = new OCPPValidator().validateOCPPRequest(
+      OCPP_CallAction.Heartbeat,
+      { customData: { vendorId: 'org.example', mainMeter: 1234 } },
+      OCPPVersion.OCPP2_0_1,
+    );
+
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeRequest.json
@@ -18,7 +18,7 @@
       "description": "Used algorithms for the hashes provided.\r\n",
       "javaType": "HashAlgorithmEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["SHA256", "SHA384", "SHA512"],
       "tsEnumNames": ["SHA256", "SHA384", "SHA512"]
     },
@@ -26,7 +26,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -52,7 +52,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -75,7 +75,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -103,7 +103,7 @@
     "OCSPRequestDataType": {
       "javaType": "OCSPRequestData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -142,7 +142,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/AuthorizeResponse.json
@@ -18,7 +18,7 @@
       "description": "ID_ Token. Status. Authorization_ Status\r\nurn:x-oca:ocpp:uid:1:569372\r\nCurrent status of the ID Token.\r\n",
       "javaType": "AuthorizationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Blocked",
@@ -48,7 +48,7 @@
       "description": "Certificate status information. \r\n- if all certificates are valid: return 'Accepted'.\r\n- if one of the certificates was revoked, return 'CertificateRevoked'.\r\n",
       "javaType": "AuthorizeCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "SignatureError",
@@ -72,7 +72,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -98,7 +98,7 @@
       "description": "Message_ Content. Format. Message_ Format_ Code\r\nurn:x-enexis:ecdm:uid:1:570848\r\nFormat of the message.\r\n",
       "javaType": "MessageFormatEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ASCII", "HTML", "URI", "UTF8"],
       "tsEnumNames": ["ASCII", "HTML", "URI", "UTF8"]
     },
@@ -106,7 +106,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -128,7 +128,7 @@
       "description": "ID_ Token\r\nurn:x-oca:ocpp:uid:2:233247\r\nContains status information about an identifier.\r\nIt is advised to not stop charging for a token that expires during charging, as ExpiryDate is only used for caching purposes. If ExpiryDate is not given, the status has no end date.\r\n",
       "javaType": "IdTokenInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -181,7 +181,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -209,7 +209,7 @@
       "description": "Message_ Content\r\nurn:x-enexis:ecdm:uid:2:234490\r\nContains message details, for a message to be displayed on a Charging Station.\r\n\r\n",
       "javaType": "MessageContent",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -232,7 +232,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/BootNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/BootNotificationRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the reason for sending this message to the CSMS.\r\n",
       "javaType": "BootReasonEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ApplicationReset",
         "FirmwareUpdate",
@@ -46,7 +46,7 @@
       "description": "Charge_ Point\r\nurn:x-oca:ocpp:uid:2:233122\r\nThe physical system where an Electrical Vehicle (EV) can be charged.\r\n",
       "javaType": "ChargingStation",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -81,7 +81,7 @@
       "description": "Wireless_ Communication_ Module\r\nurn:x-oca:ocpp:uid:2:233306\r\nDefines parameters required for initiating and maintaining wireless communication with other devices.\r\n",
       "javaType": "Modem",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -101,7 +101,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/BootNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/BootNotificationResponse.json
@@ -18,7 +18,7 @@
       "description": "This contains whether the Charging Station has been registered\r\nwithin the CSMS.\r\n",
       "javaType": "RegistrationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Pending", "Rejected"],
       "tsEnumNames": ["Accepted", "Pending", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CancelReservationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CancelReservationRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CancelReservationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CancelReservationResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates the success or failure of the canceling of a reservation by CSMS.\r\n",
       "javaType": "CancelReservationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CertificateSignedRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CertificateSignedRequest.json
@@ -18,13 +18,13 @@
       "description": "Indicates the type of the signed certificate that is returned. When omitted the certificate is used for both the 15118 connection (if implemented) and the Charging Station to CSMS connection. This field is required when a typeOfCertificate was included in the &lt;&lt;signcertificaterequest,SignCertificateRequest&gt;&gt; that requested this certificate to be signed AND both the 15118 connection and the Charging Station connection are implemented.\r\n\r\n",
       "javaType": "CertificateSigningUseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ChargingStationCertificate", "V2GCertificate"],
       "tsEnumNames": ["ChargingStationCertificate", "V2GCertificate"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CertificateSignedResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CertificateSignedResponse.json
@@ -18,7 +18,7 @@
       "description": "Returns whether certificate signing has been accepted, otherwise rejected.\r\n",
       "javaType": "CertificateSignedStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ChangeAvailabilityRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ChangeAvailabilityRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the type of availability change that the Charging Station should perform.\r\n\r\n",
       "javaType": "OperationalStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Inoperative", "Operative"],
       "tsEnumNames": ["Inoperative", "Operative"]
     },
@@ -26,7 +26,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -48,7 +48,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ChangeAvailabilityResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ChangeAvailabilityResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station is able to perform the availability change.\r\n",
       "javaType": "ChangeAvailabilityStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Scheduled"],
       "tsEnumNames": ["Accepted", "Rejected", "Scheduled"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearCacheRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearCacheRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearCacheResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearCacheResponse.json
@@ -18,7 +18,7 @@
       "description": "Accepted if the Charging Station has executed the request, otherwise rejected.\r\n",
       "javaType": "ClearCacheStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearChargingProfileRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Purpose. Charging_ Profile_ Purpose_ Code\r\nurn:x-oca:ocpp:uid:1:569231\r\nSpecifies to purpose of the charging profiles that will be cleared, if they meet the other criteria in the request.\r\n",
       "javaType": "ChargingProfilePurposeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ChargingStationExternalConstraints",
         "ChargingStationMaxProfile",
@@ -36,7 +36,7 @@
       "description": "Charging_ Profile\r\nurn:x-oca:ocpp:uid:2:233255\r\nA ChargingProfile consists of a ChargingSchedule, describing the amount of power or current that can be delivered per time interval.\r\n",
       "javaType": "ClearChargingProfile",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -60,7 +60,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearChargingProfileResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearChargingProfileResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates if the Charging Station was able to execute the request.\r\n",
       "javaType": "ClearChargingProfileStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Unknown"],
       "tsEnumNames": ["Accepted", "Unknown"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearDisplayMessageRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearDisplayMessageRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearDisplayMessageResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearDisplayMessageResponse.json
@@ -18,7 +18,7 @@
       "description": "Returns whether the Charging Station has been able to remove the message.\r\n",
       "javaType": "ClearMessageStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Unknown"],
       "tsEnumNames": ["Accepted", "Unknown"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearVariableMonitoringRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearVariableMonitoringRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearVariableMonitoringResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearVariableMonitoringResponse.json
@@ -18,14 +18,14 @@
       "description": "Result of the clear request for this monitor, identified by its Id.\r\n\r\n",
       "javaType": "ClearMonitoringStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotFound"],
       "tsEnumNames": ["Accepted", "Rejected", "NotFound"]
     },
     "ClearMonitoringResultType": {
       "javaType": "ClearMonitoringResult",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -49,7 +49,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -69,7 +69,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearedChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearedChargingLimitRequest.json
@@ -18,13 +18,13 @@
       "description": "Source of the charging limit.\r\n",
       "javaType": "ChargingLimitSourceEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["EMS", "Other", "SO", "CSO"],
       "tsEnumNames": ["EMS", "Other", "SO", "CSO"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ClearedChargingLimitResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ClearedChargingLimitResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CostUpdatedRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CostUpdatedRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CostUpdatedResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CostUpdatedResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationRequest.json
@@ -18,7 +18,7 @@
       "description": "Used algorithms for the hashes provided.\r\n",
       "javaType": "HashAlgorithmEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["SHA256", "SHA384", "SHA512"],
       "tsEnumNames": ["SHA256", "SHA384", "SHA512"]
     },
@@ -26,7 +26,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -52,7 +52,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -73,7 +73,7 @@
     "CertificateHashDataType": {
       "javaType": "CertificateHashData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -103,7 +103,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -129,7 +129,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/CustomerInformationResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the request was accepted.\r\n",
       "javaType": "CustomerInformationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Invalid"],
       "tsEnumNames": ["Accepted", "Rejected", "Invalid"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/DataTransferRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/DataTransferRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/DataTransferResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/DataTransferResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates the success or failure of the data transfer.\r\n",
       "javaType": "DataTransferStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "UnknownMessageId", "UnknownVendorId"],
       "tsEnumNames": ["Accepted", "Rejected", "UnknownMessageId", "UnknownVendorId"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/DeleteCertificateRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/DeleteCertificateRequest.json
@@ -18,14 +18,14 @@
       "description": "Used algorithms for the hashes provided.\r\n",
       "javaType": "HashAlgorithmEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["SHA256", "SHA384", "SHA512"],
       "tsEnumNames": ["SHA256", "SHA384", "SHA512"]
     },
     "CertificateHashDataType": {
       "javaType": "CertificateHashData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -53,7 +53,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/DeleteCertificateResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/DeleteCertificateResponse.json
@@ -18,7 +18,7 @@
       "description": "Charging Station indicates if it can process the request.\r\n",
       "javaType": "DeleteCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Failed", "NotFound"],
       "tsEnumNames": ["Accepted", "Failed", "NotFound"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/FirmwareStatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/FirmwareStatusNotificationRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the progress status of the firmware installation.\r\n",
       "javaType": "FirmwareStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Downloaded",
         "DownloadFailed",
@@ -54,7 +54,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/FirmwareStatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/FirmwareStatusNotificationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/Get15118EVCertificateRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/Get15118EVCertificateRequest.json
@@ -18,13 +18,13 @@
       "description": "Defines whether certificate needs to be installed or updated.\r\n",
       "javaType": "CertificateActionEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Install", "Update"],
       "tsEnumNames": ["Install", "Update"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/Get15118EVCertificateResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/Get15118EVCertificateResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the message was processed properly.\r\n",
       "javaType": "Iso15118EVCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Failed"],
       "tsEnumNames": ["Accepted", "Failed"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetBaseReportRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetBaseReportRequest.json
@@ -18,13 +18,13 @@
       "description": "This field specifies the report base.\r\n",
       "javaType": "ReportBaseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ConfigurationInventory", "FullInventory", "SummaryInventory"],
       "tsEnumNames": ["ConfigurationInventory", "FullInventory", "SummaryInventory"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetBaseReportResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetBaseReportResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station is able to accept this request.\r\n",
       "javaType": "GenericDeviceModelStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"],
       "tsEnumNames": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetCertificateStatusRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetCertificateStatusRequest.json
@@ -18,14 +18,14 @@
       "description": "Used algorithms for the hashes provided.\r\n",
       "javaType": "HashAlgorithmEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["SHA256", "SHA384", "SHA512"],
       "tsEnumNames": ["SHA256", "SHA384", "SHA512"]
     },
     "OCSPRequestDataType": {
       "javaType": "OCSPRequestData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -67,7 +67,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetCertificateStatusResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetCertificateStatusResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the charging station was able to retrieve the OCSP certificate status.\r\n",
       "javaType": "GetCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Failed"],
       "tsEnumNames": ["Accepted", "Failed"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetChargingProfilesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetChargingProfilesRequest.json
@@ -17,7 +17,7 @@
     "ChargingLimitSourceEnumType": {
       "javaType": "ChargingLimitSourceEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["EMS", "Other", "SO", "CSO"],
       "tsEnumNames": ["EMS", "Other", "SO", "CSO"]
     },
@@ -25,7 +25,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Purpose. Charging_ Profile_ Purpose_ Code\r\nurn:x-oca:ocpp:uid:1:569231\r\nDefines the purpose of the schedule transferred by this profile\r\n",
       "javaType": "ChargingProfilePurposeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ChargingStationExternalConstraints",
         "ChargingStationMaxProfile",
@@ -43,7 +43,7 @@
       "description": "Charging_ Profile\r\nurn:x-oca:ocpp:uid:2:233255\r\nA ChargingProfile consists of ChargingSchedule, describing the amount of power or current that can be delivered per time interval.\r\n",
       "javaType": "ChargingProfileCriterion",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -82,7 +82,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetChargingProfilesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetChargingProfilesResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station is able to process this request and will send &lt;&lt;reportchargingprofilesrequest, ReportChargingProfilesRequest&gt;&gt; messages.\r\n",
       "javaType": "GetChargingProfileStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "NoProfiles"],
       "tsEnumNames": ["Accepted", "NoProfiles"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleRequest.json
@@ -18,13 +18,13 @@
       "description": "Can be used to force a power or current profile.\r\n\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetCompositeScheduleResponse.json
@@ -18,7 +18,7 @@
       "description": "The unit of measure Limit is\r\nexpressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -26,7 +26,7 @@
       "description": "The Charging Station will indicate if it was\r\nable to process the request\r\n",
       "javaType": "GenericStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -34,7 +34,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -69,7 +69,7 @@
       "description": "Composite_ Schedule\r\nurn:x-oca:ocpp:uid:2:233362\r\n",
       "javaType": "CompositeSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -115,7 +115,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -135,7 +135,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetDisplayMessagesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetDisplayMessagesRequest.json
@@ -18,7 +18,7 @@
       "description": "If provided the Charging Station shall return Display Messages with the given priority only.\r\n",
       "javaType": "MessagePriorityEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["AlwaysFront", "InFront", "NormalCycle"],
       "tsEnumNames": ["AlwaysFront", "InFront", "NormalCycle"]
     },
@@ -26,13 +26,13 @@
       "description": "If provided the Charging Station shall return Display Messages with the given state only. \r\n",
       "javaType": "MessageStateEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Charging", "Faulted", "Idle", "Unavailable"],
       "tsEnumNames": ["Charging", "Faulted", "Idle", "Unavailable"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetDisplayMessagesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetDisplayMessagesResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates if the Charging Station has Display Messages that match the request criteria in the &lt;&lt;getdisplaymessagesrequest,GetDisplayMessagesRequest&gt;&gt;\r\n",
       "javaType": "GetDisplayMessagesStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Unknown"],
       "tsEnumNames": ["Accepted", "Unknown"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetInstalledCertificateIdsRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetInstalledCertificateIdsRequest.json
@@ -17,7 +17,7 @@
     "GetCertificateIdUseEnumType": {
       "javaType": "GetCertificateIdUseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "V2GRootCertificate",
         "MORootCertificate",
@@ -35,7 +35,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetInstalledCertificateIdsResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetInstalledCertificateIdsResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates the type of the requested certificate(s).\r\n",
       "javaType": "GetCertificateIdUseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "V2GRootCertificate",
         "MORootCertificate",
@@ -38,7 +38,7 @@
       "description": "Charging Station indicates if it can process the request.\r\n",
       "javaType": "GetInstalledCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "NotFound"],
       "tsEnumNames": ["Accepted", "NotFound"]
     },
@@ -46,14 +46,14 @@
       "description": "Used algorithms for the hashes provided.\r\n",
       "javaType": "HashAlgorithmEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["SHA256", "SHA384", "SHA512"],
       "tsEnumNames": ["SHA256", "SHA384", "SHA512"]
     },
     "CertificateHashDataChainType": {
       "javaType": "CertificateHashDataChain",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -79,7 +79,7 @@
     "CertificateHashDataType": {
       "javaType": "CertificateHashData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -109,7 +109,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -129,7 +129,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetLocalListVersionRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetLocalListVersionRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetLocalListVersionResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetLocalListVersionResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetLogRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetLogRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the type of log file that the Charging Station\r\nshould send.\r\n",
       "javaType": "LogEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["DiagnosticsLog", "SecurityLog"],
       "tsEnumNames": ["DiagnosticsLog", "SecurityLog"]
     },
@@ -26,7 +26,7 @@
       "description": "Log\r\nurn:x-enexis:ecdm:uid:2:233373\r\nGeneric class for the configuration of logging entries.\r\n",
       "javaType": "LogParameters",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -51,7 +51,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetLogResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetLogResponse.json
@@ -18,7 +18,7 @@
       "description": "This field indicates whether the Charging Station was able to accept the request.\r\n",
       "javaType": "LogStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "AcceptedCanceled"],
       "tsEnumNames": ["Accepted", "Rejected", "AcceptedCanceled"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetMonitoringReportRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetMonitoringReportRequest.json
@@ -17,7 +17,7 @@
     "MonitoringCriterionEnumType": {
       "javaType": "MonitoringCriterionEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ThresholdMonitoring", "DeltaMonitoring", "PeriodicMonitoring"],
       "tsEnumNames": ["ThresholdMonitoring", "DeltaMonitoring", "PeriodicMonitoring"]
     },
@@ -25,7 +25,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -50,7 +50,7 @@
       "description": "Class to report components, variables and variable attributes and characteristics.\r\n",
       "javaType": "ComponentVariable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -68,7 +68,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -92,7 +92,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -112,7 +112,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetMonitoringReportResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetMonitoringReportResponse.json
@@ -18,7 +18,7 @@
       "description": "This field indicates whether the Charging Station was able to accept the request.\r\n",
       "javaType": "GenericDeviceModelStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"],
       "tsEnumNames": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetReportRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetReportRequest.json
@@ -17,7 +17,7 @@
     "ComponentCriterionEnumType": {
       "javaType": "ComponentCriterionEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Active", "Available", "Enabled", "Problem"],
       "tsEnumNames": ["Active", "Available", "Enabled", "Problem"]
     },
@@ -25,7 +25,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -50,7 +50,7 @@
       "description": "Class to report components, variables and variable attributes and characteristics.\r\n",
       "javaType": "ComponentVariable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -68,7 +68,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -92,7 +92,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -112,7 +112,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetReportResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetReportResponse.json
@@ -18,7 +18,7 @@
       "description": "This field indicates whether the Charging Station was able to accept the request.\r\n",
       "javaType": "GenericDeviceModelStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"],
       "tsEnumNames": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetTransactionStatusRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetTransactionStatusRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetTransactionStatusResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetTransactionStatusResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetVariablesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetVariablesRequest.json
@@ -19,7 +19,7 @@
       "javaType": "AttributeEnum",
       "type": "string",
       "default": "Actual",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Actual", "Target", "MinSet", "MaxSet"],
       "tsEnumNames": ["Actual", "Target", "MinSet", "MaxSet"]
     },
@@ -27,7 +27,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -52,7 +52,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -76,7 +76,7 @@
       "description": "Class to hold parameters for GetVariables request.\r\n",
       "javaType": "GetVariableData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -97,7 +97,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -117,7 +117,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/GetVariablesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/GetVariablesResponse.json
@@ -19,7 +19,7 @@
       "javaType": "AttributeEnum",
       "type": "string",
       "default": "Actual",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Actual", "Target", "MinSet", "MaxSet"],
       "tsEnumNames": ["Actual", "Target", "MinSet", "MaxSet"]
     },
@@ -27,7 +27,7 @@
       "description": "Result status of getting the variable.\r\n\r\n",
       "javaType": "GetVariableStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Rejected",
@@ -47,7 +47,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -72,7 +72,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -96,7 +96,7 @@
       "description": "Class to hold results of GetVariables request.\r\n",
       "javaType": "GetVariableResult",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -128,7 +128,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -150,7 +150,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -170,7 +170,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/HeartbeatRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/HeartbeatRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/HeartbeatResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/HeartbeatResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/InstallCertificateRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/InstallCertificateRequest.json
@@ -18,7 +18,7 @@
       "description": "Indicates the certificate type that is sent.\r\n",
       "javaType": "InstallCertificateUseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "V2GRootCertificate",
         "MORootCertificate",
@@ -34,7 +34,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/InstallCertificateResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/InstallCertificateResponse.json
@@ -18,7 +18,7 @@
       "description": "Charging Station indicates if installation was successful.\r\n",
       "javaType": "InstallCertificateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Failed"],
       "tsEnumNames": ["Accepted", "Rejected", "Failed"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/LogStatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/LogStatusNotificationRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the status of the log upload.\r\n",
       "javaType": "UploadLogStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "BadMessage",
         "Idle",
@@ -42,7 +42,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/LogStatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/LogStatusNotificationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesRequest.json
@@ -20,7 +20,7 @@
       "javaType": "LocationEnum",
       "type": "string",
       "default": "Outlet",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Body", "Cable", "EV", "Inlet", "Outlet"],
       "tsEnumNames": ["Body", "Cable", "EV", "Inlet", "Outlet"]
     },
@@ -29,7 +29,7 @@
       "javaType": "MeasurandEnum",
       "type": "string",
       "default": "Energy.Active.Import.Register",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Current.Export",
         "Current.Import",
@@ -89,7 +89,7 @@
       "description": "Sampled_ Value. Phase. Phase_ Code\r\nurn:x-oca:ocpp:uid:1:569264\r\nIndicates how the measured value is to be interpreted. For instance between L1 and neutral (L1-N) Please note that not all values of phase are applicable to all Measurands. When phase is absent, the measured value is interpreted as an overall value.\r\n",
       "javaType": "PhaseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["L1", "L2", "L3", "N", "L1-N", "L2-N", "L3-N", "L1-L2", "L2-L3", "L3-L1"],
       "tsEnumNames": ["L1", "L2", "L3", "N", "L1_N", "L2_N", "L3_N", "L1_L2", "L2_L3", "L3_L1"]
     },
@@ -98,7 +98,7 @@
       "javaType": "ReadingContextEnum",
       "type": "string",
       "default": "Sample.Periodic",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Interruption.Begin",
         "Interruption.End",
@@ -124,7 +124,7 @@
       "description": "Meter_ Value\r\nurn:x-oca:ocpp:uid:2:233265\r\nCollection of one or more sampled values in MeterValuesRequest and TransactionEvent. All sampled values in a MeterValue are sampled at the same point in time.\r\n",
       "javaType": "MeterValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -150,7 +150,7 @@
       "description": "Sampled_ Value\r\nurn:x-oca:ocpp:uid:2:233266\r\nSingle sampled value in MeterValues. Each value can be accompanied by optional fields.\r\n\r\nTo save on mobile data usage, default values of all of the optional fields are such that. The value without any additional fields will be interpreted, as a register reading of active import energy in Wh (Watt-hour) units.\r\n",
       "javaType": "SampledValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -184,7 +184,7 @@
       "description": "Represent a signed version of the meter value.\r\n",
       "javaType": "SignedMeterValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -218,7 +218,7 @@
       "description": "Represents a UnitOfMeasure with a multiplier\r\n",
       "javaType": "UnitOfMeasure",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -240,7 +240,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Limit. Charging_ Limit_ Source. Charging_ Limit_ Source_ Code\r\nurn:x-enexis:ecdm:uid:1:570845\r\nRepresents the source of the charging limit.\r\n",
       "javaType": "ChargingLimitSourceEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["EMS", "Other", "SO", "CSO"],
       "tsEnumNames": ["EMS", "Other", "SO", "CSO"]
     },
@@ -26,7 +26,7 @@
       "description": "Charging_ Schedule. Charging_ Rate_ Unit. Charging_ Rate_ Unit_ Code\r\nurn:x-oca:ocpp:uid:1:569238\r\nThe unit of measure Limit is expressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -34,7 +34,7 @@
       "description": "Cost. Cost_ Kind. Cost_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569243\r\nThe kind of cost referred to in the message element amount\r\n",
       "javaType": "CostKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CarbonDioxideEmission", "RelativePricePercentage", "RenewableGenerationPercentage"],
       "tsEnumNames": [
         "CarbonDioxideEmission",
@@ -46,7 +46,7 @@
       "description": "Charging_ Limit\r\nurn:x-enexis:ecdm:uid:2:234489\r\n",
       "javaType": "ChargingLimit",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -65,7 +65,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -99,7 +99,7 @@
       "description": "Charging_ Schedule\r\nurn:x-oca:ocpp:uid:2:233256\r\nCharging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile. \r\n",
       "javaType": "ChargingSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -149,7 +149,7 @@
       "description": "Consumption_ Cost\r\nurn:x-oca:ocpp:uid:2:233259\r\n",
       "javaType": "ConsumptionCost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -174,7 +174,7 @@
       "description": "Cost\r\nurn:x-oca:ocpp:uid:2:233258\r\n",
       "javaType": "Cost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -197,7 +197,7 @@
       "description": "Relative_ Timer_ Interval\r\nurn:x-oca:ocpp:uid:2:233270\r\n",
       "javaType": "RelativeTimeInterval",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -221,7 +221,7 @@
       "description": "Sales_ Tariff_ Entry\r\nurn:x-oca:ocpp:uid:2:233271\r\n",
       "javaType": "SalesTariffEntry",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -251,7 +251,7 @@
       "description": "Sales_ Tariff\r\nurn:x-oca:ocpp:uid:2:233272\r\nNOTE: This dataType is based on dataTypes from &lt;&lt;ref-ISOIEC15118-2,ISO 15118-2&gt;&gt;.\r\n",
       "javaType": "SalesTariff",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -287,7 +287,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyChargingLimitResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyCustomerInformationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyCustomerInformationRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyCustomerInformationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyCustomerInformationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyDisplayMessagesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyDisplayMessagesRequest.json
@@ -18,7 +18,7 @@
       "description": "Message_ Content. Format. Message_ Format_ Code\r\nurn:x-enexis:ecdm:uid:1:570848\r\nFormat of the message.\r\n",
       "javaType": "MessageFormatEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ASCII", "HTML", "URI", "UTF8"],
       "tsEnumNames": ["ASCII", "HTML", "URI", "UTF8"]
     },
@@ -26,7 +26,7 @@
       "description": "Message_ Info. Priority. Message_ Priority_ Code\r\nurn:x-enexis:ecdm:uid:1:569253\r\nWith what priority should this message be shown\r\n",
       "javaType": "MessagePriorityEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["AlwaysFront", "InFront", "NormalCycle"],
       "tsEnumNames": ["AlwaysFront", "InFront", "NormalCycle"]
     },
@@ -34,7 +34,7 @@
       "description": "Message_ Info. State. Message_ State_ Code\r\nurn:x-enexis:ecdm:uid:1:569254\r\nDuring what state should this message be shown. When omitted this message should be shown in any state of the Charging Station.\r\n",
       "javaType": "MessageStateEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Charging", "Faulted", "Idle", "Unavailable"],
       "tsEnumNames": ["Charging", "Faulted", "Idle", "Unavailable"]
     },
@@ -42,7 +42,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -69,7 +69,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -93,7 +93,7 @@
       "description": "Message_ Content\r\nurn:x-enexis:ecdm:uid:2:234490\r\nContains message details, for a message to be displayed on a Charging Station.\r\n\r\n",
       "javaType": "MessageContent",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -118,7 +118,7 @@
       "description": "Message_ Info\r\nurn:x-enexis:ecdm:uid:2:233264\r\nContains message details, for a message to be displayed on a Charging Station.\r\n",
       "javaType": "MessageInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -164,7 +164,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyDisplayMessagesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyDisplayMessagesResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingNeedsRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingNeedsRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Needs. Requested. Energy_ Transfer_ Mode_ Code\r\nurn:x-oca:ocpp:uid:1:569209\r\nMode of energy transfer requested by the EV.\r\n",
       "javaType": "EnergyTransferModeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["DC", "AC_single_phase", "AC_two_phase", "AC_three_phase"],
       "tsEnumNames": ["DC", "AC_single_phase", "AC_two_phase", "AC_three_phase"]
     },
@@ -26,7 +26,7 @@
       "description": "AC_ Charging_ Parameters\r\nurn:x-oca:ocpp:uid:2:233250\r\nEV AC charging parameters.\r\n\r\n",
       "javaType": "ACChargingParameters",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -62,7 +62,7 @@
       "description": "Charging_ Needs\r\nurn:x-oca:ocpp:uid:2:233249\r\n",
       "javaType": "ChargingNeeds",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -88,7 +88,7 @@
       "description": "DC_ Charging_ Parameters\r\nurn:x-oca:ocpp:uid:2:233251\r\nEV DC charging parameters\r\n\r\n\r\n",
       "javaType": "DCChargingParameters",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -146,7 +146,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingNeedsResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingNeedsResponse.json
@@ -18,7 +18,7 @@
       "description": "Returns whether the CSMS has been able to process the message successfully. It does not imply that the evChargingNeeds can be met with the current charging profile.\r\n",
       "javaType": "NotifyEVChargingNeedsStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Processing"],
       "tsEnumNames": ["Accepted", "Rejected", "Processing"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Schedule. Charging_ Rate_ Unit. Charging_ Rate_ Unit_ Code\r\nurn:x-oca:ocpp:uid:1:569238\r\nThe unit of measure Limit is expressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -26,7 +26,7 @@
       "description": "Cost. Cost_ Kind. Cost_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569243\r\nThe kind of cost referred to in the message element amount\r\n",
       "javaType": "CostKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CarbonDioxideEmission", "RelativePricePercentage", "RenewableGenerationPercentage"],
       "tsEnumNames": [
         "CarbonDioxideEmission",
@@ -38,7 +38,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -72,7 +72,7 @@
       "description": "Charging_ Schedule\r\nurn:x-oca:ocpp:uid:2:233256\r\nCharging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile. \r\n",
       "javaType": "ChargingSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -121,7 +121,7 @@
       "description": "Consumption_ Cost\r\nurn:x-oca:ocpp:uid:2:233259\r\n",
       "javaType": "ConsumptionCost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -146,7 +146,7 @@
       "description": "Cost\r\nurn:x-oca:ocpp:uid:2:233258\r\n",
       "javaType": "Cost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -173,7 +173,7 @@
       "description": "Relative_ Timer_ Interval\r\nurn:x-oca:ocpp:uid:2:233270\r\n",
       "javaType": "RelativeTimeInterval",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -197,7 +197,7 @@
       "description": "Sales_ Tariff_ Entry\r\nurn:x-oca:ocpp:uid:2:233271\r\n",
       "javaType": "SalesTariffEntry",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -227,7 +227,7 @@
       "description": "Sales_ Tariff\r\nurn:x-oca:ocpp:uid:2:233272\r\nNOTE: This dataType is based on dataTypes from &lt;&lt;ref-ISOIEC15118-2,ISO 15118-2&gt;&gt;.\r\n",
       "javaType": "SalesTariff",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -263,7 +263,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEVChargingScheduleResponse.json
@@ -18,7 +18,7 @@
       "description": "Returns whether the CSMS has been able to process the message successfully. It does not imply any approval of the charging schedule.\r\n",
       "javaType": "GenericStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEventRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEventRequest.json
@@ -18,7 +18,7 @@
       "description": "Specifies the event notification type of the message.\r\n\r\n",
       "javaType": "EventNotificationEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "HardWiredNotification",
         "HardWiredMonitor",
@@ -36,7 +36,7 @@
       "description": "Type of monitor that triggered this event, e.g. exceeding a threshold value.\r\n\r\n",
       "javaType": "EventTriggerEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Alerting", "Delta", "Periodic"],
       "tsEnumNames": ["Alerting", "Delta", "Periodic"]
     },
@@ -44,7 +44,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -71,7 +71,7 @@
       "description": "Class to report an event notification for a component-variable.\r\n",
       "javaType": "EventData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -152,7 +152,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -176,7 +176,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -198,7 +198,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEventResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyEventResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyMonitoringReportRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyMonitoringReportRequest.json
@@ -18,7 +18,7 @@
       "description": "The type of this monitor, e.g. a threshold, delta or periodic monitor. \r\n",
       "javaType": "MonitorEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["UpperThreshold", "LowerThreshold", "Delta", "Periodic", "PeriodicClockAligned"],
       "tsEnumNames": [
         "UpperThreshold",
@@ -32,7 +32,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -57,7 +57,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -81,7 +81,7 @@
       "description": "Class to hold parameters of SetVariableMonitoring request.\r\n",
       "javaType": "MonitoringData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -107,7 +107,7 @@
       "description": "A monitoring setting for a variable.\r\n",
       "javaType": "VariableMonitoring",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -142,7 +142,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -162,7 +162,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyMonitoringReportResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyMonitoringReportResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyReportRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyReportRequest.json
@@ -19,7 +19,7 @@
       "javaType": "AttributeEnum",
       "type": "string",
       "default": "Actual",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Actual", "Target", "MinSet", "MaxSet"],
       "tsEnumNames": ["Actual", "Target", "MinSet", "MaxSet"]
     },
@@ -27,7 +27,7 @@
       "description": "Data type of this variable.\r\n",
       "javaType": "DataEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "string",
         "decimal",
@@ -54,7 +54,7 @@
       "javaType": "MutabilityEnum",
       "type": "string",
       "default": "ReadWrite",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ReadOnly", "WriteOnly", "ReadWrite"],
       "tsEnumNames": ["ReadOnly", "WriteOnly", "ReadWrite"]
     },
@@ -62,7 +62,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -89,7 +89,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -113,7 +113,7 @@
       "description": "Class to report components, variables and variable attributes and characteristics.\r\n",
       "javaType": "ReportData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -143,7 +143,7 @@
       "description": "Attribute data of a variable.\r\n",
       "javaType": "VariableAttribute",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -175,7 +175,7 @@
       "description": "Fixed read-only parameters of a variable.\r\n",
       "javaType": "VariableCharacteristics",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -212,7 +212,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -234,7 +234,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/NotifyReportResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/NotifyReportResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the request was accepted.\r\n",
       "javaType": "GenericStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareStatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareStatusNotificationRequest.json
@@ -18,7 +18,7 @@
       "description": "This contains the progress status of the publishfirmware\r\ninstallation.\r\n",
       "javaType": "PublishFirmwareStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Idle",
         "DownloadScheduled",
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareStatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/PublishFirmwareStatusNotificationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesRequest.json
@@ -18,7 +18,7 @@
       "description": "Source that has installed this charging profile.\r\n",
       "javaType": "ChargingLimitSourceEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["EMS", "Other", "SO", "CSO"],
       "tsEnumNames": ["EMS", "Other", "SO", "CSO"]
     },
@@ -26,7 +26,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Kind. Charging_ Profile_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569232\r\nIndicates the kind of schedule.\r\n",
       "javaType": "ChargingProfileKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Absolute", "Recurring", "Relative"],
       "tsEnumNames": ["Absolute", "Recurring", "Relative"]
     },
@@ -34,7 +34,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Purpose. Charging_ Profile_ Purpose_ Code\r\nurn:x-oca:ocpp:uid:1:569231\r\nDefines the purpose of the schedule transferred by this profile\r\n",
       "javaType": "ChargingProfilePurposeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ChargingStationExternalConstraints",
         "ChargingStationMaxProfile",
@@ -52,7 +52,7 @@
       "description": "Charging_ Schedule. Charging_ Rate_ Unit. Charging_ Rate_ Unit_ Code\r\nurn:x-oca:ocpp:uid:1:569238\r\nThe unit of measure Limit is expressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -60,7 +60,7 @@
       "description": "Cost. Cost_ Kind. Cost_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569243\r\nThe kind of cost referred to in the message element amount\r\n",
       "javaType": "CostKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CarbonDioxideEmission", "RelativePricePercentage", "RenewableGenerationPercentage"],
       "tsEnumNames": [
         "CarbonDioxideEmission",
@@ -72,7 +72,7 @@
       "description": "Charging_ Profile. Recurrency_ Kind. Recurrency_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569233\r\nIndicates the start point of a recurrence.\r\n",
       "javaType": "RecurrencyKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Daily", "Weekly"],
       "tsEnumNames": ["Daily", "Weekly"]
     },
@@ -80,7 +80,7 @@
       "description": "Charging_ Profile\r\nurn:x-oca:ocpp:uid:2:233255\r\nA ChargingProfile consists of ChargingSchedule, describing the amount of power or current that can be delivered per time interval.\r\n",
       "javaType": "ChargingProfile",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -146,7 +146,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -181,7 +181,7 @@
       "description": "Charging_ Schedule\r\nurn:x-oca:ocpp:uid:2:233256\r\nCharging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile. \r\n",
       "javaType": "ChargingSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -231,7 +231,7 @@
       "description": "Consumption_ Cost\r\nurn:x-oca:ocpp:uid:2:233259\r\n",
       "javaType": "ConsumptionCost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -256,7 +256,7 @@
       "description": "Cost\r\nurn:x-oca:ocpp:uid:2:233258\r\n",
       "javaType": "Cost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -283,7 +283,7 @@
       "description": "Relative_ Timer_ Interval\r\nurn:x-oca:ocpp:uid:2:233270\r\n",
       "javaType": "RelativeTimeInterval",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -307,7 +307,7 @@
       "description": "Sales_ Tariff_ Entry\r\nurn:x-oca:ocpp:uid:2:233271\r\n",
       "javaType": "SalesTariffEntry",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -337,7 +337,7 @@
       "description": "Sales_ Tariff\r\nurn:x-oca:ocpp:uid:2:233272\r\nNOTE: This dataType is based on dataTypes from &lt;&lt;ref-ISOIEC15118-2,ISO 15118-2&gt;&gt;.\r\n",
       "javaType": "SalesTariff",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -373,7 +373,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReportChargingProfilesResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Kind. Charging_ Profile_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569232\r\nIndicates the kind of schedule.\r\n",
       "javaType": "ChargingProfileKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Absolute", "Recurring", "Relative"],
       "tsEnumNames": ["Absolute", "Recurring", "Relative"]
     },
@@ -26,7 +26,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Purpose. Charging_ Profile_ Purpose_ Code\r\nurn:x-oca:ocpp:uid:1:569231\r\nDefines the purpose of the schedule transferred by this profile\r\n",
       "javaType": "ChargingProfilePurposeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ChargingStationExternalConstraints",
         "ChargingStationMaxProfile",
@@ -44,7 +44,7 @@
       "description": "Charging_ Schedule. Charging_ Rate_ Unit. Charging_ Rate_ Unit_ Code\r\nurn:x-oca:ocpp:uid:1:569238\r\nThe unit of measure Limit is expressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -52,7 +52,7 @@
       "description": "Cost. Cost_ Kind. Cost_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569243\r\nThe kind of cost referred to in the message element amount\r\n",
       "javaType": "CostKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CarbonDioxideEmission", "RelativePricePercentage", "RenewableGenerationPercentage"],
       "tsEnumNames": [
         "CarbonDioxideEmission",
@@ -64,7 +64,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -90,7 +90,7 @@
       "description": "Charging_ Profile. Recurrency_ Kind. Recurrency_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569233\r\nIndicates the start point of a recurrence.\r\n",
       "javaType": "RecurrencyKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Daily", "Weekly"],
       "tsEnumNames": ["Daily", "Weekly"]
     },
@@ -98,7 +98,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -120,7 +120,7 @@
       "description": "Charging_ Profile\r\nurn:x-oca:ocpp:uid:2:233255\r\nA ChargingProfile consists of ChargingSchedule, describing the amount of power or current that can be delivered per time interval.\r\n",
       "javaType": "ChargingProfile",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -183,7 +183,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -218,7 +218,7 @@
       "description": "Charging_ Schedule\r\nurn:x-oca:ocpp:uid:2:233256\r\nCharging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile. \r\n",
       "javaType": "ChargingSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -267,7 +267,7 @@
       "description": "Consumption_ Cost\r\nurn:x-oca:ocpp:uid:2:233259\r\n",
       "javaType": "ConsumptionCost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -292,7 +292,7 @@
       "description": "Cost\r\nurn:x-oca:ocpp:uid:2:233258\r\n",
       "javaType": "Cost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -315,7 +315,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -343,7 +343,7 @@
       "description": "Relative_ Timer_ Interval\r\nurn:x-oca:ocpp:uid:2:233270\r\n",
       "javaType": "RelativeTimeInterval",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -367,7 +367,7 @@
       "description": "Sales_ Tariff_ Entry\r\nurn:x-oca:ocpp:uid:2:233271\r\n",
       "javaType": "SalesTariffEntry",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -397,7 +397,7 @@
       "description": "Sales_ Tariff\r\nurn:x-oca:ocpp:uid:2:233272\r\nNOTE: This dataType is based on dataTypes from &lt;&lt;ref-ISOIEC15118-2,ISO 15118-2&gt;&gt;.\r\n",
       "javaType": "SalesTariff",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -433,7 +433,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStartTransactionResponse.json
@@ -18,7 +18,7 @@
       "description": "Status indicating whether the Charging Station accepts the request to start a transaction.\r\n",
       "javaType": "RequestStartStopStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStopTransactionRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStopTransactionRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/RequestStopTransactionResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/RequestStopTransactionResponse.json
@@ -18,7 +18,7 @@
       "description": "Status indicating whether Charging Station accepts the request to stop a transaction.\r\n",
       "javaType": "RequestStartStopStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReservationStatusUpdateRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReservationStatusUpdateRequest.json
@@ -18,13 +18,13 @@
       "description": "The updated reservation status.\r\n",
       "javaType": "ReservationUpdateStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Expired", "Removed"],
       "tsEnumNames": ["Expired", "Removed"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReservationStatusUpdateResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReservationStatusUpdateResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowRequest.json
@@ -18,7 +18,7 @@
       "description": "This field specifies the connector type.\r\n",
       "javaType": "ConnectorEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "cCCS1",
         "cCCS2",
@@ -72,7 +72,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -98,7 +98,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -120,7 +120,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -146,7 +146,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ReserveNowResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates the success or failure of the reservation.\r\n",
       "javaType": "ReserveNowStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Faulted", "Occupied", "Rejected", "Unavailable"],
       "tsEnumNames": ["Accepted", "Faulted", "Occupied", "Rejected", "Unavailable"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ResetRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ResetRequest.json
@@ -18,13 +18,13 @@
       "description": "This contains the type of reset that the Charging Station or EVSE should perform.\r\n",
       "javaType": "ResetEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Immediate", "OnIdle"],
       "tsEnumNames": ["Immediate", "OnIdle"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/ResetResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/ResetResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station is able to perform the reset.\r\n",
       "javaType": "ResetStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Scheduled"],
       "tsEnumNames": ["Accepted", "Rejected", "Scheduled"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SecurityEventNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SecurityEventNotificationRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SecurityEventNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SecurityEventNotificationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListRequest.json
@@ -18,7 +18,7 @@
       "description": "ID_ Token. Status. Authorization_ Status\r\nurn:x-oca:ocpp:uid:1:569372\r\nCurrent status of the ID Token.\r\n",
       "javaType": "AuthorizationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Blocked",
@@ -48,7 +48,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -74,7 +74,7 @@
       "description": "Message_ Content. Format. Message_ Format_ Code\r\nurn:x-enexis:ecdm:uid:1:570848\r\nFormat of the message.\r\n",
       "javaType": "MessageFormatEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ASCII", "HTML", "URI", "UTF8"],
       "tsEnumNames": ["ASCII", "HTML", "URI", "UTF8"]
     },
@@ -82,7 +82,7 @@
       "description": "This contains the type of update (full or differential) of this request.\r\n",
       "javaType": "UpdateEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Differential", "Full"],
       "tsEnumNames": ["Differential", "Full"]
     },
@@ -90,7 +90,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -112,7 +112,7 @@
       "description": "Contains the identifier to use for authorization.\r\n",
       "javaType": "AuthorizationData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -130,7 +130,7 @@
       "description": "ID_ Token\r\nurn:x-oca:ocpp:uid:2:233247\r\nContains status information about an identifier.\r\nIt is advised to not stop charging for a token that expires during charging, as ExpiryDate is only used for caching purposes. If ExpiryDate is not given, the status has no end date.\r\n",
       "javaType": "IdTokenInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -183,7 +183,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -211,7 +211,7 @@
       "description": "Message_ Content\r\nurn:x-enexis:ecdm:uid:2:234490\r\nContains message details, for a message to be displayed on a Charging Station.\r\n\r\n",
       "javaType": "MessageContent",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -234,7 +234,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SendLocalListResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station has successfully received and applied the update of the Local Authorization List.\r\n",
       "javaType": "SendLocalListStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Failed", "VersionMismatch"],
       "tsEnumNames": ["Accepted", "Failed", "VersionMismatch"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileRequest.json
@@ -18,7 +18,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Kind. Charging_ Profile_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569232\r\nIndicates the kind of schedule.\r\n",
       "javaType": "ChargingProfileKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Absolute", "Recurring", "Relative"],
       "tsEnumNames": ["Absolute", "Recurring", "Relative"]
     },
@@ -26,7 +26,7 @@
       "description": "Charging_ Profile. Charging_ Profile_ Purpose. Charging_ Profile_ Purpose_ Code\r\nurn:x-oca:ocpp:uid:1:569231\r\nDefines the purpose of the schedule transferred by this profile\r\n",
       "javaType": "ChargingProfilePurposeEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ChargingStationExternalConstraints",
         "ChargingStationMaxProfile",
@@ -44,7 +44,7 @@
       "description": "Charging_ Schedule. Charging_ Rate_ Unit. Charging_ Rate_ Unit_ Code\r\nurn:x-oca:ocpp:uid:1:569238\r\nThe unit of measure Limit is expressed in.\r\n",
       "javaType": "ChargingRateUnitEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["W", "A"],
       "tsEnumNames": ["W", "A"]
     },
@@ -52,7 +52,7 @@
       "description": "Cost. Cost_ Kind. Cost_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569243\r\nThe kind of cost referred to in the message element amount\r\n",
       "javaType": "CostKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CarbonDioxideEmission", "RelativePricePercentage", "RenewableGenerationPercentage"],
       "tsEnumNames": [
         "CarbonDioxideEmission",
@@ -64,7 +64,7 @@
       "description": "Charging_ Profile. Recurrency_ Kind. Recurrency_ Kind_ Code\r\nurn:x-oca:ocpp:uid:1:569233\r\nIndicates the start point of a recurrence.\r\n",
       "javaType": "RecurrencyKindEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Daily", "Weekly"],
       "tsEnumNames": ["Daily", "Weekly"]
     },
@@ -72,7 +72,7 @@
       "description": "Charging_ Profile\r\nurn:x-oca:ocpp:uid:2:233255\r\nA ChargingProfile consists of ChargingSchedule, describing the amount of power or current that can be delivered per time interval.\r\n",
       "javaType": "ChargingProfile",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -135,7 +135,7 @@
       "description": "Charging_ Schedule_ Period\r\nurn:x-oca:ocpp:uid:2:233257\r\nCharging schedule period structure defines a time period in a charging schedule.\r\n",
       "javaType": "ChargingSchedulePeriod",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -170,7 +170,7 @@
       "description": "Charging_ Schedule\r\nurn:x-oca:ocpp:uid:2:233256\r\nCharging schedule structure defines a list of charging periods, as used in: GetCompositeSchedule.conf and ChargingProfile. \r\n",
       "javaType": "ChargingSchedule",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -219,7 +219,7 @@
       "description": "Consumption_ Cost\r\nurn:x-oca:ocpp:uid:2:233259\r\n",
       "javaType": "ConsumptionCost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -244,7 +244,7 @@
       "description": "Cost\r\nurn:x-oca:ocpp:uid:2:233258\r\n",
       "javaType": "Cost",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -271,7 +271,7 @@
       "description": "Relative_ Timer_ Interval\r\nurn:x-oca:ocpp:uid:2:233270\r\n",
       "javaType": "RelativeTimeInterval",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -295,7 +295,7 @@
       "description": "Sales_ Tariff_ Entry\r\nurn:x-oca:ocpp:uid:2:233271\r\n",
       "javaType": "SalesTariffEntry",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -325,7 +325,7 @@
       "description": "Sales_ Tariff\r\nurn:x-oca:ocpp:uid:2:233272\r\nNOTE: This dataType is based on dataTypes from &lt;&lt;ref-ISOIEC15118-2,ISO 15118-2&gt;&gt;.\r\n",
       "javaType": "SalesTariff",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -361,7 +361,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetChargingProfileResponse.json
@@ -18,7 +18,7 @@
       "description": "Returns whether the Charging Station has been able to process the message successfully. This does not guarantee the schedule will be followed to the letter. There might be other constraints the Charging Station may need to take into account.\r\n",
       "javaType": "ChargingProfileStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetDisplayMessageRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetDisplayMessageRequest.json
@@ -18,7 +18,7 @@
       "description": "Message_ Content. Format. Message_ Format_ Code\r\nurn:x-enexis:ecdm:uid:1:570848\r\nFormat of the message.\r\n",
       "javaType": "MessageFormatEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ASCII", "HTML", "URI", "UTF8"],
       "tsEnumNames": ["ASCII", "HTML", "URI", "UTF8"]
     },
@@ -26,7 +26,7 @@
       "description": "Message_ Info. Priority. Message_ Priority_ Code\r\nurn:x-enexis:ecdm:uid:1:569253\r\nWith what priority should this message be shown\r\n",
       "javaType": "MessagePriorityEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["AlwaysFront", "InFront", "NormalCycle"],
       "tsEnumNames": ["AlwaysFront", "InFront", "NormalCycle"]
     },
@@ -34,7 +34,7 @@
       "description": "Message_ Info. State. Message_ State_ Code\r\nurn:x-enexis:ecdm:uid:1:569254\r\nDuring what state should this message be shown. When omitted this message should be shown in any state of the Charging Station.\r\n",
       "javaType": "MessageStateEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Charging", "Faulted", "Idle", "Unavailable"],
       "tsEnumNames": ["Charging", "Faulted", "Idle", "Unavailable"]
     },
@@ -42,7 +42,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -67,7 +67,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -91,7 +91,7 @@
       "description": "Message_ Content\r\nurn:x-enexis:ecdm:uid:2:234490\r\nContains message details, for a message to be displayed on a Charging Station.\r\n\r\n",
       "javaType": "MessageContent",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -116,7 +116,7 @@
       "description": "Message_ Info\r\nurn:x-enexis:ecdm:uid:2:233264\r\nContains message details, for a message to be displayed on a Charging Station.\r\n",
       "javaType": "MessageInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -159,7 +159,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetDisplayMessageResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetDisplayMessageResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station is able to display the message.\r\n",
       "javaType": "DisplayMessageStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "NotSupportedMessageFormat",
@@ -40,7 +40,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -60,7 +60,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringBaseRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringBaseRequest.json
@@ -18,13 +18,13 @@
       "description": "Specify which monitoring base will be set\r\n",
       "javaType": "MonitoringBaseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["All", "FactoryDefault", "HardWiredOnly"],
       "tsEnumNames": ["All", "FactoryDefault", "HardWiredOnly"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringBaseResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringBaseResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the Charging Station was able to accept the request.\r\n",
       "javaType": "GenericDeviceModelStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"],
       "tsEnumNames": ["Accepted", "Rejected", "NotSupported", "EmptyResultSet"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringLevelRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringLevelRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringLevelResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetMonitoringLevelResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the Charging Station was able to accept the request.\r\n",
       "javaType": "GenericStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetNetworkProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetNetworkProfileRequest.json
@@ -18,7 +18,7 @@
       "description": "APN. APN_ Authentication. APN_ Authentication_ Code\r\nurn:x-oca:ocpp:uid:1:568828\r\nAuthentication method.\r\n",
       "javaType": "APNAuthenticationEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["CHAP", "NONE", "PAP", "AUTO"],
       "tsEnumNames": ["CHAP", "NONE", "PAP", "AUTO"]
     },
@@ -26,7 +26,7 @@
       "description": "Applicable Network Interface.\r\n",
       "javaType": "OCPPInterfaceEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Wired0",
         "Wired1",
@@ -52,7 +52,7 @@
       "description": "Communication_ Function. OCPP_ Transport. OCPP_ Transport_ Code\r\nurn:x-oca:ocpp:uid:1:569356\r\nDefines the transport protocol (e.g. SOAP or JSON). Note: SOAP is not supported in OCPP 2.0, but is supported by other versions of OCPP.\r\n",
       "javaType": "OCPPTransportEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["JSON", "SOAP"],
       "tsEnumNames": ["JSON", "SOAP"]
     },
@@ -60,7 +60,7 @@
       "description": "Communication_ Function. OCPP_ Version. OCPP_ Version_ Code\r\nurn:x-oca:ocpp:uid:1:569355\r\nDefines the OCPP version used for this communication function.\r\n",
       "javaType": "OCPPVersionEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["OCPP12", "OCPP15", "OCPP16", "OCPP20"],
       "tsEnumNames": ["OCPP12", "OCPP15", "OCPP16", "OCPP20"]
     },
@@ -68,7 +68,7 @@
       "description": "VPN. Type. VPN_ Code\r\nurn:x-oca:ocpp:uid:1:569277\r\nType of VPN\r\n",
       "javaType": "VPNEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["IKEv2", "IPSec", "L2TP", "PPTP"],
       "tsEnumNames": ["IKEv2", "IPSec", "L2TP", "PPTP"]
     },
@@ -76,7 +76,7 @@
       "description": "APN\r\nurn:x-oca:ocpp:uid:2:233134\r\nCollection of configuration data needed to make a data-connection over a cellular network.\r\n\r\nNOTE: When asking a GSM modem to dial in, it is possible to specify which mobile operator should be used. This can be done with the mobile country code (MCC) in combination with a mobile network code (MNC). Example: If your preferred network is Vodafone Netherlands, the MCC=204 and the MNC=04 which means the key PreferredNetwork = 20404 Some modems allows to specify a preferred network, which means, if this network is not available, a different network is used. If you specify UseOnlyPreferredNetwork and this network is not available, the modem will not dial in.\r\n",
       "javaType": "APN",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -122,7 +122,7 @@
       "description": "Communication_ Function\r\nurn:x-oca:ocpp:uid:2:233304\r\nThe NetworkConnectionProfile defines the functional and technical parameters of a communication link.\r\n",
       "javaType": "NetworkConnectionProfile",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -173,7 +173,7 @@
       "description": "VPN\r\nurn:x-oca:ocpp:uid:2:233268\r\nVPN Configuration settings\r\n",
       "javaType": "VPN",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -211,7 +211,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetNetworkProfileResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetNetworkProfileResponse.json
@@ -18,7 +18,7 @@
       "description": "Result of operation.\r\n",
       "javaType": "SetNetworkProfileStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Failed"],
       "tsEnumNames": ["Accepted", "Rejected", "Failed"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetVariableMonitoringRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetVariableMonitoringRequest.json
@@ -18,7 +18,7 @@
       "description": "The type of this monitor, e.g. a threshold, delta or periodic monitor. \r\n\r\n",
       "javaType": "MonitorEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["UpperThreshold", "LowerThreshold", "Delta", "Periodic", "PeriodicClockAligned"],
       "tsEnumNames": [
         "UpperThreshold",
@@ -32,7 +32,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -57,7 +57,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -81,7 +81,7 @@
       "description": "Class to hold parameters of SetVariableMonitoring request.\r\n",
       "javaType": "SetMonitoringData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -123,7 +123,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -143,7 +143,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetVariableMonitoringResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetVariableMonitoringResponse.json
@@ -18,7 +18,7 @@
       "description": "The type of this monitor, e.g. a threshold, delta or periodic monitor. \r\n\r\n",
       "javaType": "MonitorEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["UpperThreshold", "LowerThreshold", "Delta", "Periodic", "PeriodicClockAligned"],
       "tsEnumNames": [
         "UpperThreshold",
@@ -32,7 +32,7 @@
       "description": "Status is OK if a value could be returned. Otherwise this will indicate the reason why a value could not be returned.\r\n",
       "javaType": "SetMonitoringStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "UnknownComponent",
@@ -54,7 +54,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -79,7 +79,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -103,7 +103,7 @@
       "description": "Class to hold result of SetVariableMonitoring request.\r\n",
       "javaType": "SetMonitoringResult",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -140,7 +140,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -162,7 +162,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -182,7 +182,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetVariablesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetVariablesRequest.json
@@ -19,7 +19,7 @@
       "javaType": "AttributeEnum",
       "type": "string",
       "default": "Actual",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Actual", "Target", "MinSet", "MaxSet"],
       "tsEnumNames": ["Actual", "Target", "MinSet", "MaxSet"]
     },
@@ -27,7 +27,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -52,7 +52,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -75,7 +75,7 @@
     "SetVariableDataType": {
       "javaType": "SetVariableData",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -101,7 +101,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -121,7 +121,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SetVariablesResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SetVariablesResponse.json
@@ -19,7 +19,7 @@
       "javaType": "AttributeEnum",
       "type": "string",
       "default": "Actual",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Actual", "Target", "MinSet", "MaxSet"],
       "tsEnumNames": ["Actual", "Target", "MinSet", "MaxSet"]
     },
@@ -27,7 +27,7 @@
       "description": "Result status of setting the variable.\r\n",
       "javaType": "SetVariableStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Rejected",
@@ -49,7 +49,7 @@
       "description": "A physical or logical component\r\n",
       "javaType": "Component",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -74,7 +74,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -97,7 +97,7 @@
     "SetVariableResultType": {
       "javaType": "SetVariableResult",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -124,7 +124,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -146,7 +146,7 @@
       "description": "Reference key to a component-variable.\r\n",
       "javaType": "Variable",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -166,7 +166,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SignCertificateRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SignCertificateRequest.json
@@ -18,13 +18,13 @@
       "description": "Indicates the type of certificate that is to be signed. When omitted the certificate is to be used for both the 15118 connection (if implemented) and the Charging Station to CSMS connection.\r\n\r\n",
       "javaType": "CertificateSigningUseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ChargingStationCertificate", "V2GCertificate"],
       "tsEnumNames": ["ChargingStationCertificate", "V2GCertificate"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/SignCertificateResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/SignCertificateResponse.json
@@ -18,7 +18,7 @@
       "description": "Specifies whether the CSMS can process the request.\r\n",
       "javaType": "GenericStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/StatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/StatusNotificationRequest.json
@@ -18,13 +18,13 @@
       "description": "This contains the current status of the Connector.\r\n",
       "javaType": "ConnectorStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Available", "Occupied", "Reserved", "Unavailable", "Faulted"],
       "tsEnumNames": ["Available", "Occupied", "Reserved", "Unavailable", "Faulted"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/StatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/StatusNotificationResponse.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventRequest.json
@@ -18,7 +18,7 @@
       "description": "Transaction. State. Transaction_ State_ Code\r\nurn:x-oca:ocpp:uid:1:569419\r\nCurrent charging state, is required when state\r\nhas changed.\r\n",
       "javaType": "ChargingStateEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Charging", "EVConnected", "SuspendedEV", "SuspendedEVSE", "Idle"],
       "tsEnumNames": ["Charging", "EVConnected", "SuspendedEV", "SuspendedEVSE", "Idle"]
     },
@@ -26,7 +26,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -53,7 +53,7 @@
       "javaType": "LocationEnum",
       "type": "string",
       "default": "Outlet",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Body", "Cable", "EV", "Inlet", "Outlet"],
       "tsEnumNames": ["Body", "Cable", "EV", "Inlet", "Outlet"]
     },
@@ -62,7 +62,7 @@
       "javaType": "MeasurandEnum",
       "type": "string",
       "default": "Energy.Active.Import.Register",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Current.Export",
         "Current.Import",
@@ -122,7 +122,7 @@
       "description": "Sampled_ Value. Phase. Phase_ Code\r\nurn:x-oca:ocpp:uid:1:569264\r\nIndicates how the measured value is to be interpreted. For instance between L1 and neutral (L1-N) Please note that not all values of phase are applicable to all Measurands. When phase is absent, the measured value is interpreted as an overall value.\r\n",
       "javaType": "PhaseEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["L1", "L2", "L3", "N", "L1-N", "L2-N", "L3-N", "L1-L2", "L2-L3", "L3-L1"],
       "tsEnumNames": ["L1", "L2", "L3", "N", "L1_N", "L2_N", "L3_N", "L1_L2", "L2_L3", "L3_L1"]
     },
@@ -131,7 +131,7 @@
       "javaType": "ReadingContextEnum",
       "type": "string",
       "default": "Sample.Periodic",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Interruption.Begin",
         "Interruption.End",
@@ -157,7 +157,7 @@
       "description": "Transaction. Stopped_ Reason. EOT_ Reason_ Code\r\nurn:x-oca:ocpp:uid:1:569413\r\nThis contains the reason why the transaction was stopped. MAY only be omitted when Reason is \"Local\".\r\n",
       "javaType": "ReasonEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "DeAuthorized",
         "EmergencyStop",
@@ -205,7 +205,7 @@
       "description": "This contains the type of this event.\r\nThe first TransactionEvent of a transaction SHALL contain: \"Started\" The last TransactionEvent of a transaction SHALL contain: \"Ended\" All others SHALL contain: \"Updated\"\r\n",
       "javaType": "TransactionEventEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Ended", "Started", "Updated"],
       "tsEnumNames": ["Ended", "Started", "Updated"]
     },
@@ -213,7 +213,7 @@
       "description": "Reason the Charging Station sends this message to the CSMS\r\n",
       "javaType": "TriggerReasonEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Authorized",
         "CablePluggedIn",
@@ -265,7 +265,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -288,7 +288,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -312,7 +312,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -341,7 +341,7 @@
       "description": "Meter_ Value\r\nurn:x-oca:ocpp:uid:2:233265\r\nCollection of one or more sampled values in MeterValuesRequest and TransactionEvent. All sampled values in a MeterValue are sampled at the same point in time.\r\n",
       "javaType": "MeterValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -367,7 +367,7 @@
       "description": "Sampled_ Value\r\nurn:x-oca:ocpp:uid:2:233266\r\nSingle sampled value in MeterValues. Each value can be accompanied by optional fields.\r\n\r\nTo save on mobile data usage, default values of all of the optional fields are such that. The value without any additional fields will be interpreted, as a register reading of active import energy in Wh (Watt-hour) units.\r\n",
       "javaType": "SampledValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -401,7 +401,7 @@
       "description": "Represent a signed version of the meter value.\r\n",
       "javaType": "SignedMeterValue",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -433,7 +433,7 @@
       "description": "Transaction\r\nurn:x-oca:ocpp:uid:2:233318\r\n",
       "javaType": "Transaction",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -469,7 +469,7 @@
       "description": "Represents a UnitOfMeasure with a multiplier\r\n",
       "javaType": "UnitOfMeasure",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -491,7 +491,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TransactionEventResponse.json
@@ -18,7 +18,7 @@
       "description": "ID_ Token. Status. Authorization_ Status\r\nurn:x-oca:ocpp:uid:1:569372\r\nCurrent status of the ID Token.\r\n",
       "javaType": "AuthorizationStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Blocked",
@@ -48,7 +48,7 @@
       "description": "Enumeration of possible idToken types.\r\n",
       "javaType": "IdTokenEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Central",
         "eMAID",
@@ -74,7 +74,7 @@
       "description": "Message_ Content. Format. Message_ Format_ Code\r\nurn:x-enexis:ecdm:uid:1:570848\r\nFormat of the message.\r\n",
       "javaType": "MessageFormatEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ASCII", "HTML", "URI", "UTF8"],
       "tsEnumNames": ["ASCII", "HTML", "URI", "UTF8"]
     },
@@ -82,7 +82,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "AdditionalInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -104,7 +104,7 @@
       "description": "ID_ Token\r\nurn:x-oca:ocpp:uid:2:233247\r\nContains status information about an identifier.\r\nIt is advised to not stop charging for a token that expires during charging, as ExpiryDate is only used for caching purposes. If ExpiryDate is not given, the status has no end date.\r\n",
       "javaType": "IdTokenInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -157,7 +157,7 @@
       "description": "Contains a case insensitive identifier to use for the authorization and the type of authorization to support multiple forms of identifiers.\r\n",
       "javaType": "IdToken",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -185,7 +185,7 @@
       "description": "Message_ Content\r\nurn:x-enexis:ecdm:uid:2:234490\r\nContains message details, for a message to be displayed on a Charging Station.\r\n\r\n",
       "javaType": "MessageContent",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -208,7 +208,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TriggerMessageRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TriggerMessageRequest.json
@@ -18,7 +18,7 @@
       "description": "Type of message to be triggered.\r\n",
       "javaType": "MessageTriggerEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "BootNotification",
         "LogStatusNotification",
@@ -50,7 +50,7 @@
       "description": "EVSE\r\nurn:x-oca:ocpp:uid:2:233123\r\nElectric Vehicle Supply Equipment\r\n",
       "javaType": "EVSE",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -72,7 +72,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/TriggerMessageResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/TriggerMessageResponse.json
@@ -18,7 +18,7 @@
       "description": "Indicates whether the Charging Station will send the requested notification or not.\r\n",
       "javaType": "TriggerMessageStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotImplemented"],
       "tsEnumNames": ["Accepted", "Rejected", "NotImplemented"]
     },
@@ -26,7 +26,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -46,7 +46,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UnlockConnectorRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UnlockConnectorRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UnlockConnectorResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UnlockConnectorResponse.json
@@ -18,7 +18,7 @@
       "description": "This indicates whether the Charging Station has unlocked the connector.\r\n",
       "javaType": "UnlockStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Unlocked", "UnlockFailed", "OngoingAuthorizedTransaction", "UnknownConnector"],
       "tsEnumNames": [
         "Unlocked",
@@ -31,7 +31,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -51,7 +51,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UnpublishFirmwareRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UnpublishFirmwareRequest.json
@@ -16,7 +16,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UnpublishFirmwareResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UnpublishFirmwareResponse.json
@@ -18,13 +18,13 @@
       "description": "Indicates whether the Local Controller succeeded in unpublishing the firmware.\r\n",
       "javaType": "UnpublishFirmwareStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["DownloadOngoing", "NoFirmware", "Unpublished"],
       "tsEnumNames": ["DownloadOngoing", "NoFirmware", "Unpublished"]
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UpdateFirmwareRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UpdateFirmwareRequest.json
@@ -18,7 +18,7 @@
       "description": "Firmware\r\nurn:x-enexis:ecdm:uid:2:233291\r\nRepresents a copy of the firmware that can be loaded/updated on the Charging Station.\r\n",
       "javaType": "Firmware",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -53,7 +53,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"

--- a/packages/types/src/ocpp/model/2.0.1/schemas/UpdateFirmwareResponse.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/UpdateFirmwareResponse.json
@@ -18,7 +18,7 @@
       "description": "This field indicates whether the Charging Station was able to accept the request.\r\n\r\n",
       "javaType": "UpdateFirmwareStatusEnum",
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Accepted",
         "Rejected",
@@ -38,7 +38,7 @@
       "description": "Element providing more information about the status.\r\n",
       "javaType": "StatusInfo",
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
         "customData": {
           "$ref": "#/definitions/CustomDataType"
@@ -58,7 +58,7 @@
     }
   },
   "type": "object",
-  "additionalProperties": true,
+  "additionalProperties": false,
   "properties": {
     "customData": {
       "$ref": "#/definitions/CustomDataType"


### PR DESCRIPTION
Every class in the OCPP 2.0.1 schemas carries `"additionalProperties": true`. The published schemas
say `false` - all 470 of them - and the spec leans on that.

### What the spec says

OCPP 2.0.1 Edition 4, Part 4 - *JSON over WebSockets implementation guide*, Chapter 9
**CustomData Extension**:

> In the JSON schema files all classes have the attribute additionalProperties set to false, such
> that a JSON parser will not accept any other properties in the message. In order to allow for some
> flexibility to create non-standard extensions for experimentation purposes, every JSON class has
> been extended with a "customData" property. This property is of type "CustomDataType", which has
> only one required property: "vendorId" ... However, since it does not have additionalProperties set
> to false it can be freely extended with new properties.

Closed classes plus one open `CustomDataType` is the whole extension mechanism. With every class
open, `customData` has no purpose - anything can be put anywhere.

The repo's **2.1** schemas already say `false`, and Part 4 of 2.1 carries the same chapter word for
word, so this is 2.0.1 alone.

### The numbers

|  | `additionalProperties: false` | `: true` |
|---|---|---|
| published 2.0.1 Part 3 schemas | 470 | 0 |
| this repo, before | 0 | 470 |
| this repo, after | 470 | 0 |

`CustomDataType` carries no `additionalProperties` key in either set, before or after, so the
extension point stays open. After the change every one of the 128 files matches the published schema
on this keyword exactly - the test in the first commit checks that structurally rather than by eye.

The diff is one literal replaced by another, 470 times, and nothing else.

### What it costs today

`OcppRouter._onCall` and `_onCallResult` validate inbound messages against these schemas, so a
station's message carrying a field that is not in the definition is accepted and the field is then
dropped by the mapper. A misspelt field reads as an absent one: a `TransactionEventRequest` with
`evseID` instead of `evse` is stored as a transaction with no EVSE rather than refused.

The outbound direction is worse, because the operator API validates request bodies against the same
schemas with `removeAdditional: 'failing'` - Ajv only strips an additional property when it *causes*
a failure, and with `additionalProperties: true` nothing fails. So a stray field in an API call
survives validation, is copied into the OCPP message, and is sent to a station whose own schema is
closed. The station answers `FormatViolation` and the whole command fails, with nothing on the CSMS
side pointing at the extra field.

### The risk in this change

It is a real tightening: a station that today sends a non-standard field outside `customData` is
accepted and after this is answered with a `FormatViolation`. That is what the spec asks for, and
`customData` is the sanctioned way for such a vendor to keep working, but it is a behaviour change
worth being deliberate about rather than a pure bugfix - so if you would rather stay lenient inbound
and tighten only the operator API, say so and I will split it that way.

I could not find a reason the flip was intentional: it arrived with `fcda3a3a` ("The wumbo types
package commit that has 1.3k changes"), a bulk move, and the 2.1 schemas that moved in the same
commit kept `false`.

Full workspace suite: 97 files, 2046 tests passing, 6 skipped. This run had Docker available, so
the testcontainers-backed integration suites ran too. The one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails the same way on `next` -
`Command failed: pnpm run db:migrate` - so it is not this change.
