### PR TITLE
fix(certificates): use jsrsasign 11 CertID param names for OCSP requests

### DIFF
--- a/packages/core/src/util/certificate/CertificateAuthority.ts
+++ b/packages/core/src/util/certificate/CertificateAuthority.ts
@@ -228,11 +228,16 @@ export class CertificateAuthorityService {
     ocspRequestData: OCPP2_1.OCSPRequestDataType[],
   ): Promise<OCPP2_1.AuthorizeCertificateStatusEnumType> {
     for (const reqData of ocspRequestData) {
+      // jsrsasign >= 11 renamed the CertID params: namehash/keyhash/serial became
+      // issname/isskey/sbjsn. The constructor does not validate, so passing the old
+      // names only fails later in getEncodedHex() with "required param members not
+      // defined". The algorithm is resolved by OID name, which is lower case, while
+      // OCPP's HashAlgorithmEnumType is upper case.
       const ocspRequest = new Request({
-        alg: reqData.hashAlgorithm,
-        keyhash: reqData.issuerKeyHash,
-        namehash: reqData.issuerNameHash,
-        serial: reqData.serialNumber,
+        alg: reqData.hashAlgorithm.toLowerCase(),
+        isskey: reqData.issuerKeyHash,
+        issname: reqData.issuerNameHash,
+        sbjsn: reqData.serialNumber,
       });
       this._logger.debug(`OCSP request: ${JSON.stringify(ocspRequest)}`);
 

--- a/packages/core/test/util/certificate/CertificateAuthority.test.ts
+++ b/packages/core/test/util/certificate/CertificateAuthority.test.ts
@@ -291,5 +291,43 @@ describe('CertificateAuthorityService', () => {
       expect(KJUR.asn1.ocsp.OCSPUtil.getOCSPResponseInfo).toHaveBeenCalledWith(mockOCSPResponse);
       expect(actualResult).toBe(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted);
     });
+
+    // Regression guard. KJUR.asn1.ocsp.CertID does not validate in its constructor, so a
+    // request built with the wrong param names is only rejected when it gets encoded --
+    // which happens inside sendOCSPRequest, and that is mocked out above. The assertion
+    // `expect.any(KJUR.asn1.ocsp.Request)` therefore passes for a request that can never
+    // be put on the wire. Encoding it here is what actually pins the shape down:
+    //   - jsrsasign >= 11 expects issname / isskey / sbjsn, not namehash / keyhash / serial
+    //     (otherwise: "required param members not defined")
+    //   - the digest is resolved by OID name, which is lower case, while OCPP's
+    //     HashAlgorithmEnumType is upper case
+    //     (otherwise: "Name of ObjectIdentifier not defined: SHA256")
+    it.each([
+      OCPP2_0_1.HashAlgorithmEnumType.SHA256,
+      OCPP2_0_1.HashAlgorithmEnumType.SHA384,
+      OCPP2_0_1.HashAlgorithmEnumType.SHA512,
+    ])('builds an OCSP request that can be DER-encoded (%s)', async (hashAlgorithm) => {
+      const mockOCSPResponse = faker.lorem.word();
+      let encoded: string | undefined;
+      mockCertUtil.sendOCSPRequest.mockImplementation(async (ocspRequest) => {
+        encoded = ocspRequest.getEncodedHex();
+        return mockOCSPResponse;
+      });
+
+      // Hash lengths are not checked by the encoder, so SHA-256 sized values are fine
+      // for every algorithm here; the point is the algorithm *name*.
+      const actualResult = await certificateAuthorityService.validateCertificateHashData([
+        {
+          hashAlgorithm,
+          issuerNameHash: '0fd741fe2020f72842fa212a4dc59f00d8d9e04a48d6eb01ea68e63978ac0c4a',
+          issuerKeyHash: '12fe0b46efda4f18ef12ab80c467ac1ba3b70f775dc2503414e899521f94b7e9',
+          serialNumber: '3044',
+          responderURL: faker.internet.url(),
+        } as OCPP2_0_1.OCSPRequestDataType,
+      ]);
+
+      expect(actualResult).toBe(OCPP2_0_1.AuthorizeCertificateStatusEnumType.Accepted);
+      expect(encoded).toMatch(/^30[0-9a-f]+$/); // DER SEQUENCE
+    });
   });
 });


### PR DESCRIPTION
## What

`validateCertificateHashData()` builds its OCSP `CertID` with the jsrsasign 10.x
parameter names and passes the OCPP hash-algorithm enum through verbatim. Neither is
accepted by jsrsasign 11.1.3, which is the version resolved in the tree today, so the
request throws while being encoded — and every Plug & Charge `Authorize` carrying
`iso15118CertificateHashData` comes back as `idTokenInfo.status = "Invalid"` /
`certificateStatus = "NoCertificateAvailable"`.

