### PR TITLE
fix(types): close the OCPP 1.6 schema classes

### DIFF
--- a/packages/base/test/modules/ocpp16AdditionalProperties.test.ts
+++ b/packages/base/test/modules/ocpp16AdditionalProperties.test.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPP1_6_CALL_RESULT_SCHEMA_RECORD, OCPP1_6_CALL_SCHEMA_RECORD } from '../../index.js';
+import { OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import { OCPPValidator } from '@interfaces/modules/OCPPValidator.js';
+
+/**
+ * OCPP-J 1.6 errata, §3.2 "JSON Schema files do allow for extra fields within inner objects":
+ *
+ *   "It is not allowed to add extra fields/values to OCPP messages, this could cause
+ *    interoperability issues in the field. The WSDL files are correct, the original JSON Schema
+ *    files allow extra fields on inner objects and extra values on enums, which was not intended.
+ *    Most of the JSON Schema files have been updated to fix this. The line: "additionalProperties":
+ *    false has been added to the definition of all object and enum definitions."
+ *
+ * Unlike OCPP 2.x there is no customData extension point in 1.6, so a class is simply closed.
+ */
+type Schema = Record<string, unknown>;
+
+function walk(node: unknown, path: string, visit: (node: Schema, path: string) => void): void {
+  if (Array.isArray(node)) {
+    node.forEach((child, i) => walk(child, `${path}[${i}]`, visit));
+    return;
+  }
+  if (node === null || typeof node !== 'object') {
+    return;
+  }
+  const schema = node as Schema;
+  if (schema.type === 'object') {
+    visit(schema, path);
+  }
+  for (const [key, value] of Object.entries(schema)) {
+    walk(value, `${path}.${key}`, visit);
+  }
+}
+
+function openObjects(schema: Schema, name: string): string[] {
+  const open: string[] = [];
+  walk(schema, name, (node, path) => {
+    if (node.additionalProperties !== false) {
+      open.push(`${path} (additionalProperties: ${JSON.stringify(node.additionalProperties)})`);
+    }
+  });
+  return open;
+}
+
+describe('OCPP 1.6 schemas are closed', () => {
+  const records: [string, Record<string, object>][] = [
+    ['call', OCPP1_6_CALL_SCHEMA_RECORD],
+    ['call result', OCPP1_6_CALL_RESULT_SCHEMA_RECORD],
+  ];
+
+  for (const [label, record] of records) {
+    it(`every ${label} schema closes every class`, () => {
+      const open = Object.entries(record).flatMap(([action, schema]) =>
+        openObjects(schema as Schema, action),
+      );
+
+      expect(open).toEqual([]);
+    });
+  }
+
+  it('refuses a property the message definition does not have', () => {
+    const result = new OCPPValidator().validateOCPPRequest(
+      OCPP_CallAction.Authorize,
+      { idTag: 'TAG01', notAField: 1 },
+      OCPPVersion.OCPP1_6,
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  it('refuses a property inside an inner object, which is what the erratum is about', () => {
+    const result = new OCPPValidator().validateOCPPRequest(
+      OCPP_CallAction.MeterValues,
+      {
+        connectorId: 1,
+        meterValue: [
+          {
+            timestamp: '2026-08-27T10:00:00.000Z',
+            sampledValue: [{ value: '1', notAField: 1 }],
+          },
+        ],
+      },
+      OCPPVersion.OCPP1_6,
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  it('still accepts a message that only uses fields the definition has', () => {
+    const result = new OCPPValidator().validateOCPPRequest(
+      OCPP_CallAction.Authorize,
+      { idTag: 'TAG01' },
+      OCPPVersion.OCPP1_6,
+    );
+
+    expect(result.errors ?? []).toEqual([]);
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/packages/types/src/ocpp/model/1.6/schemas/AuthorizeRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/AuthorizeRequest.json
@@ -7,7 +7,7 @@
       "maxLength": 20
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["idTag"],
   "$id": "AuthorizeRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/AuthorizeResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/AuthorizeResponse.json
@@ -17,17 +17,17 @@
           "$ref": "#/definitions/AuthorizeResponseStatus"
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": ["status"]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["idTagInfo"],
   "$id": "AuthorizeResponse",
   "definitions": {
     "AuthorizeResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"],
       "tsEnumNames": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/BootNotificationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/BootNotificationRequest.json
@@ -39,7 +39,7 @@
       "maxLength": 25
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["chargePointVendor", "chargePointModel"],
   "$id": "BootNotificationRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/BootNotificationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/BootNotificationResponse.json
@@ -13,13 +13,13 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status", "currentTime", "interval"],
   "$id": "BootNotificationResponse",
   "definitions": {
     "BootNotificationResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Pending", "Rejected"],
       "tsEnumNames": ["Accepted", "Pending", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/CancelReservationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/CancelReservationRequest.json
@@ -6,7 +6,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["reservationId"],
   "$id": "CancelReservationRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/CancelReservationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/CancelReservationResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/CancelReservationResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "CancelReservationResponse",
   "definitions": {
     "CancelReservationResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ChangeAvailabilityRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ChangeAvailabilityRequest.json
@@ -9,13 +9,13 @@
       "$ref": "#/definitions/ChangeAvailabilityRequestType"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "type"],
   "$id": "ChangeAvailabilityRequest",
   "definitions": {
     "ChangeAvailabilityRequestType": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Inoperative", "Operative"],
       "tsEnumNames": ["Inoperative", "Operative"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ChangeAvailabilityResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ChangeAvailabilityResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ChangeAvailabilityResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ChangeAvailabilityResponse",
   "definitions": {
     "ChangeAvailabilityResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "Scheduled"],
       "tsEnumNames": ["Accepted", "Rejected", "Scheduled"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ChangeConfigurationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ChangeConfigurationRequest.json
@@ -11,7 +11,7 @@
       "maxLength": 500
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["key", "value"],
   "$id": "ChangeConfigurationRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/ChangeConfigurationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ChangeConfigurationResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ChangeConfigurationResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ChangeConfigurationResponse",
   "definitions": {
     "ChangeConfigurationResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "RebootRequired", "NotSupported"],
       "tsEnumNames": ["Accepted", "Rejected", "RebootRequired", "NotSupported"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ClearCacheRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ClearCacheRequest.json
@@ -2,7 +2,7 @@
   "title": "ClearCacheRequest",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "ClearCacheRequest",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/ClearCacheResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ClearCacheResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ClearCacheResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ClearCacheResponse",
   "definitions": {
     "ClearCacheResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ClearChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ClearChargingProfileRequest.json
@@ -15,12 +15,12 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "ClearChargingProfileRequest",
   "definitions": {
     "ClearChargingProfileRequestChargingProfilePurpose": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"],
       "tsEnumNames": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ClearChargingProfileResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ClearChargingProfileResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ClearChargingProfileResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ClearChargingProfileResponse",
   "definitions": {
     "ClearChargingProfileResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Unknown"],
       "tsEnumNames": ["Accepted", "Unknown"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/DataTransferRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/DataTransferRequest.json
@@ -14,7 +14,7 @@
       "type": "string"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["vendorId"],
   "$id": "DataTransferRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/DataTransferResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/DataTransferResponse.json
@@ -9,13 +9,13 @@
       "type": "string"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "DataTransferResponse",
   "definitions": {
     "DataTransferResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "UnknownMessageId", "UnknownVendorId"],
       "tsEnumNames": ["Accepted", "Rejected", "UnknownMessageId", "UnknownVendorId"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/DiagnosticsStatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/DiagnosticsStatusNotificationRequest.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/DiagnosticsStatusNotificationRequestStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "DiagnosticsStatusNotificationRequest",
   "definitions": {
     "DiagnosticsStatusNotificationRequestStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Idle", "Uploaded", "UploadFailed", "Uploading"],
       "tsEnumNames": ["Idle", "Uploaded", "UploadFailed", "Uploading"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/DiagnosticsStatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/DiagnosticsStatusNotificationResponse.json
@@ -2,7 +2,7 @@
   "title": "DiagnosticsStatusNotificationResponse",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "DiagnosticsStatusNotificationResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/FirmwareStatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/FirmwareStatusNotificationRequest.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/FirmwareStatusNotificationRequestStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "FirmwareStatusNotificationRequest",
   "definitions": {
     "FirmwareStatusNotificationRequestStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Downloaded",
         "DownloadFailed",

--- a/packages/types/src/ocpp/model/1.6/schemas/FirmwareStatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/FirmwareStatusNotificationResponse.json
@@ -2,7 +2,7 @@
   "title": "FirmwareStatusNotificationResponse",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "FirmwareStatusNotificationResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleRequest.json
@@ -12,13 +12,13 @@
       "$ref": "#/definitions/GetCompositeScheduleRequestChargingRateUnit"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "duration"],
   "$id": "GetCompositeScheduleRequest",
   "definitions": {
     "GetCompositeScheduleRequestChargingRateUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["A", "W"],
       "tsEnumNames": ["A", "W"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetCompositeScheduleResponse.json
@@ -41,7 +41,7 @@
                 "type": "integer"
               }
             },
-            "additionalProperties": true,
+            "additionalProperties": false,
             "required": ["startPeriod", "limit"]
           }
         },
@@ -50,23 +50,23 @@
           "multipleOf": 0.1
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": ["chargingRateUnit", "chargingSchedulePeriod"]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "GetCompositeScheduleResponse",
   "definitions": {
     "GetCompositeScheduleResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     },
     "GetCompositeScheduleResponseChargingRateUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["A", "W"],
       "tsEnumNames": ["A", "W"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetConfigurationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetConfigurationRequest.json
@@ -10,7 +10,7 @@
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "GetConfigurationRequest",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetConfigurationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetConfigurationResponse.json
@@ -19,7 +19,7 @@
             "maxLength": 500
           }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": ["key", "readonly"]
       }
     },
@@ -31,7 +31,7 @@
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "GetConfigurationResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetDiagnosticsRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetDiagnosticsRequest.json
@@ -21,7 +21,7 @@
       "format": "date-time"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["location"],
   "$id": "GetDiagnosticsRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/GetDiagnosticsResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetDiagnosticsResponse.json
@@ -7,7 +7,7 @@
       "maxLength": 255
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "GetDiagnosticsResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetLocalListVersionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetLocalListVersionRequest.json
@@ -2,7 +2,7 @@
   "title": "GetLocalListVersionRequest",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "GetLocalListVersionRequest",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/GetLocalListVersionResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/GetLocalListVersionResponse.json
@@ -6,7 +6,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["listVersion"],
   "$id": "GetLocalListVersionResponse",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/HeartbeatRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/HeartbeatRequest.json
@@ -2,7 +2,7 @@
   "title": "HeartbeatRequest",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "HeartbeatRequest",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/HeartbeatResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/HeartbeatResponse.json
@@ -7,7 +7,7 @@
       "format": "date-time"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["currentTime"],
   "$id": "HeartbeatResponse",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/MeterValuesRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/MeterValuesRequest.json
@@ -44,23 +44,23 @@
                   "$ref": "#/definitions/MeterValuesRequestUnit"
                 }
               },
-              "additionalProperties": true,
+              "additionalProperties": false,
               "required": ["value"]
             }
           }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": ["timestamp", "sampledValue"]
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "meterValue"],
   "$id": "MeterValuesRequest",
   "definitions": {
     "MeterValuesRequestContext": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Interruption.Begin",
         "Interruption.End",
@@ -84,13 +84,13 @@
     },
     "MeterValuesRequestFormat": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Raw", "SignedData"],
       "tsEnumNames": ["Raw", "SignedData"]
     },
     "MeterValuesRequestMeasurand": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Energy.Active.Export.Register",
         "Energy.Active.Import.Register",
@@ -142,19 +142,19 @@
     },
     "MeterValuesRequestPhase": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["L1", "L2", "L3", "N", "L1-N", "L2-N", "L3-N", "L1-L2", "L2-L3", "L3-L1"],
       "tsEnumNames": ["L1", "L2", "L3", "N", "L1_N", "L2_N", "L3_N", "L1_L2", "L2_L3", "L3_L1"]
     },
     "MeterValuesRequestLocation": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Cable", "EV", "Inlet", "Outlet", "Body"],
       "tsEnumNames": ["Cable", "EV", "Inlet", "Outlet", "Body"]
     },
     "MeterValuesRequestUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Wh",
         "kWh",

--- a/packages/types/src/ocpp/model/1.6/schemas/MeterValuesResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/MeterValuesResponse.json
@@ -2,7 +2,7 @@
   "title": "MeterValuesResponse",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "MeterValuesResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionRequest.json
@@ -67,7 +67,7 @@
                     "type": "integer"
                   }
                 },
-                "additionalProperties": true,
+                "additionalProperties": false,
                 "required": ["startPeriod", "limit"]
               }
             },
@@ -76,11 +76,11 @@
               "multipleOf": 0.1
             }
           },
-          "additionalProperties": true,
+          "additionalProperties": false,
           "required": ["chargingRateUnit", "chargingSchedulePeriod"]
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
         "chargingProfileId",
         "stackLevel",
@@ -90,31 +90,31 @@
       ]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["idTag"],
   "$id": "RemoteStartTransactionRequest",
   "definitions": {
     "RemoteStartTransactionRequestChargingProfilePurpose": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"],
       "tsEnumNames": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"]
     },
     "RemoteStartTransactionRequestChargingProfileKind": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Absolute", "Recurring", "Relative"],
       "tsEnumNames": ["Absolute", "Recurring", "Relative"]
     },
     "RemoteStartTransactionRequestRecurrencyKind": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Daily", "Weekly"],
       "tsEnumNames": ["Daily", "Weekly"]
     },
     "RemoteStartTransactionRequestChargingRateUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["A", "W"],
       "tsEnumNames": ["A", "W"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/RemoteStartTransactionResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/RemoteStartTransactionResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "RemoteStartTransactionResponse",
   "definitions": {
     "RemoteStartTransactionResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/RemoteStopTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/RemoteStopTransactionRequest.json
@@ -6,7 +6,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["transactionId"],
   "$id": "RemoteStopTransactionRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/RemoteStopTransactionResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/RemoteStopTransactionResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/RemoteStopTransactionResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "RemoteStopTransactionResponse",
   "definitions": {
     "RemoteStopTransactionResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ReserveNowRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ReserveNowRequest.json
@@ -21,7 +21,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "expiryDate", "idTag", "reservationId"],
   "$id": "ReserveNowRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/ReserveNowResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ReserveNowResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ReserveNowResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ReserveNowResponse",
   "definitions": {
     "ReserveNowResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Faulted", "Occupied", "Rejected", "Unavailable"],
       "tsEnumNames": ["Accepted", "Faulted", "Occupied", "Rejected", "Unavailable"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ResetRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ResetRequest.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ResetRequestType"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["type"],
   "$id": "ResetRequest",
   "definitions": {
     "ResetRequestType": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Hard", "Soft"],
       "tsEnumNames": ["Hard", "Soft"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/ResetResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/ResetResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/ResetResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "ResetResponse",
   "definitions": {
     "ResetResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected"],
       "tsEnumNames": ["Accepted", "Rejected"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/SendLocalListRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/SendLocalListRequest.json
@@ -29,11 +29,11 @@
                 "$ref": "#/definitions/SendLocalListRequestStatus"
               }
             },
-            "additionalProperties": true,
+            "additionalProperties": false,
             "required": ["status"]
           }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": ["idTag"]
       }
     },
@@ -41,19 +41,19 @@
       "$ref": "#/definitions/SendLocalListRequestUpdateType"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["listVersion", "updateType"],
   "$id": "SendLocalListRequest",
   "definitions": {
     "SendLocalListRequestStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"],
       "tsEnumNames": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"]
     },
     "SendLocalListRequestUpdateType": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Differential", "Full"],
       "tsEnumNames": ["Differential", "Full"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/SendLocalListResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/SendLocalListResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/SendLocalListResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "SendLocalListResponse",
   "definitions": {
     "SendLocalListResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Failed", "NotSupported", "VersionMismatch"],
       "tsEnumNames": ["Accepted", "Failed", "NotSupported", "VersionMismatch"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileRequest.json
@@ -63,7 +63,7 @@
                     "type": "integer"
                   }
                 },
-                "additionalProperties": true,
+                "additionalProperties": false,
                 "required": ["startPeriod", "limit"]
               }
             },
@@ -72,11 +72,11 @@
               "multipleOf": 0.1
             }
           },
