### PR TITLE
fix: Acme CSR signing uses wrong issuer when TLS chain isn't self-issued

### DIFF
--- a/apps/ocpp-server/migrations/20260902120000-add-mtls-ca-certificate-file-path.ts
+++ b/apps/ocpp-server/migrations/20260902120000-add-mtls-ca-certificate-file-path.ts
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+import { DataTypes, QueryInterface } from 'sequelize';
+
+const TABLE_NAME = 'ServerNetworkProfiles';
+const COLUMN_NAME = 'mtlsCertificateAuthorityCertificateFilePath';
+
+export default {
+  up: async (queryInterface: QueryInterface) => {
+    const table = await queryInterface.describeTable(TABLE_NAME);
+    if (table[COLUMN_NAME]) {
+      return;
+    }
+
+    // Nullable: existing servers keep deriving the CSR-signing issuer from the
+    // second entry of tlsCertificateChainFilePath, which is the behaviour they
+    // have today. Only a server whose TLS chain is not issued by its own sub CA
+    // needs to set this.
+    await queryInterface.addColumn(TABLE_NAME, COLUMN_NAME, {
+      type: DataTypes.STRING(255),
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    const table = await queryInterface.describeTable(TABLE_NAME);
+    if (!table[COLUMN_NAME]) {
+      return;
+    }
+    await queryInterface.removeColumn(TABLE_NAME, COLUMN_NAME);
+  },
+};

--- a/apps/operator-ui/src/lib/queries/fields/server.network.profile.fields.ts
+++ b/apps/operator-ui/src/lib/queries/fields/server.network.profile.fields.ts
@@ -36,6 +36,7 @@ export const SERVER_NETWORK_PROFILE_FULL_FIELDS = fieldSet([
   'tlsKeyFilePath',
   'tlsCertificateChainFilePath',
   'mtlsCertificateAuthorityKeyFilePath',
+  'mtlsCertificateAuthorityCertificateFilePath',
   'rootCACertificateFilePath',
   'dynamicTenantResolution',
 ]);

--- a/packages/core/src/dal/interfaces/queries/Websocket.ts
+++ b/packages/core/src/dal/interfaces/queries/Websocket.ts
@@ -81,6 +81,10 @@ export const WebsocketRequestSchema = QuerySchema('WebsocketRequestSchema', [
     type: 'string',
   },
   {
+    key: 'mtlsCertificateAuthorityCertificateFilePath',
+    type: 'string',
+  },
+  {
     key: 'rootCACertificateFilePath',
     type: 'string',
   },

--- a/packages/core/src/dal/layers/drizzle/repository/ServerNetworkProfile.ts
+++ b/packages/core/src/dal/layers/drizzle/repository/ServerNetworkProfile.ts
@@ -32,6 +32,8 @@ export function toServerNetworkProfileDto(
     tlsKeyFilePath: entity.tlsKeyFilePath ?? undefined,
     tlsCertificateChainFilePath: entity.tlsCertificateChainFilePath ?? undefined,
     mtlsCertificateAuthorityKeyFilePath: entity.mtlsCertificateAuthorityKeyFilePath ?? undefined,
+    mtlsCertificateAuthorityCertificateFilePath:
+      entity.mtlsCertificateAuthorityCertificateFilePath ?? undefined,
     rootCACertificateFilePath: entity.rootCACertificateFilePath ?? undefined,
     chargingStations: undefined,
     tenantId: entity.tenantId ?? undefined,
@@ -82,6 +84,8 @@ export class DrizzleServerNetworkProfileRepository
       tlsCertificateChainFilePath: websocketServerConfig.tlsCertificateChainFilePath ?? null,
       mtlsCertificateAuthorityKeyFilePath:
         websocketServerConfig.mtlsCertificateAuthorityKeyFilePath ?? null,
+      mtlsCertificateAuthorityCertificateFilePath:
+        websocketServerConfig.mtlsCertificateAuthorityCertificateFilePath ?? null,
       rootCACertificateFilePath: websocketServerConfig.rootCACertificateFilePath ?? null,
       tenantId,
     };

--- a/packages/core/src/dal/layers/drizzle/schema/ServerNetworkProfile.ts
+++ b/packages/core/src/dal/layers/drizzle/schema/ServerNetworkProfile.ts
@@ -27,6 +27,16 @@ function serverNetworkProfileColumns() {
     mtlsCertificateAuthorityKeyFilePath: varchar('mtlsCertificateAuthorityKeyFilePath', {
       length: 255,
     }),
+    // Sub CA's own certificate, used as the issuer when
+    // signing a charging station's CSR (OCPP SignCertificate). Optional: when unset, the issuer falls
+    // back to the second entry of tlsCertificateChainFilePath, which only holds when the CSMS's own TLS
+    // certificate is issued by this same sub CA. Set it explicitly when tlsCertificateChainFilePath
+    // instead carries a publicly-issued certificate (e.g. Let's Encrypt) for the CSMS's TLS identity --
+    // otherwise the signed certificate's issuer will not match its actual signer.
+    mtlsCertificateAuthorityCertificateFilePath: varchar(
+      'mtlsCertificateAuthorityCertificateFilePath',
+      { length: 255 },
+    ),
     rootCACertificateFilePath: varchar('rootCACertificateFilePath', { length: 255 }),
     tenantId: integer('tenantId'),
     createdAt: timestamp('createdAt', { withTimezone: true, mode: 'date' })

--- a/packages/core/src/dal/layers/sequelize/model/Location/ServerNetworkProfile.ts
+++ b/packages/core/src/dal/layers/sequelize/model/Location/ServerNetworkProfile.ts
@@ -69,6 +69,15 @@ export class ServerNetworkProfile
   @Column(DataType.STRING)
   declare mtlsCertificateAuthorityKeyFilePath?: string;
 
+  // Sub CA's own certificate, used as the issuer when
+  // signing a charging station's CSR (OCPP SignCertificate). Optional: when unset, the issuer falls
+  // back to the second entry of tlsCertificateChainFilePath, which only holds when the CSMS's own TLS
+  // certificate is issued by this same sub CA. Set it explicitly when tlsCertificateChainFilePath
+  // instead carries a publicly-issued certificate (e.g. Let's Encrypt) for the CSMS's TLS identity --
+  // otherwise the signed certificate's issuer will not match its actual signer.
+  @Column(DataType.STRING)
+  declare mtlsCertificateAuthorityCertificateFilePath?: string;
+
   @Column(DataType.STRING)
   declare rootCACertificateFilePath?: string;
 

--- a/packages/core/src/dal/layers/sequelize/repository/ServerNetworkProfile.ts
+++ b/packages/core/src/dal/layers/sequelize/repository/ServerNetworkProfile.ts
@@ -37,6 +37,8 @@ export class SequelizeServerNetworkProfileRepository
       websocketServerConfig.tlsCertificateChainFilePath;
     serverNetworkProfile.mtlsCertificateAuthorityKeyFilePath =
       websocketServerConfig.mtlsCertificateAuthorityKeyFilePath;
+    serverNetworkProfile.mtlsCertificateAuthorityCertificateFilePath =
+      websocketServerConfig.mtlsCertificateAuthorityCertificateFilePath;
     serverNetworkProfile.rootCACertificateFilePath =
       websocketServerConfig.rootCACertificateFilePath;
     serverNetworkProfile.tenantId = websocketServerConfig.tenantId;

--- a/packages/core/src/util/certificate/client/acme.ts
+++ b/packages/core/src/util/certificate/client/acme.ts
@@ -61,10 +61,13 @@ export class Acme implements IChargingStationCertificateAuthorityClient {
     );
 
     const securityProfile3Servers = websocketServersConfig.filter((s) => s.securityProfile === 3);
-    const requiredPaths = securityProfile3Servers.flatMap((s) => [
-      s.tlsCertificateChainFilePath as string,
-      s.mtlsCertificateAuthorityKeyFilePath as string,
-    ]);
+    const requiredPaths = securityProfile3Servers.flatMap((s) =>
+      [
+        s.tlsCertificateChainFilePath as string,
+        s.mtlsCertificateAuthorityKeyFilePath as string,
+        s.mtlsCertificateAuthorityCertificateFilePath as string | undefined,
+      ].filter((p): p is string => !!p),
+    );
     const existResults = await Promise.all(
       requiredPaths.map((p) => fileStorage.exists(p, undefined, { trusted: true })),
     );
@@ -75,20 +78,51 @@ export class Acme implements IChargingStationCertificateAuthorityClient {
     const securityCertChainKeyMap = new Map<string, [string, string]>();
     for (const server of securityProfile3Servers) {
       try {
-        const certChain = await fileStorage.getFile(
-          server.tlsCertificateChainFilePath as string,
-          undefined,
-          { trusted: true },
-        );
+        // What gets stored here is the certificate that will issue charging
+        // station certificates, not the CSMS's own TLS chain. The two are the
+        // same only when the CSMS's TLS certificate happens to be issued by
+        // this sub CA.
+        let subCACertPem: string;
+        const dedicatedSubCACertPath = server.mtlsCertificateAuthorityCertificateFilePath;
+        if (dedicatedSubCACertPath) {
+          const dedicatedSubCACert = await fileStorage.getFile(dedicatedSubCACertPath, undefined, {
+            trusted: true,
+          });
+          if (dedicatedSubCACert === undefined) {
+            throw new Error(`Sub CA certificate file not found for server ${server.id}`);
+          }
+          subCACertPem = dedicatedSubCACert;
+        } else {
+          // Fallback for servers that do not name the sub CA certificate: the
+          // second entry of the TLS chain issued the CSMS's own leaf, which is
+          // the sub CA only in the self-issued case.
+          const certChain = await fileStorage.getFile(
+            server.tlsCertificateChainFilePath as string,
+            undefined,
+            { trusted: true },
+          );
+          if (certChain === undefined) {
+            throw new Error(`Certificate file not found for server ${server.id}`);
+          }
+          const certChainArray: string[] = parseCertificateChainPem(certChain);
+          if (certChainArray.length < 2) {
+            throw new Error(
+              `The size of the chain is ${certChainArray.length}. Sub CA certificate for signing not found`,
+            );
+          }
+          subCACertPem = certChainArray[1];
+        }
+
         const mtlsKey = await fileStorage.getFile(
           server.mtlsCertificateAuthorityKeyFilePath as string,
           undefined,
           { trusted: true },
         );
-        if (certChain === undefined || mtlsKey === undefined) {
+        if (mtlsKey === undefined) {
           throw new Error(`Certificate file not found for server ${server.id}`);
         }
-        securityCertChainKeyMap.set(server.id, [certChain, mtlsKey]);
+
+        securityCertChainKeyMap.set(server.id, [subCACertPem, mtlsKey]);
       } catch (error) {
         log.error(
           'Unable to start Certificates module due to invalid security certificates for {}: {}',
@@ -205,26 +239,20 @@ export class Acme implements IChargingStationCertificateAuthorityClient {
     if (!nextEntry) {
       throw new Error('Failed to get certificate chain, securityCertChainKeyMap is empty');
     }
-    const [serverId, [certChain, subCAPrivateKey]] = nextEntry;
-    this._logger.debug(`Found certificate chain in server ${serverId}: ${certChain}`);
-
-    const certChainArray: string[] = parseCertificateChainPem(certChain);
-    if (certChainArray.length < 2) {
-      throw new Error(
-        `The size of the chain is ${certChainArray.length}. Sub CA certificate for signing not found`,
-      );
-    }
-    this._logger.info(`Found Sub CA certificate: ${certChainArray[1]}`);
+    // The map already holds the resolved sub CA certificate, not a chain --
+    // create() picked it from mtlsCertificateAuthorityCertificateFilePath, or
+    // derived it from the TLS chain once at startup.
+    const [serverId, [subCACertPem, subCAPrivateKey]] = nextEntry;
+    this._logger.info(`Found Sub CA certificate for server ${serverId}: ${subCACertPem}`);
 
     const signedCertPem: string = createSignedCertificateFromCSR(
       csrString,
-      certChainArray[1],
+      subCACertPem,
       subCAPrivateKey,
     ).getPEM();
 
-    // Generate and return certificate chain for signed certificate
-    certChainArray[0] = signedCertPem.replace(/\n+$/, '');
-    return certChainArray.join('\n');
+    // Signed leaf followed by the sub CA that issued it
+    return `${signedCertPem.replace(/\n+$/, '')}\n${subCACertPem}`;
   }
 
   updateCertificateChainKeyMap(

--- a/packages/core/test/util/certificate/client/Acme.test.ts
+++ b/packages/core/test/util/certificate/client/Acme.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import type { IFileStorage } from '@citrineos/base';
+import { ConfigLoader, type IFileStorage } from '@citrineos/base';
 import type { SystemConfig } from '@citrineos/types';
 import { faker } from '@faker-js/faker';
 import * as CertificateUtil from '@util/certificate/CertificateUtil.js';
@@ -17,6 +17,8 @@ vi.mock('@util/certificate/CertificateUtil');
 describe('ACME', () => {
   const mockTlsCertificateChain = faker.lorem.word();
   const mockMtlsCertificateAuthorityKey = faker.lorem.word();
+  const mockLeafPem = faker.lorem.word();
+  const mockSubCAPem = faker.lorem.word();
   let mockCertUtil: Mocked<typeof CertificateUtil>;
   let mockClient: Mocked<Client>;
   let mockFileStorage: IFileStorage;
@@ -28,6 +30,9 @@ describe('ACME', () => {
   beforeAll(async () => {
     global.fetch = vi.fn();
     mockCertUtil = CertificateUtil as Mocked<typeof CertificateUtil>;
+    // No mtlsCertificateAuthorityCertificateFilePath on this server, so create()
+    // falls back to the second entry of the tls certificate chain.
+    mockCertUtil.parseCertificateChainPem.mockReturnValue([mockLeafPem, mockSubCAPem]);
 
     const websocketServersConfigFile = 'websocket-servers.json';
     const websocketServers = [
@@ -82,11 +87,10 @@ describe('ACME', () => {
   });
 
   describe('getCertificateChain', () => {
-    it('succeeds', async () => {
-      const mockLeafPem = faker.lorem.word();
-      const mockSubCAPem = faker.lorem.word();
+    it('signs against the sub CA cert derived from the tls certificate chain', async () => {
+      // The chain is parsed once in create(); by the time a CSR arrives the map
+      // already holds the sub CA certificate itself.
       const mockCertificate = aValidSignedCertificate();
-      mockCertUtil.parseCertificateChainPem.mockReturnValueOnce([mockLeafPem, mockSubCAPem]);
       mockCertUtil.createSignedCertificateFromCSR.mockReturnValueOnce(mockCertificate);
 
       const givenCSR = faker.lorem.word();
@@ -94,12 +98,76 @@ describe('ACME', () => {
 
       const expectedResult = mockCertificate.getPEM().replace(/\n+$/, '') + '\n' + mockSubCAPem;
       expect(actualResult).toBe(expectedResult);
-      expect(mockCertUtil.parseCertificateChainPem).toHaveBeenCalledWith(mockTlsCertificateChain);
       expect(mockCertUtil.createSignedCertificateFromCSR).toHaveBeenCalledWith(
         givenCSR,
         mockSubCAPem,
         mockMtlsCertificateAuthorityKey,
       );
+    });
+
+    it('signs against mtlsCertificateAuthorityCertificateFilePath when set, ignoring the tls chain', async () => {
+      // The case the fallback gets wrong: the CSMS's own TLS chain is issued by
+      // a public CA, so its second entry is that CA -- not the sub CA that must
+      // appear as the issuer of a charging station certificate.
+      const dedicatedSubCAPem = faker.lorem.word();
+      const dedicatedMtlsKey = faker.lorem.word();
+      const dedicatedServers = [
+        {
+          id: '3',
+          host: '0.0.0.0',
+          port: 8444,
+          pingInterval: 60,
+          protocols: ['ocpp2.0.1'],
+          securityProfile: 3,
+          allowUnknownChargingStations: false,
+          dynamicTenantResolution: false,
+          tenantId: 1,
+          tlsKeyFilePath: faker.lorem.word(),
+          tlsCertificateChainFilePath: faker.lorem.word(),
+          mtlsCertificateAuthorityKeyFilePath: faker.lorem.word(),
+          mtlsCertificateAuthorityCertificateFilePath: faker.lorem.word(),
+        },
+      ];
+      const dedicatedFileStorage = {
+        saveFile: vi.fn().mockResolvedValue(undefined),
+        getFile: vi
+          .fn()
+          .mockResolvedValueOnce(JSON.stringify(dedicatedServers))
+          .mockResolvedValueOnce(dedicatedSubCAPem)
+          .mockResolvedValueOnce(dedicatedMtlsKey)
+          .mockResolvedValueOnce(faker.lorem.word()),
+        exists: vi.fn().mockResolvedValue(true),
+        createDirectory: vi.fn().mockResolvedValue(undefined),
+        deleteFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as IFileStorage;
+
+      // loadWebsocketServersConfig caches the parsed servers on a static, so a
+      // second create() would otherwise reuse the ones from beforeAll.
+      (ConfigLoader as unknown as { websocketServers: unknown }).websocketServers = undefined;
+
+      const dedicatedAcme = await Acme.create(
+        systemConfig,
+        dedicatedFileStorage,
+        logger,
+        mockClient,
+      );
+
+      const mockCertificate = aValidSignedCertificate();
+      mockCertUtil.createSignedCertificateFromCSR.mockReturnValueOnce(mockCertificate);
+      const givenCSR = faker.lorem.word();
+
+      const actualResult = await dedicatedAcme.getCertificateChain(givenCSR);
+
+      expect(actualResult).toBe(
+        mockCertificate.getPEM().replace(/\n+$/, '') + '\n' + dedicatedSubCAPem,
+      );
+      expect(mockCertUtil.createSignedCertificateFromCSR).toHaveBeenCalledWith(
+        givenCSR,
+        dedicatedSubCAPem,
+        dedicatedMtlsKey,
+      );
+      // The tls chain is never read when a dedicated sub CA certificate is set.
+      expect(mockCertUtil.parseCertificateChainPem).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -42,6 +42,13 @@ export const websocketServerSchema = z
     tlsKeyFilePath: z.string().optional(),
     tlsCertificateChainFilePath: z.string().optional(),
     mtlsCertificateAuthorityKeyFilePath: z.string().optional(),
+    // Sub CA's own certificate, used as the issuer when signing a charging station's CSR
+    // (OCPP SignCertificate). Optional: when unset, the issuer falls back to the second entry
+    // of tlsCertificateChainFilePath, which only holds when the CSMS's own TLS certificate is
+    // issued by this same sub CA. Set it explicitly when tlsCertificateChainFilePath instead
+    // carries a publicly-issued certificate (e.g. Let's Encrypt) for the CSMS's TLS identity --
+    // otherwise the signed certificate's issuer will not match its actual signer.
+    mtlsCertificateAuthorityCertificateFilePath: z.string().optional(),
     rootCACertificateFilePath: z.string().optional(),
     tenantId: z.number().int().positive().optional(),
     // When true, tenant is resolved at connection upgrade time from the request path

--- a/packages/types/src/interfaces/dto/server.network.profile.dto.ts
+++ b/packages/types/src/interfaces/dto/server.network.profile.dto.ts
@@ -18,6 +18,9 @@ export const ServerNetworkProfileSchema = BaseSchema.extend({
   tlsKeyFilePath: z.string().optional(),
   tlsCertificateChainFilePath: z.string().optional(),
   mtlsCertificateAuthorityKeyFilePath: z.string().optional(),
+  // Sub CA certificate used as the issuer when signing charging station CSRs. See
+  // websocketServerSchema in ../../config/types.ts for when this must be set.
+  mtlsCertificateAuthorityCertificateFilePath: z.string().optional(),
   rootCACertificateFilePath: z.string().optional(),
   chargingStations: z.array(ChargingStationSchema).nullable().optional(),
 });


### PR DESCRIPTION
## Summary

`Acme.getCertificateChain()` (used to sign charging station CSRs via the OCPP `SignCertificate` flow) derives the signing issuer from the second entry of `tlsCertificateChainFilePath`. This assumes the CSMS's own TLS certificate chain is always rooted in the same private sub CA that also signs charging station certs.

That assumption breaks for a hybrid PKI setup: CSMS TLS identity from a public CA (e.g. Let's Encrypt, or terminated at a reverse proxy) while a separate private sub CA signs charging station leaf certs for mutual TLS (Security Profile 3). In that case, `tlsCertificateChainFilePath[1]` is the public CA's intermediate, not the private sub CA — so the newly signed charging station certificate's issuer field doesn't actually match the key that signed it (the sub CA's private key), and the certificate is rejected as invalid by spec-compliant OCPP clients during the TLS handshake.

Found and confirmed via an end-to-end Security Profile 3 deployment against a private CA, where charging stations failed to complete the mTLS handshake with a newly OCPP-issued certificate despite `CertificateSigned` succeeding — packet capture confirmed the signed leaf's issuer DN didn't match the actual signing key.

## Fix

- Add an optional `mtlsCertificateAuthorityCertificateFilePath` field (mirroring the existing `mtlsCertificateAuthorityKeyFilePath`) so deployments can point directly at the sub CA certificate used to sign charging station CSRs, independent of whatever `tlsCertificateChainFilePath` holds for the CSMS's own TLS identity.
- `Acme.create()` resolves the sub CA cert per server: uses the dedicated field when configured, otherwise falls back to the existing `tlsCertificateChainFilePath[1]`-derived behavior — so existing self-issued-PKI deployments (where both assumptions coincide) are unaffected.
- `Acme.getCertificateChain()` now signs directly against the resolved sub CA cert instead of re-deriving it from the full chain each call.

## Test plan

- [x] `pnpm --filter @citrineos/types build` — schema changes compile
- [x] `pnpm --filter @citrineos/core build` — consumer changes compile
- [x] `vitest run test/util/certificate/client/Acme.test.ts` — updated existing coverage for the fallback path, added new coverage for the dedicated-field path
- [x] `vitest run test/modules/Certificates test/modules/OcppRouter/module/DataApi.test.ts` — no regressions in adjacent certificate/config-handling code (80 tests passing)
- [x] Verified end-to-end against a real charging station over Security Profile 3 with a hybrid PKI setup (public TLS cert for the CSMS, private sub CA for charging station certs)

Note: this field is only consumed by the static `websocketServers` config path (`Acme`). The DB-backed `ServerNetworkProfile` admin-provisioning path (`DataApi`/`installCertificateHelperService`) is a separate certificate-lifecycle feature for CitrineOS's own self-issued PKI and isn't affected by or wired to this field — happy to extend it there too if maintainers want that for parity.