### PR TITLE
fix(ocpp): ignore a message type number the CSMS does not know

### DIFF
--- a/packages/ocpp/src/modules/ocpp-router/router.ts
+++ b/packages/ocpp/src/modules/ocpp-router/router.ts
@@ -267,24 +267,24 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
           break;
         }
         default: {
-          let errorCode;
-          switch (protocol) {
-            case OCPPVersion.OCPP1_6:
-            case OCPPVersion.OCPP2_0_1:
-            case OCPPVersion.OCPP2_1: {
-              errorCode = ErrorCode.FormatViolation;
-              break;
-            }
-            default: {
-              throw new Error('Unknown protocol: ' + protocol);
-            }
-          }
-          throw new OcppError(
-            messageId,
-            errorCode,
-            'Unknown message type id: ' + messageTypeId,
-            {},
+          this._logger.warn(
+            `Ignoring message with unknown message type id ${messageTypeId}`,
+            identifier,
           );
+          await this._messagesExchangeSink.record(
+            buildFrameEvent({
+              tenantId,
+              ocppConnectionName,
+              origin: MessageOrigin.ChargingStation,
+              correlationId: uuidv4(),
+              protocol,
+              raw: message,
+              timestamp: timestamp.toISOString(),
+              type: messageTypeId,
+              action: this.getActionFromIncompletelyParsedRpcMessage(rpcMessage, messageTypeId),
+            }),
+          );
+          return true;
         }
       }
     } catch (error) {

--- a/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
+++ b/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
@@ -335,35 +335,43 @@ describe('MessageRouterImpl', () => {
         expect(frames(sink, 'inbound')).toEqual([expect.objectContaining({ parsed: false })]);
       });
 
-      it('should return false and send CallError for unknown message type id', async () => {
-        const badMessage = JSON.stringify([99, CORRELATION_ID, 'SomeAction', {}]);
+      /**
+       * OCPP-J Part 4 §4.1.3, in 2.0.1 Edition 4 and 2.1 Edition 2 alike: "When a system receives a
+       * message with a Message Type Number not in this list, it SHALL ignore the message payload."
+       * The 2026-02 errata clarifies that the whole message is to be ignored, and deprecates the
+       * MessageTypeNotSupported error code because an unsupported message type number is silently
+       * ignored. 2.1 added CALLRESULTERROR (5) and SEND (6); N15.FR.02 adds that a SEND is not to
+       * be confirmed with a CALLRESULT or a CALLERROR.
+       */
+      it.each([
+        ['SEND, added by OCPP 2.1', 6],
+        ['CALLRESULTERROR, added by OCPP 2.1', 5],
+        ['a number no version defines', 99],
+      ])('ignores %s rather than answering it', async (_label, messageTypeId) => {
+        const message = JSON.stringify([messageTypeId, CORRELATION_ID, 'SomeAction', {}]);
 
-        const result = await router.onMessage(IDENTIFIER, badMessage, timestamp, PROTOCOL);
+        await router.onMessage(IDENTIFIER, message, timestamp, PROTOCOL);
 
-        expect(result).toBe(false);
-        // Should send a CallError back via network hook
-        expect(networkHook).toHaveBeenCalled();
+        expect(networkHook).not.toHaveBeenCalled();
+      });
+
+      it.each(['ocpp1.6', 'ocpp2.0.1', 'ocpp2.1'])(
+        'ignores an unknown message type id on %s',
+        async (protocol) => {
+          const message = JSON.stringify([99, CORRELATION_ID, 'SomeAction', {}]);
+
+          await router.onMessage(IDENTIFIER, message, timestamp, protocol as typeof PROTOCOL);
+
+          expect(networkHook).not.toHaveBeenCalled();
+        },
+      );
+
+      it('still records the message it ignored', async () => {
+        const message = JSON.stringify([6, CORRELATION_ID, 'SomeAction', {}]);
+
+        await router.onMessage(IDENTIFIER, message, timestamp, PROTOCOL);
+
         expect(frames(sink, 'inbound')).toEqual([expect.objectContaining({ parsed: false })]);
-      });
-
-      it('should send CallError with FormationViolation for ocpp1.6 unknown message type', async () => {
-        const badMessage = JSON.stringify([99, CORRELATION_ID, 'SomeAction', {}]);
-
-        await router.onMessage(IDENTIFIER, badMessage, timestamp, 'ocpp1.6');
-
-        expect(networkHook).toHaveBeenCalled();
-        const sentMessage = JSON.parse(networkHook.mock.calls[0][1]);
-        expect(sentMessage[2]).toBe(ErrorCode.FormatViolation);
-      });
-
-      it('should send CallError with FormatViolation for ocpp2.0.1 unknown message type', async () => {
-        const badMessage = JSON.stringify([99, CORRELATION_ID, 'SomeAction', {}]);
-
-        await router.onMessage(IDENTIFIER, badMessage, timestamp, 'ocpp2.0.1');
-
-        expect(networkHook).toHaveBeenCalled();
-        const sentMessage = JSON.parse(networkHook.mock.calls[0][1]);
-        expect(sentMessage[2]).toBe(ErrorCode.FormatViolation);
       });
 
       it('should not send CallError for failed CallResult processing', async () => {

--- a/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
+++ b/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
@@ -335,14 +335,6 @@ describe('MessageRouterImpl', () => {
         expect(frames(sink, 'inbound')).toEqual([expect.objectContaining({ parsed: false })]);
       });
 
-      /**
-       * OCPP-J Part 4 §4.1.3, in 2.0.1 Edition 4 and 2.1 Edition 2 alike: "When a system receives a
-       * message with a Message Type Number not in this list, it SHALL ignore the message payload."
-       * The 2026-02 errata clarifies that the whole message is to be ignored, and deprecates the
-       * MessageTypeNotSupported error code because an unsupported message type number is silently
-       * ignored. 2.1 added CALLRESULTERROR (5) and SEND (6); N15.FR.02 adds that a SEND is not to
-       * be confirmed with a CALLRESULT or a CALLERROR.
-       */
       it.each([
         ['SEND, added by OCPP 2.1', 6],
         ['CALLRESULTERROR, added by OCPP 2.1', 5],


### PR DESCRIPTION
A station that speaks a newer OCPP than the CSMS gets an error for every message the CSMS does not
recognise. It is supposed to get silence.

### The requirement

OCPP-J Part 4 §4.1.3, after listing the message type numbers - identical wording in OCPP 2.0.1
Edition 4 and OCPP 2.1 Edition 2:

> When a system receives a message with a Message Type Number not in this list, it SHALL ignore the
> message payload.

The 2.0.1 Edition 4 **errata 2026-06** returns to this twice:

- §4.1 *"Update handling of unknown message type"* - "The sentence about ignoring unknown message
  types has been improved slightly. It mentioned to ignore the message payload, but the intention
  was to ignore the entire message."
- §4.2 *"MessageTypeNotSupported is deprecated"* - "As of OCPP 2.1 a message type number that is not
  supported is silently ignored, as described in section 4.4. This is therefore no longer a valid
  error code."

### What the router does

```ts
default: {
  let errorCode;
  switch (protocol) { ... errorCode = ErrorCode.FormatViolation; ... }
  throw new OcppError(messageId, errorCode, 'Unknown message type id: ' + messageTypeId, {});
}
```

which the surrounding `catch` turns into a CALLERROR on the wire:

```
[4,"msg-001","FormatViolation","Unknown message type id: 6",{}]
```

`MessageTypeId` here is `Call = 2`, `CallResult = 3`, `CallError = 4`. OCPP 2.1 added two more -
`CALLRESULTERROR = 5` and `SEND = 6` - so both land in that branch.

`SEND` is the one that bites. It is how a periodic event stream delivers its data, and **N15.FR.02**
says:

> When receiving a message of RPC message type "SEND" → CSMS SHALL NOT confirm the message upon
> receipt with "CALLRESULT" or "CALLERROR".

So a 2.1 station that opens a stream is answered with an error per data message, which is both the
opposite of the requirement and noisy.

### The change

The unknown-type branch logs and returns instead of throwing. The message is still recorded to the
messages exchange sink as an unparsed inbound frame, so the audit trail does not change, and a message that is not JSON
at all still gets a CALLERROR - that is a framing failure, not an unknown type.

This does **not** implement SEND or periodic event streams. Ignoring is what the spec asks of a CSMS
that does not support a message type; implementing N11-N15 is separate work.

### Tests I replaced

`MessageRouterImpl.test.ts` had three tests asserting the CALLERROR - `should return false and send
CallError for unknown message type id` and the two per-protocol `FormatViolation` ones. They encoded
the behaviour this PR changes, so they are replaced rather than added to, and the replacements cover
`SEND`, `CALLRESULTERROR` and an arbitrary number, on all three protocols, plus the two things that
must not change.

Full workspace suite: 96 files, 2046 tests passing, 6 skipped. Docker was available for this run so the
testcontainers-backed suites ran too; the one failing file,
`apps/ocpp-server/test/e2e/security-event-e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`) and is not this change.