-          "additionalProperties": true,
+          "additionalProperties": false,
           "required": ["chargingRateUnit", "chargingSchedulePeriod"]
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": [
         "chargingProfileId",
         "stackLevel",
@@ -86,31 +86,31 @@
       ]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "csChargingProfiles"],
   "$id": "SetChargingProfileRequest",
   "definitions": {
     "SetChargingProfileRequestChargingProfilePurpose": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"],
       "tsEnumNames": ["ChargePointMaxProfile", "TxDefaultProfile", "TxProfile"]
     },
     "SetChargingProfileRequestChargingProfileKind": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Absolute", "Recurring", "Relative"],
       "tsEnumNames": ["Absolute", "Recurring", "Relative"]
     },
     "SetChargingProfileRequestRecurrencyKind": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Daily", "Weekly"],
       "tsEnumNames": ["Daily", "Weekly"]
     },
     "SetChargingProfileRequestChargingRateUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["A", "W"],
       "tsEnumNames": ["A", "W"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/SetChargingProfileResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/SetChargingProfileResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "SetChargingProfileResponse",
   "definitions": {
     "SetChargingProfileResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotSupported"],
       "tsEnumNames": ["Accepted", "Rejected", "NotSupported"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/StartTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StartTransactionRequest.json
@@ -20,7 +20,7 @@
       "format": "date-time"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "idTag", "meterStart", "timestamp"],
   "$id": "StartTransactionRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/StartTransactionResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StartTransactionResponse.json
@@ -17,20 +17,20 @@
           "$ref": "#/definitions/StartTransactionResponseStatus"
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": ["status"]
     },
     "transactionId": {
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["idTagInfo", "transactionId"],
   "$id": "StartTransactionResponse",
   "definitions": {
     "StartTransactionResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"],
       "tsEnumNames": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/StatusNotificationRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StatusNotificationRequest.json
@@ -28,13 +28,13 @@
       "maxLength": 50
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId", "errorCode", "status"],
   "$id": "StatusNotificationRequest",
   "definitions": {
     "StatusNotificationRequestErrorCode": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "ConnectorLockFailure",
         "EVCommunicationError",
@@ -74,7 +74,7 @@
     },
     "StatusNotificationRequestStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Available",
         "Preparing",

--- a/packages/types/src/ocpp/model/1.6/schemas/StatusNotificationResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StatusNotificationResponse.json
@@ -2,7 +2,7 @@
   "title": "StatusNotificationResponse",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "StatusNotificationResponse",
   "definitions": {}
 }

