### PR TITLE
fix(types): let evseId be 0 where OCPP addresses the Charging Station

### DIFF
--- a/packages/base/test/modules/ocpp-validator.test.ts
+++ b/packages/base/test/modules/ocpp-validator.test.ts
@@ -415,6 +415,85 @@ describe('OCPPValidator', () => {
         expect(result.isValid).toBe(true);
       });
     });
+
+    /**
+     * evseId 0 is the Charging Station itself: MeterValues from the grid meter (J01.FR.14),
+     * a limit that applies to the whole station (K11), a ClearChargingProfile of the
+     * ChargingStationMaxProfile (K10). The Part 3 schemas bound it at 0, not 1.
+     */
+    describe('evseId 0 addresses the Charging Station', () => {
+      const meterValuesForTheGridMeter = {
+        evseId: 0,
+        meterValue: [
+          {
+            timestamp: '2026-06-10T13:42:56.340Z',
+            sampledValue: [{ value: 3.4, location: 'Inlet' }],
+          },
+        ],
+      };
+
+      it.each([OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1])(
+        'accepts a MeterValuesRequest for the grid meter on %s',
+        (protocol) => {
+          const result = validator.validateOCPPRequest(
+            OCPP_CallAction.MeterValues,
+            meterValuesForTheGridMeter,
+            protocol,
+          );
+
+          expect(result.isValid).toBe(true);
+          expect(result.errors).toBeUndefined();
+        },
+      );
+
+      it.each([OCPPVersion.OCPP2_0_1, OCPPVersion.OCPP2_1])(
+        'still refuses a negative evseId in a MeterValuesRequest on %s',
+        (protocol) => {
+          const result = validator.validateOCPPRequest(
+            OCPP_CallAction.MeterValues,
+            { ...meterValuesForTheGridMeter, evseId: -1 },
+            protocol,
+          );
+
+          expect(result.isValid).toBe(false);
+        },
+      );
+
+      it('accepts a NotifyChargingLimitRequest for the whole station on OCPP 2.1', () => {
+        const result = validator.validateOCPPRequest(
+          OCPP_CallAction.NotifyChargingLimit,
+          { evseId: 0, chargingLimit: { chargingLimitSource: 'EMS' } },
+          OCPPVersion.OCPP2_1,
+        );
+
+        expect(result.isValid).toBe(true);
+      });
+
+      it('accepts a ClearedChargingLimitRequest for the whole station on OCPP 2.1', () => {
+        const result = validator.validateOCPPRequest(
+          OCPP_CallAction.ClearedChargingLimit,
+          { evseId: 0, chargingLimitSource: 'EMS' },
+          OCPPVersion.OCPP2_1,
+        );
+
+        expect(result.isValid).toBe(true);
+      });
+
+      it('lets the CSMS clear the ChargingStationMaxProfile on OCPP 2.1', () => {
+        const result = validator.validateOCPPRequest(
+          OCPP_CallAction.ClearChargingProfile,
+          {
+            chargingProfileCriteria: {
+              evseId: 0,
+              chargingProfilePurpose: 'ChargingStationMaxProfile',
+            },
+          },
+          OCPPVersion.OCPP2_1,
+        );
+
+        expect(result.isValid).toBe(true);
+      });
+    });
   });
 
   describe('validateOCPPResponse', () => {
@@ -524,6 +603,26 @@ describe('OCPPValidator', () => {
       );
 
       expect(result.isValid).toBe(false);
+    });
+
+    it('accepts a station-wide composite schedule (evseId 0) on OCPP 2.1', () => {
+      const result = validator.validateOCPPResponse(
+        OCPP_CallAction.GetCompositeSchedule,
+        {
+          status: 'Accepted',
+          schedule: {
+            evseId: 0,
+            duration: 3600,
+            scheduleStart: '2026-06-10T13:42:56.340Z',
+            chargingRateUnit: 'A',
+            chargingSchedulePeriod: [{ startPeriod: 0, limit: 32 }],
+          },
+        },
+        OCPPVersion.OCPP2_1,
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toBeUndefined();
     });
   });
 

