### PR TITLE
fix(ocpp): answer an action the CSMS does not know with NotImplemented

### DIFF
--- a/packages/ocpp/src/modules/ocpp-router/router.ts
+++ b/packages/ocpp/src/modules/ocpp-router/router.ts
@@ -604,7 +604,19 @@ export class MessageRouterImpl extends AbstractMessageRouter implements IMessage
 
     this._logger.debug('_onCall:', identifier, message, timestamp.toISOString(), protocol);
 
-    const action = mapToCallAction(protocol, message.action);
+    let action: CallAction;
+    try {
+      action = mapToCallAction(protocol, message.action);
+    } catch {
+      // OCPP-J 4.3: "NotImplemented - Requested Action is not known by receiver." That covers an
+      // action no version defines and one this protocol version does not, e.g. a 2.1 message on a
+      // 2.0.1 connection. InternalError tells the station the CSMS broke; it did not.
+      throw new OcppError(
+        messageId,
+        ErrorCode.NotImplemented,
+        `Action ${message.action} is not known for ${protocol}`,
+      );
+    }
     const isAllowed = await this._onCallIsAllowed(action, identifier);
     if (!isAllowed) {
       throw new OcppError(messageId, ErrorCode.SecurityError, `Action ${action} not allowed`);

--- a/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
+++ b/packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts
@@ -500,6 +500,36 @@ describe('MessageRouterImpl', () => {
       expect(sentMessage[2]).toBe(ErrorCode.SecurityError);
     });
 
+    /**
+     * OCPP-J 4.3: "NotImplemented - Requested Action is not known by receiver." InternalError is
+     * "an internal error occurred and the receiver was not able to process the requested Action",
+     * which is what a station was told when it merely spoke a newer dialect.
+     */
+    it.each([
+      ['an action no version defines', 'NotAnAction', OCPPVersion.OCPP2_0_1],
+      ['a 2.1 action on a 2.0.1 connection', 'NotifyPriorityCharging', OCPPVersion.OCPP2_0_1],
+      ['a 2.x action on a 1.6 connection', 'TransactionEvent', OCPPVersion.OCPP1_6],
+    ])('answers %s with NotImplemented', async (_label, action, protocol) => {
+      const callMessage = JSON.stringify([MessageTypeId.Call, CORRELATION_ID, action, {}]);
+
+      const result = await router.onMessage(IDENTIFIER, callMessage, timestamp, protocol);
+
+      expect(result).toBe(false);
+      const sentMessage = JSON.parse(networkHook.mock.calls[0][1]);
+      expect(sentMessage[0]).toBe(MessageTypeId.CallError);
+      expect(sentMessage[1]).toBe(CORRELATION_ID);
+      expect(sentMessage[2]).toBe(ErrorCode.NotImplemented);
+      expect(sender.send).not.toHaveBeenCalled();
+    });
+
+    it('still records a Call whose action it does not know', async () => {
+      const callMessage = JSON.stringify([MessageTypeId.Call, CORRELATION_ID, 'NotAnAction', {}]);
+
+      await router.onMessage(IDENTIFIER, callMessage, timestamp, PROTOCOL);
+
+      expect(dispatcher.dispatchMessageReceived).toHaveBeenCalled();
+    });
+
     it('should send CallError when validation fails', async () => {
       cache.exists.mockResolvedValue(false);
       vi.spyOn(router as any, '_validateCall').mockReturnValue({


### PR DESCRIPTION
## What

An action the CSMS does not know was answered `CALLERROR InternalError "Unable to process message"`. It is now `NotImplemented`.

OCPP-J Part 4 §4.3, identical wording in 1.6, 2.0.1 and 2.1:

| Code | Meaning |
|---|---|
| `NotImplemented` | Requested Action is not known by receiver |
| `NotSupported` | Requested Action is recognized but not supported by the receiver |
| `InternalError` | An internal error occurred and the receiver was not able to process the requested Action successfully |

## How it happened

`mapToCallAction` (`packages/base/src/ocpp/rpc/message.ts:430`) throws a plain `Error` for an action string outside the protocol's action set. `_onCall` called it on its first line, **before** its own `try` (`router.ts:607`), so the error escaped to `onMessage`'s catch at `router.ts:329`, which wraps anything that is not an `OcppError` as `InternalError`.

So a 2.1 station connected as 2.0.1 that sends `NotifyPriorityCharging`, `ReportDERControl` or `NotifyDERAlarm` - or any station sending an action no version defines - is told the CSMS *broke*. It did not; it does not implement that action. The distinction matters to the station: an `InternalError` is plausibly transient and worth retrying, a `NotImplemented` is not.

The known-but-unrouted case (action in the set, no module handler) was already `NotSupported` via `AbstractModule.ts:293`; that path is untouched.

## Change

`_onCall` maps the action inside its own error handling and throws `OcppError(NotImplemented)` for an unknown one, which the existing path turns into the CALLERROR. Fourteen lines. The message is still recorded through `dispatchMessageReceived`.

## Tests

`packages/ocpp/test/modules/ocpp-router/message-router-impl.test.ts`, four new: an action no version defines, a 2.1 action on a 2.0.1 connection, a 2.x action on a 1.6 connection - each answered `CallError` with `NotImplemented` on the same messageId and never forwarded to the broker; and the ignored call still reaches the webhook dispatcher. 80 tests in the file, green. `packages/ocpp` builds and lints clean.

Independent of #968 (message *type* numbers, `router.ts:253`); this is the *action* name at `router.ts:607`. Different hunks.

