### PR TITLE
fix(core): assume Local when a 1.6 StopTransaction omits the reason

### DIFF
--- a/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.ts
@@ -124,7 +124,11 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
       return;
     }
 
-    const stoppedReason = request.reason || (request.idTag ? 'Remote' : 'Local');
+    // 4.10: "If a transaction is ended in a normal way (e.g. EV-driver presented his
+    // identification to stop the transaction), the Reason element MAY be omitted and the Reason
+    // SHOULD be assumed 'Local'." The example is the case where an idTag is present, so an omitted
+    // reason is Local either way.
+    const stoppedReason = request.reason ?? OCPP1_6.StopTransactionRequestReason.Local;
 
     const stopTransaction = await this._transactionEventRepository.createStopTransaction(
       tenantId,

--- a/packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/requests/1.6/StopTransactionRequestOcpp16Handler.test.ts
@@ -140,6 +140,17 @@ describe('StopTransactionRequestOcpp16Handler', () => {
     expect((transaction as unknown as { stoppedReason?: string }).stoppedReason).toBe(derived);
   });
 
+  it('derives Local as the stop reason when the driver presented an identification', async () => {
+    const transaction = aTransaction(true);
+    const { handler } = makeHandler(transaction);
+
+    await handler.handle(makeMessage({ ...request, reason: undefined }));
+
+    // 4.10 gives "EV-driver presented his identification to stop the transaction" as its own
+    // example of the omitted-reason case, so an idTag is not evidence of a remote stop.
+    expect((transaction as unknown as { stoppedReason?: string }).stoppedReason).toBe('Local');
+  });
+
   it('derives Local as the stop reason when no idTag was presented', async () => {
     const transaction = aTransaction(true);
     const { handler } = makeHandler(transaction);


### PR DESCRIPTION
A driver who taps their card to stop a 1.6 transaction has it recorded as stopped **remotely**, and
the transaction row keeps no stop reason at all.

### The rule

OCPP 1.6 Edition 2, §4.10 *Stop Transaction*:

> If a transaction is ended in a normal way (e.g. EV-driver presented his identification to stop the
> transaction), the Reason element MAY be omitted and the Reason SHOULD be assumed **'Local'**. If
> the transaction is not ended normally, the Reason SHOULD be set to a correct value.

The example the spec chooses - the driver presenting their identification - is exactly the case where
`idTag` is present. An omitted reason means `Local` whether or not the driver identified themselves;
it is the *omission* that carries the meaning, because a station that stopped for any other cause is
told to say so.

### What the handler does

```ts
request.reason || (request.idTag ? 'Remote' : 'Local'),
```

An `idTag` is read as evidence of a remote stop, which inverts the spec's own example. `Remote` in
1.6 means the CSMS asked for it with a `RemoteStopTransaction.req`, so a card tap is recorded as
something the operator did.

A second line down:

```ts
transaction.stoppedReason = request.reason;
```

The default never reaches the `Transaction` row - only the `StopTransaction` row gets it - so the two
records of the same event disagree, and the transaction is left with no reason at all whenever the
station omitted one. `Transaction.stoppedReason` is what the OCPI Sessions and CDRs queries read
(`transaction.queries.ts`), so that is the value a roaming partner sees.

### The change

One `stoppedReason` computed once, defaulting to `Local`, used for both rows. A reason the station
*did* send is untouched.

`StopTransactionRequestOcpp16Handler` had no test file; the new one covers both omitted cases, the
transaction row, and that an explicit reason still wins.

Full workspace suite: 97 files, 2046 tests passing, 6 skipped. Docker was available so the
testcontainers-backed suites ran too; the one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`).
