### PR TITLE
Fix: OCPP 1.6 Charging Station Status Mapping in operator-ui 

### DIFF
--- a/apps/operator-ui/src/lib/client/pages/charging-stations/charging.station.status.tag.tsx
+++ b/apps/operator-ui/src/lib/client/pages/charging-stations/charging.station.status.tag.tsx
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { ChargingStationStatusEnum } from '@citrineos/types';
 import GenericTag from '@lib/client/components/tag';
 import {
-  ChargingStationStatus,
   getChargingStationStatus,
   type ChargingStationStatusCountsDto,
 } from '@lib/cls/charging.station.dto';
@@ -17,13 +17,14 @@ export const ChargingStationStatusTag = ({ station }: ChargingStationStatusTagPr
   return (
     <GenericTag
       colorMap={{
-        [ChargingStationStatus.AVAILABLE]: 'green',
-        [ChargingStationStatus.CHARGING]: 'blue',
-        [ChargingStationStatus.CHARGING_SUSPENDED]: 'violet',
-        [ChargingStationStatus.UNAVAILABLE]: 'gray',
-        [ChargingStationStatus.FAULTED]: 'red',
+        [ChargingStationStatusEnum.AVAILABLE]: 'green',
+        [ChargingStationStatusEnum.CHARGING]: 'blue',
+        [ChargingStationStatusEnum.CHARGING_SUSPENDED]: 'violet',
+        [ChargingStationStatusEnum.RESERVED]: 'cyan',
+        [ChargingStationStatusEnum.UNAVAILABLE]: 'gray',
+        [ChargingStationStatusEnum.FAULTED]: 'red',
       }}
-      enumType={ChargingStationStatus}
+      enumType={ChargingStationStatusEnum}
       enumValue={status}
     />
   );

--- a/apps/operator-ui/src/lib/cls/charging.station.dto.tsx
+++ b/apps/operator-ui/src/lib/cls/charging.station.dto.tsx
@@ -6,16 +6,19 @@ import {
   type ChargingStationCapabilityEnumType,
   type ChargingStationDto,
   type ChargingStationParkingRestrictionEnumType,
+  type ChargingStationStatusEnumType,
   type ConnectorDto,
   type ConnectorStatusEnumType,
   type EvseDto,
   type LatestStatusNotificationDto,
   type LocationDto,
   type StatusNotificationDto,
+  ChargingStateEnum,
   ChargingStationSchema,
+  ChargingStationStatusEnum,
+  ConnectorStatusEnum,
   LatestStatusNotificationSchema,
   LocationSchema,
-  OCPP2_0_1,
   TransactionSchema,
 } from '@citrineos/types';
 import { Expose } from 'class-transformer';
@@ -108,46 +111,64 @@ export class ChargingStationClass implements Partial<ChargingStationDto> {
     | null;
 }
 
-// TODO: Add missing enums and types for local use
-export enum ChargingStationStatus {
-  CHARGING = 'CHARGING',
-  CHARGING_SUSPENDED = 'CHARGING_SUSPENDED',
-  AVAILABLE = 'AVAILABLE',
-  UNAVAILABLE = 'UNAVAILABLE',
-  FAULTED = 'FAULTED',
-}
+export type ChargingStationStatusCounts = Record<ChargingStationStatusEnumType, number>;
 
-export interface ChargingStationStatusCounts {
-  [ChargingStationStatus.CHARGING]: number;
-  [ChargingStationStatus.CHARGING_SUSPENDED]: number;
-  [ChargingStationStatus.AVAILABLE]: number;
-  [ChargingStationStatus.UNAVAILABLE]: number;
-  [ChargingStationStatus.FAULTED]: number;
-}
+/**
+ * Order in which a station's aggregated status is picked when its EVSEs disagree.
+ */
+const STATUS_PRIORITY: ChargingStationStatusEnumType[] = [
+  ChargingStationStatusEnum.FAULTED,
+  ChargingStationStatusEnum.CHARGING,
+  ChargingStationStatusEnum.AVAILABLE,
+  ChargingStationStatusEnum.CHARGING_SUSPENDED,
+  ChargingStationStatusEnum.RESERVED,
+  ChargingStationStatusEnum.UNAVAILABLE,
+];
 
-export const getChargingStationStatus = (chargingStation: ChargingStationStatusCountsDto) => {
+export const getChargingStationStatus = (
+  chargingStation: ChargingStationStatusCountsDto,
+): ChargingStationStatusEnumType | undefined => {
   const counts = getChargingStationStatusCounts(chargingStation);
+  return STATUS_PRIORITY.find((status) => counts[status] > 0);
+};
 
-  if (counts[ChargingStationStatus.FAULTED] > 0) {
-    return ChargingStationStatus.FAULTED;
-  } else if (counts[ChargingStationStatus.CHARGING] > 0) {
-    return ChargingStationStatus.CHARGING;
-  } else if (counts[ChargingStationStatus.AVAILABLE] > 0) {
-    return ChargingStationStatus.AVAILABLE;
-  } else if (counts[ChargingStationStatus.CHARGING_SUSPENDED] > 0) {
-    return ChargingStationStatus.CHARGING_SUSPENDED;
-  } else if (counts[ChargingStationStatus.UNAVAILABLE] > 0) {
-    return ChargingStationStatus.UNAVAILABLE;
+const connectorStatusToChargingStationStatus = (
+  connectorStatus: ConnectorStatusEnumType,
+  activeTransaction: { isActive?: boolean; chargingState?: string | null } | undefined,
+): ChargingStationStatusEnumType => {
+  switch (connectorStatus) {
+    case ConnectorStatusEnum.Available:
+      return ChargingStationStatusEnum.AVAILABLE;
+    case ConnectorStatusEnum.Charging:
+      return ChargingStationStatusEnum.CHARGING;
+    case ConnectorStatusEnum.Preparing:
+    case ConnectorStatusEnum.SuspendedEV:
+    case ConnectorStatusEnum.SuspendedEVSE:
+    case ConnectorStatusEnum.Finishing:
+      return ChargingStationStatusEnum.CHARGING_SUSPENDED;
+    case ConnectorStatusEnum.Occupied:
+      return activeTransaction?.isActive &&
+        activeTransaction.chargingState === ChargingStateEnum.Charging
+        ? ChargingStationStatusEnum.CHARGING
+        : ChargingStationStatusEnum.CHARGING_SUSPENDED;
+    case ConnectorStatusEnum.Reserved:
+      return ChargingStationStatusEnum.RESERVED;
+    case ConnectorStatusEnum.Faulted:
+      return ChargingStationStatusEnum.FAULTED;
+    case ConnectorStatusEnum.Unavailable:
+    case ConnectorStatusEnum.Unknown:
+      return ChargingStationStatusEnum.UNAVAILABLE;
   }
 };
 
 export const getChargingStationStatusCounts = (chargingStation: ChargingStationStatusCountsDto) => {
   const counts: ChargingStationStatusCounts = {
-    [ChargingStationStatus.CHARGING]: 0,
-    [ChargingStationStatus.CHARGING_SUSPENDED]: 0,
-    [ChargingStationStatus.AVAILABLE]: 0,
-    [ChargingStationStatus.UNAVAILABLE]: 0,
-    [ChargingStationStatus.FAULTED]: 0,
+    [ChargingStationStatusEnum.AVAILABLE]: 0,
+    [ChargingStationStatusEnum.CHARGING]: 0,
+    [ChargingStationStatusEnum.CHARGING_SUSPENDED]: 0,
+    [ChargingStationStatusEnum.RESERVED]: 0,
+    [ChargingStationStatusEnum.UNAVAILABLE]: 0,
+    [ChargingStationStatusEnum.FAULTED]: 0,
   };
   const evses = chargingStation?.evses;
   if (evses && evses.length > 0) {
@@ -164,41 +185,13 @@ export const getChargingStationStatusCounts = (chargingStation: ChargingStationS
       });
       if (latestStatusNotificationForEvse) {
         const connectorStatus: ConnectorStatusEnumType =
-          latestStatusNotificationForEvse?.connectorStatus ||
-          OCPP2_0_1.ConnectorStatusEnumType.Unavailable;
-        switch (connectorStatus) {
-          case OCPP2_0_1.ConnectorStatusEnumType.Available:
-            counts[ChargingStationStatus.AVAILABLE]++;
-            break;
-          case OCPP2_0_1.ConnectorStatusEnumType.Occupied: {
-            const activeTransaction = (chargingStation as ChargingStationClass)?.transactions?.find(
-              (transaction) => transaction.evseId === evse.id,
-            );
-            if (activeTransaction && activeTransaction.isActive) {
-              const chargingState = activeTransaction.chargingState;
-              if (chargingState === OCPP2_0_1.ChargingStateEnumType.Charging) {
-                counts[ChargingStationStatus.CHARGING]++;
-              } else {
-                counts[ChargingStationStatus.CHARGING_SUSPENDED]++;
-              }
-            } else {
-              counts[ChargingStationStatus.CHARGING_SUSPENDED]++;
-            }
-            break;
-          }
-          case OCPP2_0_1.ConnectorStatusEnumType.Faulted:
-            counts[ChargingStationStatus.FAULTED]++;
-            break;
-          case OCPP2_0_1.ConnectorStatusEnumType.Unavailable:
-            counts[ChargingStationStatus.UNAVAILABLE]++;
-            break;
-          case OCPP2_0_1.ConnectorStatusEnumType.Reserved:
-          default:
-            // no handling
-            break;
-        }
+          latestStatusNotificationForEvse?.connectorStatus || ConnectorStatusEnum.Unavailable;
+        const activeTransaction = (chargingStation as ChargingStationClass)?.transactions?.find(
+          (transaction) => transaction.evseId === evse.id,
+        );
+        counts[connectorStatusToChargingStationStatus(connectorStatus, activeTransaction)]++;
       } else {
-        counts[ChargingStationStatus.UNAVAILABLE]++;
+        counts[ChargingStationStatusEnum.UNAVAILABLE]++;
       }
     }
   }

--- a/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
+++ b/packages/core/src/modules/Transactions/src/module/StatusNotificationService.ts
@@ -11,6 +11,7 @@ import {
 import { OCPP1_6, OCPP2_0_1, type ConnectorDto } from '@citrineos/types';
 import type { IDeviceModelRepository, ILocationRepository } from '@dal/interfaces/repositories.js';
 import * as OCPP1_6_Mapper from '@dal/layers/sequelize/mapper/1.6/index.js';
+import * as OCPP2_0_1_Mapper from '@dal/layers/sequelize/mapper/2.0.1/index.js';
 import { Component, EvseType, Variable } from '@dal/layers/sequelize/model/DeviceModel/index.js';
 import { Connector, StatusNotification } from '@dal/layers/sequelize/model/Location/index.js';
 import type { ILogObj } from 'tslog';
@@ -71,6 +72,9 @@ export class StatusNotificationService {
       tenantId,
       ocppConnectionName: ocppConnectionName,
       ...statusNotificationRequest,
+      connectorStatus: OCPP2_0_1_Mapper.LocationMapper.mapConnectorStatus(
+        statusNotificationRequest.connectorStatus,
+      ),
     });
     await this._locationRepository.addStatusNotificationToChargingStation(
       tenantId,
@@ -271,7 +275,10 @@ export class StatusNotificationService {
         tenantId,
         ...statusNotificationRequest,
         ocppConnectionName: ocppConnectionName,
-        connectorStatus: statusNotificationRequest.status,
+        connectorStatus:
+          OCPP1_6_Mapper.LocationMapper.mapStatusNotificationRequestStatusToConnectorStatus(
+            statusNotificationRequest.status,
+          ),
       };
       if (matchingEvse) {
         statusNotificationInput.evseId = matchingEvse.evseTypeId;

--- a/packages/types/src/interfaces/dto/types/enums.ts
+++ b/packages/types/src/interfaces/dto/types/enums.ts
@@ -105,6 +105,16 @@ export const ChargingStationParkingRestrictionSchema = z.enum([
   'Motorcycles',
 ]);
 
+// Operational status of a charging station.
+export const ChargingStationStatusEnumSchema = z.enum([
+  'AVAILABLE',
+  'CHARGING',
+  'CHARGING_SUSPENDED',
+  'RESERVED',
+  'UNAVAILABLE',
+  'FAULTED',
+]);
+
 export const ChargingStationSequenceTypeSchema = z.enum([
   'customerInformation',
   'getBaseReport',
@@ -617,6 +627,7 @@ export const ChargingStateEnum = ChargingStateEnumSchema.enum;
 export const ChargingStationCapabilityEnum = ChargingStationCapabilitySchema.enum;
 export const ChargingStationParkingRestrictionEnum = ChargingStationParkingRestrictionSchema.enum;
 export const ChargingStationSequenceTypeEnum = ChargingStationSequenceTypeSchema.enum;
+export const ChargingStationStatusEnum = ChargingStationStatusEnumSchema.enum;
 export const ClearMessageStatusEnum = ClearMessageStatusEnumSchema.enum;
 export const ConnectorErrorCodeEnum = ConnectorErrorCodeEnumSchema.enum;
 export const ConnectorFormatEnum = ConnectorFormatEnumSchema.enum;
@@ -705,6 +716,7 @@ export type ChargingStationParkingRestrictionEnumType = z.infer<
 >;
 export type ClearMessageStatusEnumType = z.infer<typeof ClearMessageStatusEnumSchema>;
 export type ChargingStationSequenceTypeEnumType = z.infer<typeof ChargingStationSequenceTypeSchema>;
+export type ChargingStationStatusEnumType = z.infer<typeof ChargingStationStatusEnumSchema>;
 export type ConnectorErrorCodeEnumType = z.infer<typeof ConnectorErrorCodeEnumSchema>;
 export type ConnectorFormatEnumType = z.infer<typeof ConnectorFormatEnumSchema>;
 export type ConnectorPowerTypeEnumType = z.infer<typeof ConnectorPowerTypeEnumSchema>;


### PR DESCRIPTION
### Changes
1. Add a new `ChargingStationStatusEnum`
2. Extend mapping for 1.6 Status and add handling for `RESERVED`
3. Replace protocol specific enum usages with citrine general enum

### Tests
1. Charging with 1.6 Evereset <img width="1522" height="159" alt="Screenshot 2026-09-01 at 4 19 48 PM" src="https://github.com/user-attachments/assets/7cf826e2-c58f-4384-ac84-0e9d6292f48e" />
2. Charing with 2.0.1 (tested using wscat) <img width="1520" height="155" alt="Screenshot 2026-09-01 at 4 32 03 PM" src="https://github.com/user-attachments/assets/c70d7239-0399-4369-8efe-c8a6352eb8e0" />