### PR TITLE
perf(ocpp-server): index the columns the message handlers read by

### DIFF
--- a/apps/ocpp-server/migrations/20260902120000-add-hot-path-indexes.ts
+++ b/apps/ocpp-server/migrations/20260902120000-add-hot-path-indexes.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { QueryInterface } from 'sequelize';
+
+export const HOT_PATH_INDEXES: ReadonlyArray<{ name: string; table: string; columns: string[] }> = [
+  {
+    name: 'transactions_tenant_id_ocpp_connection_name_is_active',
+    table: 'Transactions',
+    columns: ['tenantId', 'ocppConnectionName', 'isActive'],
+  },
+  {
+    name: 'transactions_tenant_id_ocpp_connection_name_transaction_id',
+    table: 'Transactions',
+    columns: ['tenantId', 'ocppConnectionName', 'transactionId'],
+  },
+  {
+    name: 'transactions_authorization_id',
+    table: 'Transactions',
+    columns: ['authorizationId'],
+  },
+  {
+    name: 'transactions_tenant_id_updated_at',
+    table: 'Transactions',
+    columns: ['tenantId', 'updatedAt'],
+  },
+  {
+    name: 'meter_values_transaction_database_id',
+    table: 'MeterValues',
+    columns: ['transactionDatabaseId'],
+  },
+  {
+    name: 'meter_values_transaction_event_id',
+    table: 'MeterValues',
+    columns: ['transactionEventId'],
+  },
+  {
+    name: 'transaction_events_transaction_database_id',
+    table: 'TransactionEvents',
+    columns: ['transactionDatabaseId'],
+  },
+  {
+    name: 'latest_status_notifications_tenant_id_ocpp_connection_name',
+    table: 'LatestStatusNotifications',
+    columns: ['tenantId', 'ocppConnectionName'],
+  },
+  {
+    name: 'connectors_evse_id',
+    table: 'Connectors',
+    columns: ['evseId'],
+  },
+  {
+    name: 'charging_profiles_transaction_database_id',
+    table: 'ChargingProfiles',
+    columns: ['transactionDatabaseId'],
+  },
+  {
+    name: 'charging_schedules_charging_profile_database_id',
+    table: 'ChargingSchedules',
+    columns: ['chargingProfileDatabaseId'],
+  },
+  {
+    name: 'charging_needs_transaction_database_id',
+    table: 'ChargingNeeds',
+    columns: ['transactionDatabaseId'],
+  },
+  {
+    name: 'authorizations_tenant_partner_id',
+    table: 'Authorizations',
+    columns: ['tenantPartnerId'],
+  },
+];
+
+const quoted = (columns: string[]) => columns.map((column) => `"${column}"`).join(', ');
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  for (const index of HOT_PATH_INDEXES) {
+    await queryInterface.sequelize.query(
+      `CREATE INDEX IF NOT EXISTS "${index.name}" ON "${index.table}" (${quoted(index.columns)})`,
+    );
+  }
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  for (const index of HOT_PATH_INDEXES) {
+    await queryInterface.sequelize.query(`DROP INDEX IF EXISTS "${index.name}"`);
+  }
+}


### PR DESCRIPTION
## What

One migration adding thirteen indexes for the lookups the message handlers run on every transaction event, meter value and status notification. The table below is the reference for which query each one serves.

## Why

Postgres does not index a foreign key column on its own. I applied every migration on `next` to a scratch Postgres and dumped `pg_indexes` and `pg_constraint`: **104 foreign key columns have no index at all**, and past their primary keys `MeterValues` and `TransactionEvents` have **none**. Cross-referenced with the `where` clauses in `packages/dal/src/repositories` (`packages/core/src/dal` before #990), these are the ones with a hot query behind them:

| Index | Query it serves |
|---|---|
| `Transactions (tenantId, ocppConnectionName, isActive)` | `getActiveTransactionByStationIdAndEvseId`, `getEvseIdsWithActiveTransactionByStationId`, `deactivateActiveTransactionsByStationIdAndEvseId`, `createChargingNeeds` - every MeterValues, every 2.x TransactionEvent |
| `Transactions (tenantId, ocppConnectionName, transactionId)` | `readTransactionByStationIdAndTransactionId`, `updateTransactionByStationIdAndTransactionId`, 1.6 StopTransaction. The unique index is on `(stationId, transactionId)`; these read by the name column |
| `Transactions (authorizationId)` | `readAllActiveTransactionsByAuthorizationId` - the concurrent-transaction check on every Authorize and TransactionEvent(Started); the OCPI join |
| `Transactions (tenantId, updatedAt)` | `getTransactions` / `getTransactionsCount`, OCPI Sessions and CDRs date paging |
| `MeterValues (transactionDatabaseId)` | `readAllMeterValuesByTransactionDataBaseId` and the `MeterValue` include on every Transaction read |
| `MeterValues (transactionEventId)` | the include on a TransactionEvent read |
| `TransactionEvents (transactionDatabaseId)` | the include on every Transaction read |
| `LatestStatusNotifications (tenantId, ocppConnectionName)` | `addStatusNotificationToChargingStation`, every StatusNotification |
| `Connectors (evseId)` | `readChargingStationByStationId` includes Evse -> Connector, on every StatusNotification and transaction event |
| `ChargingProfiles (transactionDatabaseId)` | TxProfile lookups in `ChargingProfile.ts`, `SetChargingProfileEndpoint`, E17 resume |
| `ChargingSchedules (chargingProfileDatabaseId)` | schedule reads and the include |
| `ChargingNeeds (transactionDatabaseId)` | `where { evseId, transactionDatabaseId }` |
| `Authorizations (tenantPartnerId)` | OCPI Sessions / CDRs join Authorization -> TenantPartner |

`tenantId` leads where the base repository adds it to every `where`. Not added: an index on `tenantId` alone for the other ~60 FK columns - low cardinality, always paired, not worth the write cost.

## Measured

Scratch database, migrations on `next` applied, then 20k transactions, 600k meter values, 200k transaction events; `EXPLAIN (ANALYZE)` before and after this migration ran through `sequelize-cli db:migrate`:

| Query | Before | After |
|---|---|---|
| MeterValues by transaction | Parallel Seq Scan, **17.5 ms** | Bitmap Index Scan, **0.28 ms** |
| TransactionEvents by transaction | Parallel Seq Scan, 12.7 ms | Bitmap Index Scan, 0.20 ms |
| Active transactions on a station | Seq Scan, 2.0 ms | Bitmap Index Scan, 0.56 ms |
| Transactions in a date window (count) | Seq Scan, 2.9 ms | Index Only Scan, 0.23 ms |

The first is the one behind every cost calculation and every `totalKwh` update, and it scales with the largest table a CSMS has.

## Safety

`CREATE INDEX IF NOT EXISTS`, so re-running is a no-op; `down` drops exactly the thirteen. No model or Drizzle schema change, following the precedent of `20260205150000-add-latest-ocpp-message-timestamp` (index in the migration only).

## Tests

No test file. `apps/ocpp-server` has no entry in the root `vitest.config.ts` `projects` array, so nothing under `apps/ocpp-server/test/` runs in CI - the existing `test/e2e/security-event-e2e.test.ts` says as much in its own header. A suite there would have been dead weight, and adding an `ocpp-server` project to the shared config would switch that e2e on from inside a perf PR.

Verified locally instead, against `c1bd4ca` with testcontainers: every named index exists on the named table with the named columns after `up`, `up` twice leaves one of each, and `down` removes exactly those and nothing else. That also confirms all thirteen table and column names still resolve after the partitioning work. Build, full suite and lint are clean.
