### PR TITLE
feat: gate Swagger UI behind an OIDC (Keycloak-compatible) login

### DIFF
--- a/packages/core/src/util/util/swagger.ts
+++ b/packages/core/src/util/util/swagger.ts
@@ -14,6 +14,7 @@ import { LocalStorage } from '../files/localStorage.js';
 import type { OpenAPIV3_1 } from 'openapi-types';
 import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import * as packageJson from '../../../package.json' with { type: 'json' };
+import { registerSwaggerOidcLogin } from './swaggerOidcLogin.js';
 
 /**
  * This transformation is used to set default tags
@@ -180,6 +181,10 @@ const registerFastifySwagger = (systemConfig: SystemConfig, server: FastifyInsta
 
 export async function initSwagger(systemConfig: SystemConfig, server: FastifyInstance) {
   registerFastifySwagger(systemConfig, server);
+  // Must run before registerSwaggerUi: it installs the onRequest hook that
+  // gates systemConfig.util.swagger.path (and registers the OAuth2 callback
+  // route under it) before @fastify/swagger-ui's own routes exist.
+  registerSwaggerOidcLogin(systemConfig, server);
   await registerSwaggerUi(systemConfig, server);
   await registerFastifyAuth(server);
 }

--- a/packages/core/src/util/util/swaggerOidcLogin.ts
+++ b/packages/core/src/util/util/swaggerOidcLogin.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Gates the Swagger UI (systemConfig.util.swagger.path) behind an OIDC
+ * Authorization Code login: unauthenticated browsers are redirected to the
+ * configured provider (Keycloak or any other standards-compliant OIDC
+ * issuer), a callback route exchanges the code for a token, and a
+ * session cookie is set once the token verifies.
+ *
+ * This is intentionally separate from util.authProvider/ApiAuthPlugin
+ * (registerApiAuth in citrineOSServer.ts, which explicitly excludes
+ * '/docs' from its checks): that plugin only verifies a bearer token a
+ * caller already has and returns a bare 401 if one is missing, which
+ * cannot give a browser opening this page anywhere to log in. Token
+ * verification here reuses OIDCAuthProvider.authenticateToken so the JWKS
+ * fetch/cache/signature-check logic isn't duplicated.
+ */
+
+import type { SystemConfig } from '@citrineos/types';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { OIDCAuthProvider } from '../authorization/index.js';
+
+const COOKIE_NAME = 'citrineos_swagger_auth';
+
+type SwaggerOidcLoginConfig = NonNullable<
+  NonNullable<SystemConfig['util']['swagger']>['oidcLogin']
+>;
+
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    out[part.slice(0, idx).trim()] = decodeURIComponent(part.slice(idx + 1).trim());
+  }
+  return out;
+}
+
+function setSessionCookie(reply: FastifyReply, token: string, maxAgeSeconds: number) {
+  const attrs = [
+    `${COOKIE_NAME}=${encodeURIComponent(token)}`,
+    'Path=/',
+    'HttpOnly',
+    'Secure',
+    'SameSite=Lax',
+    `Max-Age=${maxAgeSeconds}`,
+  ];
+  reply.header('set-cookie', attrs.join('; '));
+}
+
+function authorizationUrl(config: SwaggerOidcLoginConfig, redirectUri: string): string {
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: 'openid',
+  });
+  return `${config.authorizationEndpoint}?${params.toString()}`;
+}
+
+function requestOrigin(request: FastifyRequest): string {
+  const proto = (request.headers['x-forwarded-proto'] as string) || request.protocol;
+  const host = (request.headers['x-forwarded-host'] as string) || request.headers.host;
+  return `${proto}://${host}`;
+}
+
+export function registerSwaggerOidcLogin(systemConfig: SystemConfig, server: FastifyInstance) {
+  const swaggerPath = systemConfig.util.swagger?.path;
+  const config = systemConfig.util.swagger?.oidcLogin;
+  if (!swaggerPath || !config) return;
+
+  const provider = new OIDCAuthProvider({
+    jwksUri: config.jwksUri,
+    issuer: config.issuer,
+    audience: config.clientId,
+  });
+
+  const callbackPath = `${swaggerPath}/callback`;
+
+  server.get(callbackPath, async (request: FastifyRequest, reply: FastifyReply) => {
+    const code = (request.query as { code?: string }).code;
+    if (!code) {
+      reply.code(400);
+      return { error: 'missing authorization code' };
+    }
+    const redirectUri = `${requestOrigin(request)}${callbackPath}`;
+    try {
+      const tokenResponse = await fetch(config.tokenEndpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: redirectUri,
+          client_id: config.clientId,
+          client_secret: config.clientSecret,
+        }),
+      });
+      if (!tokenResponse.ok) {
+        reply.code(502);
+        return { error: 'OIDC token exchange failed' };
+      }
+      const tokenData = (await tokenResponse.json()) as {
+        access_token?: string;
+        expires_in?: number;
+      };
+      const authResult = tokenData.access_token
+        ? await provider.authenticateToken(tokenData.access_token)
+        : undefined;
+      if (!tokenData.access_token || !authResult?.isAuthenticated) {
+        reply.code(401);
+        return { error: 'invalid OIDC token' };
+      }
+      setSessionCookie(reply, tokenData.access_token, tokenData.expires_in ?? 300);
+      reply.redirect(swaggerPath);
+      return;
+    } catch (e) {
+      console.error('swaggerOidcLogin: callback failed', e);
+      reply.code(502);
+      return { error: 'OIDC token exchange failed' };
+    }
+  });
+
+  server.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {
+    if (!request.url.startsWith(swaggerPath)) return;
+    if (request.url.startsWith(callbackPath)) return;
+
+    const cookies = parseCookies(request.headers.cookie);
+    const token = cookies[COOKIE_NAME];
+    if (token) {
+      const authResult = await provider.authenticateToken(token);
+      if (authResult.isAuthenticated) return;
+    }
+    const redirectUri = `${requestOrigin(request)}${callbackPath}`;
+    reply.redirect(authorizationUrl(config, redirectUri));
+  });
+}

