### PR TITLE
fix(ocpi): select the connector Tariff relation in location queries

### DIFF
--- a/packages/ocpi-base/src/graphql/queries/location-queries.ts
+++ b/packages/ocpi-base/src/graphql/queries/location-queries.ts
@@ -71,6 +71,9 @@ export const GET_LOCATIONS_QUERY = gql`
             powerType
             termsAndConditionsUrl
             type
+            tariff: Tariff {
+              id
+            }
             status
             errorCode
             timestamp
@@ -163,6 +166,9 @@ export const GET_LOCATION_BY_ID_QUERY = gql`
             powerType
             termsAndConditionsUrl
             type
+            tariff: Tariff {
+              id
+            }
             status
             errorCode
             timestamp
@@ -258,6 +264,9 @@ export const GET_CONNECTOR_BY_ID_QUERY = gql`
             powerType
             termsAndConditionsUrl
             type
+            tariff: Tariff {
+              id
+            }
             status
             errorCode
             timestamp


### PR DESCRIPTION
# PR: fix(ocpi): select the connector Tariff relation in location queries

## What

`GET /ocpi/2.2.1/locations` returned `tariff_ids: null` on connectors even when a `Tariff` was linked via `Connectors.tariffId` and `/tariffs` served it correctly. `ConnectorMapper.fromGraphql` reads the connector's **Tariff relation** (`connector.tariff`), but the location queries never selected it, so it was always `undefined`.

This adds `tariff: Tariff { id }` (aliased lowercase to match the mapper) to the connectors selection in all three query blocks — `GET_LOCATIONS`, `GET_LOCATION_BY_ID`, `GET_CONNECTOR_BY_ID`.

The `Connectors → Tariff` object relationship already exists in the Hasura metadata (`foreign_key_constraint_on: tariffId`), so no metadata change is required.

## Diff (one file, 9 lines)

`packages/ocpi-base/src/graphql/queries/location-queries.ts` — in each of the three `connectors: Connectors { … }` selections, after `type`:

```graphql
            termsAndConditionsUrl
            type
+           tariff: Tariff {
+             id
+           }
            status
```

## Testing

Verified against a running instance (Hasura-backed): with a DC tariff and an AC tariff linked to their connectors, `GET /ocpi/2.2.1/locations` now emits `tariff_ids: ["1"]` on DC connectors and `["2"]` on AC connectors; previously `null`. `GET /ocpi/2.2.1/tariffs` output is unchanged.

Fixes https://github.com/citrineos/citrineos/issues/224