```diff
   const ocspRequest = new Request({
-    alg: reqData.hashAlgorithm,
-    keyhash: reqData.issuerKeyHash,
-    namehash: reqData.issuerNameHash,
-    serial: reqData.serialNumber,
+    alg: reqData.hashAlgorithm.toLowerCase(),
+    isskey: reqData.issuerKeyHash,
+    issname: reqData.issuerNameHash,
+    sbjsn: reqData.serialNumber,
   });
```

## Why it slips through

`KJUR.asn1.ocsp.CertID` does no validation in its constructor — it stores whatever
object it is handed, and the debug log below it prints a plausible-looking request.
The failure only surfaces later, in `getEncodedHex()`:

```js
// jsrsasign 11.1.3, KJUR.asn1.ocsp.CertID.tohex
if (s.issname != undefined && s.isskey != undefined && s.sbjsn != undefined) { ... }
else { throw new Error("required param members not defined") }
```

```
ERROR CertificateAuthority.js  Failed to fetch OCSP response: Error: required param members not defined
    at KJUR.asn1.ocsp.CertID.tohex          (jsrsasign.js:234:8306)
    at KJUR.asn1.ocsp.Request.getEncodedHex (jsrsasign.js:234:9712)
```

Fix the names and a second one appears, because jsrsasign resolves the digest by OID
*name*, which is lower case, while `HashAlgorithmEnumType` is upper case:

```
ERROR CertificateAuthority.js  Failed to fetch OCSP response: Name of ObjectIdentifier not defined: SHA256
```

TypeScript cannot help here — all four values are `string`. And because the exception
is caught and mapped onto `NoCertificateAvailable`, it surfaces as a plausible
"certificate not available" answer rather than as an internal error, which makes it
easy to misattribute to the contract certificate chain or to the V2G CA config.

## Test

The existing suite mocks `CertificateUtil` wholesale, so `sendOCSPRequest()` never
runs and `getEncodedHex()` is never called. The assertion

```ts
expect(mockCertUtil.sendOCSPRequest).toHaveBeenCalledWith(
  expect.any(KJUR.asn1.ocsp.Request),
  givenResponderURL,
);
```

is satisfied by a request that can never be put on the wire. (The existing case also
uses `faker.lorem.word()` for the hashes and serial, which are not valid hex.)

The added case encodes the request *inside* the `sendOCSPRequest` mock and asserts the
result is a DER SEQUENCE, over all three `HashAlgorithmEnumType` values — which is what
actually pins down both the parameter names and the algorithm casing.

```
# packages/core, before the fix
Tests  3 failed | 11 passed (14)
  → expected 'NoCertificateAvailable' to be 'Accepted'

# after
Tests  14 passed (14)
```

## Verification

Verified end to end against a real charge point: EVerest
(`config-sil-ocpp201-pnc.yaml`, OCPP 2.0.1 over TLS, Security Profile 2) running an
ISO 15118-2 session with `Contract` as the selected payment option. With this change the
OCSP request encodes and is actually transmitted; against a responder that speaks the
current dialect the flow completes with `certificateStatus: "Accepted"`,
`PnC Authorization received`, and the transaction starts.

Environment: `ghcr.io/citrineos/citrineos-server:latest` (pulled 2026-09-01),
`@citrineos/ocpp-server@2.0.0-beta3`, `jsrsasign@11.1.3`.

## Deliberately out of scope

While tracing this I hit a third problem that I have **not** touched here, because it
changes the wire format and should be a maintainer decision:

`sendOCSPRequest()` posts `ocspRequest.getEncodedHex()` — ASCII hex — as the body of an
`application/ocsp-request`, where RFC 6960 §A.1 specifies binary DER; and
`validateCertificateHashData()` sends a bare `KJUR.asn1.ocsp.Request`
(`SEQUENCE { CertID }`) rather than a complete `OCSPRequest`. Standard parsers (e.g.
`cryptography.x509.ocsp.load_der_ocsp_request`) reject it, and a public responder I
tried answered 405. Notably `validateCertificateChain()`, in this same file, uses
`KJUR.asn1.ocsp.OCSPRequest` with a `reqList`, which is correct — so the two paths in
this file disagree with each other.

Happy to open a separate issue or a follow-up PR for that if you would like it
addressed. I kept this PR to the part that is unambiguous and safe to merge on its own.

## Notes

- Two commits: the fix, then the regression test.
- `pnpm --filter @citrineos/core test` → 14/14. I did not run the repo-wide `pnpm test`
  or the operator-ui e2e lanes locally.
- Both changed files are Prettier-clean (`prettier/prettier` is an error in this repo's
  eslint config).
- No behaviour change outside the construction of the OCSP request.