--- a/packages/core/test/util/util/swaggerOidcLogin.test.ts
+++ b/packages/core/test/util/util/swaggerOidcLogin.test.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { SystemConfig } from '@citrineos/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OIDCAuthProvider } from '@util/index.js';
+import { registerSwaggerOidcLogin } from '@util/util/swaggerOidcLogin.js';
+
+const oidcLoginConfig = {
+  issuer: 'https://idp.example.com/realms/test',
+  authorizationEndpoint: 'https://idp.example.com/realms/test/protocol/openid-connect/auth',
+  tokenEndpoint: 'https://idp.example.com/realms/test/protocol/openid-connect/token',
+  jwksUri: 'https://idp.example.com/realms/test/protocol/openid-connect/certs',
+  clientId: 'internal',
+  clientSecret: 'shh',
+};
+
+const mockSystemConfig = {
+  modules: {},
+  util: {
+    swagger: {
+      path: '/docs',
+      logoPath: '',
+      oidcLogin: oidcLoginConfig,
+    },
+  },
+} as unknown as SystemConfig;
+
+describe('registerSwaggerOidcLogin', () => {
+  let server: FastifyInstance;
+
+  beforeEach(() => {
+    server = Fastify();
+    registerSwaggerOidcLogin(mockSystemConfig, server);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    await server.close();
+  });
+
+  it('does nothing when oidcLogin is not configured', async () => {
+    const bare = Fastify();
+    registerSwaggerOidcLogin(
+      { modules: {}, util: { swagger: { path: '/docs', logoPath: '' } } } as unknown as SystemConfig,
+      bare,
+    );
+    bare.get('/docs', async () => ({ ok: true }));
+    await bare.ready();
+    const response = await bare.inject({ method: 'GET', url: '/docs' });
+    expect(response.statusCode).toBe(200);
+    await bare.close();
+  });
+
+  it('redirects unauthenticated requests under the swagger path to the authorization endpoint', async () => {
+    server.get('/docs', async () => ({ ok: true }));
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/docs' });
+
+    expect(response.statusCode).toBe(302);
+    const location = new URL(response.headers['location'] as string);
+    expect(`${location.origin}${location.pathname}`).toBe(oidcLoginConfig.authorizationEndpoint);
+    expect(location.searchParams.get('client_id')).toBe(oidcLoginConfig.clientId);
+    expect(location.searchParams.get('response_type')).toBe('code');
+    expect(location.searchParams.get('redirect_uri')).toBe('http://localhost:80/docs/callback');
+  });
+
+  it('leaves requests outside the swagger path untouched', async () => {
+    server.get('/health', async () => ({ ok: true }));
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/health' });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('callback rejects a request with no authorization code', async () => {
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/docs/callback' });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('callback exchanges the code, verifies the token, and sets a session cookie', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'good-token', expires_in: 300 }),
+      }),
+    );
+    vi.spyOn(OIDCAuthProvider.prototype, 'authenticateToken').mockResolvedValue({
+      isAuthenticated: true,
+      user: { id: 'u1', name: 'u1', email: '', roles: [], tenantId: '1', metadata: {} },
+    } as any);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/docs/callback?code=abc123' });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers['location']).toBe('/docs');
+    const cookie = response.headers['set-cookie'] as string;
+    expect(cookie).toContain('citrineos_swagger_auth=good-token');
+    expect(cookie).toContain('HttpOnly');
+  });
+
+  it('callback rejects a token that fails verification', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'bad-token', expires_in: 300 }),
+      }),
+    );
+    vi.spyOn(OIDCAuthProvider.prototype, 'authenticateToken').mockResolvedValue({
+      isAuthenticated: false,
+      error: 'invalid signature',
+    } as any);
+    await server.ready();
+
+    const response = await server.inject({ method: 'GET', url: '/docs/callback?code=abc123' });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('allows a request bearing a valid session cookie through without redirecting', async () => {
+    vi.spyOn(OIDCAuthProvider.prototype, 'authenticateToken').mockResolvedValue({
+      isAuthenticated: true,
+      user: { id: 'u1', name: 'u1', email: '', roles: [], tenantId: '1', metadata: {} },
+    } as any);
+    server.get('/docs', async () => ({ ok: true }));
+    await server.ready();
+
+    const response = await server.inject({
+      method: 'GET',
+      url: '/docs',
+      headers: { cookie: 'citrineos_swagger_auth=good-token' },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+});

--- a/packages/core/test/util/util/swaggerOidcLogin.test.ts
+++ b/packages/core/test/util/util/swaggerOidcLogin.test.ts
@@ -44,7 +44,10 @@ describe('registerSwaggerOidcLogin', () => {
   it('does nothing when oidcLogin is not configured', async () => {
     const bare = Fastify();
     registerSwaggerOidcLogin(
-      { modules: {}, util: { swagger: { path: '/docs', logoPath: '' } } } as unknown as SystemConfig,
+      {
+        modules: {},
+        util: { swagger: { path: '/docs', logoPath: '' } },
+      } as unknown as SystemConfig,
       bare,
     );
     bare.get('/docs', async () => ({ ok: true }));

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -263,6 +263,20 @@ export const systemConfigInputSchema = z.object({
         logoPath: z.string(),
         exposeData: z.boolean().default(true).optional(),
         exposeMessage: z.boolean().default(true).optional(),
+        // Gates the Swagger UI itself behind an OIDC Authorization Code
+        // login (browser redirect + callback + session cookie), separate
+        // from util.authProvider -- that only verifies a bearer token a
+        // caller already has, which a browser opening this page does not.
+        oidcLogin: z
+          .object({
+            issuer: z.string(),
+            authorizationEndpoint: z.string(),
+            tokenEndpoint: z.string(),
+            jwksUri: z.string(),
+            clientId: z.string(),
+            clientSecret: z.string(),
+          })
+          .optional(),
       })
       .optional(),
     networkConnection: z.object({
@@ -593,6 +607,16 @@ export const systemConfigSchema = z
           logoPath: z.string(),
           exposeData: z.boolean(),
           exposeMessage: z.boolean(),
+          oidcLogin: z
+            .object({
+              issuer: z.string(),
+              authorizationEndpoint: z.string(),
+              tokenEndpoint: z.string(),
+              jwksUri: z.string(),
+              clientId: z.string(),
+              clientSecret: z.string(),
+            })
+            .optional(),
         })
         .optional(),
       networkConnection: z.object({


### PR DESCRIPTION
## Summary

The Swagger UI (`util.swagger.path`, `/docs`) has no authentication at all today — `registerFastifyAuth` decorates an `authorization` preHandler that is never actually attached to any route. Separately, `registerApiAuth` explicitly excludes `/docs` from `ApiAuthPlugin`'s global bearer-token check, since that mechanism can't help here anyway: it only verifies a token a caller already has and returns a bare 401 if one is missing, which gives a browser opening this page nowhere to log in.

## Fix

Adds an optional `util.swagger.oidcLogin` config block. When set, unauthenticated requests under the swagger path are redirected to the configured provider's authorization endpoint; a new `<path>/callback` route exchanges the returned code for a token and sets an httpOnly session cookie once it verifies.

Token verification reuses `OIDCAuthProvider.authenticateToken` so the JWKS fetch/cache/signature logic isn't duplicated — this is the same provider `util.authProvider.oidc` already uses for bearer-token API auth, just applied to a browser redirect flow instead. Works with Keycloak or any other standards-compliant OIDC issuer. When `oidcLogin` is left unset, behavior is unchanged (Swagger stays open, as today).

## Test plan

- [x] `pnpm --filter @citrineos/types build` — schema changes compile
- [x] `pnpm --filter @citrineos/core build` — consumer changes compile
- [x] `tsc -b apps/ocpp-server/tsconfig.json` — downstream app unaffected
- [x] `vitest run` (packages/core): 1146 passed, 19 skipped — only the two pre-existing environment-dependent suites failed (Postgres/RabbitMQ testcontainers unavailable in this sandbox), unrelated to this change
- [x] New `test/util/util/swaggerOidcLogin.test.ts` (7 tests): no-op when unconfigured, redirect with correct `authorization_endpoint`/`client_id`/`redirect_uri`, non-swagger routes untouched, callback missing-code/invalid-token/valid-token paths, valid session cookie passes through
- [x] Verified end-to-end against a real Keycloak realm on a parallel deployment (same pattern backported to our 1.9.x release line): `GET /docs/` 302s to Keycloak with the correct `redirect_uri`, callback exchanges the code and sets the cookie, and the existing OCPP HTTP API / websocket connections are unaffected



