### PR TITLE
fix(core): do not sweep the connector after a refused 1.6 StartTransaction

### DIFF
--- a/packages/core/src/handlers/requests/1.6/StartTransactionRequestOcpp16Handler.ts
+++ b/packages/core/src/handlers/requests/1.6/StartTransactionRequestOcpp16Handler.ts
@@ -94,12 +94,18 @@ export class StartTransactionRequestOcpp16Handler extends AbstractHandler {
       await this._ocppSender.sendCallResultWithMessage(message, response);
     }
 
-    await this.deactivateOtherActiveTransactionsAtEvse16(
-      tenantId,
-      response.transactionId.toString(),
-      ocppConnectionName,
-      request,
-    );
+    // Only sweep the connector once a transaction has actually taken it. The sweep closes every
+    // active transaction on the connector except the new one, and a refused StartTransaction has no
+    // new one - authorizeOcpp16IdToken leaves transactionId at 0 - so the exclusion would match
+    // nothing and the transaction that is genuinely charging would be closed.
+    if (response.idTagInfo.status === OCPP1_6.StartTransactionResponseStatus.Accepted) {
+      await this.deactivateOtherActiveTransactionsAtEvse16(
+        tenantId,
+        response.transactionId.toString(),
+        ocppConnectionName,
+        request,
+      );
+    }
 
     // Deactivate reservation only if the transaction was accepted.
     // A rejected StartTransaction (auth failure or DB error) should not

--- a/packages/core/test/handlers/requests/1.6/StartTransactionRequestOcpp16Handler.test.ts
+++ b/packages/core/test/handlers/requests/1.6/StartTransactionRequestOcpp16Handler.test.ts
@@ -63,6 +63,8 @@ function makeHandler(
   const transactionService = {
     authorizeOcpp16IdToken: vi.fn().mockResolvedValue({
       idTagInfo: { status: OCPP1_6.StartTransactionResponseStatus.Accepted },
+      // authorizeOcpp16IdToken seeds every response with 0 and only the accepted path replaces it.
+      transactionId: 0,
     }),
     deactivateReservation: vi.fn().mockResolvedValue(undefined),
     deactivateOtherActiveTransactionsAtEvse: vi.fn().mockResolvedValue(undefined),
@@ -128,6 +130,79 @@ describe('StartTransactionRequestOcpp16Handler', () => {
       );
 
       expect(transactionService.deactivateOtherActiveTransactionsAtEvse).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The point of the sweep is that a *new* transaction has taken the connector, so anything still
+     * marked active there is stale. A StartTransaction the CSMS refused starts nothing, and
+     * authorizeOcpp16IdToken seeds the response with transactionId 0, so the "exclude the new
+     * transaction" filter matches nothing and every live transaction on that connector is closed -
+     * including the one that is actually charging.
+     */
+    it('does not sweep the connector when the idTag was refused', async () => {
+      const { handler, transactionService } = makeHandler({
+        transactionService: {
+          authorizeOcpp16IdToken: vi.fn().mockResolvedValue({
+            idTagInfo: { status: OCPP1_6.StartTransactionResponseStatus.Invalid },
+            transactionId: 0,
+          }),
+        },
+      });
+
+      await handler.handle(
+        makeMessage({
+          connectorId: 1,
+          idTag: 'UNKNOWN',
+          meterStart: 0,
+          timestamp: new Date().toISOString(),
+        } as OCPP1_6.StartTransactionRequest),
+      );
+
+      expect(transactionService.deactivateOtherActiveTransactionsAtEvse).not.toHaveBeenCalled();
+    });
+
+    it('does not sweep the connector when the transaction could not be created', async () => {
+      const { handler, transactionService } = makeHandler({
+        transactionEventRepository: {
+          createTransactionByStartTransaction: vi
+            .fn()
+            .mockRejectedValue(new Error('Charging station station-001 does not exist')),
+        },
+      });
+
+      await handler.handle(
+        makeMessage({
+          connectorId: 1,
+          idTag: 'TAG001',
+          meterStart: 0,
+          timestamp: new Date().toISOString(),
+        } as OCPP1_6.StartTransactionRequest),
+      );
+
+      expect(transactionService.deactivateOtherActiveTransactionsAtEvse).not.toHaveBeenCalled();
+    });
+
+    it('does not consume a reservation when the idTag was refused', async () => {
+      const { handler, transactionService } = makeHandler({
+        transactionService: {
+          authorizeOcpp16IdToken: vi.fn().mockResolvedValue({
+            idTagInfo: { status: OCPP1_6.StartTransactionResponseStatus.Invalid },
+            transactionId: 0,
+          }),
+        },
+      });
+
+      await handler.handle(
+        makeMessage({
+          connectorId: 1,
+          idTag: 'UNKNOWN',
+          meterStart: 0,
+          reservationId: 5,
+          timestamp: new Date().toISOString(),
+        } as OCPP1_6.StartTransactionRequest),
+      );
+
+      expect(transactionService.deactivateReservation).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
A 1.6 `StartTransaction` the CSMS **refuses** closes the transaction that is charging on that
connector.

### The mechanism

`StartTransactionRequestOcpp16Handler` ends with an unconditional sweep:

```ts
await this.deactivateOtherActiveTransactionsAtEvse16(
  tenantId,
  response.transactionId.toString(),
  ocppConnectionName,
  request,
);
```

which reaches `deactivateActiveTransactionsByStationIdAndEvseId`:

```ts
where: {
  ocppConnectionName,
  isActive: true,
  transactionId: { [Op.ne]: excludeTransactionId },
},
include: [{ model: Evse, where: { evseTypeId: evseId }, required: true }],
```

Every active transaction on that EVSE except the one just started is marked inactive. That is the
right thing to do *when a transaction was just started* - it clears a stale row the CSMS still thinks
is live.

But the sweep runs on every path. `TransactionService.authorizeOcpp16IdToken` seeds its response with

```ts
transactionId: 0, // default zero for rejected transaction
```

and only the accepted path replaces it. So when the idTag is refused, `excludeTransactionId` is
`"0"`, which excludes nothing, and the transaction genuinely charging on that connector is closed.
The same happens when the idTag is accepted but `createTransactionByStartTransaction` throws - the
handler sets the status to `Invalid` and leaves `transactionId` at 0.

### What that costs

The CSMS stops treating the live session as active. The `StopTransaction` that eventually arrives
finds `isActive` already false, the session ends with whatever `meterStop` arithmetic that path does,
and anything downstream reading `isActive` - the OCPI Sessions query, the operator UI's start/stop
controls - has already written the session off.

Reaching it takes a second `StartTransaction` on an occupied connector with an idTag the CSMS
refuses. A charge point should not do that, but this is exactly the sort of thing the sweep exists to
tidy up after, and a refused authorization is a perfectly ordinary event - an unknown card presented
at a busy connector is enough.

### The change

The sweep runs only when the status is `Accepted`, which is the only path that has a new transaction
to exclude. The reservation just below it is already guarded that way, with a comment giving the same
reasoning, so this brings the two into line.

Three tests added to the existing file: refused idTag, transaction-creation failure, and the
reservation case that already behaved. One fixture correction came with them - the mocked
`authorizeOcpp16IdToken` did not return the `transactionId: 0` the real one always sets, which is why
the existing tests never saw this.

Full workspace suite: 96 files, 2045 tests passing, 6 skipped. Docker was available so the
testcontainers-backed suites ran too; the one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`).