--- a/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesRequest.json
+++ b/packages/types/src/ocpp/model/2.0.1/schemas/MeterValuesRequest.json
@@ -248,7 +248,7 @@
     "evseId": {
       "description": "Request_ Body. EVSEID. Numeric_ Identifier\r\nurn:x-enexis:ecdm:uid:1:571101\r\nThis contains a number (&gt;0) designating an EVSE of the Charging Station. ‘0’ (zero) is used to designate the main power meter.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "meterValue": {

--- a/packages/types/src/ocpp/model/2.1/schemas/ClearChargingProfileRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/ClearChargingProfileRequest.json
@@ -33,7 +33,7 @@
         "evseId": {
           "description": "Specifies the id of the EVSE for which to clear charging profiles. An evseId of zero (0) specifies the charging profile for the overall Charging Station. Absence of this parameter means the clearing applies to all charging profiles that match the other criteria in the request.\r\n\r\n",
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "maximum": 2147483647
         },
         "chargingProfilePurpose": {

--- a/packages/types/src/ocpp/model/2.1/schemas/ClearedChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/ClearedChargingLimitRequest.json
@@ -26,7 +26,7 @@
     "evseId": {
       "description": "EVSE Identifier.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "customData": {

--- a/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleResponse.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/GetCompositeScheduleResponse.json
@@ -165,7 +165,7 @@
       "properties": {
         "evseId": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": 0,
           "maximum": 2147483647
         },
         "duration": {

--- a/packages/types/src/ocpp/model/2.1/schemas/MeterValuesRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/MeterValuesRequest.json
@@ -306,7 +306,7 @@
     "evseId": {
       "description": "This contains a number (&gt;0) designating an EVSE of the Charging Station. ‘0’ (zero) is used to designate the main power meter.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "meterValue": {

--- a/packages/types/src/ocpp/model/2.1/schemas/NotifyChargingLimitRequest.json
+++ b/packages/types/src/ocpp/model/2.1/schemas/NotifyChargingLimitRequest.json
@@ -852,7 +852,7 @@
     "evseId": {
       "description": "The EVSE to which the charging limit is set. If absent or when zero, it applies to the entire Charging Station.\r\n",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 2147483647
     },
     "chargingLimit": {


### PR DESCRIPTION
## What

`evseId` 0 is the Charging Station itself, and five schemas refused it with `"minimum": 1` on the same line their own description says otherwise. Six one-line schema changes, `1` → `0`:

| Schema | Version | The spec's own words |
|---|---|---|
| `MeterValuesRequest.evseId` | 2.0.1 **and** 2.1 | "'0' (zero) is used to designate the main power meter." |
| `NotifyChargingLimitRequest.evseId` | 2.1 | "If absent or when zero, it applies to the entire Charging Station." |
| `ClearedChargingLimitRequest.evseId` | 2.1 | Part 3 schema: `"minimum": 0` |
| `ClearChargingProfileRequest` → `ClearChargingProfileType.evseId` | 2.1 | "An evseId of zero (0) specifies the charging profile for the overall Charging Station." |
| `GetCompositeScheduleResponse` → `CompositeScheduleType.evseId` | 2.1 | Part 2 §2.27: `integer, 0 <= val` |

The published 2.1 Part 3 schemas carry `"minimum": 0` on every one of these; the 2.0.1 schema carries no minimum at all. The repo had `1`.

## Why it matters

**J01.FR.14** (2.0.1 and 2.1): when `AlignedDataCtrlr.Interval > 0` the station SHALL send a `MeterValuesRequest` "for all evseIds, locations and phases for which a configured measurand is supported", and the spec's own worked example under J01 is:

> a MeterValuesRequest with: evseId = 0; with 3 SampledValue elements, one per phase with location = Inlet.

That message is answered `FormatViolation` today. `MeterValuesRequestOcpp2Handler` already has the branch for it - `// When evseId is 0, the MeterValuesRequest message SHALL be associated with the entire Charging Station.` - but the schema validator runs first (`AbstractRouter.ts:118`), so the branch is unreachable.

The CSMS validates outbound messages too (`OcppSender.ts:86`), so on 2.1 it also refused its **own** `ClearChargingProfile` of a `ChargingStationMaxProfile` (K10, always `evseId` 0), and rejected the station-wide composite schedule a `GetCompositeSchedule(evseId: 0)` returns.

## What stays

- 2.0.1 `NotifyChargingLimitRequest.evseId` keeps `1` - its text says "evseId must be > 0".
- Every `evseId` whose text says "> 0" (ReserveNow, Reset, UnlockConnector, StatusNotification, `IdTokenInfoType.evseId`) is untouched.
- The `maximum` (int32) stays on all of them; a negative `evseId` is still refused (tested).

## Tests

`OCPPValidator.test.ts`: MeterValues with `evseId: 0` accepted on 2.0.1 and 2.1 and `-1` still refused on both; NotifyChargingLimit, ClearedChargingLimit and ClearChargingProfile at `evseId: 0` accepted on 2.1; a `GetCompositeScheduleResponse` whose schedule has `evseId: 0` accepted on 2.1. 59 tests in the file, all green; `packages/types` and `packages/base` build and lint clean.

Does not overlap #959 (validator `multipleOfPrecision`) or #960 (2.1 `multipleOf` on `ChargingSchedulePeriodType.limit`): different hunks in the two shared files.
