### PR TITLE
feat(core): make the AMQP queue type configurable, allowing quorum queues

### DIFF
--- a/packages/core/src/util/queue/rabbit-mq/receiver.ts
+++ b/packages/core/src/util/queue/rabbit-mq/receiver.ts
@@ -31,6 +31,28 @@ import { RabbitMQChannelManager } from './ChannelManager.js';
  */
 export class RabbitMqReceiver extends AbstractMessageHandler {
   protected static readonly QUEUE_PREFIX = 'rabbit_queue_';
+
+  protected readonly _queueType: 'classic' | 'quorum';
+
+  /**
+   * Declaration options for every queue this receiver asserts.
+   *
+   * A quorum queue cannot be auto-delete. When one is requested anyway the
+   * broker does not fail the declaration -- it quietly gives back a classic
+   * queue, so a `default_queue_type = quorum` vhost silently keeps producing
+   * classic queues. Asking for the type explicitly, and dropping autoDelete
+   * with it, is what makes the setting observable.
+   */
+  protected _queueOptions(): amqplib.Options.AssertQueue {
+    if (this._queueType === 'quorum') {
+      return {
+        durable: true,
+        exclusive: false,
+        arguments: { 'x-queue-type': 'quorum' },
+      };
+    }
+    return { durable: true, autoDelete: true, exclusive: false };
+  }
   protected static readonly CHANNEL_ID = 'receiver';
 
   protected _channelManager: RabbitMQChannelManager;
@@ -67,6 +89,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
       throw new Error('RabbitMQ exchange is not configured');
     }
     this.exchange = exchange;
