### PR TITLE
fix(ocpi): map Location.operator from tenant business name

### DIFF
--- a/packages/ocpi-base/src/mapper/location-mapper.ts
+++ b/packages/ocpi-base/src/mapper/location-mapper.ts
@@ -64,6 +64,7 @@ export class LocationMapper {
       id: location.id!.toString(),
       country_code: location.tenant!.countryCode!,
       party_id: location.tenant!.partyId!,
+      operator: { name: location.tenant!.name },
       publish: location.publishUpstream,
       name: location.name,
       address: location.address,
@@ -93,6 +94,7 @@ export class LocationMapper {
 
   fromPartialGraphql(location: Partial<LocationDto>): Partial<LocationDTO> {
     return {
+      operator: location.tenant ? { name: location.tenant.name } : undefined,
       publish: location.publishUpstream,
       name: location.name,
       address: location.address,


### PR DESCRIPTION
## Summary

Populate OCPI `Location.operator` from the tenant's business name. The field is
defined in `LocationDTOSchema` (`operator: BusinessDetailsSchema.nullable().optional()`)
but `LocationMapper` never set it, so every served Location omitted operator
identity even though the source (`tenant.name`) is already selected by the
location GraphQL query and read elsewhere in the same mapper.

Related to the `tariff_ids` mapping gap (#224 / citrineos-core#1018) — same
class of issue: a value available in the query but dropped by the mapper.

## Details

- **Problem:** `LocationMapper.fromGraphql` already reads `location.tenant!.countryCode`
  and `location.tenant!.partyId` for `country_code` / `party_id`, but never maps
  `tenant.name` into the OCPI `operator` BusinessDetails object. Aggregators /
  eMSPs consuming `/ocpi/2.2.1/locations` therefore receive no operator identity.
- **Approach:** set `operator: { name: location.tenant!.name }`. `BusinessDetails`
  only requires `name` (a required `z.string()` on `TenantSchema`); `website` and
  `logo` are optional and have no source field on the tenant, so they are left unset
  (populating them would need new source data — out of scope here).
- **`fromPartialGraphql` (PATCH):** guarded — `operator` is only emitted when
  `tenant` is present in the partial, since partial updates do not carry tenant
  identity. Avoids a null-deref on partial location updates.
- **Impact:** one field added to the two Location mapping paths. No query change,
  no schema change, no behavior change for existing fields. `suboperator` / `owner`
  remain unset (no tenant source for a distinct sub-operator / owner name).

## Verify

- [x] Build passes — `@citrineos/ocpi-base` and its deps build clean (`tsc`, no type errors).
- [x] Lint passes — `eslint .` on ocpi-base reports 0 errors (pre-existing unused-var warnings only, unrelated files).
- [x] Type-checks — vitest typecheck reports no type errors.
- [x] ocpi-base tests pass — all ocpi-base tests green. (The only failing suites in a full workspace run are infrastructure-dependent integration tests in the separate `@citrineos/ocpp` package — RabbitMQ / network-connection — which fail without a live broker and are untouched by this change.)
