### PR TITLE
Separate the OCPP 1.6 and 2.x connector commissioning paths

### DIFF
--- a/packages/dal/src/db/drizzle/schema/connector.ts
+++ b/packages/dal/src/db/drizzle/schema/connector.ts
@@ -25,9 +25,9 @@ function connectorColumns() {
     ocppConnectionName: varchar('ocppConnectionName', { length: 255 }).notNull(),
     evseId: integer('evseId').notNull(),
     // Serial int starting at 1 used in OCPP 1.6 to refer to the connector, unique per station.
-    connectorId: integer('connectorId').notNull(),
+    connectorId: integer('connectorId'),
     // Serial int starting at 1 used in OCPP 2.0.1 to refer to the connector, unique per EVSE.
-    evseTypeConnectorId: integer('evseTypeConnectorId').notNull(),
+    evseTypeConnectorId: integer('evseTypeConnectorId'),
     status: varchar('status', { length: 255 }).default('Unknown'),
     type: varchar('type', { length: 255 }),
     format: varchar('format', { length: 255 }),

--- a/packages/dal/src/models/location/connector.ts
+++ b/packages/dal/src/models/location/connector.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Contributors to the CitrineOS Project
 //
 // SPDX-License-Identifier: Apache-2.0
+import { DEFAULT_TENANT_ID, OCPP1_6_Namespace } from '@citrineos/base';
 import type {
   ChargingStationDto,
   ConnectorDto,
@@ -18,7 +19,6 @@ import type {
   TenantDto,
   TransactionDto,
 } from '@citrineos/types';
-import { DEFAULT_TENANT_ID, OCPP1_6_Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
@@ -68,15 +68,12 @@ export class Connector extends Model implements ConnectorDto {
 
   @Column({
     unique: 'stationId_connectorId',
-    allowNull: false,
     type: DataType.INTEGER,
   })
   declare connectorId: number; // This is the serial int starting at 1 used in OCPP 1.6 to refer to the connector, unique per Charging Station.
 
-  @ForeignKey(() => EvseType)
   @Column({
     unique: 'evseId_evseTypeConnectorId',
-    allowNull: false,
     type: DataType.INTEGER,
   })
   declare evseTypeConnectorId?: number; // This is the serial int starting at 1 used in OCPP 2.0.1 to refer to the connector, unique per EVSE.
@@ -136,9 +133,6 @@ export class Connector extends Model implements ConnectorDto {
 
   @BelongsTo(() => Evse, 'evseId')
   declare evse?: EvseDto;
-
-  @BelongsTo(() => EvseType, 'evseTypeConnectorId')
-  declare evseTypeByConnector?: EvseTypeDto;
 
   @HasMany(() => EvseType, 'connectorId')
   declare evseTypes?: EvseTypeDto[];

--- a/packages/dal/src/repositories/drizzle/connector.ts
+++ b/packages/dal/src/repositories/drizzle/connector.ts
@@ -19,8 +19,8 @@ export function toConnectorDto(entity: ConnectorEntity): ConnectorDto {
     stationId: entity.stationId ?? undefined,
     ocppConnectionName: entity.ocppConnectionName,
     evseId: entity.evseId,
-    connectorId: entity.connectorId,
-    evseTypeConnectorId: entity.evseTypeConnectorId,
+    connectorId: entity.connectorId ?? undefined,
+    evseTypeConnectorId: entity.evseTypeConnectorId ?? undefined,
     // Enums stored as strings in the DB — cast back to the DTO's enum unions.
     status: entity.status as ConnectorDto['status'],
     type: entity.type as ConnectorDto['type'],

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -11,21 +11,21 @@ import type {
   CertificateCreate,
   CertificateDto,
   CertificateUseEnumType,
-  DeleteCertificateAttemptCreate,
-  DeleteCertificateAttemptDto,
-  DeleteCertificateStatusEnumType,
-  InstallCertificateAttemptCreate,
-  InstallCertificateAttemptDto,
-  InstallCertificateStatusEnumType,
-  InstalledCertificateCreate,
-  InstalledCertificateDto,
-  HashAlgorithmEnumType,
   ChargingLimitSourceEnumType,
   ChargingProfilePurposeEnumType,
   ChargingStateEnumType,
   ChargingStationSequenceTypeEnumType,
   ConnectorDto,
+  DeleteCertificateAttemptCreate,
+  DeleteCertificateAttemptDto,
+  DeleteCertificateStatusEnumType,
   EvseDto,
+  HashAlgorithmEnumType,
+  InstallCertificateAttemptCreate,
+  InstallCertificateAttemptDto,
+  InstallCertificateStatusEnumType,
+  InstalledCertificateCreate,
+  InstalledCertificateDto,
   MeterValueDto,
   OCPP1_6,
   OCPP2_common_types,
@@ -254,6 +254,11 @@ export interface ILocationRepository extends CrudRepository<Location> {
     ocppConnectionName: string,
     ocpp201EvseType: OCPP2_common_types.EVSEType,
   ) => Promise<Connector | undefined>;
+  readConnectorsWithTariffsByStationId: (
+    tenantId: number,
+    ocppConnectionName: string,
+    evseTypeId?: number,
+  ) => Promise<Connector[]>;
   setChargingStationIsOnlineAndOCPPVersion: (
     tenantId: number,
     ocppConnectionName: string,
@@ -275,25 +280,21 @@ export interface ILocationRepository extends CrudRepository<Location> {
     chargingStation: ChargingStation,
   ): Promise<ChargingStation>;
   createOrUpdateEvse(tenantId: number, evse: EvseDto): Promise<EvseDto>;
-  createOrUpdateConnector(
+  createOrUpdateOcpp16Connector(
     tenantId: number,
-    connector: ConnectorDto,
+    connector: ConnectorDto & { connectorId: number },
   ): Promise<Connector | undefined>;
-  /**
-   * Commissions a default evse + evseTypeConnector record for an OCPP 1.6 connector.
-   * Used in ad-hoc/`allowUnknownChargingStations` flows where the charge point arrives
-   * uncommissioned (OCPP 1.6 has no native EVSE concept). Conservative default:
-   * one connector → one evse. Returns the FK ids the caller should stamp on the
-   * Connector record being upserted.
-   */
-  commissionEvseForOcpp16Connector(
+  createOrUpdateOcpp2Connector(
+    tenantId: number,
+    connector: ConnectorDto & { evseTypeConnectorId: number },
+  ): Promise<Connector | undefined>;
+  autocommissionEvseForOcpp16Connector(
     tenantId: number,
     ocppConnectionName: string,
-    connectorId: number,
-  ): Promise<{ evseId: number; evseTypeConnectorId: number }>;
+  ): Promise<{ evseId: number }>;
   updateAllConnectorsByQuery(
     tenantId: number,
-    value: Partial<Connector>,
+    value: ConnectorDto,
     query: object,
   ): Promise<Connector[]>;
   updateChargingStationTimestamp(

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -38,6 +38,9 @@ import type {
   TenantDto,
   UpdateEnumType,
 } from '@citrineos/types';
+import type { AuthorizationQuerystring } from '../interfaces/queries/authorization.js';
+import type { TariffQueryString } from '../interfaces/queries/tariff.js';
+import type { VariableAttributeQuerystring } from '../interfaces/queries/variable-attribute.js';
 import type {
   ChargingProfileInput,
   CompositeScheduleInput,
@@ -54,11 +57,11 @@ import type { ChargingStationSecurityInfo } from '../models/charging-station-sec
 import type { ChargingStationSequence } from '../models/charging-station-sequence/charging-station-sequence.js';
 import type { Component } from '../models/device-model/component.js';
 import type { EvseType } from '../models/device-model/evse-type.js';
-import type { Variable } from '../models/device-model/variable.js';
 import type { VariableAttribute } from '../models/device-model/variable-attribute.js';
 import type { VariableCharacteristics } from '../models/device-model/variable-characteristics.js';
-import type { ChargingStation } from '../models/location/charging-station.js';
+import type { Variable } from '../models/device-model/variable.js';
 import type { ChargingStationNetworkProfile } from '../models/location/charging-station-network-profile.js';
+import type { ChargingStation } from '../models/location/charging-station.js';
 import type { Connector } from '../models/location/connector.js';
 import type { Evse } from '../models/location/evse.js';
 import type { Location } from '../models/location/location.js';
@@ -74,9 +77,6 @@ import type {
 } from '../models/transaction-event/index.js';
 import type { TransactionEvent } from '../models/transaction-event/transaction-event.js';
 import type { EventData, VariableMonitoring } from '../models/variable-monitoring/index.js';
-import type { AuthorizationQuerystring } from '../interfaces/queries/authorization.js';
-import type { TariffQueryString } from '../interfaces/queries/tariff.js';
-import type { VariableAttributeQuerystring } from '../interfaces/queries/variable-attribute.js';
 
 export interface IAuthorizationRepository {
   readAllByQuerystring: (
@@ -288,7 +288,7 @@ export interface ILocationRepository extends CrudRepository<Location> {
     tenantId: number,
     connector: ConnectorDto & { evseTypeConnectorId: number },
   ): Promise<Connector | undefined>;
-  autocommissionEvseForOcpp16Connector(
+  autoCommissionEvseForOcpp16Connector(
     tenantId: number,
     ocppConnectionName: string,
   ): Promise<{ evseId: number }>;

--- a/packages/dal/src/repositories/sequelize/location.ts
+++ b/packages/dal/src/repositories/sequelize/location.ts
@@ -10,7 +10,7 @@ import {
   type OCPP2_0_1,
   OCPPVersion,
 } from '@citrineos/types';
-import { Op } from 'sequelize';
+import { Op, type WhereOptions } from 'sequelize';
 import { type ILocationRepository } from '../repositories.js';
 import { EvseType } from '../../models/device-model/evse-type.js';
 import { ChargingStation } from '../../models/location/charging-station.js';
@@ -19,6 +19,7 @@ import { Evse } from '../../models/location/evse.js';
 import { LatestStatusNotification } from '../../models/location/latest-status-notification.js';
 import { Location } from '../../models/location/location.js';
 import { StatusNotification } from '../../models/location/status-notification.js';
+import { Tariff } from '../../models/tariff/tariffs.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './base.js';
 
 export class SequelizeLocationRepository
@@ -343,20 +344,39 @@ export class SequelizeLocationRepository
     return result!;
   }
 
-  async createOrUpdateConnector(
+  async createOrUpdateOcpp16Connector(
+    tenantId: number,
+    connector: ConnectorDto & { connectorId: number },
+  ): Promise<Connector | undefined> {
+    return await this.upsertConnector(tenantId, connector, {
+      tenantId,
+      ocppConnectionName: connector.ocppConnectionName,
+      connectorId: connector.connectorId,
+    });
+  }
+
+  async createOrUpdateOcpp2Connector(
+    tenantId: number,
+    connector: ConnectorDto & { evseTypeConnectorId: number },
+  ): Promise<Connector | undefined> {
+    return await this.upsertConnector(tenantId, connector, {
+      tenantId,
+      evseId: connector.evseId,
+      evseTypeConnectorId: connector.evseTypeConnectorId,
+    });
+  }
+
+  private async upsertConnector(
     tenantId: number,
     connector: ConnectorDto,
+    where: WhereOptions<Connector>,
   ): Promise<Connector | undefined> {
     let result;
     await this.s.transaction(async (sequelizeTransaction) => {
       const [savedConnector, connectorCreated] = await this.connector.readOrCreateByQuery(
         tenantId,
         {
-          where: {
-            tenantId,
-            ocppConnectionName: connector.ocppConnectionName,
-            connectorId: connector.connectorId,
-          },
+          where,
           defaults: {
             ...connector,
           },
@@ -380,36 +400,23 @@ export class SequelizeLocationRepository
 
   async updateAllConnectorsByQuery(
     tenantId: number,
-    value: Partial<Connector>,
+    value: Partial<ConnectorDto>,
     query: object,
   ): Promise<Connector[]> {
     return await this.connector.updateAllByQuery(tenantId, value, query);
   }
 
-  async commissionEvseForOcpp16Connector(
+  async autocommissionEvseForOcpp16Connector(
     tenantId: number,
     ocppConnectionName: string,
-    connectorId: number,
-  ): Promise<{ evseId: number; evseTypeConnectorId: number }> {
-    return await this.s.transaction(async (sequelizeTransaction) => {
-      // OCPP 1.6 has no native EVSE concept. Conservative default: each connector
-      // maps to its own (Evse, EvseType) pair using the 1.6 connectorId as the
-      // OCPP 2.0.1 evse id. EvseType.connectorId stays null because the EVSE
-      // is implicit (single-connector hardware abstraction). The Evse's
-      // stationId FK is auto-resolved from ocppConnectionName by the
-      // BeforeCreate hook on the Evse model.
-      const [evseType] = await EvseType.findOrCreate({
-        where: { tenantId, id: connectorId, connectorId: null },
-        defaults: { tenantId, id: connectorId, connectorId: null },
-        transaction: sequelizeTransaction,
-      });
-      const [evse] = await Evse.findOrCreate({
-        where: { tenantId, ocppConnectionName, evseTypeId: connectorId },
-        defaults: { tenantId, ocppConnectionName, evseTypeId: connectorId },
-        transaction: sequelizeTransaction,
-      });
-      return { evseId: evse.id, evseTypeConnectorId: evseType.databaseId };
+  ): Promise<{ evseId: number }> {
+    // OCPP 1.6 has no native EVSE concept. Conservative default: each connector
+    // maps to its own Evse
+    const evse = await Evse.create({
+      tenantId,
+      ocppConnectionName,
     });
+    return { evseId: evse.id };
   }
 
   async updateChargingStationTimestamp(
@@ -473,6 +480,33 @@ export class SequelizeLocationRepository
         include: [{ model: Evse, where: { evseTypeId: ocpp201EvseType.id }, required: true }],
       })) ?? undefined
     );
+  }
+
+  async readConnectorsWithTariffsByStationId(
+    tenantId: number,
+    ocppConnectionName: string,
+    evseTypeId?: number,
+  ): Promise<Connector[]> {
+    return await this.connector.readAllByQuery(tenantId, {
+      where: {
+        tenantId,
+        ocppConnectionName,
+        tariffId: { [Op.ne]: null },
+      },
+      include: [
+        {
+          model: Evse,
+          as: 'evse',
+          required: true,
+          ...(evseTypeId !== undefined && { where: { evseTypeId } }),
+        },
+        {
+          model: Tariff,
+          as: 'tariff',
+          required: true,
+        },
+      ],
+    });
   }
 }
 

--- a/packages/dal/src/repositories/sequelize/location.ts
+++ b/packages/dal/src/repositories/sequelize/location.ts
@@ -11,8 +11,6 @@ import {
   OCPPVersion,
 } from '@citrineos/types';
 import { Op, type WhereOptions } from 'sequelize';
-import { type ILocationRepository } from '../repositories.js';
-import { EvseType } from '../../models/device-model/evse-type.js';
 import { ChargingStation } from '../../models/location/charging-station.js';
 import { Connector } from '../../models/location/connector.js';
 import { Evse } from '../../models/location/evse.js';
@@ -20,6 +18,7 @@ import { LatestStatusNotification } from '../../models/location/latest-status-no
 import { Location } from '../../models/location/location.js';
 import { StatusNotification } from '../../models/location/status-notification.js';
 import { Tariff } from '../../models/tariff/tariffs.js';
+import { type ILocationRepository } from '../repositories.js';
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './base.js';
 
 export class SequelizeLocationRepository
@@ -406,7 +405,7 @@ export class SequelizeLocationRepository
     return await this.connector.updateAllByQuery(tenantId, value, query);
   }
 
-  async autocommissionEvseForOcpp16Connector(
+  async autoCommissionEvseForOcpp16Connector(
     tenantId: number,
     ocppConnectionName: string,
   ): Promise<{ evseId: number }> {

--- a/packages/dal/test/repositories/sequelize/location.test.ts
+++ b/packages/dal/test/repositories/sequelize/location.test.ts
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { ConnectorDto, SystemConfig } from '@citrineos/types';
+import { Connector } from '@dal/models/location/connector.js';
+import { Evse } from '@dal/models/location/evse.js';
+import { Tariff } from '@dal/models/tariff/tariffs.js';
+import { SequelizeLocationRepository } from '@dal/repositories/sequelize/location.js';
+import { createTestContainer, getTestInstance } from '../../test-container.js';
+import { Op } from 'sequelize';
+import type { Sequelize } from 'sequelize-typescript';
+import type { ILogObj, Logger } from 'tslog';
+import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
+
+// Mock the util module to avoid circular dependency issues during test loading
+vi.mock('@dal/db/sequelize/util', () => ({
+  DefaultSequelizeInstance: {
+    getInstance: vi.fn(),
+  },
+}));
+
+const TENANT_ID = 1;
+const OCPP_CONNECTION_NAME = 'CP_TEST_001';
+
+describe('SequelizeLocationRepository', () => {
+  const { container } = createTestContainer();
+  let repository: SequelizeLocationRepository;
+  let mockTransaction: unknown;
+
+  beforeEach(() => {
+    mockTransaction = Symbol('transaction');
+    const mockSequelize = {
+      transaction: vi.fn((callback: (transaction: unknown) => Promise<unknown>) =>
+        callback(mockTransaction),
+      ),
+    } as unknown as Mocked<Sequelize>;
+
+    const mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      getSubLogger: vi.fn().mockReturnThis(),
+    } as unknown as Mocked<Logger<ILogObj>>;
+
+    repository = getTestInstance(container, SequelizeLocationRepository, {
+      config: {} as SystemConfig,
+      logger: mockLogger,
+      sequelizeInstance: mockSequelize,
+    });
+  });
+
+  describe('readConnectorsWithTariffsByStationId', () => {
+    const aConnectorRow = () => ({ id: 1, tariffId: 7 }) as unknown as Connector;
+
+    it('should read only the station connectors that carry a tariff', async () => {
+      const readAllByQuery = vi
+        .spyOn(repository.connector, 'readAllByQuery')
+        .mockResolvedValue([aConnectorRow()]);
+
+      const result = await repository.readConnectorsWithTariffsByStationId(
+        TENANT_ID,
+        OCPP_CONNECTION_NAME,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(readAllByQuery).toHaveBeenCalledWith(
+        TENANT_ID,
+        expect.objectContaining({
+          where: {
+            tenantId: TENANT_ID,
+            ocppConnectionName: OCPP_CONNECTION_NAME,
+            tariffId: { [Op.ne]: null },
+          },
+        }),
+      );
+    });
+
+    it('should require both the evse and the tariff so untariffed connectors cannot leak through', async () => {
+      const readAllByQuery = vi
+        .spyOn(repository.connector, 'readAllByQuery')
+        .mockResolvedValue([aConnectorRow()]);
+
+      await repository.readConnectorsWithTariffsByStationId(TENANT_ID, OCPP_CONNECTION_NAME);
+
+      const [, query] = readAllByQuery.mock.calls[0] as [number, { include: any[] }];
+      expect(query.include).toEqual([
+        { model: Evse, as: 'evse', required: true },
+        { model: Tariff, as: 'tariff', required: true },
+      ]);
+    });
+
+    it('should not constrain the evse when no evseTypeId is requested (I09.FR.01)', async () => {
+      const readAllByQuery = vi
+        .spyOn(repository.connector, 'readAllByQuery')
+        .mockResolvedValue([aConnectorRow()]);
+
+      await repository.readConnectorsWithTariffsByStationId(TENANT_ID, OCPP_CONNECTION_NAME);
+
+      const [, query] = readAllByQuery.mock.calls[0] as [number, { include: any[] }];
+      expect(query.include[0]).not.toHaveProperty('where');
+    });
+
+    it('should constrain the evse to the requested evseTypeId (I09.FR.02)', async () => {
+      const readAllByQuery = vi
+        .spyOn(repository.connector, 'readAllByQuery')
+        .mockResolvedValue([aConnectorRow()]);
+
+      await repository.readConnectorsWithTariffsByStationId(TENANT_ID, OCPP_CONNECTION_NAME, 2);
+
+      const [, query] = readAllByQuery.mock.calls[0] as [number, { include: any[] }];
+      expect(query.include[0]).toMatchObject({ where: { evseTypeId: 2 } });
+    });
+
+    it('should treat evseTypeId 0 as a filter rather than as absent', async () => {
+      // evseId 0 addresses the station in OCPP 2.1, so the handler maps it to undefined
+      // before calling in. A repository given an explicit 0 must still filter on it.
+      const readAllByQuery = vi
+        .spyOn(repository.connector, 'readAllByQuery')
+        .mockResolvedValue([aConnectorRow()]);
+
+      await repository.readConnectorsWithTariffsByStationId(TENANT_ID, OCPP_CONNECTION_NAME, 0);
+
+      const [, query] = readAllByQuery.mock.calls[0] as [number, { include: any[] }];
+      expect(query.include[0]).toMatchObject({ where: { evseTypeId: 0 } });
+    });
+  });
+
+  describe('connector upserts', () => {
+    const anOcpp16Connector = (): ConnectorDto & { connectorId: number } =>
+      ({
+        tenantId: TENANT_ID,
+        ocppConnectionName: OCPP_CONNECTION_NAME,
+        evseId: 4,
+        connectorId: 3,
+        status: 'Available',
+      }) as ConnectorDto & { connectorId: number };
+
+    const anOcpp2Connector = (): ConnectorDto & { evseTypeConnectorId: number } =>
+      ({
+        tenantId: TENANT_ID,
+        ocppConnectionName: OCPP_CONNECTION_NAME,
+        evseId: 4,
+        evseTypeConnectorId: 1,
+        status: 'Available',
+      }) as ConnectorDto & { evseTypeConnectorId: number };
+
+    const stubUpsert = (created: boolean) => {
+      const saved = { id: 42 } as unknown as Connector;
+      const readOrCreateByQuery = vi
+        .spyOn(repository.connector, 'readOrCreateByQuery')
+        .mockResolvedValue([saved, created]);
+      const updateAllByQuery = vi
+        .spyOn(repository.connector, 'updateAllByQuery')
+        .mockResolvedValue([saved]);
+      return { saved, readOrCreateByQuery, updateAllByQuery };
+    };
+
+    describe('createOrUpdateOcpp16Connector', () => {
+      it('should key the connector on its station-wide connectorId', async () => {
+        const { readOrCreateByQuery } = stubUpsert(true);
+
+        await repository.createOrUpdateOcpp16Connector(TENANT_ID, anOcpp16Connector());
+
+        expect(readOrCreateByQuery).toHaveBeenCalledWith(
+          TENANT_ID,
+          expect.objectContaining({
+            where: {
+              tenantId: TENANT_ID,
+              ocppConnectionName: OCPP_CONNECTION_NAME,
+              connectorId: 3,
+            },
+          }),
+        );
+      });
+    });
+
+    describe('createOrUpdateOcpp2Connector', () => {
+      it('should key the connector on its evse and per-evse connector number', async () => {
+        // A 2.x connector has no station-wide connectorId, and keying on a null one would
+        // match nothing under Postgres NULL semantics — a duplicate row on every report.
+        const { readOrCreateByQuery } = stubUpsert(true);
+
+        await repository.createOrUpdateOcpp2Connector(TENANT_ID, anOcpp2Connector());
+
+        expect(readOrCreateByQuery).toHaveBeenCalledWith(
+          TENANT_ID,
+          expect.objectContaining({
+            where: {
+              tenantId: TENANT_ID,
+              evseId: 4,
+              evseTypeConnectorId: 1,
+            },
+          }),
+        );
+      });
+    });
+
+    it('should never put an undefined value in the lookup key', async () => {
+      const { readOrCreateByQuery } = stubUpsert(true);
+
+      await repository.createOrUpdateOcpp16Connector(TENANT_ID, anOcpp16Connector());
+      await repository.createOrUpdateOcpp2Connector(TENANT_ID, anOcpp2Connector());
+
+      for (const [, query] of readOrCreateByQuery.mock.calls as [number, { where: object }][]) {
+        expect(Object.values(query.where)).not.toContain(undefined);
+      }
+    });
+
+    it('should update the existing row instead of creating when the connector is already known', async () => {
+      const { saved, updateAllByQuery } = stubUpsert(false);
+      const connector = anOcpp2Connector();
+
+      const result = await repository.createOrUpdateOcpp2Connector(TENANT_ID, connector);
+
+      expect(updateAllByQuery).toHaveBeenCalledWith(
+        TENANT_ID,
+        connector,
+        expect.objectContaining({ where: { id: saved.id } }),
+      );
+      expect(result).toBe(saved);
+    });
+  });
+});

--- a/packages/ocpp/src/handlers/requests/2/get-tariffs-request-ocpp-21-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/get-tariffs-request-ocpp-21-handler.ts
@@ -9,16 +9,15 @@ import {
   type IOcppSender,
 } from '@citrineos/base';
 import { type HandlerProperties, OCPP2_1, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
-import { Op } from 'sequelize';
 import {
   Authorization,
-  Connector,
   Evse,
   type IAuthorizationRepository,
   type ILocationRepository,
   Tariff,
   Transaction,
 } from '@citrineos/dal';
+import { Op } from 'sequelize';
 
 /**
  * Handle OCPP 2.1 GetTariffs request
@@ -97,28 +96,11 @@ export class GetTariffsRequestOcpp21Handler extends AbstractHandler {
 
       // Query default tariffs from Connectors
       // I09.FR.01 & I09.FR.02: Filter by evseId if requested
-      const connectors = await Connector.findAll({
-        where: {
-          tenantId,
-          ocppConnectionName,
-          tariffId: { [Op.ne]: null },
-        },
-        include: [
-          {
-            model: Evse,
-            as: 'evse',
-            required: true,
-            ...(requestedEvseId > 0 && {
-              where: { evseTypeId: requestedEvseId },
-            }),
-          },
-          {
-            model: Tariff,
-            as: 'tariff',
-            required: true,
-          },
-        ],
-      });
+      const connectors = await this._locationRepository.readConnectorsWithTariffsByStationId(
+        tenantId,
+        ocppConnectionName,
+        requestedEvseId > 0 ? requestedEvseId : undefined,
+      );
 
       // I09.FR.04: DefaultTariff includes evseIds list
       for (const connector of connectors) {

--- a/packages/ocpp/src/modules/transactions/status-notification-service.ts
+++ b/packages/ocpp/src/modules/transactions/status-notification-service.ts
@@ -75,18 +75,13 @@ export class StatusNotificationService {
         statusNotificationRequest.connectorStatus,
       ),
     });
-    await this._locationRepository.addStatusNotificationToChargingStation(
-      tenantId,
-      ocppConnectionName,
-      statusNotification,
-    );
 
     let matchingEvse = chargingStation.evses?.find(
       (evse) => evse.evseTypeId === statusNotificationRequest.evseId,
     );
-    let matchingConnector: ConnectorDto | undefined = (
-      matchingEvse?.connectors as Connector[] | undefined
-    )?.find((c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId);
+    // let matchingConnector: ConnectorDto | undefined = (
+    //   matchingEvse?.connectors as Connector[] | undefined
+    // )?.find((c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId);
 
     const connectionJson = await this._cache.get<string>(
       createIdentifier(tenantId, ocppConnectionName),
@@ -96,32 +91,18 @@ export class StatusNotificationService {
       ? JSON.parse(connectionJson)
       : null;
     if (!connection?.allowUnknownChargingStations) {
-      if (!matchingConnector) {
+      if (!matchingEvse) {
         this._logger.error(
           `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is false`,
         );
         return;
       }
-    } else if (!matchingConnector) {
-      if (!matchingEvse) {
-        matchingEvse = await this._locationRepository.createOrUpdateEvse(tenantId, {
-          evseTypeId: statusNotificationRequest.evseId,
-          ocppConnectionName,
-        });
-      }
-      matchingConnector = {
-        tenantId,
-        stationId: chargingStation.id,
-        evseId: matchingEvse.id!,
-        evseTypeConnectorId: statusNotificationRequest.connectorId,
-        /**
-         * Note: This is the OCPP 1.6 connectorId, which is NOT the same as the evseTypeConnectorId
-         * for OCPP 2.0.1 -- it is possible this will collide with an existing connectorId on a
-         * multi-evse station. Do not autocommission multi-evse stations.
-         */
-        connectorId: statusNotificationRequest.connectorId,
-        ocppConnectionName: ocppConnectionName,
-      };
+    } else if (!matchingEvse) {
+      matchingEvse = await this._locationRepository.createOrUpdateEvse(tenantId, {
+        evseTypeId: statusNotificationRequest.evseId,
+        ocppConnectionName,
+      });
+
       if (matchingEvse.evseTypeId! > 1) {
         this._logger.warn(
           `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is true, but the EVSE has evseTypeId ${matchingEvse.evseTypeId}. This may cause a collision with an existing connectorId on a multi-evse station.`,
@@ -129,7 +110,25 @@ export class StatusNotificationService {
       }
     }
 
-    await this._locationRepository.createOrUpdateConnector(tenantId, matchingConnector);
+    const connector = {
+      tenantId,
+      stationId: chargingStation.id,
+      evseId: matchingEvse.id!,
+      evseTypeConnectorId: statusNotificationRequest.connectorId,
+      ocppConnectionName: ocppConnectionName,
+      status: OCPP2_0_1_Mapper.LocationMapper.mapConnectorStatus(
+        statusNotificationRequest.connectorStatus,
+      ),
+      timestamp: statusNotificationRequest.timestamp,
+    };
+
+    await this._locationRepository.createOrUpdateOcpp2Connector(tenantId, connector);
+
+    await this._locationRepository.addStatusNotificationToChargingStation(
+      tenantId,
+      ocppConnectionName,
+      statusNotification,
+    );
 
     let components = await this._componentRepository.readAllByQuery(tenantId, {
       where: {
@@ -195,9 +194,6 @@ export class StatusNotificationService {
           (connector) => connector.connectorId === statusNotificationRequest.connectorId,
         ),
       );
-      const matchingConnector = matchingEvse?.connectors?.find(
-        (connector) => connector.connectorId === statusNotificationRequest.connectorId,
-      );
 
       // We upsert the Connector BEFORE saving the StatusNotification because
       // StatusNotifications.connectorId has an FK to Connectors.connectorId.
@@ -219,7 +215,7 @@ export class StatusNotificationService {
         info: statusNotificationRequest.info,
         vendorId: statusNotificationRequest.vendorId,
         vendorErrorCode: statusNotificationRequest.vendorErrorCode,
-      } as Connector;
+      } as ConnectorDto & { connectorId: number };
 
       if (chargingStation.use16StatusNotification0 && statusNotificationRequest.connectorId === 0) {
         // update all connectors at this station — connectorId stripped so we
@@ -235,9 +231,6 @@ export class StatusNotificationService {
           },
         );
       } else if (statusNotificationRequest.connectorId !== 0) {
-        // Connector model declares evseId and evseTypeConnectorId as allowNull:false.
-        // For commissioned stations these come from the matching evse/connector;
-        // for ad-hoc 1.6 stations we auto-commission below (citrineos/citrineos#160).
         if (!matchingEvse) {
           const connectionJson = await this._cache.get<string>(
             createIdentifier(tenantId, ocppConnectionName),
@@ -251,21 +244,16 @@ export class StatusNotificationService {
               `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is false`,
             );
           }
-          const commissioned = await this._locationRepository.commissionEvseForOcpp16Connector(
+          const commissioned = await this._locationRepository.autocommissionEvseForOcpp16Connector(
             tenantId,
             ocppConnectionName,
-            statusNotificationRequest.connectorId,
           );
           connector.evseId = commissioned.evseId;
-          connector.evseTypeConnectorId = commissioned.evseTypeConnectorId;
         } else {
-          // matchingConnector is found via the same predicate as matchingEvse,
-          // so it is guaranteed to be defined when matchingEvse is.
           connector.evseId = matchingEvse.id as number;
-          connector.evseTypeConnectorId = matchingConnector!.evseTypeConnectorId as number;
         }
 
-        await this._locationRepository.createOrUpdateConnector(tenantId, connector);
+        await this._locationRepository.createOrUpdateOcpp16Connector(tenantId, connector);
       }
 
       // Now that the Connector record exists (upserted above, or pre-existing in

--- a/packages/ocpp/src/modules/transactions/status-notification-service.ts
+++ b/packages/ocpp/src/modules/transactions/status-notification-service.ts
@@ -8,11 +8,16 @@ import {
   type ICache,
   type IWebsocketConnection,
 } from '@citrineos/base';
-import { OCPP1_6, OCPP2_0_1, type ConnectorDto } from '@citrineos/types';
 import type { IDeviceModelRepository, ILocationRepository } from '@citrineos/dal';
-import { OCPP1_6_Mapper, OCPP2_0_1_Mapper } from '@citrineos/dal';
-import { Component, EvseType, Variable } from '@citrineos/dal';
-import { Connector, StatusNotification } from '@citrineos/dal';
+import {
+  Component,
+  EvseType,
+  OCPP1_6_Mapper,
+  OCPP2_0_1_Mapper,
+  StatusNotification,
+  Variable,
+} from '@citrineos/dal';
+import { OCPP1_6, OCPP2_0_1, type ConnectorDto } from '@citrineos/types';
 import type { ILogObj } from 'tslog';
 import { Logger } from 'tslog';
 
@@ -79,9 +84,6 @@ export class StatusNotificationService {
     let matchingEvse = chargingStation.evses?.find(
       (evse) => evse.evseTypeId === statusNotificationRequest.evseId,
     );
-    // let matchingConnector: ConnectorDto | undefined = (
-    //   matchingEvse?.connectors as Connector[] | undefined
-    // )?.find((c) => c.evseTypeConnectorId === statusNotificationRequest.connectorId);
 
     const connectionJson = await this._cache.get<string>(
       createIdentifier(tenantId, ocppConnectionName),
@@ -244,7 +246,7 @@ export class StatusNotificationService {
               `Connector ${statusNotificationRequest.connectorId} on station ${ocppConnectionName} does not exist and allowUnknownChargingStations is false`,
             );
           }
-          const commissioned = await this._locationRepository.autocommissionEvseForOcpp16Connector(
+          const commissioned = await this._locationRepository.autoCommissionEvseForOcpp16Connector(
             tenantId,
             ocppConnectionName,
           );

--- a/packages/ocpp/test/handlers/requests/2/get-tariffs-request-ocpp-21-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/get-tariffs-request-ocpp-21-handler.test.ts
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type IMessage, DEFAULT_TENANT_ID } from '@citrineos/base';
 import {
   type OcppRequest,
@@ -16,6 +15,7 @@ import {
 import type { IAuthorizationRepository, ILocationRepository } from '@citrineos/dal';
 import { GetTariffsRequestOcpp21Handler } from '@handlers/index.js';
 import { createTestContainer, makeMockOcppSender } from '@test/test-container.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock sequelize models
 vi.mock('@dal/models/location/connector.js', () => ({
@@ -52,7 +52,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
   let ocppSender: ReturnType<typeof makeMockOcppSender>;
   let mockLocationRepository: Partial<ILocationRepository>;
   let mockAuthorizationRepository: Partial<IAuthorizationRepository>;
-  let mockConnectorFindAll: any;
+  let mockReadConnectorsWithTariffs: any;
   let mockAuthorizationFindAll: any;
   let mockTransactionFindAll: any;
 
@@ -61,8 +61,6 @@ describe('GetTariffsRequestOcpp21Handler', () => {
     const { Connector } = await import('@dal/models/location/connector.js');
     const { Transaction } = await import('@dal/models/transaction-event/transaction.js');
 
-    // Mock the sequelize.Connector.findAll which is what the handler actually uses
-    mockConnectorFindAll = vi.mocked(Connector.findAll);
     mockTransactionFindAll = vi.mocked(Transaction.findAll);
 
     // Driver tariffs come from the authorization repository, not the model directly.
@@ -71,11 +69,14 @@ describe('GetTariffsRequestOcpp21Handler', () => {
       findAllAuthorizationsWithTariffs: mockAuthorizationFindAll,
     };
 
+    // Default tariffs come from the location repository.
+    mockReadConnectorsWithTariffs = vi.fn();
     mockLocationRepository = {
       readChargingStationByStationId: vi.fn().mockResolvedValue({
         id: 1,
         ocppConnectionName: 'station-001',
       }),
+      readConnectorsWithTariffsByStationId: mockReadConnectorsWithTariffs,
     };
 
     const { logger } = createTestContainer();
@@ -98,7 +99,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
 
   describe('I09.FR.03 - No tariffs returns NoTariff status', () => {
     it('should return NoTariff status when no tariffs exist', async () => {
-      mockConnectorFindAll.mockResolvedValue([]);
+      mockReadConnectorsWithTariffs.mockResolvedValue([]);
       mockAuthorizationFindAll.mockResolvedValue([]);
       mockTransactionFindAll.mockResolvedValue([]);
 
@@ -109,9 +110,48 @@ describe('GetTariffsRequestOcpp21Handler', () => {
     });
   });
 
+  describe('Default tariffs are read through the location repository', () => {
+    beforeEach(() => {
+      mockReadConnectorsWithTariffs.mockResolvedValue([]);
+      mockAuthorizationFindAll.mockResolvedValue([]);
+      mockTransactionFindAll.mockResolvedValue([]);
+    });
+
+    it('should ask for every EVSE when evseId=0 (I09.FR.01)', async () => {
+      // evseId 0 addresses the station as a whole, so it must not be forwarded as a
+      // filter — doing so would look for an EVSE numbered 0 and find nothing.
+      await handleAndGetResponse({ evseId: 0 });
+
+      expect(mockReadConnectorsWithTariffs).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        'station-001',
+        undefined,
+      );
+    });
+
+    it('should ask only for the requested EVSE when evseId>0 (I09.FR.02)', async () => {
+      await handleAndGetResponse({ evseId: 3 });
+
+      expect(mockReadConnectorsWithTariffs).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        'station-001',
+        3,
+      );
+    });
+
+    it('should not read connectors at all when the station is unknown', async () => {
+      mockLocationRepository.readChargingStationByStationId = vi.fn().mockResolvedValue(undefined);
+
+      const response = await handleAndGetResponse({ evseId: 0 });
+
+      expect(response.status).toBe(OCPP2_1.TariffGetStatusEnumType.Rejected);
+      expect(mockReadConnectorsWithTariffs).not.toHaveBeenCalled();
+    });
+  });
+
   describe('I09.FR.01 & I09.FR.04 - evseId=0 returns all default tariffs with evseIds', () => {
     it('should return default tariffs for all EVSEs when evseId=0', async () => {
-      mockConnectorFindAll.mockResolvedValue([
+      mockReadConnectorsWithTariffs.mockResolvedValue([
         {
           id: 1,
           tariffId: 1,
@@ -151,7 +191,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
 
   describe('I09.FR.02 - evseId>0 returns tariffs only for that EVSE', () => {
     it('should return tariffs only for requested EVSE when evseId>0', async () => {
-      mockConnectorFindAll.mockResolvedValue([
+      mockReadConnectorsWithTariffs.mockResolvedValue([
         {
           id: 1,
           tariffId: 1,
@@ -176,7 +216,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
 
   describe('I09.FR.05 - DriverTariff includes idTokens list', () => {
     it('should return driver-specific tariffs with idTokens', async () => {
-      mockConnectorFindAll.mockResolvedValue([]);
+      mockReadConnectorsWithTariffs.mockResolvedValue([]);
       mockAuthorizationFindAll.mockResolvedValue([
         {
           id: 1,
@@ -224,7 +264,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
 
   describe('I09.FR.06 - DriverTariff with active transaction includes evseIds', () => {
     it('should include evseIds for driver tariffs with active transactions', async () => {
-      mockConnectorFindAll.mockResolvedValue([]);
+      mockReadConnectorsWithTariffs.mockResolvedValue([]);
       mockAuthorizationFindAll.mockResolvedValue([
         {
           id: 1,
@@ -272,7 +312,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
 
   describe('I09.FR.07 - Include validFrom when present', () => {
     it('should include validFrom field when tariff has validFrom date', async () => {
-      mockConnectorFindAll.mockResolvedValue([
+      mockReadConnectorsWithTariffs.mockResolvedValue([
         {
           id: 1,
           tariffId: 1,
@@ -294,7 +334,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
     });
 
     it('should NOT include validFrom field when tariff has no validFrom date', async () => {
-      mockConnectorFindAll.mockResolvedValue([]);
+      mockReadConnectorsWithTariffs.mockResolvedValue([]);
       mockAuthorizationFindAll.mockResolvedValue([
         {
           id: 1,
@@ -319,7 +359,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
   describe('Complete scenario from I09 use case', () => {
     it('should return all tariffs as described in I09 scenario', async () => {
       // Setup: Default tariff on all EVSEs
-      mockConnectorFindAll.mockResolvedValue([
+      mockReadConnectorsWithTariffs.mockResolvedValue([
         {
           id: 1,
           tariffId: 1,
@@ -432,7 +472,7 @@ describe('GetTariffsRequestOcpp21Handler', () => {
     });
 
     it('should return Rejected status when database query fails', async () => {
-      mockConnectorFindAll.mockRejectedValue(new Error('Database connection failed'));
+      mockReadConnectorsWithTariffs.mockRejectedValue(new Error('Database connection failed'));
 
       const response = await handleAndGetResponse({ evseId: 0 });
 

--- a/packages/ocpp/test/modules/transactions/status-notification-service-integration.test.ts
+++ b/packages/ocpp/test/modules/transactions/status-notification-service-integration.test.ts
@@ -2,9 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
-import type { Sequelize } from 'sequelize-typescript';
 import { DEFAULT_TENANT_ID, type ICache, type IWebsocketConnection } from '@citrineos/base';
 import type { SystemConfig } from '@citrineos/types';
 import {
@@ -16,6 +13,9 @@ import {
   Tenant,
 } from '@citrineos/dal';
 import { StatusNotificationService } from '@modules/transactions/status-notification-service.js';
+import type { Sequelize } from 'sequelize-typescript';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 let pgContainer: StartedTestContainer;
 let sequelizeInstance: Sequelize;
@@ -69,63 +69,68 @@ beforeEach(async () => {
   await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'default' } as never);
 });
 
-describe('SequelizeLocationRepository.commissionEvseForOcpp16Connector (#160 integration)', () => {
-  it('creates an Evse and returns ids that satisfy the Connector FK constraints', async () => {
+describe('SequelizeLocationRepository.autocommissionEvseForOcpp16Connector (#160 integration)', () => {
+  it('creates an Evse whose id satisfies the Connector FK constraints', async () => {
     const ocppConnectionName = 'CS-1.6-clean-db';
     await ChargingStation.create({
       ocppConnectionName,
       tenantId: DEFAULT_TENANT_ID,
     });
 
-    const { evseId, evseTypeConnectorId } =
-      await locationRepository.commissionEvseForOcpp16Connector(
-        DEFAULT_TENANT_ID,
-        ocppConnectionName,
-        1,
-      );
+    const { evseId } = await locationRepository.autocommissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      ocppConnectionName,
+    );
 
     expect(evseId).toBeGreaterThan(0);
-    expect(evseTypeConnectorId).toBeGreaterThan(0);
 
     // Confirm the Evse row exists and is linked to the right station
     const evse = await Evse.findOne({ where: { id: evseId } });
     expect(evse).not.toBeNull();
     expect(evse?.ocppConnectionName).toBe(ocppConnectionName);
 
-    // Critical: verify the returned ids satisfy whatever FK rules the live DB enforces
-    // by actually inserting a Connector row.
+    // Critical: verify the returned id satisfies whatever FK rules the live DB enforces
+    // by actually inserting a Connector row. A 1.6 connector carries no
+    // evseTypeConnectorId, so the column has to be genuinely nullable.
     const dbConnector = await Connector.create({
       tenantId: DEFAULT_TENANT_ID,
       ocppConnectionName,
       connectorId: 1,
       evseId,
-      evseTypeConnectorId,
       status: 'Available',
       timestamp: new Date(),
       errorCode: 'NoError',
     });
     expect(dbConnector.id).toBeGreaterThan(0);
+    expect(dbConnector.evseTypeConnectorId).toBeNull();
   });
 
-  it('is idempotent: a second call for the same station+connector returns the same evseId', async () => {
-    const ocppConnectionName = 'CS-1.6-idempotent';
+  it('accepts a 2.0.1 connector that carries no OCPP 1.6 connectorId', async () => {
+    // Mirror image of the above: a 2.0.1 connector is identified per-EVSE and has no
+    // station-wide 1.6 number, so connectorId has to be nullable in the live schema too.
+    const ocppConnectionName = 'CS-2.0.1-no-connector-id';
     await ChargingStation.create({
       ocppConnectionName,
       tenantId: DEFAULT_TENANT_ID,
     });
-
-    const first = await locationRepository.commissionEvseForOcpp16Connector(
-      DEFAULT_TENANT_ID,
+    const evse = await Evse.create({
       ocppConnectionName,
-      2,
-    );
-    const second = await locationRepository.commissionEvseForOcpp16Connector(
-      DEFAULT_TENANT_ID,
-      ocppConnectionName,
-      2,
-    );
+      tenantId: DEFAULT_TENANT_ID,
+      evseTypeId: 1,
+    });
 
-    expect(second.evseId).toBe(first.evseId);
+    const dbConnector = await Connector.create({
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName,
+      evseId: evse.id,
+      evseTypeConnectorId: 1,
+      status: 'Available',
+      timestamp: new Date(),
+      errorCode: 'NoError',
+    });
+
+    expect(dbConnector.id).toBeGreaterThan(0);
+    expect(dbConnector.connectorId).toBeNull();
   });
 });
 
@@ -171,7 +176,8 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     });
     expect(connector).not.toBeNull();
     expect(connector?.evseId).toBeDefined();
-    expect(connector?.evseTypeConnectorId).toBeDefined();
+    // The 1.6 request never reports a 2.0.1 per-EVSE connector number.
+    expect(connector?.evseTypeConnectorId).toBeNull();
 
     // Reporter's "cascade" concern: StartTransaction must be able to find
     // this connector via readConnectorByStationIdAndOcpp16ConnectorId.
@@ -184,6 +190,53 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     expect(lookedUp?.id).toBe(connector?.id);
   });
 
+  it('does not autocommission a second Evse when the same connector reports again', async () => {
+    // autocommissionEvseForOcpp16Connector creates unconditionally, so the guard against
+    // an Evse per StatusNotification is the matching-evse lookup ahead of it.
+    const ocppConnectionName = 'CS-1.6-e2e-repeat';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    });
+
+    const websocketConnection: IWebsocketConnection = {
+      id: 'test-server',
+      timeConnected: new Date().toISOString(),
+      protocol: 'ocpp1.6',
+      allowUnknownChargingStations: true,
+    };
+    cache = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(websocketConnection)),
+    } as unknown as ICache;
+
+    const service = new StatusNotificationService({
+      componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+      locationRepository,
+      cache,
+    });
+
+    for (const status of ['Available', 'Charging']) {
+      await service.processOcpp16StatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        connectorId: 1,
+        status,
+        errorCode: 'NoError',
+        timestamp: new Date().toISOString(),
+      } as any);
+    }
+
+    expect(await Evse.count({ where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName } })).toBe(
+      1,
+    );
+    expect(
+      await Connector.count({ where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName } }),
+    ).toBe(1);
+    const connector = await Connector.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName, connectorId: 1 },
+    });
+    expect(connector?.status).toBe('Charging');
+  });
+
   it('processes a 1.6 StatusNotification for a commissioned station (matching evse path)', async () => {
     const ocppConnectionName = 'CS-1.6-e2e-commissioned';
     await ChargingStation.create({
@@ -192,18 +245,15 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     });
     // Use the commission helper for a clean pre-existing setup, then upsert
     // a Connector tied to it so the matching-evse branch fires in the handler.
-    const { evseId, evseTypeConnectorId } =
-      await locationRepository.commissionEvseForOcpp16Connector(
-        DEFAULT_TENANT_ID,
-        ocppConnectionName,
-        1,
-      );
+    const { evseId } = await locationRepository.autocommissionEvseForOcpp16Connector(
+      DEFAULT_TENANT_ID,
+      ocppConnectionName,
+    );
     await Connector.create({
       tenantId: DEFAULT_TENANT_ID,
       ocppConnectionName,
       connectorId: 1,
       evseId,
-      evseTypeConnectorId,
       status: 'Available',
       timestamp: new Date(),
       errorCode: 'NoError',
@@ -240,5 +290,109 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     });
     expect(connector?.status).toBe('Charging');
     expect(connector?.evseId).toBe(evseId);
+  });
+});
+
+describe('StatusNotificationService.processStatusNotification end-to-end (2.0.1 integration)', () => {
+  const aService = (allowUnknownChargingStations: boolean) => {
+    const websocketConnection: IWebsocketConnection = {
+      id: 'test-server',
+      timeConnected: new Date().toISOString(),
+      protocol: 'ocpp2.0.1',
+      allowUnknownChargingStations,
+    };
+    cache = {
+      get: vi.fn().mockResolvedValue(JSON.stringify(websocketConnection)),
+    } as unknown as ICache;
+
+    return new StatusNotificationService({
+      componentRepository: { readAllByQuery: vi.fn().mockResolvedValue([]) } as any,
+      deviceModelRepository: { createOrUpdateDeviceModelByStationId: vi.fn() } as any,
+      locationRepository,
+      cache,
+    });
+  };
+
+  it('upserts a synthesized 2.0.1 connector that carries no OCPP 1.6 connectorId', async () => {
+    // The synthesized connector has connectorId unset, so the 2.x path has to key the
+    // upsert on (evseId, evseTypeConnectorId) — Sequelize rejects an undefined where
+    // value outright, so keying on connectorId would throw here.
+    const ocppConnectionName = 'CS-2.0.1-e2e-clean';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    });
+
+    await expect(
+      aService(true).processStatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        evseId: 1,
+        connectorId: 1,
+        connectorStatus: 'Available',
+        timestamp: new Date().toISOString(),
+      } as any),
+    ).resolves.not.toThrow();
+
+    const connector = await Connector.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName, evseTypeConnectorId: 1 },
+    });
+    expect(connector).not.toBeNull();
+    expect(connector?.connectorId).toBeNull();
+  });
+
+  it('updates the same row rather than inserting a duplicate when the connector reports again', async () => {
+    // (stationId, connectorId) is the only unique constraint on Connectors and NULLs are
+    // distinct in Postgres, so a lookup keyed on a null connectorId would insert a fresh
+    // row on every StatusNotification instead of updating the existing one.
+    const ocppConnectionName = 'CS-2.0.1-e2e-repeat';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    });
+    const service = aService(true);
+
+    for (const connectorStatus of ['Available', 'Occupied']) {
+      await service.processStatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        evseId: 1,
+        connectorId: 1,
+        connectorStatus,
+        timestamp: new Date().toISOString(),
+      } as any);
+    }
+
+    expect(
+      await Connector.count({ where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName } }),
+    ).toBe(1);
+    const connector = await Connector.findOne({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName },
+    });
+    expect(connector?.status).toBe('Occupied');
+  });
+
+  it('keeps each EVSEs connector distinct when both report their connector 1', async () => {
+    // Per-EVSE numbering: EVSE 1 connector 1 and EVSE 2 connector 1 are two connectors.
+    // Both are synthesized with connectorId unset, so only (evseId, evseTypeConnectorId)
+    // tells them apart.
+    const ocppConnectionName = 'CS-2.0.1-e2e-multi-evse';
+    await ChargingStation.create({
+      ocppConnectionName,
+      tenantId: DEFAULT_TENANT_ID,
+    });
+    const service = aService(true);
+
+    for (const evseId of [1, 2]) {
+      await service.processStatusNotification(DEFAULT_TENANT_ID, ocppConnectionName, {
+        evseId,
+        connectorId: 1,
+        connectorStatus: 'Available',
+        timestamp: new Date().toISOString(),
+      } as any);
+    }
+
+    const connectors = await Connector.findAll({
+      where: { tenantId: DEFAULT_TENANT_ID, ocppConnectionName },
+      include: [Evse],
+    });
+    expect(connectors).toHaveLength(2);
+    expect(connectors.map((c) => c.evse?.evseTypeId).sort()).toEqual([1, 2]);
   });
 });

--- a/packages/ocpp/test/modules/transactions/status-notification-service-integration.test.ts
+++ b/packages/ocpp/test/modules/transactions/status-notification-service-integration.test.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DEFAULT_TENANT_ID, type ICache, type IWebsocketConnection } from '@citrineos/base';
-import type { SystemConfig } from '@citrineos/types';
 import {
   ChargingStation,
   Connector,
@@ -12,6 +11,7 @@ import {
   SequelizeLocationRepository,
   Tenant,
 } from '@citrineos/dal';
+import type { SystemConfig } from '@citrineos/types';
 import { StatusNotificationService } from '@modules/transactions/status-notification-service.js';
 import type { Sequelize } from 'sequelize-typescript';
 import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
@@ -69,7 +69,7 @@ beforeEach(async () => {
   await Tenant.create({ id: DEFAULT_TENANT_ID, name: 'default' } as never);
 });
 
-describe('SequelizeLocationRepository.autocommissionEvseForOcpp16Connector (#160 integration)', () => {
+describe('SequelizeLocationRepository.autoCommissionEvseForOcpp16Connector (#160 integration)', () => {
   it('creates an Evse whose id satisfies the Connector FK constraints', async () => {
     const ocppConnectionName = 'CS-1.6-clean-db';
     await ChargingStation.create({
@@ -77,7 +77,7 @@ describe('SequelizeLocationRepository.autocommissionEvseForOcpp16Connector (#160
       tenantId: DEFAULT_TENANT_ID,
     });
 
-    const { evseId } = await locationRepository.autocommissionEvseForOcpp16Connector(
+    const { evseId } = await locationRepository.autoCommissionEvseForOcpp16Connector(
       DEFAULT_TENANT_ID,
       ocppConnectionName,
     );
@@ -190,8 +190,8 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     expect(lookedUp?.id).toBe(connector?.id);
   });
 
-  it('does not autocommission a second Evse when the same connector reports again', async () => {
-    // autocommissionEvseForOcpp16Connector creates unconditionally, so the guard against
+  it('does not auto-commission a second Evse when the same connector reports again', async () => {
+    // auto-commissionEvseForOcpp16Connector creates unconditionally, so the guard against
     // an Evse per StatusNotification is the matching-evse lookup ahead of it.
     const ocppConnectionName = 'CS-1.6-e2e-repeat';
     await ChargingStation.create({
@@ -245,7 +245,7 @@ describe('StatusNotificationService.processOcpp16StatusNotification end-to-end (
     });
     // Use the commission helper for a clean pre-existing setup, then upsert
     // a Connector tied to it so the matching-evse branch fires in the handler.
-    const { evseId } = await locationRepository.autocommissionEvseForOcpp16Connector(
+    const { evseId } = await locationRepository.autoCommissionEvseForOcpp16Connector(
       DEFAULT_TENANT_ID,
       ocppConnectionName,
     );

--- a/packages/ocpp/test/modules/transactions/status-notification-service.test.ts
+++ b/packages/ocpp/test/modules/transactions/status-notification-service.test.ts
@@ -7,8 +7,12 @@ import {
   type ICache,
   type IWebsocketConnection,
 } from '@citrineos/base';
-import { Component, type IDeviceModelRepository, type ILocationRepository } from '@citrineos/dal';
-import { StatusNotification } from '@citrineos/dal';
+import {
+  Component,
+  type IDeviceModelRepository,
+  type ILocationRepository,
+  StatusNotification,
+} from '@citrineos/dal';
 import { StatusNotificationService } from '@modules/transactions/status-notification-service.js';
 import { createTestContainer, getTestInstance } from '@test/test-container.js';
 import { beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
@@ -82,7 +86,7 @@ describe('StatusNotificationService', () => {
       createOrUpdateOcpp16Connector: vi.fn(),
       createOrUpdateOcpp2Connector: vi.fn(),
       createOrUpdateEvse: vi.fn(),
-      autocommissionEvseForOcpp16Connector: vi.fn(),
+      autoCommissionEvseForOcpp16Connector: vi.fn(),
       updateAllConnectorsByQuery: vi.fn(),
     } as unknown as Mocked<ILocationRepository>;
 
@@ -573,7 +577,7 @@ describe('StatusNotificationService', () => {
         }),
       );
       const newEvseId = 99;
-      locationRepository.autocommissionEvseForOcpp16Connector.mockResolvedValue({
+      locationRepository.autoCommissionEvseForOcpp16Connector.mockResolvedValue({
         evseId: newEvseId,
       });
       vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
@@ -586,9 +590,9 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      // The 1.6 connectorId is deliberately not passed: autocommissioning no longer
+      // The 1.6 connectorId is deliberately not passed: auto-commissioning no longer
       // derives the EVSE (or its EvseType) from it.
-      expect(locationRepository.autocommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+      expect(locationRepository.autoCommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
       );
@@ -666,7 +670,7 @@ describe('StatusNotificationService', () => {
           cs.evses = [aEvse()];
         }),
       );
-      locationRepository.autocommissionEvseForOcpp16Connector.mockResolvedValue({
+      locationRepository.autoCommissionEvseForOcpp16Connector.mockResolvedValue({
         evseId: 50,
       });
 
@@ -685,7 +689,7 @@ describe('StatusNotificationService', () => {
 
       expect(buildSpy).toHaveBeenCalled();
       expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
-      expect(locationRepository.autocommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+      expect(locationRepository.autoCommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
       );

--- a/packages/ocpp/test/modules/transactions/status-notification-service.test.ts
+++ b/packages/ocpp/test/modules/transactions/status-notification-service.test.ts
@@ -79,9 +79,10 @@ describe('StatusNotificationService', () => {
     locationRepository = {
       addStatusNotificationToChargingStation: vi.fn(),
       readChargingStationByStationId: vi.fn(),
-      createOrUpdateConnector: vi.fn(),
+      createOrUpdateOcpp16Connector: vi.fn(),
+      createOrUpdateOcpp2Connector: vi.fn(),
       createOrUpdateEvse: vi.fn(),
-      commissionEvseForOcpp16Connector: vi.fn(),
+      autocommissionEvseForOcpp16Connector: vi.fn(),
       updateAllConnectorsByQuery: vi.fn(),
     } as unknown as Mocked<ILocationRepository>;
 
@@ -209,14 +210,13 @@ describe('StatusNotificationService', () => {
 
   describe('Test process OCPP 2.0.1 StatusNotification on a multi-EVSE Charging Station', () => {
     // In OCPP 2.0.1 the connectorId is scoped to the EVSE, so a station with two single-connector
-    // EVSEs reports connectorId 1 twice - once for each EVSE. Connector.connectorId is the
-    // station-wide OCPP 1.6 numbering and is what createOrUpdateConnector upserts on, so the
-    // incoming connectorId has to be resolved through the matching EVSE rather than used directly.
+    // EVSEs reports connectorId 1 twice - once for each EVSE. The incoming connectorId therefore
+    // has to be resolved through the matching EVSE rather than used as a station-wide identifier.
     const aTwoEvseChargingStation = () =>
       aChargingStation((cs) => {
         cs.evses = [
           aEvse((evse) => {
-            evse.id = 1;
+            evse.id = 10;
             evse.evseTypeId = 1;
             evse.connectors = [
               aConnector((c) => {
@@ -228,7 +228,7 @@ describe('StatusNotificationService', () => {
             ];
           }),
           aEvse((evse) => {
-            evse.id = 2;
+            evse.id = 20;
             evse.evseTypeId = 2;
             evse.connectors = [
               aConnector((c) => {
@@ -250,7 +250,7 @@ describe('StatusNotificationService', () => {
       vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
     });
 
-    it('should update the second EVSEs own connector when it reports its connector 1', async () => {
+    it('should update the second EVSE when it reports its connector 1', async () => {
       await statusNotificationService.processStatusNotification(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
@@ -260,13 +260,13 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp2Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
-        expect.objectContaining({ evseId: 2, connectorId: 2, evseTypeConnectorId: 1 }),
+        expect.objectContaining({ evseId: 20, evseTypeConnectorId: 1 }),
       );
     });
 
-    it('should update the first EVSEs own connector when it reports its connector 1', async () => {
+    it('should update the first EVSEwhen it reports its connector 1', async () => {
       await statusNotificationService.processStatusNotification(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
@@ -276,13 +276,13 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp2Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
-        expect.objectContaining({ evseId: 1, connectorId: 1, evseTypeConnectorId: 1 }),
+        expect.objectContaining({ evseId: 10, evseTypeConnectorId: 1 }),
       );
     });
 
-    it('should give each EVSE a distinct connector when both report their connector 1', async () => {
+    it('should give each EVSE a distinct update when both report their connector 1', async () => {
       for (const evseId of [1, 2]) {
         await statusNotificationService.processStatusNotification(
           DEFAULT_TENANT_ID,
@@ -294,11 +294,11 @@ describe('StatusNotificationService', () => {
         );
       }
 
-      const targeted = locationRepository.createOrUpdateConnector.mock.calls.map(
-        ([, connector]) => connector.connectorId,
+      const targeted = locationRepository.createOrUpdateOcpp2Connector.mock.calls.map(
+        ([, connector]) => connector.evseId,
       );
 
-      expect(targeted).toEqual([1, 2]);
+      expect(targeted).toEqual([10, 20]);
     });
   });
 
@@ -335,17 +335,59 @@ describe('StatusNotificationService', () => {
         evseTypeId: 1,
         ocppConnectionName: MOCK_STATION_ID,
       });
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp2Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         expect.objectContaining({
           tenantId: DEFAULT_TENANT_ID,
           stationId: MOCK_STATION_ID,
           evseId: 99,
           evseTypeConnectorId: 1,
-          connectorId: 1,
           ocppConnectionName: MOCK_STATION_ID,
         }),
       );
+    });
+
+    it('should not invent an OCPP 1.6 connectorId for a synthesized 2.0.1 connector', async () => {
+      // The 2.0.1 connectorId is scoped to the EVSE, so reusing it as the station-wide
+      // 1.6 connectorId collides with a real connector on a multi-EVSE station. The
+      // synthesized record carries evseTypeConnectorId only and leaves connectorId unset.
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [
+            aEvse((evse) => {
+              evse.id = 1;
+              evse.evseTypeId = 1;
+              evse.connectors = [
+                aConnector((c) => {
+                  c.connectorId = 1;
+                  c.evseTypeConnectorId = 1;
+                }),
+              ];
+            }),
+          ];
+        }),
+      );
+      locationRepository.createOrUpdateEvse.mockResolvedValue(
+        aEvse((evse) => {
+          evse.id = 2;
+          evse.evseTypeId = 2;
+          evse.connectors = [];
+        }),
+      );
+
+      await statusNotificationService.processStatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aStatusNotificationRequest((request) => {
+          // EVSE 2's connector 1 — the same per-EVSE number EVSE 1 already uses.
+          request.evseId = 2;
+          request.connectorId = 1;
+        }),
+      );
+
+      const [, synthesized] = locationRepository.createOrUpdateOcpp2Connector.mock.calls[0];
+      expect(synthesized.connectorId).toBeUndefined();
+      expect(synthesized).toMatchObject({ evseId: 2, evseTypeConnectorId: 1 });
     });
 
     it('should reuse the existing EVSE and only synthesize the connector when the EVSE is known', async () => {
@@ -366,20 +408,44 @@ describe('StatusNotificationService', () => {
       );
 
       expect(locationRepository.createOrUpdateEvse).not.toHaveBeenCalled();
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp2Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         expect.objectContaining({
           evseId: MOCK_EVSE_ID,
           evseTypeConnectorId: 2,
-          connectorId: 2,
         }),
       );
     });
 
-    it('should record the StatusNotification but skip the connector upsert when allowUnknownChargingStations is false', async () => {
-      // The 2.0.1 path logs and returns rather than throwing: the StatusNotification
-      // is already persisted as an audit record before the check, but nothing is
-      // commissioned and the device model is left untouched.
+    it('should upsert the Connector before recording the StatusNotification', async () => {
+      // StatusNotification rows point at a Connector, so the connector has to be
+      // upserted first or the notification references a row that does not exist yet.
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.evses = [aEvse()];
+        }),
+      );
+
+      await statusNotificationService.processStatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aStatusNotificationRequest((request) => {
+          request.evseId = MOCK_EVSE_ID;
+          request.connectorId = MOCK_CONNECTOR_ID;
+        }),
+      );
+
+      const connectorUpsertOrder =
+        locationRepository.createOrUpdateOcpp2Connector.mock.invocationCallOrder[0];
+      const statusNotificationOrder =
+        locationRepository.addStatusNotificationToChargingStation.mock.invocationCallOrder[0];
+      expect(connectorUpsertOrder).toBeLessThan(statusNotificationOrder);
+    });
+
+    it('should record nothing at all when allowUnknownChargingStations is false', async () => {
+      // The 2.0.1 path logs and returns rather than throwing. The StatusNotification is
+      // written after the connector upsert, so an unknown connector under strict mode
+      // leaves no rows behind at all rather than an audit record pointing nowhere.
       locationRepository.readChargingStationByStationId.mockResolvedValue(
         aChargingStation((cs) => {
           cs.evses = [];
@@ -403,9 +469,9 @@ describe('StatusNotificationService', () => {
         ),
       ).resolves.toBeUndefined();
 
-      expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
+      expect(locationRepository.addStatusNotificationToChargingStation).not.toHaveBeenCalled();
       expect(locationRepository.createOrUpdateEvse).not.toHaveBeenCalled();
-      expect(locationRepository.createOrUpdateConnector).not.toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateOcpp2Connector).not.toHaveBeenCalled();
       expect(deviceModelRepository.createOrUpdateDeviceModelByStationId).not.toHaveBeenCalled();
     });
   });
@@ -428,7 +494,7 @@ describe('StatusNotificationService', () => {
       );
 
       expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateOcpp16Connector).toHaveBeenCalled();
     });
 
     it('should not save StatusNotification or connector when Charging Station does not exist', async () => {
@@ -441,7 +507,8 @@ describe('StatusNotificationService', () => {
       );
 
       expect(locationRepository.addStatusNotificationToChargingStation).not.toHaveBeenCalled();
-      expect(locationRepository.createOrUpdateConnector).not.toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateOcpp16Connector).not.toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateOcpp2Connector).not.toHaveBeenCalled();
     });
   });
 
@@ -465,14 +532,16 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         expect.objectContaining({ evseId: MOCK_EVSE_ID }),
       );
     });
 
-    it('should stamp evseTypeConnectorId on the Connector record when matching evse exists', async () => {
-      // Connector model also requires evseTypeConnectorId (FK to EvseType, allowNull:false).
+    it('should leave evseTypeConnectorId unset on the Connector record', async () => {
+      // The 1.6 request only carries the station-wide connectorId. evseTypeConnectorId is
+      // the per-EVSE 2.0.1 number; stamping the 1.6 value into it claims a 2.0.1 identity
+      // the station never reported, so the 1.6 path leaves it alone.
       locationRepository.readChargingStationByStationId.mockResolvedValue(
         aChargingStation((cs) => {
           cs.evses = [aEvse()];
@@ -488,10 +557,9 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
-        DEFAULT_TENANT_ID,
-        expect.objectContaining({ evseTypeConnectorId: MOCK_CONNECTOR_ID }),
-      );
+      const [, connector] = locationRepository.createOrUpdateOcpp16Connector.mock.calls[0];
+      expect(connector.evseTypeConnectorId).toBeUndefined();
+      expect(connector.connectorId).toBe(MOCK_CONNECTOR_ID);
     });
 
     it('should auto-commission an evse and stamp its FKs onto the Connector when allowUnknownChargingStations is true and no matching evse exists', async () => {
@@ -505,10 +573,8 @@ describe('StatusNotificationService', () => {
         }),
       );
       const newEvseId = 99;
-      const newEvseTypeConnectorId = 1;
-      locationRepository.commissionEvseForOcpp16Connector.mockResolvedValue({
+      locationRepository.autocommissionEvseForOcpp16Connector.mockResolvedValue({
         evseId: newEvseId,
-        evseTypeConnectorId: newEvseTypeConnectorId,
       });
       vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
 
@@ -520,19 +586,21 @@ describe('StatusNotificationService', () => {
         }),
       );
 
-      expect(locationRepository.commissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+      // The 1.6 connectorId is deliberately not passed: autocommissioning no longer
+      // derives the EVSE (or its EvseType) from it.
+      expect(locationRepository.autocommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
-        7,
       );
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         expect.objectContaining({
           evseId: newEvseId,
-          evseTypeConnectorId: newEvseTypeConnectorId,
           connectorId: 7,
         }),
       );
+      const [, connector] = locationRepository.createOrUpdateOcpp16Connector.mock.calls[0];
+      expect(connector.evseTypeConnectorId).toBeUndefined();
     });
 
     it('should throw and not upsert connector when allowUnknownChargingStations is false and no connector exists', async () => {
@@ -560,7 +628,7 @@ describe('StatusNotificationService', () => {
         ),
       ).rejects.toThrow(/does not exist and allowUnknownChargingStations is false/);
 
-      expect(locationRepository.createOrUpdateConnector).not.toHaveBeenCalled();
+      expect(locationRepository.createOrUpdateOcpp16Connector).not.toHaveBeenCalled();
     });
   });
 
@@ -598,9 +666,8 @@ describe('StatusNotificationService', () => {
           cs.evses = [aEvse()];
         }),
       );
-      locationRepository.commissionEvseForOcpp16Connector.mockResolvedValue({
+      locationRepository.autocommissionEvseForOcpp16Connector.mockResolvedValue({
         evseId: 50,
-        evseTypeConnectorId: 1,
       });
 
       const buildSpy = vi.spyOn(StatusNotification, 'build').mockImplementation((input: any) => {
@@ -618,15 +685,43 @@ describe('StatusNotificationService', () => {
 
       expect(buildSpy).toHaveBeenCalled();
       expect(locationRepository.addStatusNotificationToChargingStation).toHaveBeenCalled();
-      expect(locationRepository.commissionEvseForOcpp16Connector).toHaveBeenCalledWith(
+      expect(locationRepository.autocommissionEvseForOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
         MOCK_STATION_ID,
-        404,
       );
-      expect(locationRepository.createOrUpdateConnector).toHaveBeenCalledWith(
+      expect(locationRepository.createOrUpdateOcpp16Connector).toHaveBeenCalledWith(
         DEFAULT_TENANT_ID,
-        expect.objectContaining({ evseId: 50, evseTypeConnectorId: 1, connectorId: 404 }),
+        expect.objectContaining({ evseId: 50, connectorId: 404 }),
       );
+    });
+  });
+
+  describe('Test process OCPP 1.6 StatusNotification broadcast to connector 0', () => {
+    it('should strip connectorId when fanning a connector-0 status out to every connector', async () => {
+      // connectorId is the row's own identity; carrying the reported 0 into the bulk
+      // update would overwrite every connector's number with 0.
+      locationRepository.readChargingStationByStationId.mockResolvedValue(
+        aChargingStation((cs) => {
+          cs.use16StatusNotification0 = true;
+          cs.evses = [aEvse()];
+        }),
+      );
+      vi.spyOn(StatusNotification, 'build').mockImplementation(() => aStatusNotification());
+
+      await statusNotificationService.processOcpp16StatusNotification(
+        DEFAULT_TENANT_ID,
+        MOCK_STATION_ID,
+        aOcpp16StatusNotificationRequest((req) => {
+          req.connectorId = 0;
+        }),
+      );
+
+      expect(locationRepository.updateAllConnectorsByQuery).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        expect.objectContaining({ connectorId: undefined }),
+        { where: { stationId: MOCK_STATION_ID, tenantId: DEFAULT_TENANT_ID } },
+      );
+      expect(locationRepository.createOrUpdateOcpp16Connector).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/types/src/interfaces/dto/connector-dto.ts
+++ b/packages/types/src/interfaces/dto/connector-dto.ts
@@ -18,7 +18,7 @@ export const ConnectorSchemaWithoutParent = BaseSchema.extend({
   stationId: z.number().int().optional(),
   ocppConnectionName: z.string(),
   evseId: z.number().int(),
-  connectorId: z.number().int(),
+  connectorId: z.number().int().optional(),
   evseTypeConnectorId: z.number().int().optional(),
   status: ConnectorStatusEnumSchema.default('Unknown').optional(),
   type: ConnectorTypeEnumSchema.nullable().optional(),


### PR DESCRIPTION
A Connector is identified two different ways depending on the protocol: 1.6 numbers connectors station-wide (connectorId), 2.0.1 numbers them per EVSE (evseTypeConnectorId). Both columns were NOT NULL, so each path had to invent the other protocol's number. The 2.x path reused the per-EVSE number as the station-wide one, which collides with a real connector on a multi-EVSE station; the 1.6 path commissioned an EvseType keyed off the 1.6 connectorId.

Both columns are now nullable and each path fills only its own:

- createOrUpdateConnector splits into createOrUpdateOcpp16Connector (keyed on ocppConnectionName + connectorId) and createOrUpdateOcpp2Connector (keyed on evseId + evseTypeConnectorId), so a null in the other protocol's column never makes the upsert insert a duplicate row.
- commissionEvseForOcpp16Connector becomes autocommissionEvseForOcpp16Connector and creates the Evse only; the EvseType it used to derive from the 1.6 connectorId is no longer needed.
- The 2.0.1 path upserts the Connector before writing the StatusNotification that references it.
- GetTariffs reads its default tariffs through the new ILocationRepository.readConnectorsWithTariffsByStationId instead of querying the Connector model directly from the handler.