### PR TITLE
fix(types): accept both spellings of the 1.6 temperature unit

### DIFF
--- a/packages/base/test/modules/ocpp16UnitOfMeasure.test.ts
+++ b/packages/base/test/modules/ocpp16UnitOfMeasure.test.ts
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import { OCPPValidator } from '@interfaces/modules/OCPPValidator.js';
+
+/**
+ * OCPP-J 1.6 errata, "(2025-04) - MeterValues.json and StopTransaction.json incorrect spelling of
+ * Celsius V2", summary:
+ *
+ *   1. The JSON schema StopTransaction.req is updated to also include the corrected spelling
+ *      Celsius.
+ *   2. Charge Point implementers are advised to remain using the not corrected version of the
+ *      spelling; Celcius.
+ *   3. Central System implementers are advised to use the updated JSON schema for their JSON schema
+ *      validation and accept both spellings; Celsius and Celcius.
+ *
+ * So a CSMS has to take both, and the misspelling is the one stations are told to keep sending.
+ */
+const SPELLINGS = ['Celcius', 'Celsius'];
+
+describe('OCPP 1.6 temperature unit spelling', () => {
+  const validator = new OCPPValidator();
+
+  function aSampledValue(unit: string) {
+    return {
+      value: '21.5',
+      measurand: 'Temperature',
+      unit,
+    };
+  }
+
+  it.each(SPELLINGS)('accepts %s in MeterValues', (unit) => {
+    const result = validator.validateOCPPRequest(
+      OCPP_CallAction.MeterValues,
+      {
+        connectorId: 1,
+        meterValue: [
+          { timestamp: '2026-08-27T10:00:00.000Z', sampledValue: [aSampledValue(unit)] },
+        ],
+      },
+      OCPPVersion.OCPP1_6,
+    );
+
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.isValid).toBe(true);
+  });
+
+  it.each(SPELLINGS)('accepts %s in StopTransaction transactionData', (unit) => {
+    const result = validator.validateOCPPRequest(
+      OCPP_CallAction.StopTransaction,
+      {
+        transactionId: 1,
+        meterStop: 5000,
+        timestamp: '2026-08-27T10:00:00.000Z',
+        transactionData: [
+          { timestamp: '2026-08-27T10:00:00.000Z', sampledValue: [aSampledValue(unit)] },
+        ],
+      },
+      OCPPVersion.OCPP1_6,
+    );
+
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/packages/types/src/ocpp/model/1.6/schemas/StopTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StopTransactionRequest.json
@@ -210,6 +210,7 @@
         "A",
         "V",
         "K",
+        "Celcius",
         "Celsius",
         "Fahrenheit",
         "Percent"


### PR DESCRIPTION
A 1.6 station that reports a temperature in its `StopTransaction` has the whole message rejected with
a `FormationViolation`, if it spells the unit the way OCPP tells it to.

### The erratum

OCPP-J 1.6 errata, **"(2025-04) - MeterValues.json and StopTransaction.json incorrect spelling of
Celsius V2"** - the OCA's second pass at a typo in the original schemas, which spelled the unit
`Celcius`. The summary is explicit about who does what:

> 1. The JSON schema StopTransaction.req is updated to also include the corrected spelling Celsius.
> 2. Charge Point implementers are advised to **remain using the not corrected version of the
>    spelling; Celcius**.
> 3. Central System implementers are advised to use the updated JSON schema for their JSON schema
>    validation and **accept both spellings; Celsius and Celcius**.

and the reasoning above it:

> Updating the JSON schemas so they contain both spellings is the correct decision, because the main
> purpose of the JSON schemas is that they are being used for JSON Schema validation. In this case we
> always want to allow both spellings, to maximize interoperability.

So the misspelling is not a legacy quirk to be tolerated - it is the spelling stations are told to
send.

### What this repo has

| schema | `Celcius` | `Celsius` |
|---|---|---|
| published `MeterValues.json` | yes | yes |
| published `StopTransaction.json` | yes | yes |
| `MeterValuesRequest.json` here | yes | yes |
| `StopTransactionRequest.json` here | **no** | yes |

One file lost it. `OcppRouter._onCall` validates inbound messages against these schemas and throws
`FormatViolation` on failure, so a station that reports temperature happily sends `MeterValues` all
transaction long and then has its `StopTransaction` refused - and a refused `StopTransaction` is the
one message a station will retry indefinitely, because it never gets its `.conf`. The transaction
never closes.

Restoring the value makes the enum identical to the published schema, which the test asserts by
validating both spellings through `OCPPValidator` on both messages.

Full workspace suite: 97 files, 2046 tests passing, 6 skipped. Docker was available so the
testcontainers-backed suites ran too; the one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`).
