### PR TITLE
fix(dal): scope createChargingNeeds and getTransactionsCount to the tenant

### DIFF
--- a/packages/dal/src/repositories/sequelize/charging-profile.ts
+++ b/packages/dal/src/repositories/sequelize/charging-profile.ts
@@ -182,6 +182,7 @@ export class SequelizeChargingProfileRepository
   ): Promise<ChargingNeeds> {
     const activeTransaction = await Transaction.findOne({
       where: {
+        tenantId,
         ocppConnectionName: ocppConnectionName,
         isActive: true,
       },

--- a/packages/dal/src/repositories/sequelize/transaction-event.ts
+++ b/packages/dal/src/repositories/sequelize/transaction-event.ts
@@ -511,7 +511,7 @@ export class SequelizeTransactionEventRepository
 
   async getTransactionsCount(tenantId: number, dateFrom?: Date, dateTo?: Date): Promise<number> {
     const queryOptions: WhereOptions<any> = {
-      where: {},
+      where: { tenantId },
     };
 
     if (dateFrom) {

--- a/packages/dal/test/repositories/sequelize/shared-station-name-tenant-scope-integration.test.ts
+++ b/packages/dal/test/repositories/sequelize/shared-station-name-tenant-scope-integration.test.ts
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import type { Sequelize } from 'sequelize-typescript';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import { OCPP2_0_1, type SystemConfig } from '@citrineos/types';
+import {
+  ChargingStation,
+  DefaultSequelizeInstance,
+  Evse,
+  EvseType,
+  SequelizeChargingProfileRepository,
+  SequelizeTransactionEventRepository,
+  Tenant,
+  Transaction,
+} from '../../../index.js';
+
+const OTHER_TENANT_ID = DEFAULT_TENANT_ID + 1;
+const SHARED_STATION_NAME = 'CS-SHARED';
+const OCPP_EVSE_NUMBER = 1;
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let config: SystemConfig;
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  config = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as SystemConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(config);
+  await sequelizeInstance.query('CREATE EXTENSION IF NOT EXISTS citext;');
+  await sequelizeInstance.sync({ force: true });
+}, 90_000);
+
+afterAll(async () => {
+  await sequelizeInstance?.close();
+  await pgContainer?.stop();
+});
+
+let nextEvseTypeNumber = 1;
+
+async function aStationWithOneEvse(tenantId: number): Promise<number> {
+  await ChargingStation.create({
+    ocppConnectionName: SHARED_STATION_NAME,
+    isOnline: true,
+    tenantId,
+  } as never);
+  await EvseType.create({ tenantId, id: nextEvseTypeNumber++, connectorId: null } as never);
+  const evse = await Evse.create({
+    tenantId,
+    ocppConnectionName: SHARED_STATION_NAME,
+    evseTypeId: OCPP_EVSE_NUMBER,
+  } as never);
+  return (evse as unknown as { id: number }).id;
+}
+
+async function anActiveTransaction(
+  tenantId: number,
+  evseDatabaseId: number,
+  transactionId: string,
+) {
+  const transaction = await Transaction.create({
+    tenantId,
+    ocppConnectionName: SHARED_STATION_NAME,
+    transactionId,
+    isActive: true,
+    evseId: evseDatabaseId,
+  } as never);
+  return (transaction as unknown as { id: number }).id;
+}
+
+function chargingNeedsOn(evseId: number): OCPP2_0_1.NotifyEVChargingNeedsRequest {
+  return {
+    evseId,
+    chargingNeeds: {
+      requestedEnergyTransfer: OCPP2_0_1.EnergyTransferModeEnumType.AC_three_phase,
+      acChargingParameters: {
+        energyAmount: 20000,
+        evMinCurrent: 6,
+        evMaxCurrent: 32,
+        evMaxVoltage: 400,
+      },
+    },
+  };
+}
+
+describe('Repository reads on a station name shared by two tenants', () => {
+  let chargingProfileRepository: SequelizeChargingProfileRepository;
+  let transactionEventRepository: SequelizeTransactionEventRepository;
+  let ownEvseDatabaseId: number;
+  let otherEvseDatabaseId: number;
+
+  beforeEach(async () => {
+    await sequelizeInstance.truncate({ cascade: true, restartIdentity: true });
+    await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'A' } as never);
+    await Tenant.create({ id: OTHER_TENANT_ID, name: 'B' } as never);
+    nextEvseTypeNumber = 1;
+
+    otherEvseDatabaseId = await aStationWithOneEvse(OTHER_TENANT_ID);
+    ownEvseDatabaseId = await aStationWithOneEvse(DEFAULT_TENANT_ID);
+
+    const dependencies = { config, logger: undefined, sequelizeInstance } as never;
+    chargingProfileRepository = new SequelizeChargingProfileRepository(dependencies);
+    transactionEventRepository = new SequelizeTransactionEventRepository(dependencies);
+  });
+
+  describe('createChargingNeeds', () => {
+    it("does not attach the needs to the other tenant's transaction", async () => {
+      await anActiveTransaction(OTHER_TENANT_ID, otherEvseDatabaseId, 'T-OTHER');
+
+      await expect(
+        chargingProfileRepository.createChargingNeeds(
+          DEFAULT_TENANT_ID,
+          chargingNeedsOn(OCPP_EVSE_NUMBER),
+          SHARED_STATION_NAME,
+        ),
+      ).rejects.toThrow(/No active transaction found/);
+    });
+
+    it("attaches the needs to the caller's own transaction when both tenants have one", async () => {
+      await anActiveTransaction(OTHER_TENANT_ID, otherEvseDatabaseId, 'T-OTHER');
+      const ownTransactionId = await anActiveTransaction(
+        DEFAULT_TENANT_ID,
+        ownEvseDatabaseId,
+        'T-OWN',
+      );
+
+      const chargingNeeds = await chargingProfileRepository.createChargingNeeds(
+        DEFAULT_TENANT_ID,
+        chargingNeedsOn(OCPP_EVSE_NUMBER),
+        SHARED_STATION_NAME,
+      );
+
+      expect(chargingNeeds.transactionDatabaseId).toBe(ownTransactionId);
+      expect(chargingNeeds.evseId).toBe(ownEvseDatabaseId);
+    });
+  });
+
+  describe('getTransactionsCount', () => {
+    it("counts only the caller's tenant", async () => {
+      await anActiveTransaction(OTHER_TENANT_ID, otherEvseDatabaseId, 'T-OTHER-1');
+      await anActiveTransaction(OTHER_TENANT_ID, otherEvseDatabaseId, 'T-OTHER-2');
+      await anActiveTransaction(DEFAULT_TENANT_ID, ownEvseDatabaseId, 'T-OWN');
+
+      const count = await transactionEventRepository.getTransactionsCount(DEFAULT_TENANT_ID);
+
+      expect(count).toBe(1);
+    });
+
+    it('agrees with the page getTransactions returns for the same tenant', async () => {
+      await anActiveTransaction(OTHER_TENANT_ID, otherEvseDatabaseId, 'T-OTHER-1');
+      await anActiveTransaction(DEFAULT_TENANT_ID, ownEvseDatabaseId, 'T-OWN-1');
+      await anActiveTransaction(DEFAULT_TENANT_ID, ownEvseDatabaseId, 'T-OWN-2');
+
+      const [count, page] = await Promise.all([
+        transactionEventRepository.getTransactionsCount(DEFAULT_TENANT_ID),
+        transactionEventRepository.getTransactions(DEFAULT_TENANT_ID),
+      ]);
+
+      expect(count).toBe(page.length);
+      expect(count).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## What

Two Sequelize reads bypassed the tenant-scoped base repository and left `tenantId` out of their `where`. Both now carry it.

| Method | Was | Effect |
|---|---|---|
| `SequelizeChargingProfileRepository.createChargingNeeds` (`ChargingProfile.ts:179`) | `Transaction.findOne({ where: { ocppConnectionName, isActive: true }, include: [Evse where evseTypeId] })` | Picks up a same-named station's active transaction **in another tenant** |
| `SequelizeTransactionEventRepository.getTransactionsCount` (`TransactionEvent.ts:520`) | `Transaction.count({ where: {} + date window })` | Counts every tenant's transactions; `getTransactions` beside it is tenant-scoped |

## Why it is reachable

A station name is unique **per tenant**, not globally - the constraint is `ChargingStations_stationName_tenantId_key ("ocppConnectionName", "tenantId")`. So two tenants can each have a `CS-1`, and every lookup by station name that omits the tenant can cross between them. That is the reason #884, #900, #911 and #916 exist; these two are the same class, found by sweeping the repository layer for direct `Model.findOne/count` calls whose `where` has no `tenantId`. These were the only two.

For `createChargingNeeds` the consequence is not just a wrong row: the `ChargingNeeds` written against the other tenant's transaction is what `calculateChargingProfile` reads, so the `SetChargingProfile` the CSMS then sends the station was computed from a stranger's requested energy.

## Tests

`packages/dal/test/repositories/sequelize/shared-station-name-tenant-scope-integration.test.ts` (testcontainers): two tenants, each with a station called `CS-SHARED` and one EVSE.

- With an active transaction only in the other tenant, `createChargingNeeds` for the caller's tenant now throws `No active transaction found`; before the fix it **resolved** with a `ChargingNeeds` row pointing at the other tenant's transaction.
- With a transaction in both, the needs attach to the caller's own transaction and EVSE (before: `expected 1 to be 2`).
- `getTransactionsCount` returns 1 with one own and two foreign transactions (before: 3), and equals the length of the page `getTransactions` returns.

Run without the fix, all four fail as described; with it, all four pass. `packages/dal` builds and lints clean. A new test file rather than an addition to `charging-needs-lookup-integration.test.ts`, which #960 is editing.

