### PR TITLE
fix(core): anchor a 1.6 composite schedule at the scheduleStart the station sent

### DIFF
--- a/packages/core/src/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.ts
+++ b/packages/core/src/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.ts
@@ -50,7 +50,14 @@ export class GetCompositeScheduleResponseOcpp16Handler extends AbstractHandler {
       const compositeSchedule = {
         evseId: response.connectorId ?? 0,
         duration: response.chargingSchedule.duration ?? 0,
-        scheduleStart: response.chargingSchedule.startSchedule ?? new Date().toISOString(),
+        // GetCompositeSchedule.conf carries scheduleStart itself - "Periods contained in the
+        // charging profile are relative to this point in time" - so that is the anchor, and the
+        // schedule's own startSchedule is only a fallback. Defaulting to the current time would
+        // shift every period by however long the response took to arrive.
+        scheduleStart:
+          response.scheduleStart ??
+          response.chargingSchedule.startSchedule ??
+          new Date().toISOString(),
         chargingRateUnit: response.chargingSchedule
           .chargingRateUnit as unknown as ChargingRateUnitEnumType,
         chargingSchedulePeriod: response.chargingSchedule.chargingSchedulePeriod.map((p) => ({

--- a/packages/core/src/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.ts
+++ b/packages/core/src/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.ts
@@ -50,10 +50,6 @@ export class GetCompositeScheduleResponseOcpp16Handler extends AbstractHandler {
       const compositeSchedule = {
         evseId: response.connectorId ?? 0,
         duration: response.chargingSchedule.duration ?? 0,
-        // GetCompositeSchedule.conf carries scheduleStart itself - "Periods contained in the
-        // charging profile are relative to this point in time" - so that is the anchor, and the
-        // schedule's own startSchedule is only a fallback. Defaulting to the current time would
-        // shift every period by however long the response took to arrive.
         scheduleStart:
           response.scheduleStart ??
           response.chargingSchedule.startSchedule ??

--- a/packages/core/test/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.test.ts
@@ -17,11 +17,6 @@ import type { IChargingProfileRepository } from '@dal/interfaces/repositories.js
 import { GetCompositeScheduleResponseOcpp16Handler } from '@handlers/index.js';
 import { createTestContainer } from '@test/testContainer.js';
 
-/**
- * OCPP 1.6 Edition 2, GetCompositeSchedule.conf: `scheduleStart` is a field of the response, not of
- * the schedule inside it - "Time. Periods contained in the charging profile are relative to this
- * point in time. If status is 'Rejected', this field may be absent."
- */
 const SCHEDULE_START = '2026-08-27T09:00:00.000Z';
 const SCHEDULE_OWN_START = '2026-08-27T08:00:00.000Z';
 

--- a/packages/core/test/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/responses/1.6/GetCompositeScheduleResponseOcpp16Handler.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
+import {
+  type OcppResponse,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP1_6,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import type { IChargingProfileRepository } from '@dal/interfaces/repositories.js';
+import { GetCompositeScheduleResponseOcpp16Handler } from '@handlers/index.js';
+import { createTestContainer } from '@test/testContainer.js';
+
+/**
+ * OCPP 1.6 Edition 2, GetCompositeSchedule.conf: `scheduleStart` is a field of the response, not of
+ * the schedule inside it - "Time. Periods contained in the charging profile are relative to this
+ * point in time. If status is 'Rejected', this field may be absent."
+ */
+const SCHEDULE_START = '2026-08-27T09:00:00.000Z';
+const SCHEDULE_OWN_START = '2026-08-27T08:00:00.000Z';
+
+function makeMessage<T extends OcppResponse>(payload: T): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: 'station-001',
+      correlationId: 'corr-001',
+      timestamp: new Date().toISOString(),
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.SmartCharging,
+    action: OCPP_CallAction.GetCompositeSchedule,
+    state: MessageState.Response,
+    protocol: OCPPVersion.OCPP1_6,
+  } as unknown as IMessage<T>;
+}
+
+function aResponse(
+  overrides: Partial<OCPP1_6.GetCompositeScheduleResponse> = {},
+): OCPP1_6.GetCompositeScheduleResponse {
+  return {
+    status: OCPP1_6.GetCompositeScheduleResponseStatus.Accepted,
+    connectorId: 1,
+    scheduleStart: SCHEDULE_START,
+    chargingSchedule: {
+      duration: 3600,
+      chargingRateUnit: OCPP1_6.GetCompositeScheduleResponseChargingRateUnit.A,
+      chargingSchedulePeriod: [{ startPeriod: 0, limit: 16 }],
+    },
+    ...overrides,
+  } as OCPP1_6.GetCompositeScheduleResponse;
+}
+
+describe('GetCompositeScheduleResponseOcpp16Handler', () => {
+  let handler: GetCompositeScheduleResponseOcpp16Handler;
+  let createCompositeSchedule: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const { logger } = createTestContainer();
+    createCompositeSchedule = vi.fn().mockResolvedValue({ id: 1 });
+    handler = new GetCompositeScheduleResponseOcpp16Handler({
+      logger,
+      chargingProfileRepository: {
+        createCompositeSchedule,
+      } as unknown as IChargingProfileRepository,
+    });
+  });
+
+  async function storedSchedule(response: OCPP1_6.GetCompositeScheduleResponse) {
+    await handler.handle(makeMessage(response));
+    return createCompositeSchedule.mock.calls[0]?.[1];
+  }
+
+  it('anchors the periods at the scheduleStart the station reported', async () => {
+    const stored = await storedSchedule(aResponse());
+
+    expect(stored.scheduleStart).toBe(SCHEDULE_START);
+  });
+
+  it('prefers the response scheduleStart over the schedule own startSchedule', async () => {
+    const stored = await storedSchedule(
+      aResponse({
+        chargingSchedule: {
+          duration: 3600,
+          startSchedule: SCHEDULE_OWN_START,
+          chargingRateUnit: OCPP1_6.GetCompositeScheduleResponseChargingRateUnit.A,
+          chargingSchedulePeriod: [{ startPeriod: 0, limit: 16 }],
+        },
+      } as Partial<OCPP1_6.GetCompositeScheduleResponse>),
+    );
+
+    expect(stored.scheduleStart).toBe(SCHEDULE_START);
+  });
+
+  it('falls back to the schedule own startSchedule when the response carries none', async () => {
+    const stored = await storedSchedule(
+      aResponse({
+        scheduleStart: undefined,
+        chargingSchedule: {
+          duration: 3600,
+          startSchedule: SCHEDULE_OWN_START,
+          chargingRateUnit: OCPP1_6.GetCompositeScheduleResponseChargingRateUnit.A,
+          chargingSchedulePeriod: [{ startPeriod: 0, limit: 16 }],
+        },
+      } as Partial<OCPP1_6.GetCompositeScheduleResponse>),
+    );
+
+    expect(stored.scheduleStart).toBe(SCHEDULE_OWN_START);
+  });
+
+  it('stores nothing when the station rejected the request', async () => {
+    await handler.handle(
+      makeMessage(
+        aResponse({
+          status: OCPP1_6.GetCompositeScheduleResponseStatus.Rejected,
+          scheduleStart: undefined,
+          chargingSchedule: undefined,
+        } as Partial<OCPP1_6.GetCompositeScheduleResponse>),
+      ),
+    );
+
+    expect(createCompositeSchedule).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
A composite schedule read back from a 1.6 station is stored against the wrong point in time, so every
period in it is offset by however long the response took to arrive.

### The field

OCPP 1.6 Edition 2, `GetCompositeSchedule.conf`:

| field | card. | description |
|---|---|---|
| `status` | 1..1 | Required. |
| `connectorId` | 0..1 | Optional. The charging schedule contained in this notification applies to a Connector. |
| `scheduleStart` | 0..1 | Optional. Time. **Periods contained in the charging profile are relative to this point in time.** If status is "Rejected", this field may be absent. |
| `chargingSchedule` | 0..1 | Optional. |

`scheduleStart` is a field of the *response*, and it is the one the spec names as the anchor for the
periods. `ChargingSchedule` has its own optional `startSchedule`, but that is the schedule's start,
not the composite's.

### What the handler does

```ts
scheduleStart: response.chargingSchedule.startSchedule ?? new Date().toISOString(),
```

`response.scheduleStart` is never read. A station that answers the way the spec describes - the
composite anchored by `scheduleStart`, and no `startSchedule` inside a schedule that was computed
rather than configured - lands on the `new Date()` fallback, so the schedule is stored as starting at
the moment the CallResult happened to be processed.

§4.9 of the same document says the Charge Point calculates the intervals "from the moment the request
PDU is received: Time X, up to X + Duration", so the gap is the request/response round trip plus any
queueing on either side - small in a lab, not small on a congested link or when the CSMS is catching
up on a backlog. Every `startPeriod` offset is wrong by that amount, in the direction of the schedule
appearing to start later than it does.

### The change

Read `response.scheduleStart` first, keep `chargingSchedule.startSchedule` as the fallback for a
station that only sends that, and keep the current time as the last resort so nothing that works
today stops working.

`GetCompositeScheduleResponseOcpp16Handler` had no test file; the new one covers the three sources in
order and that a `Rejected` response still stores nothing.

Full workspace suite: 97 files, 2046 tests passing, 6 skipped. Docker was available so the
testcontainers-backed suites ran too; the one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`).
