### PR TITLE
feat: configurable SignedMeterValue maxLength for OCPP 2.0.1

### DIFF
--- a/apps/ocpp-server/src/citrineOSServer.ts
+++ b/apps/ocpp-server/src/citrineOSServer.ts
@@ -165,7 +165,11 @@ export class CitrineOSServer {
     // Create a separate OCPPValidator with its own Ajv instance for OCPP message validation.
     // This must be distinct from _ajv: OCPP messages are parsed JSON (no coercion needed),
     // whereas _ajv coerces types for Fastify's HTTP schema compilation.
-    this._ocppValidator = new OCPPValidator(this._logger);
+    const signedMeterValuesConfiguration = this._config.modules.transactions?.signedMeterValuesConfiguration;
+    this._ocppValidator = new OCPPValidator(this._logger, undefined, {
+      signedMeterDataMaxLength: signedMeterValuesConfiguration?.signedMeterDataMaxLength,
+      publicKeyMaxLength: signedMeterValuesConfiguration?.publicKeyMaxLength,
+    });
 
     // Set cache implementation
     this._cache = this.initCache(cache);

--- a/packages/base/src/interfaces/modules/OCPPValidator.ts
+++ b/packages/base/src/interfaces/modules/OCPPValidator.ts
@@ -22,15 +22,76 @@ import {
 } from '@citrineos/types';
 import { OcppError } from '@ocpp/rpc/message.js';
 
+/**
+ * Overrides for OCPP 2.0.1's SignedMeterValueType.signedMeterData/publicKey maxLength (spec default: 2500
+ * characters each). Some real charging stations submit OCMF-signed meter data past that spec limit -- see
+ * OCPPValidator.applySignedMeterValueLimits for details.
+ */
+export interface SignedMeterValueLimits {
+  signedMeterDataMaxLength?: number;
+  publicKeyMaxLength?: number;
+}
+
 export class OCPPValidator {
   protected _ajv: Ajv;
   protected readonly _logger: Logger<ILogObj>;
 
-  constructor(logger?: Logger<ILogObj>, ajv?: Ajv) {
+  constructor(
+    logger?: Logger<ILogObj>,
+    ajv?: Ajv,
+    signedMeterValueLimits?: SignedMeterValueLimits,
+  ) {
     this._ajv = ajv || OCPPValidator.createValidatorAjvInstance();
     this._logger = logger
       ? logger.getSubLogger({ name: this.constructor.name })
       : new Logger<ILogObj>({ name: this.constructor.name });
+
+    if (signedMeterValueLimits) {
+      OCPPValidator.applySignedMeterValueLimits(signedMeterValueLimits, this._logger);
+    }
+  }
+
+  /**
+   * Widens OCPP 2.0.1's built-in SignedMeterValueType.signedMeterData/publicKey maxLength (spec default: 2500
+   * characters each) in the shared TransactionEventRequest/MeterValuesRequest schemas, before they're compiled
+   * by ajv. 2500 is the OCA's own OCPP 2.0.1 spec value, not a CitrineOS restriction -- but it's proven too
+   * small in practice for some real charging stations' OCMF-signed meter data (e.g. with an embedded
+   * certificate chain or multiple register readings), which otherwise gets rejected outright as a
+   * FormatViolation, silently dropping that station's meter values for the rest of the transaction. OCPP 2.1
+   * itself raised signedMeterData's limit to 32768 for exactly this reason.
+   *
+   * Must be called before the first validateOCPPRequest() call for TransactionEvent/MeterValues -- ajv caches
+   * a compiled validator per schema $id on first use, so any override applied afterward has no effect on an
+   * already-compiled validator. In practice this means calling it once at startup, e.g. when constructing the
+   * single shared OCPPValidator instance.
+   *
+   * @param limits - Override values; a field left undefined keeps the OCPP 2.0.1 spec default (2500) unchanged.
+   * @param logger - Optional logger for debug output.
+   */
+  static applySignedMeterValueLimits(
+    limits: SignedMeterValueLimits,
+    logger?: Logger<ILogObj>,
+  ): void {
+    if (limits.signedMeterDataMaxLength === undefined && limits.publicKeyMaxLength === undefined) {
+      return;
+    }
+    for (const action of [OCPP_CallAction.TransactionEvent, OCPP_CallAction.MeterValues]) {
+      const schema = OCPP2_0_1_CALL_SCHEMA_RECORD[action] as any;
+      const signedMeterValueType = schema?.definitions?.SignedMeterValueType?.properties;
+      if (!signedMeterValueType) {
+        continue;
+      }
+      if (limits.signedMeterDataMaxLength !== undefined && signedMeterValueType.signedMeterData) {
+        signedMeterValueType.signedMeterData.maxLength = limits.signedMeterDataMaxLength;
+      }
+      if (limits.publicKeyMaxLength !== undefined && signedMeterValueType.publicKey) {
+        signedMeterValueType.publicKey.maxLength = limits.publicKeyMaxLength;
+      }
+      logger?.debug(
+        `Applied signed meter value length overrides to OCPP 2.0.1 ${action} schema`,
+        limits,
+      );
+    }
   }
 
   /**

--- a/packages/base/test/modules/OCPPValidator.test.ts
+++ b/packages/base/test/modules/OCPPValidator.test.ts
@@ -37,6 +37,124 @@ describe('OCPPValidator', () => {
     });
   });
 
+  describe('applySignedMeterValueLimits', () => {
+    // These tests mutate the shared, process-wide TransactionEventRequest/MeterValuesRequest schema
+    // objects (imported once and reused by every OCPPValidator instance), so each test restores the
+    // OCPP 2.0.1 spec default (2500) afterward to avoid leaking state into other tests.
+    afterEach(() => {
+      OCPPValidator.applySignedMeterValueLimits({
+        signedMeterDataMaxLength: 2500,
+        publicKeyMaxLength: 2500,
+      });
+    });
+
+    const meterValuePayload = (signedMeterData: string, publicKey: string) => ({
+      eventType: 'Updated',
+      timestamp: '2026-01-01T00:00:00Z',
+      triggerReason: 'MeterValuePeriodic',
+      seqNo: 0,
+      transactionInfo: { transactionId: 'tx-1' },
+      meterValue: [
+        {
+          timestamp: '2026-01-01T00:00:00Z',
+          sampledValue: [
+            {
+              value: 0,
+              signedMeterValue: {
+                signedMeterData,
+                signingMethod: 'ECDSA',
+                encodingMethod: 'OCMF',
+                publicKey,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    it('rejects signedMeterData past the OCPP 2.0.1 spec default of 2500 characters', () => {
+      // A fresh instance is required: ajv caches a compiled validator per schema $id on first use,
+      // so an already-constructed `validator` from beforeEach may have compiled before this test runs.
+      const freshValidator = new OCPPValidator();
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.TransactionEvent,
+        meterValuePayload('x'.repeat(2600), 'y'.repeat(100)),
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toBeDefined();
+    });
+
+    it('accepts longer signedMeterData once signedMeterDataMaxLength is widened', () => {
+      OCPPValidator.applySignedMeterValueLimits({ signedMeterDataMaxLength: 10000 });
+
+      const freshValidator = new OCPPValidator();
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.TransactionEvent,
+        meterValuePayload('x'.repeat(2600), 'y'.repeat(100)),
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('accepts longer publicKey once publicKeyMaxLength is widened', () => {
+      OCPPValidator.applySignedMeterValueLimits({ publicKeyMaxLength: 10000 });
+
+      const freshValidator = new OCPPValidator();
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.TransactionEvent,
+        meterValuePayload('x'.repeat(100), 'y'.repeat(2600)),
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('also widens the limit for MeterValues requests, not just TransactionEvent', () => {
+      OCPPValidator.applySignedMeterValueLimits({ signedMeterDataMaxLength: 10000 });
+
+      const freshValidator = new OCPPValidator();
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.MeterValues,
+        {
+          evseId: 1,
+          meterValue: meterValuePayload('x'.repeat(2600), 'y'.repeat(100)).meterValue,
+        },
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it('is a no-op when called with no overrides', () => {
+      OCPPValidator.applySignedMeterValueLimits({});
+
+      const freshValidator = new OCPPValidator();
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.TransactionEvent,
+        meterValuePayload('x'.repeat(2600), 'y'.repeat(100)),
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(false);
+    });
+
+    it('applies limits automatically when passed to the constructor', () => {
+      const freshValidator = new OCPPValidator(undefined, undefined, {
+        signedMeterDataMaxLength: 10000,
+      });
+      const result = freshValidator.validateOCPPRequest(
+        OCPP_CallAction.TransactionEvent,
+        meterValuePayload('x'.repeat(2600), 'y'.repeat(100)),
+        OCPPVersion.OCPP2_0_1,
+      );
+
+      expect(result.isValid).toBe(true);
+    });
+  });
+
   describe('createServerAjvInstance', () => {
     it('should create a new Ajv instance when none is provided', () => {
       const ajv = OCPPValidator.createServerAjvInstance();

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -197,6 +197,16 @@ export const systemConfigInputSchema = z.object({
           publicKeyFileId: z.string(),
           signingMethod: z.enum(signedMeterValuesSigningMethods),
           rejectUnsupportedSignedMeterValues: z.boolean().default(false).optional(),
+          // OCPP 2.0.1's own SignedMeterValueType.signedMeterData/publicKey schema caps both fields at 2500
+          // characters -- the OCA's own spec limit, not a CitrineOS restriction. In practice some real charging
+          // stations occasionally submit OCMF-signed meter data (e.g. with an embedded certificate chain or
+          // multiple register readings) that exceeds 2500 characters, which otherwise gets rejected outright as
+          // a FormatViolation and silently drops that station's meter values for the rest of the transaction.
+          // OCPP 2.1 itself raised signedMeterData's limit to 32768 for exactly this reason. These fields let a
+          // deployment widen the OCPP 2.0.1 limit to match real-world station behavior; unset keeps the spec
+          // default (2500) unchanged.
+          signedMeterDataMaxLength: z.number().int().positive().optional(),
+          publicKeyMaxLength: z.number().int().positive().optional(),
         })
         .optional(),
       /** Base URL for generating receipt URLs when ReceiptByCSMS is true (C21). */
@@ -521,6 +531,10 @@ export const systemConfigSchema = z
               publicKeyFileId: z.string(),
               signingMethod: z.enum(signedMeterValuesSigningMethods),
               rejectUnsupportedSignedMeterValues: z.boolean().optional(),
+              // See the matching field in the output schema above for why this exists: some real charging
+              // stations submit OCMF-signed meter data past OCPP 2.0.1's spec-mandated 2500-character limit.
+              signedMeterDataMaxLength: z.number().int().positive().optional(),
+              publicKeyMaxLength: z.number().int().positive().optional(),
             })
             .optional(),
           /** Base URL for generating receipt URLs when ReceiptByCSMS is true (C21). */


### PR DESCRIPTION
## Summary

OCPP 2.0.1's own JSON schema caps `SignedMeterValueType.signedMeterData` and `.publicKey` at 2500 characters each. This is the OCA's own spec value (both schema files carry `"comment": "OCPP 2.0.1 FINAL"` and are otherwise unmodified copies of the official generated schemas) -- not something CitrineOS introduced or tightened.

In practice, this limit is proven too small for real deployments: **we hit this on a real DC fast charger** (a Reinhausen DCC-150) sending OCMF-signed meter data -- with an embedded certificate chain and multiple register readings -- that runs to ~2772 characters, comfortably over the 2500 cap. CitrineOS rejects the whole `TransactionEvent`/`MeterValues` message outright as a `FormatViolation`, which silently drops that station's meter values for the rest of the transaction (no partial acceptance -- the entire message fails ajv validation).

Notably, **OCPP 2.1 already raised `signedMeterData`'s limit to 32768** for what looks like exactly this reason (`publicKey` stays at 2500 in both versions), so this isn't a hypothetical edge case -- the OCA itself has acknowledged 2.0.1's limit is too tight for real-world signed meter data.

Since deployments can't unilaterally speak OCPP 2.1 just to work around this, and today there's no way to adjust the 2.0.1 limit without hand-patching the compiled schema JSON (not survivable across a rebuild, not a real fix), this PR adds a proper config-driven override.

## Changes

* `modules.transactions.signedMeterValuesConfiguration` gains two new optional fields: `signedMeterDataMaxLength` and `publicKeyMaxLength`. Unset keeps the OCPP 2.0.1 spec default (2500) unchanged.
* `OCPPValidator` gains a static `applySignedMeterValueLimits()` that patches the shared `TransactionEventRequest`/`MeterValuesRequest` schemas' `SignedMeterValueType` definitions in place, before ajv compiles them. Also callable via an optional third constructor parameter.
* `CitrineOSServer` threads the new config fields into the single shared `OCPPValidator` instance it constructs at startup.

The override is intentionally narrow (just these two known pain points) rather than a generic schema-patching mechanism, to keep the change small and the behavior predictable.

## Test plan

- [x] `pnpm --filter @citrineos/types build` / `@citrineos/base build` / `@citrineos/core build` / `ocpp-server build` -- all clean
- [x] `vitest run test/modules/OCPPValidator.test.ts` -- 56/56 passing, including 6 new tests covering: default-limit rejection, widening `signedMeterDataMaxLength`, widening `publicKeyMaxLength`, that the override applies to `MeterValues` as well as `TransactionEvent`, a no-op call with no overrides, and applying limits via the constructor
- [x] `eslint` clean on all touched files
- [x] Verified end-to-end against the real charging station described above (after hand-patching the equivalent field on an older deployment) that widening the limit is what actually fixes the dropped-meter-values symptom