--- a/packages/types/src/ocpp/model/1.6/schemas/StopTransactionRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StopTransactionRequest.json
@@ -55,23 +55,23 @@
                   "$ref": "#/definitions/StopTransactionRequestUnit"
                 }
               },
-              "additionalProperties": true,
+              "additionalProperties": false,
               "required": ["value"]
             }
           }
         },
-        "additionalProperties": true,
+        "additionalProperties": false,
         "required": ["timestamp", "sampledValue"]
       }
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["transactionId", "timestamp", "meterStop"],
   "$id": "StopTransactionRequest",
   "definitions": {
     "StopTransactionRequestReason": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "EmergencyStop",
         "EVDisconnected",
@@ -101,7 +101,7 @@
     },
     "StopTransactionRequestContext": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Interruption.Begin",
         "Interruption.End",
@@ -125,13 +125,13 @@
     },
     "StopTransactionRequestFormat": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Raw", "SignedData"],
       "tsEnumNames": ["Raw", "SignedData"]
     },
     "StopTransactionRequestMeasurand": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Energy.Active.Export.Register",
         "Energy.Active.Import.Register",
@@ -183,19 +183,19 @@
     },
     "StopTransactionRequestPhase": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["L1", "L2", "L3", "N", "L1-N", "L2-N", "L3-N", "L1-L2", "L2-L3", "L3-L1"],
       "tsEnumNames": ["L1", "L2", "L3", "N", "L1_N", "L2_N", "L3_N", "L1_L2", "L2_L3", "L3_L1"]
     },
     "StopTransactionRequestLocation": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Cable", "EV", "Inlet", "Outlet", "Body"],
       "tsEnumNames": ["Cable", "EV", "Inlet", "Outlet", "Body"]
     },
     "StopTransactionRequestUnit": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "Wh",
         "kWh",