+    this._queueType = config.messageBroker.amqp?.queueType ?? 'classic';
     this._isRouterMode = !!routerMode;
     if (this._isRouterMode) {
       const id = config.messageBroker.amqp?.instanceIdentifier ?? `router-${Date.now()}`;
@@ -109,11 +132,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
   async initializeInstanceQueue(queueName: string): Promise<void> {
     const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
     await channel.assertExchange(this.exchange, 'headers', { durable: false });
-    await channel.assertQueue(queueName, {
-      durable: true,
-      autoDelete: true,
-      exclusive: false,
-    });
+    await channel.assertQueue(queueName, this._queueOptions());
 
     const { consumerTag } = await channel.consume(queueName, (msg) =>
       this._onMessage(msg, channel),
@@ -167,11 +186,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     const channel = await this._channelManager.getChannel(RabbitMqReceiver.CHANNEL_ID);
 
     await channel.assertExchange(this.exchange, 'headers', { durable: false });
-    await channel.assertQueue(queueName, {
-      durable: true,
-      autoDelete: true,
-      exclusive: false,
-    });
+    await channel.assertQueue(queueName, this._queueOptions());
 
     // Re-bind all active charger subscriptions (idempotent if queue already has them)
     let reboundCount = 0;
@@ -287,11 +302,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
 
     // Assert exchange and queue
     await channel.assertExchange(this.exchange, 'headers', { durable: false });
-    await channel.assertQueue(queueName, {
-      durable: true,
-      autoDelete: true,
-      exclusive: false,
-    });
+    await channel.assertQueue(queueName, this._queueOptions());
 
     // Bind queue based on provided actions and filters
     if (actions && actions.length > 0) {
@@ -371,6 +382,21 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
         this._logger.debug(`Unsubscribed from ${identifier} with consumer tag ${consumerTag}.`);
       }
       this._consumerTags.delete(identifier);
+
+      if (this._queueType === 'quorum') {
+        // With a classic queue the broker removed this on its own once the
+        // last consumer went away. A quorum queue cannot be auto-delete, so
+        // without this every charger that ever connects leaves a queue
+        // behind. `ifUnused` protects a queue another consumer still holds.
+        const queueName = `${RabbitMqReceiver.QUEUE_PREFIX}${identifier}`;
+        try {
+          await channel.deleteQueue(queueName, { ifUnused: true });
+          this._logger.debug(`Deleted queue ${queueName} after unsubscribe.`);
+        } catch (error) {
+          this._logger.warn(`Could not delete queue ${queueName} after unsubscribe.`, error);
+        }
+      }
+
       return true;
     } else {
       this._logger.warn(`No consumer tag found for ${identifier} during unsubscribe.`);

--- a/packages/core/test/util/providers/RabbitMqProvider.ts
+++ b/packages/core/test/util/providers/RabbitMqProvider.ts
@@ -21,6 +21,7 @@ import type { RabbitMQChannelManager } from '@util/queue/rabbit-mq/ChannelManage
 export function aSystemConfigWithAmqp(override?: {
   exchange?: string;
   instanceIdentifier?: string;
+  queueType?: 'classic' | 'quorum';
   noAmqp?: boolean;
 }): SystemConfig {
   if (override?.noAmqp) {
@@ -34,6 +35,7 @@ export function aSystemConfigWithAmqp(override?: {
         ...(override?.instanceIdentifier !== undefined && {
           instanceIdentifier: override.instanceIdentifier,
         }),
+        ...(override?.queueType !== undefined && { queueType: override.queueType }),
       },
     },
   } as unknown as SystemConfig;
@@ -51,6 +53,7 @@ export function aMockAmqpChannel(): amqplib.Channel {
     assertQueue: vi.fn().mockResolvedValue({}),
     bindQueue: vi.fn().mockResolvedValue({}),
     unbindQueue: vi.fn().mockResolvedValue({}),
+    deleteQueue: vi.fn().mockResolvedValue({}),
     consume: vi
       .fn()
       .mockImplementation(() =>

--- a/packages/core/test/util/queue/rabbit-mq/receiver.test.ts
+++ b/packages/core/test/util/queue/rabbit-mq/receiver.test.ts
@@ -78,6 +78,27 @@ describe('RabbitMqReceiver', () => {
         expect(mockChannel.consume).toHaveBeenCalledTimes(1);
       });
 
+      it('should declare a quorum queue without autoDelete when configured', async () => {
+        // A quorum queue cannot be auto-delete. Asking for one anyway makes the
+        // broker hand back a classic queue instead of failing, which is how a
+        // `default_queue_type = quorum` vhost silently keeps producing classic
+        // queues -- so the type has to be requested explicitly.
+        const quorumReceiver = getTestInstance(container, RabbitMqReceiver, {
+          config: aSystemConfigWithAmqp({ queueType: 'quorum' }),
+          channelManager: mockChannelManager,
+          module: undefined,
+          routerMode: undefined,
+        });
+
+        await quorumReceiver.subscribe('Provisioning', [OCPP_CallAction.BootNotification], {});
+
+        expect(mockChannel.assertQueue).toHaveBeenCalledWith('rabbit_queue_Provisioning', {
+          durable: true,
+          exclusive: false,
+          arguments: { 'x-queue-type': 'quorum' },
+        });
+      });
+
       it('should bind one entry per action when multiple actions are provided', async () => {
         await receiver.subscribe(
           'Transactions',
@@ -135,6 +156,33 @@ describe('RabbitMqReceiver', () => {
     });
 
     describe('unsubscribe()', () => {
+      it('should delete the queue on unsubscribe when queues are quorum', async () => {
+        // Classic queues are declared autoDelete, so the broker removed them
+        // once the last consumer left. Quorum queues cannot be, so without
+        // this every charger that ever connects leaves a queue behind.
+        const quorumReceiver = getTestInstance(container, RabbitMqReceiver, {
+          config: aSystemConfigWithAmqp({ queueType: 'quorum' }),
+          channelManager: mockChannelManager,
+          module: undefined,
+          routerMode: undefined,
+        });
+        await quorumReceiver.subscribe('Provisioning', [OCPP_CallAction.BootNotification], {});
+
+        await quorumReceiver.unsubscribe('Provisioning');
+
+        expect(mockChannel.deleteQueue).toHaveBeenCalledWith('rabbit_queue_Provisioning', {
+          ifUnused: true,
+        });
+      });
+
+      it('should leave queue removal to the broker when queues are classic', async () => {
+        await receiver.subscribe('Provisioning', [OCPP_CallAction.BootNotification], {});
+
+        await receiver.unsubscribe('Provisioning');
+
+        expect(mockChannel.deleteQueue).not.toHaveBeenCalled();
+      });
+
       it('should cancel the consumer and return true for a known identifier', async () => {
         (mockChannel.consume as any).mockResolvedValueOnce({ consumerTag: 'tag-abc' });
         await receiver.subscribe('Provisioning', [OCPP_CallAction.BootNotification], {});

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -142,6 +142,14 @@ export const configSchema = z.object({
           exchange: z.string().default('citrineos'),
           instanceIdentifier: z.string().optional(),
           maxReconnectDelaySeconds: z.number().int().min(1).default(30),
+          // Type used when declaring queues. Quorum queues are Raft-replicated
+          // and recover from a network partition on their own; classic queues
+          // paired with a mirroring policy are Mnesia-replicated and do not.
+          // Quorum queues cannot be auto-delete, so this also decides whether
+          // per-identifier queues are cleaned up by the broker or explicitly on
+          // unsubscribe. Default stays `classic` so existing deployments are
+          // unaffected.
+          queueType: z.enum(['classic', 'quorum']).default('classic'),
         })
         .prefault({}),
     })


### PR DESCRIPTION
## Problem

`RabbitMqReceiver` declares every queue with `autoDelete: true`. A quorum queue **cannot** be auto-delete, and RabbitMQ does not reject such a declaration — it silently returns a **classic** queue instead.

The consequence is that a broker configured for quorum queues keeps producing classic ones, with nothing on the client side to indicate the setting had no effect:

```
# node config and vhost metadata both set
default_queue_type = quorum
rabbitmqctl list_vhosts name default_queue_type   ->  /  quorum

# every queue still comes back classic
rabbitmqctl list_queues name type durable auto_delete
rabbit_queue_evdriver_requests   classic   true   true
```

We deleted the queues and let CitrineOS re-declare them several times before working out that `autoDelete` was the reason.

## Why it matters

Classic queues combined with an `ha-mode` mirroring policy are Mnesia-replicated, and Mnesia does not heal a network partition by itself.

On a three-node 3.13 cluster we operate, a partition between one node and the other two left that node's queues wedged. `QueueDeclare` started returning `404 NOT_FOUND ... due to timeout`, so CitrineOS could not finish booting and was restarted by Docker **122 times** until the queues were deleted manually. Restarting the broker did not clear it.

A quorum queue in the same cluster, belonging to another service, rode the same partition out with a Raft leader election and needed no intervention. Classic queues are also removed entirely in RabbitMQ 4.x, so the migration is one-way regardless.

## Change

Adds `messageBroker.amqp.queueType`, `classic` (default) or `quorum`. The default preserves today's behaviour exactly, so existing deployments are unaffected.

When set to `quorum`:

- queues are declared with `arguments: { 'x-queue-type': 'quorum' }` and **without** `autoDelete`
- per-identifier queues are deleted explicitly in `unsubscribe()`, which is the cleanup `autoDelete` used to provide. `ifUnused: true` leaves alone any queue another consumer still holds, and a queue that is already gone is logged rather than failing the unsubscribe

All three `assertQueue` call sites go through one `_queueOptions()` helper so the two modes cannot drift.

## Tests

`packages/core/test/util/queue/rabbit-mq/receiver.test.ts` — 30 pass, 3 new:

- a quorum declaration carries `x-queue-type` and omits `autoDelete`
- `unsubscribe()` deletes the queue with `ifUnused` when the type is quorum
- `unsubscribe()` leaves removal to the broker when the type is classic