### PR TITLE
fix(ocpp): stop offering ClearedChargingLimit as a message the CSMS sends

### DIFF
--- a/packages/ocpp/src/apis/ocpp/2/smart-charging.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging.ts
@@ -1,26 +1,15 @@
 // SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
-import { type MessageEndpointClass, forwardMessageEndpoint } from '@citrineos/base';
-import { EventGroup, OCPP_CallAction } from '@citrineos/types';
-import { OCPP2_PROTOCOLS, ocpp2Schema } from './schemas.js';
+import type { MessageEndpointClass } from '@citrineos/base';
 import { ClearChargingProfileEndpoint } from './smart-charging/clear-charging-profile-endpoint.js';
 import { GetChargingProfilesEndpoint } from './smart-charging/get-charging-profiles-endpoint.js';
 import { GetCompositeScheduleEndpoint } from './smart-charging/get-composite-schedule-endpoint.js';
 import { SetChargingProfileEndpoint } from './smart-charging/set-charging-profile-endpoint.js';
 
-const ocpp2 = (action: OCPP_CallAction, schemaName: string) =>
-  forwardMessageEndpoint({
-    action,
-    protocols: OCPP2_PROTOCOLS,
-    eventGroup: EventGroup.SmartCharging,
-    bodySchema: ocpp2Schema(schemaName),
-  });
-
 export const SMART_CHARGING_MESSAGE_ENDPOINTS = [
   ClearChargingProfileEndpoint,
   GetChargingProfilesEndpoint,
   SetChargingProfileEndpoint,
-  ocpp2(OCPP_CallAction.ClearedChargingLimit, 'ClearedChargingLimitRequestSchema'),
   GetCompositeScheduleEndpoint,
 ] satisfies ReadonlyArray<MessageEndpointClass>;

--- a/packages/ocpp/test/apis/ocpp/smart-charging-endpoint-list.test.ts
+++ b/packages/ocpp/test/apis/ocpp/smart-charging-endpoint-list.test.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from 'vitest';
+import { OCPP_CallAction } from '@citrineos/types';
+import { SMART_CHARGING_MESSAGE_ENDPOINTS } from '@/apis/ocpp/2/smart-charging.js';
+
+/**
+ * A message endpoint forwards a CALL from the operator API to the station, so it can only carry an
+ * action the CSMS sends. Part 2 defines these smart charging messages as sent by the Charging
+ * Station to the CSMS: a station that receives one of them as a CALL answers NotImplemented.
+ */
+const STATION_TO_CSMS = [
+  OCPP_CallAction.ClearedChargingLimit,
+  OCPP_CallAction.NotifyChargingLimit,
+  OCPP_CallAction.NotifyEVChargingNeeds,
+  OCPP_CallAction.NotifyEVChargingSchedule,
+  OCPP_CallAction.ReportChargingProfiles,
+];
+
+describe('smart charging message endpoints', () => {
+  it('only forward actions the CSMS sends to the station', () => {
+    const actions = SMART_CHARGING_MESSAGE_ENDPOINTS.map((endpoint) => endpoint.route.action);
+
+    expect(actions).toEqual([
+      OCPP_CallAction.ClearChargingProfile,
+      OCPP_CallAction.GetChargingProfiles,
+      OCPP_CallAction.SetChargingProfile,
+      OCPP_CallAction.GetCompositeSchedule,
+    ]);
+    expect(actions.filter((action) => STATION_TO_CSMS.includes(action))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`SMART_CHARGING_MESSAGE_ENDPOINTS` registered `ClearedChargingLimit` as a forward endpoint (`smartCharging.ts:24`), so the operator API offered a route that sends a `ClearedChargingLimitRequest` CALL **to** a station. Removed.

## Why

`ClearedChargingLimitRequest` goes the other way. Part 2, in 2.0.1 (§1.14.1) and 2.1 (§1.14.1) alike:

> This contains the field definition of the ClearedChargingLimitRequest PDU **sent by the Charging Station to the CSMS**.

It is how a station tells the CSMS an external limit (K12) has been lifted, and the CSMS's job is to acknowledge it - which `ClearedChargingLimitRequestOcpp2Handler` does. A station that receives one as a CALL answers `NotImplemented`, so the route could only ever produce an operator request the CSMS accepted and a station refused.

Nothing else referenced the endpoint: no test, no client, no docs.

## Change

One entry removed from the list, and the now-unused `ocpp2()` helper and its imports with it. The four endpoints left are the four smart charging messages the CSMS sends: `ClearChargingProfile`, `GetChargingProfiles`, `SetChargingProfile`, `GetCompositeSchedule`.

## Tests

New `packages/ocpp/test/apis/ocpp/smart-charging-endpoint-list.test.ts`: the list's actions are exactly those four, and none of the five station-to-CSMS smart charging actions (`ClearedChargingLimit`, `NotifyChargingLimit`, `NotifyEVChargingNeeds`, `NotifyEVChargingSchedule`, `ReportChargingProfiles`) appears in it. A separate file rather than an addition to `smart-charging-endpoints.test.ts`, which #939 is editing. The endpoint test directory is green at 130 tests; `packages/ocpp` builds and lints clean.