--- a/packages/types/src/ocpp/model/1.6/schemas/StopTransactionResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/StopTransactionResponse.json
@@ -17,16 +17,16 @@
           "$ref": "#/definitions/StopTransactionResponseStatus"
         }
       },
-      "additionalProperties": true,
+      "additionalProperties": false,
       "required": ["status"]
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "StopTransactionResponse",
   "definitions": {
     "StopTransactionResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"],
       "tsEnumNames": ["Accepted", "Blocked", "Expired", "Invalid", "ConcurrentTx"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/TriggerMessageRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/TriggerMessageRequest.json
@@ -9,13 +9,13 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["requestedMessage"],
   "$id": "TriggerMessageRequest",
   "definitions": {
     "TriggerMessageRequestRequestedMessage": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": [
         "BootNotification",
         "DiagnosticsStatusNotification",

--- a/packages/types/src/ocpp/model/1.6/schemas/TriggerMessageResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/TriggerMessageResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/TriggerMessageResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "TriggerMessageResponse",
   "definitions": {
     "TriggerMessageResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Accepted", "Rejected", "NotImplemented"],
       "tsEnumNames": ["Accepted", "Rejected", "NotImplemented"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/UnlockConnectorRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/UnlockConnectorRequest.json
@@ -6,7 +6,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["connectorId"],
   "$id": "UnlockConnectorRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/UnlockConnectorResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/UnlockConnectorResponse.json
@@ -6,13 +6,13 @@
       "$ref": "#/definitions/UnlockConnectorResponseStatus"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["status"],
   "$id": "UnlockConnectorResponse",
   "definitions": {
     "UnlockConnectorResponseStatus": {
       "type": "string",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "enum": ["Unlocked", "UnlockFailed", "NotSupported"],
       "tsEnumNames": ["Unlocked", "UnlockFailed", "NotSupported"]
     }

--- a/packages/types/src/ocpp/model/1.6/schemas/UpdateFirmwareRequest.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/UpdateFirmwareRequest.json
@@ -17,7 +17,7 @@
       "type": "integer"
     }
   },
-  "additionalProperties": true,
+  "additionalProperties": false,
   "required": ["location", "retrieveDate"],
   "$id": "UpdateFirmwareRequest",
   "definitions": {}

--- a/packages/types/src/ocpp/model/1.6/schemas/UpdateFirmwareResponse.json
+++ b/packages/types/src/ocpp/model/1.6/schemas/UpdateFirmwareResponse.json
@@ -2,7 +2,7 @@
   "title": "UpdateFirmwareResponse",
   "type": "object",
   "properties": {},
-  "additionalProperties": true,
+  "additionalProperties": false,
   "$id": "UpdateFirmwareResponse",
   "definitions": {}
 }


### PR DESCRIPTION
Every object in the OCPP 1.6 schemas here carries `"additionalProperties": true`. The published
schemas say `false` - all 74 of them - and the OCA added that line specifically to fix this, in an
erratum that names the consequence.

### The erratum

OCPP-J 1.6 errata, **§3.2 "JSON Schema files do allow for extra fields within inner objects"**:

> It is not allowed to add extra fields/values to OCPP messages, this could cause interoperability
> issues in the field.
>
> The WSDL files are correct, the original JSON Schema files allow extra fields on inner objects and
> extra values on enums, which was not intended.
>
> Most of the JSON Schema files have been updated to fix this. The line: `"additionalProperties":
> false` has been added to the definition of all object and enum definitions.

So this is not a reading of the schemas - it is a correction the OCA made *to* the schemas, with the
rationale written down. This repo has the pre-erratum behaviour.

### The numbers

| | `additionalProperties: false` | `: true` |
|---|---|---|
| published 1.6 JSON schemas | 74 | 0 |
| this repo, before | 0 | 74 |
| this repo, after | 74 | 0 |

Counted over object types with `$ref`s resolved, across the 56 schemas that have a published
counterpart. The diff is 126 occurrences of one literal replaced by another and nothing else - more
than 74 because the enum definitions carry the keyword too, which is what the erratum means by "all
object **and enum** definitions"; on a `type: string` schema it is inert either way, and it is left
matching the published file rather than singled out.

The four security-extension schemas in the same directory - `SignedUpdateFirmware` and
`SignedFirmwareStatusNotification` - **already** say `false`, so this also makes the 1.6 set
internally consistent: at the moment four files are closed and fifty-six are open.

### What it costs today

`OcppRouter._onCall` and `_onCallResult` validate inbound messages against these schemas, so a
station's message carrying a field that is not in the definition is accepted and then dropped by the
mapper. A misspelt field reads as an absent one rather than an error.

Outbound is worse, because the operator API validates request bodies against the same schemas with
`removeAdditional: 'failing'` - Ajv only strips an additional property when it *causes* a failure,
and with `additionalProperties: true` nothing fails. A stray field in an API call therefore survives
validation, is copied into the OCPP message, and goes to a station whose own schema is closed; the
station answers a `CallError` and the command fails, with nothing on the CSMS side pointing at the
extra field. That is precisely the "interoperability issues in the field" the erratum is about.

### The risk in this change

It is a real tightening: a station that today sends a non-standard field is accepted, and after this
gets a `FormatViolation`. That is what the erratum asks for, and unlike OCPP 2.x there is no
`customData` escape hatch in 1.6, so a vendor doing this has nowhere sanctioned to go - which is why
the erratum tells them not to. Still a behaviour change worth being deliberate about, so if you would
rather stay lenient inbound and tighten only the operator API, say so and I will split it that way.

This is the 1.6 counterpart of citrineos/citrineos-core#967 (the same defect in the 2.0.1 schemas).
They touch different directories and can land in either order; the 2.1 schemas already say `false`.

Full workspace suite: 97 files, 2047 tests passing, 6 skipped. Docker was available so the
testcontainers-backed suites ran too; the one failing file,
`packages/core/test/dal/e2e/security-event.e2e.test.ts`, fails identically on `next`
(`Command failed: pnpm run db:migrate`).
