### PR TITLE
fix(base): strip unknown fields from an operator API request instead of forwarding them

### DIFF
--- a/packages/base/src/interfaces/modules/OCPPValidator.ts
+++ b/packages/base/src/interfaces/modules/OCPPValidator.ts
@@ -45,7 +45,7 @@ export class OCPPValidator {
     const ajvInstance =
       ajv ||
       new Ajv({
-        removeAdditional: 'failing',
+        removeAdditional: 'all',
         useDefaults: true,
         coerceTypes: true, // HTTP query/path params arrive as strings and need coercion
         strict: false,

--- a/packages/base/test/modules/OCPPValidator.test.ts
+++ b/packages/base/test/modules/OCPPValidator.test.ts
@@ -61,6 +61,23 @@ describe('OCPPValidator', () => {
       };
       expect(() => ajv.compile(schema)).not.toThrow();
     });
+
+    it('strips a property the schema does not declare', () => {
+      const ajv = OCPPValidator.createServerAjvInstance();
+      // Every OCPP schema in this repo sets additionalProperties: true, so an undeclared property
+      // never causes a failure and 'failing' has nothing to remove. The operator API copies the
+      // validated body into the OCPP message, so the stray field reaches the station, which
+      // answers a FormatViolation for the whole command.
+      const validate = ajv.compile({
+        type: 'object',
+        additionalProperties: true,
+        properties: { idToken: { type: 'string' } },
+      });
+
+      const payload: Record<string, unknown> = { idToken: 'TAG001', typo: 'not a field' };
+      expect(validate(payload)).toBe(true);
+      expect(payload).toEqual({ idToken: 'TAG001' });
+    });
   });
 
   describe('createValidatorAjvInstance', () => {


### PR DESCRIPTION
Follows on from #967 and #973, which @thanaParis closed on the grounds that the CSMS should log a
protocol violation and carry on rather than refuse a message over an extra field. I take that point
and I am not reopening either. This is the half of that finding the leniency argument does not
cover, and it is one line.

## What happens

`OCPPValidator.createServerAjvInstance` - the Ajv instance Fastify compiles the operator API's
schemas with - is configured `removeAdditional: 'failing'`. Ajv removes a property under that
setting only when the property is what *makes* validation fail, which means `additionalProperties:
false`. Every OCPP schema in this repo sets `additionalProperties: true`, so nothing ever fails on an
extra field and nothing is ever stripped.

The operator API then copies the validated body into the OCPP message it builds. So a mistyped or
stale field posted to the API survives validation, is copied into the CALL, and the station answers a
`FormatViolation` for the whole command. A `SetChargingProfile` or `RequestStartTransaction` is
refused outright, and nothing on the CSMS side says which field did it.

That is the CSMS being lenient about the wrong thing: it accepts junk from the operator and passes
the consequence to the station.

## The change

```diff
-        removeAdditional: 'failing',
+        removeAdditional: 'all',
```

`'all'` removes every property the schema does not declare. It is what `packages/ocpi-base` already
does for its own Ajv instance (`packages/ocpi-base/src/index.ts`), so this brings the two HTTP
surfaces into line.

**This does not change how the CSMS treats stations.** Messages arriving from a charging station go
through `createValidatorAjvInstance`, which is untouched. The CSMS stays exactly as lenient inbound
as it is today, which is what #967 and #973 were closed to preserve.

## Tests

Failing-test-first, as usual. The test compiles a schema with `additionalProperties: true` - the
shape every OCPP schema here has - passes an object with one undeclared property, and asserts the
property is gone after `validate()` returns true.

On `next` it fails with `expected { idToken: 'TAG001', …(1) } to deeply equal { idToken: 'TAG001' }`.

`packages/base` is green (590 tests), and `packages/core` + `packages/base` together are green at
2079 passed. The one failure in that run, `security-event.e2e.test.ts`, fails identically on `next`
here - it wants Docker for `pnpm run db:migrate`.
