### PR TITLE
feature(ocpp-server) adds CaliforniaPricing for OCPP 1.6

### DIFF
--- a/packages/dal/src/repositories/drizzle/connector.ts
+++ b/packages/dal/src/repositories/drizzle/connector.ts
@@ -50,6 +50,7 @@ export function toConnectorDto(entity: ConnectorEntity): ConnectorDto {
     vendorId: entity.vendorId,
     vendorErrorCode: entity.vendorErrorCode,
     termsAndConditionsUrl: entity.termsAndConditionsUrl,
+    tariffId: entity.tariffId,
     // Relations are not present on a flat DB row.
     tariff: undefined,
     evse: undefined,
@@ -176,6 +177,21 @@ export class DrizzleConnectorRepository
       .limit(1)) as ConnectorEntity[];
 
     return rows[0] ? await this.withEvse(tenantId, rows[0]) : undefined;
+  }
+
+  async readConnectorsByStationId(
+    tenantId: number,
+    ocppConnectionName: string,
+  ): Promise<ConnectorDto[]> {
+    const table = this.getTable(tenantId);
+    const rows = (await this.db
+      .select()
+      .from(table)
+      .where(
+        and(eq(table.ocppConnectionName, ocppConnectionName), this.tenantFilter(table, tenantId)),
+      )) as ConnectorEntity[];
+
+    return rows.map((row) => this.toDto(row));
   }
 
   async readConnectorByStationIdAndOcpp201EvseType(

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -282,6 +282,10 @@ export interface IConnectorRepository {
     ocppConnectionName: string,
     ocpp16ConnectorId: number,
   ) => Promise<ConnectorDto | undefined>;
+  readConnectorsByStationId: (
+    tenantId: number,
+    ocppConnectionName: string,
+  ) => Promise<ConnectorDto[]>;
   readConnectorByStationIdAndOcpp201EvseType: (
     tenantId: number,
     ocppConnectionName: string,

--- a/packages/dal/src/repositories/sequelize/location.ts
+++ b/packages/dal/src/repositories/sequelize/location.ts
@@ -477,6 +477,15 @@ export class SequelizeLocationRepository
     );
   }
 
+  async readConnectorsByStationId(
+    tenantId: number,
+    ocppConnectionName: string,
+  ): Promise<ConnectorDto[]> {
+    return await Connector.findAll({
+      where: { tenantId, ocppConnectionName },
+    });
+  }
+
   async readEvseByStationIdAndOcpp201EvseId(
     tenantId: number,
     ocppConnectionName: string,

--- a/packages/dal/src/repositories/sequelize/transaction-event.ts
+++ b/packages/dal/src/repositories/sequelize/transaction-event.ts
@@ -31,6 +31,26 @@ import { TransactionEvent } from '../../models/transaction-event/transaction-eve
 import { SequelizeRepository, type SequelizeRepositoryDependencies } from './base.js';
 import { SequelizeChargingStationSequenceRepository } from './charging-station-sequence.js';
 
+/** Seconds between the transaction start and the newest meter value; 1.6 has no reported value. */
+function elapsedSecondsSinceStart(
+  startTime: string | undefined,
+  meterValues: MeterValueDto[],
+): number | undefined {
+  if (!startTime || meterValues.length === 0) {
+    return undefined;
+  }
+
+  const startTimestamp = new Date(startTime).getTime();
+  const latestMeterValueTimestamp = Math.max(
+    ...meterValues.map((meterValue) => new Date(meterValue.timestamp).getTime()),
+  );
+  if (!Number.isFinite(startTimestamp) || !Number.isFinite(latestMeterValueTimestamp)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.floor((latestMeterValueTimestamp - startTimestamp) / 1000));
+}
+
 export class SequelizeTransactionEventRepository
   extends SequelizeRepository<TransactionEvent>
   implements ITransactionEventRepository
@@ -668,6 +688,7 @@ export class SequelizeTransactionEventRepository
           meterStart ?? undefined,
         ),
         meterStart: meterStart,
+        timeSpentCharging: elapsedSecondsSinceStart(transaction.startTime, meterValues),
       });
     } else {
       await transaction.update({
@@ -676,6 +697,7 @@ export class SequelizeTransactionEventRepository
           transaction.totalKwh ?? 0,
           transaction.meterStart ?? undefined,
         ),
+        timeSpentCharging: elapsedSecondsSinceStart(transaction.startTime, meterValues),
       });
     }
   }

--- a/packages/ocpp/index.ts
+++ b/packages/ocpp/index.ts
@@ -10,6 +10,7 @@ export * from '@services/index.js';
 export * from '@util/index.js';
 
 // Module exports
+export * from '@modules/california-pricing/index.js';
 export * from '@modules/certificates/index.js';
 export * from '@modules/configuration/index.js';
 export * from '@modules/ev-driver/index.js';

--- a/packages/ocpp/src/handlers/requests/1.6/stop-transaction-request-ocpp-16-handler.ts
+++ b/packages/ocpp/src/handlers/requests/1.6/stop-transaction-request-ocpp-16-handler.ts
@@ -23,28 +23,33 @@ import {
   Transaction,
 } from '@citrineos/dal';
 import { OCPP1_6_Mapper } from '@citrineos/dal';
+import type { CostCalculator } from '@modules/transactions/cost-calculator.js';
 
 @AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.StopTransaction)
 export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
   protected _ocppSender: IOcppSender;
   protected _authorizationRepository: IAuthorizationRepository;
   protected _transactionEventRepository: ITransactionEventRepository;
+  protected _costCalculator: CostCalculator;
 
   constructor({
     logger,
     ocppSender,
     authorizationRepository,
     transactionEventRepository,
+    costCalculator,
   }: AbstractHandlerDependencies & {
     ocppSender: IOcppSender;
     authorizationRepository: IAuthorizationRepository;
     transactionEventRepository: ITransactionEventRepository;
+    costCalculator: CostCalculator;
   }) {
     super(logger);
 
     this._ocppSender = ocppSender;
     this._authorizationRepository = authorizationRepository;
     this._transactionEventRepository = transactionEventRepository;
+    this._costCalculator = costCalculator;
   }
 
   async handle(
@@ -155,13 +160,31 @@ export class StopTransactionRequestOcpp16Handler extends AbstractHandler {
       transaction.totalKwh = (request.meterStop - transaction.startTransaction.meterStart) / 1000; // Convert from Wh to kWh
     } else {
       this._logger.warn(
-        `StartTransaction record not found at station ${ocppConnectionName} for transactionId ${request.transactionId}. 
+        `StartTransaction record not found at station ${ocppConnectionName} for transactionId ${request.transactionId}.
         Cannot calculate totalKwh.`,
       );
     }
     transaction.isActive = false;
     transaction.stoppedReason = stoppedReason;
     transaction.endTime = request.timestamp;
+
+    // Sole owner of the final timeSpentCharging: 1.6 reports no charging duration, so the whole
+    // session is billed as charging time. Always set, so cost calculation never sees it unset.
+    const startTime = transaction.startTime ? Date.parse(transaction.startTime) : Number.NaN;
+    const stopTime = Date.parse(request.timestamp);
+    const elapsedSeconds = Math.floor((stopTime - startTime) / 1000);
+    transaction.timeSpentCharging = Number.isFinite(elapsedSeconds)
+      ? Math.max(0, elapsedSeconds)
+      : 0;
     await transaction.save();
+
+    const totalCost = await this._costCalculator.calculateTotalCost(tenantId, transaction);
+    if (totalCost != null) {
+      await this._transactionEventRepository.updateTransactionTotalCostById(
+        tenantId,
+        totalCost,
+        transaction.id,
+      );
+    }
   }
 }

--- a/packages/ocpp/src/modules/california-pricing/california-pricing-service.ts
+++ b/packages/ocpp/src/modules/california-pricing/california-pricing-service.ts
@@ -1,0 +1,313 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { type IOcppSender } from '@citrineos/base';
+import { EventGroup, OCPP1_6, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type { Logger, ILogObj } from 'tslog';
+import { Logger as TsLogger } from 'tslog';
+import type {
+  IChangeConfigurationRepository,
+  IConnectorRepository,
+  ITariffRepository,
+  ITransactionEventRepository,
+} from '@citrineos/dal';
+import {
+  COSTMSG_VENDOR_ID,
+  CUSTOM_DISPLAY_COST_AND_PRICE_KEY,
+  CostMsgId,
+  DEFAULT_PRICE_KEY,
+  type ChargingPrice,
+  type DefaultPriceData,
+  type FinalCostData,
+  type RunningCostData,
+  type SetUserPriceData,
+} from './costmsg.js';
+import { sameJson } from './json.js';
+import type { CostCalculator } from '@modules/transactions/cost-calculator.js';
+
+/**
+ * Encapsulates the OCA California pricing (org.openchargealliance.costmsg) customization for
+ * OCPP 1.6. Owns the enable-gate check, the CustomDisplayCostAndPrice probe, the DefaultPrice
+ * ChangeConfiguration, and the construction/sending of the outbound SetUserPrice / RunningCost /
+ * FinalCost DataTransfer messages. Injected into the module's observer handlers so they stay thin.
+ */
+export class CaliforniaPricingService {
+  private readonly _logger: Logger<ILogObj>;
+  private readonly _ocppSender: IOcppSender;
+  private readonly _changeConfigurationRepository: IChangeConfigurationRepository;
+  private readonly _tariffRepository: ITariffRepository;
+  private readonly _transactionEventRepository: ITransactionEventRepository;
+  private readonly _locationRepository: IConnectorRepository;
+  protected _costCalculator: CostCalculator;
+
+  constructor({
+    transactionEventRepository,
+    logger,
+    ocppSender,
+    changeConfigurationRepository,
+    tariffRepository,
+    locationRepository,
+    costCalculator,
+  }: {
+    logger: Logger<ILogObj>;
+    ocppSender: IOcppSender;
+    changeConfigurationRepository: IChangeConfigurationRepository;
+    transactionEventRepository: ITransactionEventRepository;
+    tariffRepository: ITariffRepository;
+    locationRepository: IConnectorRepository;
+    costCalculator: CostCalculator;
+  }) {
+    this._logger = logger
+      ? logger.getSubLogger({ name: this.constructor.name })
+      : new TsLogger<ILogObj>({ name: this.constructor.name });
+    this._transactionEventRepository = transactionEventRepository;
+    this._costCalculator = costCalculator;
+    this._ocppSender = ocppSender;
+    this._changeConfigurationRepository = changeConfigurationRepository;
+    this._tariffRepository = tariffRepository;
+    this._locationRepository = locationRepository;
+  }
+
+  /**
+   * True when the charger reported CustomDisplayCostAndPrice=true (via GetConfiguration,
+   * persisted in the ChangeConfiguration table). Gates the transaction-driven costmsg sends
+   */
+  async isEnabled(tenantId: number, ocppConnectionName: string): Promise<boolean> {
+    const config = await this._changeConfigurationRepository.findByStationAndKey(
+      tenantId,
+      ocppConnectionName,
+      CUSTOM_DISPLAY_COST_AND_PRICE_KEY,
+    );
+    return config?.value === 'true';
+  }
+
+  /** tariff for a connector, or undefined when no tariff is configured. */
+  async resolvePrice(
+    tenantId: number,
+    ocppConnectionName: string,
+    transactionId: number | undefined,
+  ): Promise<ChargingPrice | undefined> {
+    if (transactionId == null) {
+      return undefined;
+    }
+
+    const transaction =
+      await this._transactionEventRepository.readTransactionByStationIdAndTransactionId(
+        tenantId,
+        ocppConnectionName,
+        transactionId.toString(),
+      );
+    if (transaction == null || transaction.connectorId == null) {
+      return undefined;
+    }
+    const tariff = await this._tariffRepository.findByConnectorId(
+      tenantId,
+      transaction.connectorId,
+    );
+    return {
+      kWhPrice: tariff?.pricePerKwh ?? 0,
+      hourPrice: (tariff?.pricePerMin ?? 0) * 60,
+      flatFee: tariff?.pricePerSession ?? 0,
+    };
+  }
+
+  /**
+   * Total cost so far. The persisted transaction is written by the primary MeterValues handler on
+   * a separate queue, so it can still hold the previous interval when we get here; the reading
+   * from the message being handled overrides it.
+   *
+   * @param currentReading - Meter register (kWh) and its timestamp, from the triggering message.
+   */
+  async calculateCost(
+    tenantId: number,
+    ocppConnectionName: string,
+    transactionId: number | undefined,
+    currentReading: { meterKwh: number; timestamp: string },
+  ): Promise<number | undefined> {
+    if (transactionId == null) {
+      return undefined;
+    }
+
+    const transaction =
+      await this._transactionEventRepository.readTransactionByStationIdAndTransactionId(
+        tenantId,
+        ocppConnectionName,
+        transactionId.toString(),
+      );
+    if (transaction == null || transaction.connectorId == null) {
+      return undefined;
+    }
+
+    transaction.totalKwh = currentReading.meterKwh - (transaction.meterStart ?? 0);
+    const startTime = transaction.startTime;
+    if (startTime != null) {
+      transaction.timeSpentCharging = Math.max(
+        0,
+        Math.floor((Date.parse(currentReading.timestamp) - Date.parse(startTime)) / 1000),
+      );
+    }
+    return await this._costCalculator.calculateTotalCost(tenantId, transaction);
+  }
+
+  async sendSetUserPrice(
+    tenantId: number,
+    ocppConnectionName: string,
+    data: SetUserPriceData,
+  ): Promise<void> {
+    await this._send(tenantId, ocppConnectionName, CostMsgId.SetUserPrice, data);
+  }
+
+  async sendRunningCost(
+    tenantId: number,
+    ocppConnectionName: string,
+    data: RunningCostData,
+  ): Promise<void> {
+    await this._send(tenantId, ocppConnectionName, CostMsgId.RunningCost, data);
+  }
+
+  /**
+   * Resolves the station-wide DefaultPrice from its connectors' tariffs and sets it. DefaultPrice
+   * is station-wide, so it only works when every connector shares the same tariff
+   * if they differ, logs an error and sends nothing.
+   *
+   * @param reportedDefaultPrice stations reported price, if read otherwise null
+   */
+  async applyStationDefaultPrice(
+    tenantId: number,
+    ocppConnectionName: string,
+    reportedDefaultPrice: string | null,
+  ): Promise<void> {
+    const connectors = await this._locationRepository.readConnectorsByStationId(
+      tenantId,
+      ocppConnectionName,
+    );
+    if (connectors.length === 0) {
+      this._logger.warn(`No connectors found for ${ocppConnectionName}; not setting DefaultPrice.`);
+      return;
+    }
+
+    const tariffIds = new Set(connectors.map((connector) => connector.tariffId ?? null));
+    if (tariffIds.size > 1) {
+      this._logger.error(
+        `Connectors on ${ocppConnectionName} use different tariffs (${[...tariffIds].join(', ')}). ` +
+          `DefaultPrice is station-wide and can not be set`,
+      );
+      return;
+    }
+
+    // All connectors share one tariff; load it (by connector) only when there is one to load.
+    const [sharedTariffId] = [...tariffIds];
+    const tariff =
+      sharedTariffId != null
+        ? await this._tariffRepository.findByConnectorId(tenantId, connectors[0].id!)
+        : undefined;
+    if (!tariff) {
+      this._logger.warn(
+        `No tariff configured for connectors on ${ocppConnectionName}; DefaultPrice will use zero prices.`,
+      );
+    }
+    const priceParts = [
+      tariff?.pricePerKwh ? `${tariff.pricePerKwh} ${tariff.currency}/kWh` : undefined,
+      tariff?.pricePerMin ? `${tariff.pricePerMin} ${tariff.currency}/minute` : undefined,
+      tariff?.pricePerSession ? `${tariff.pricePerSession} ${tariff.currency}` : undefined,
+    ].filter((part) => part !== undefined);
+
+    const newPrice = {
+      priceText: priceParts.length > 0 ? priceParts.join(' + ') : 'No tariff configured',
+      chargingPrice: {
+        kWhPrice: tariff?.pricePerKwh ?? 0,
+        hourPrice: (tariff?.pricePerMin ?? 0) * 60,
+        flatFee: tariff?.pricePerSession ?? 0,
+      },
+    };
+
+    // Skip if the value on station is what we were about to send
+    const value = JSON.stringify(newPrice);
+    if (reportedDefaultPrice != null && sameJson(reportedDefaultPrice, value)) {
+      return;
+    }
+
+    await this.sendDefaultPrice(tenantId, ocppConnectionName, newPrice);
+  }
+
+  async sendDefaultPrice(
+    tenantId: number,
+    ocppConnectionName: string,
+    data: DefaultPriceData,
+  ): Promise<void> {
+    const value = JSON.stringify(data);
+
+    const payload: OCPP1_6.ChangeConfigurationRequest = {
+      key: DEFAULT_PRICE_KEY,
+      value,
+    };
+    const confirmation = await this._ocppSender.sendCall({
+      ocppConnectionName,
+      tenantId,
+      protocol: OCPPVersion.OCPP1_6,
+      action: OCPP_CallAction.ChangeConfiguration,
+      eventGroup: EventGroup.CaliforniaPricing,
+      payload,
+    });
+    if (!confirmation.success) {
+      this._logger.error(
+        `Failed to set DefaultPrice on ${ocppConnectionName}: ${confirmation.payload}`,
+      );
+    }
+  }
+
+  async sendFinalCost(
+    tenantId: number,
+    ocppConnectionName: string,
+    data: FinalCostData,
+  ): Promise<void> {
+    await this._send(tenantId, ocppConnectionName, CostMsgId.FinalCost, data);
+  }
+
+  async requestCustomDisplayCostAndPrice(
+    tenantId: number,
+    ocppConnectionName: string,
+  ): Promise<void> {
+    const confirmation = await this._ocppSender.sendCall({
+      ocppConnectionName,
+      tenantId,
+      protocol: OCPPVersion.OCPP1_6,
+      action: OCPP_CallAction.GetConfiguration,
+      eventGroup: EventGroup.CaliforniaPricing,
+      payload: {
+        key: [CUSTOM_DISPLAY_COST_AND_PRICE_KEY],
+      } satisfies OCPP1_6.GetConfigurationRequest,
+    });
+    if (!confirmation.success) {
+      this._logger.error(
+        `Failed to send getConfiguration to ${ocppConnectionName}: ${confirmation.payload}`,
+      );
+    }
+  }
+
+  private async _send(
+    tenantId: number,
+    ocppConnectionName: string,
+    messageId: CostMsgId,
+    data: unknown,
+  ): Promise<void> {
+    const payload: OCPP1_6.DataTransferRequest = {
+      vendorId: COSTMSG_VENDOR_ID,
+      messageId,
+      data: JSON.stringify(data),
+    };
+    const confirmation = await this._ocppSender.sendCall({
+      ocppConnectionName,
+      tenantId,
+      protocol: OCPPVersion.OCPP1_6,
+      action: OCPP_CallAction.DataTransfer,
+      eventGroup: EventGroup.CaliforniaPricing,
+      payload,
+    });
+    if (!confirmation.success) {
+      this._logger.error(
+        `Failed to send costmsg ${messageId} to ${ocppConnectionName}: ${confirmation.payload}`,
+      );
+    }
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/costmsg.ts
+++ b/packages/ocpp/src/modules/california-pricing/costmsg.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for the OCA "OCPP & California Pricing Requirements" (v3.1) customization,
+ * carried over OCPP 1.6 DataTransfer messages. The JSON below is serialized into the opaque
+ * DataTransfer `data` string field. See the application note, section 3.
+ */
+
+/** Vendor identifier that scopes every DataTransfer message of this customization. */
+export const COSTMSG_VENDOR_ID = 'org.openchargealliance.costmsg';
+
+/** DataTransfer `messageId` values used by this customization */
+export enum CostMsgId {
+  SetUserPrice = 'SetUserPrice',
+  RunningCost = 'RunningCost',
+  FinalCost = 'FinalCost',
+}
+
+/** Configuration key a Central System reads to detect/enable the customization. */
+export const CUSTOM_DISPLAY_COST_AND_PRICE_KEY = 'CustomDisplayCostAndPrice';
+
+/** Configuration key that holds the station-wide default price (set via ChangeConfiguration). */
+export const DEFAULT_PRICE_KEY = 'DefaultPrice';
+
+/** Whether a running/final cost is being charged for active charging or for idle time. */
+export type CostState = 'Charging' | 'Idle';
+
+/** Unit prices applied while the EV is charging (Table 5). */
+export interface ChargingPrice {
+  kWhPrice?: number;
+  hourPrice?: number;
+  flatFee?: number;
+}
+
+/** SetUserPrice payload (Table 2) */
+export interface SetUserPriceData {
+  idToken: string;
+  priceText: string;
+}
+
+/** RunningCost payload (Table 4) */
+export interface RunningCostData {
+  transactionId: number;
+  timestamp: string;
+  meterValue: number;
+  cost: number;
+  state: CostState;
+  chargingPrice: ChargingPrice;
+}
+
+/** FinalCost payload (Table 3) */
+export interface FinalCostData {
+  transactionId: number;
+  cost: number;
+  priceText: string;
+  qrCodeText?: string;
+}
+
+/** DefaultPrice value (Table 1) */
+export interface DefaultPriceData {
+  priceText: string;
+  priceTextOffline?: string;
+  chargingPrice?: ChargingPrice;
+}

--- a/packages/ocpp/src/modules/california-pricing/handlers/custom-display-cost-and-price-16-handler.ts
+++ b/packages/ocpp/src/modules/california-pricing/handlers/custom-display-cost-and-price-16-handler.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AbstractHandler,
+  type AbstractHandlerDependencies,
+  AsRequestHandler,
+  type IMessage,
+} from '@citrineos/base';
+import { type HandlerProperties, OCPP1_6, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type { CaliforniaPricingService } from '../california-pricing-service.js';
+
+/**
+ * on bootup, request CustomDisplayCostAndPrice configuration
+ */
+@AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.BootNotification)
+export class CustomDisplayCostAndPriceOcpp16Handler extends AbstractHandler {
+  protected _californiaPricingService: CaliforniaPricingService;
+
+  constructor({
+    logger,
+    californiaPricingService,
+  }: AbstractHandlerDependencies & {
+    californiaPricingService: CaliforniaPricingService;
+  }) {
+    super(logger);
+    this._californiaPricingService = californiaPricingService;
+  }
+
+  async handle(
+    message: IMessage<OCPP1_6.BootNotificationRequest>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(
+      this.createHandlerReceivedMessageLog('BootNotificationRequest'),
+      message,
+      props,
+    );
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+
+    await this._californiaPricingService.requestCustomDisplayCostAndPrice(
+      tenantId,
+      ocppConnectionName,
+    );
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/handlers/default-price-ocpp-16-handler.ts
+++ b/packages/ocpp/src/modules/california-pricing/handlers/default-price-ocpp-16-handler.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AbstractHandler,
+  type AbstractHandlerDependencies,
+  AsResponseHandler,
+  type IMessage,
+} from '@citrineos/base';
+import { type HandlerProperties, OCPP1_6, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type { CaliforniaPricingService } from '../california-pricing-service.js';
+import { CUSTOM_DISPLAY_COST_AND_PRICE_KEY, DEFAULT_PRICE_KEY } from '../costmsg.js';
+
+/**
+ * Observes 1.6 GetConfiguration responses
+ * when the charger reports CustomDisplayCostAndPrice=true
+ * sets the station-wide DefaultPrice
+ */
+@AsResponseHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.GetConfiguration)
+export class DefaultPriceCaliforniaPricingOcpp16Handler extends AbstractHandler {
+  protected _californiaPricingService: CaliforniaPricingService;
+
+  constructor({
+    logger,
+    californiaPricingService,
+  }: AbstractHandlerDependencies & {
+    californiaPricingService: CaliforniaPricingService;
+  }) {
+    super(logger);
+    this._californiaPricingService = californiaPricingService;
+  }
+
+  async handle(
+    message: IMessage<OCPP1_6.GetConfigurationResponse>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(
+      this.createHandlerReceivedMessageLog('GetConfigurationResponse'),
+      message,
+      props,
+    );
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+
+    const enabled = message.payload.configurationKey?.some(
+      (config) => config.key === CUSTOM_DISPLAY_COST_AND_PRICE_KEY && config.value === 'true',
+    );
+    if (!enabled) {
+      return;
+    }
+    const reportedDefaultPrice =
+      message.payload.configurationKey?.find((config) => config.key === DEFAULT_PRICE_KEY)?.value ??
+      null;
+
+    await this._californiaPricingService.applyStationDefaultPrice(
+      tenantId,
+      ocppConnectionName,
+      reportedDefaultPrice,
+    );
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/handlers/final-cost-ocpp-16-handler.ts
+++ b/packages/ocpp/src/modules/california-pricing/handlers/final-cost-ocpp-16-handler.ts
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AbstractHandler,
+  type AbstractHandlerDependencies,
+  AsRequestHandler,
+  type IMessage,
+} from '@citrineos/base';
+import { type HandlerProperties, OCPP1_6, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type { CaliforniaPricingService } from '../california-pricing-service.js';
+
+/**
+ * Observes 1.6 StopTransaction and, when the customization is enabled, sends a FinalCost with the
+ * total for the session.
+ */
+@AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.StopTransaction)
+export class FinalCostCaliforniaPricingOcpp16Handler extends AbstractHandler {
+  protected _californiaPricingService: CaliforniaPricingService;
+
+  constructor({
+    logger,
+    californiaPricingService,
+  }: AbstractHandlerDependencies & {
+    californiaPricingService: CaliforniaPricingService;
+  }) {
+    super(logger);
+    this._californiaPricingService = californiaPricingService;
+  }
+
+  async handle(
+    message: IMessage<OCPP1_6.StopTransactionRequest>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(
+      this.createHandlerReceivedMessageLog('StopTransactionRequest'),
+      message,
+      props,
+    );
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+    const { transactionId, meterStop, timestamp } = message.payload;
+
+    if (!(await this._californiaPricingService.isEnabled(tenantId, ocppConnectionName))) {
+      return;
+    }
+    const cost = await this._californiaPricingService.calculateCost(
+      tenantId,
+      ocppConnectionName,
+      transactionId,
+      { meterKwh: meterStop / 1000, timestamp },
+    );
+    const finalCost = cost ?? 0;
+
+    await this._californiaPricingService.sendFinalCost(tenantId, ocppConnectionName, {
+      transactionId,
+      cost: finalCost,
+      priceText: `Final cost is ${finalCost}`,
+    });
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/handlers/running-cost-ocpp-16-handler.ts
+++ b/packages/ocpp/src/modules/california-pricing/handlers/running-cost-ocpp-16-handler.ts
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AbstractHandler,
+  type AbstractHandlerDependencies,
+  AsRequestHandler,
+  type IMessage,
+  MeterValueUtils,
+} from '@citrineos/base';
+import {
+  type HandlerProperties,
+  MeasurandEnum,
+  OCPP1_6,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import { OCPP1_6_Mapper } from '@citrineos/dal';
+import type { CaliforniaPricingService } from '../california-pricing-service.js';
+
+/**
+ * Observes 1.6 MeterValues and, when the customization is enabled, sends a RunningCost update
+ * carrying the unit price so the charger can display a running cost between meter intervals.
+ * Does not send the MeterValuesResponse — that remains owned by the primary handler.
+ */
+@AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.MeterValues)
+export class RunningCostCaliforniaPricingOcpp16Handler extends AbstractHandler {
+  protected _californiaPricingService: CaliforniaPricingService;
+
+  constructor({
+    logger,
+    californiaPricingService,
+  }: AbstractHandlerDependencies & {
+    californiaPricingService: CaliforniaPricingService;
+  }) {
+    super(logger);
+    this._californiaPricingService = californiaPricingService;
+  }
+
+  async handle(
+    message: IMessage<OCPP1_6.MeterValuesRequest>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(this.createHandlerReceivedMessageLog('MeterValuesRequest'), message, props);
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+    const { connectorId, transactionId, meterValue } = message.payload;
+
+    if (transactionId == null || connectorId === 0) {
+      return;
+    }
+    if (!(await this._californiaPricingService.isEnabled(tenantId, ocppConnectionName))) {
+      return;
+    }
+
+    const reading = RunningCostCaliforniaPricingOcpp16Handler.latestRegisterReading(meterValue);
+    if (reading == null) {
+      return;
+    }
+
+    const price = await this._californiaPricingService.resolvePrice(
+      tenantId,
+      ocppConnectionName,
+      transactionId,
+    );
+    const cost = await this._californiaPricingService.calculateCost(
+      tenantId,
+      ocppConnectionName,
+      transactionId,
+      reading,
+    );
+
+    await this._californiaPricingService.sendRunningCost(tenantId, ocppConnectionName, {
+      transactionId,
+      timestamp: reading.timestamp,
+      meterValue: Math.round(reading.meterKwh * 1000),
+      cost: cost ?? 0,
+      state: 'Charging',
+      chargingPrice: price ?? {},
+    });
+  }
+
+  /**
+   * Latest Energy.Active.Import.Register reading in kWh with its timestamp, using MeterValueUtils
+   * for unit/phase normalization. Undefined when the batch carries no such reading, in which case
+   * there is nothing to base a running cost on.
+   */
+  private static latestRegisterReading(
+    meterValues: OCPP1_6.MeterValuesRequest['meterValue'],
+  ): { meterKwh: number; timestamp: string } | undefined {
+    const dtos = meterValues.map((mv) => OCPP1_6_Mapper.MeterValueMapper.fromMeterValueType(mv));
+    let latest: { meterKwh: number; timestamp: string } | undefined;
+    let latestTs = Number.NEGATIVE_INFINITY;
+    for (const mv of dtos) {
+      const sample = mv.sampledValue.find(
+        (sv) =>
+          (!sv.measurand || sv.measurand === MeasurandEnum['Energy.Active.Import.Register']) &&
+          !sv.phase,
+      );
+      const ts = Date.parse(mv.timestamp);
+      if (sample && ts >= latestTs) {
+        latestTs = ts;
+        latest = { meterKwh: MeterValueUtils.normalizeToKwh(sample), timestamp: mv.timestamp };
+      }
+    }
+    return latest;
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/handlers/set-user-price-ocpp-16-handler.ts
+++ b/packages/ocpp/src/modules/california-pricing/handlers/set-user-price-ocpp-16-handler.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import {
+  AbstractHandler,
+  type AbstractHandlerDependencies,
+  AsRequestHandler,
+  type IMessage,
+} from '@citrineos/base';
+import { type HandlerProperties, OCPP1_6, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type { CaliforniaPricingService } from '../california-pricing-service.js';
+
+/**
+ * Observes 1.6 Authorize requests and, when the California pricing customization is enabled for
+ * the station, sends a SetUserPrice DataTransfer for the identified driver. Does not send the
+ * AuthorizeResponse — that remains owned by the primary Authorize handler.
+ *
+ * Not registered in CALIFORNIA_PRICING_HANDLERS: cost calculation does not take the Authorization
+ * TariffId into account, so there is no driver-specific price to send yet.
+ */
+@AsRequestHandler([OCPPVersion.OCPP1_6], OCPP_CallAction.Authorize)
+export class SetUserPriceCaliforniaPricingOcpp16Handler extends AbstractHandler {
+  protected _californiaPricingService: CaliforniaPricingService;
+
+  constructor({
+    logger,
+    californiaPricingService,
+  }: AbstractHandlerDependencies & {
+    californiaPricingService: CaliforniaPricingService;
+  }) {
+    super(logger);
+    this._californiaPricingService = californiaPricingService;
+  }
+
+  async handle(
+    message: IMessage<OCPP1_6.AuthorizeRequest>,
+    props?: HandlerProperties,
+  ): Promise<void> {
+    this._logger.debug(this.createHandlerReceivedMessageLog('AuthorizeRequest'), message, props);
+
+    const tenantId = message.context.tenantId;
+    const ocppConnectionName = message.context.ocppConnectionName;
+
+    if (!(await this._californiaPricingService.isEnabled(tenantId, ocppConnectionName))) {
+      return;
+    }
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/index.ts
+++ b/packages/ocpp/src/modules/california-pricing/index.ts
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { CaliforniaPricingModule } from './module.js';
+export { CaliforniaPricingService } from './california-pricing-service.js';
+export { registerCaliforniaPricingServices } from './register.js';
+export * from './costmsg.js';

--- a/packages/ocpp/src/modules/california-pricing/json.ts
+++ b/packages/ocpp/src/modules/california-pricing/json.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/** Recursively sorts object keys so two structurally-equal JSON values serialize identically. */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = canonicalize((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+/**
+ * Compares two JSON strings by value, tolerating whitespace and key-order differences.
+ * Falls back to string equality when either side is not valid JSON.
+ */
+export function sameJson(a: string, b: string): boolean {
+  try {
+    return (
+      JSON.stringify(canonicalize(JSON.parse(a))) === JSON.stringify(canonicalize(JSON.parse(b)))
+    );
+  } catch {
+    return a === b;
+  }
+}

--- a/packages/ocpp/src/modules/california-pricing/module.ts
+++ b/packages/ocpp/src/modules/california-pricing/module.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { type AbstractHandler, type OcppModuleDependencies, AbstractModule } from '@citrineos/base';
+import { EventGroup } from '@citrineos/types';
+
+export interface CaliforniaPricingModuleDependencies extends OcppModuleDependencies {
+  californiaPricingHandlers?: AbstractHandler[];
+}
+
+/**
+ * Optional module implementing the OCA "OCPP & California Pricing Requirements" customization
+ * (org.openchargealliance.costmsg) for OCPP 1.6. It observes Authorize/MeterValues/StopTransaction
+ * and emits SetUserPrice/RunningCost/FinalCost DataTransfer messages, gated per station on the
+ * CustomDisplayCostAndPrice configuration key.
+ */
+export class CaliforniaPricingModule extends AbstractModule {
+  constructor({
+    config,
+    cache,
+    sender,
+    handler,
+    logger,
+    ocppValidator,
+    ocppSender,
+    californiaPricingHandlers,
+  }: CaliforniaPricingModuleDependencies) {
+    super(
+      config,
+      cache,
+      handler,
+      sender,
+      EventGroup.CaliforniaPricing,
+      ocppSender,
+      logger,
+      ocppValidator,
+      californiaPricingHandlers,
+    );
+  }
+}
+
+export default CaliforniaPricingModule;

--- a/packages/ocpp/src/modules/california-pricing/register.ts
+++ b/packages/ocpp/src/modules/california-pricing/register.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { asClass, asFunction, type AwilixContainer } from 'awilix';
+import {
+  type AbstractHandler,
+  buildHandlers,
+  type HandlerClass,
+  type HandlerResolverCradle,
+} from '@citrineos/base';
+import { DefaultPriceCaliforniaPricingOcpp16Handler } from './handlers/default-price-ocpp-16-handler.js';
+import { FinalCostCaliforniaPricingOcpp16Handler } from './handlers/final-cost-ocpp-16-handler.js';
+import { RunningCostCaliforniaPricingOcpp16Handler } from './handlers/running-cost-ocpp-16-handler.js';
+import { CustomDisplayCostAndPriceOcpp16Handler } from './handlers/custom-display-cost-and-price-16-handler.js';
+import { CaliforniaPricingService } from './california-pricing-service.js';
+
+/**
+ * The observer handlers this module owns. They live here rather than in the shared handler tree
+ * because they serve a vendor customization (org.openchargealliance.costmsg), not an OCPP action.
+ * Each subscribes to an action already handled elsewhere; because this module has its own
+ * EventGroup queue, it receives its own copy and never sends the OCPP response for these actions.
+ *
+ * SetUserPriceCaliforniaPricingOcpp16Handler is deliberately absent: cost calculation does not
+ * take the Authorization TariffId into account, so there is no driver-specific price to send yet.
+ * Add it here once user-specific pricing is supported, otherwise it would subscribe this module's
+ * queue to every Authorize for no effect.
+ */
+const CALIFORNIA_PRICING_HANDLERS = [
+  DefaultPriceCaliforniaPricingOcpp16Handler,
+  RunningCostCaliforniaPricingOcpp16Handler,
+  FinalCostCaliforniaPricingOcpp16Handler,
+  CustomDisplayCostAndPriceOcpp16Handler,
+] satisfies ReadonlyArray<HandlerClass>;
+
+/**
+ * Registers the CaliforniaPricing module's internal services as scoped dependencies.
+ * The service classes stay private to this package — only this registrar is exported.
+ */
+export function registerCaliforniaPricingServices(container: AwilixContainer): void {
+  container.register({
+    californiaPricingService: asClass(CaliforniaPricingService).scoped(),
+    californiaPricingHandlers: asFunction((cradle: HandlerResolverCradle): AbstractHandler[] =>
+      buildHandlers(cradle.moduleScope, CALIFORNIA_PRICING_HANDLERS),
+    ).scoped(),
+  });
+}

--- a/packages/ocpp/src/modules/transactions/cost-calculator.ts
+++ b/packages/ocpp/src/modules/transactions/cost-calculator.ts
@@ -4,7 +4,6 @@
 import type { ITariffRepository } from '@citrineos/dal';
 import type { TariffDto } from '@citrineos/types';
 import type { ILogObj, Logger } from 'tslog';
-import { TransactionService } from './transaction-service.js';
 import { Transaction } from '@citrineos/dal';
 import { baseCalculateTotalCost, childLogger } from '@citrineos/base';
 
@@ -12,19 +11,15 @@ export class CostCalculator {
   private readonly _logger: Logger<ILogObj>;
 
   private readonly _tariffRepository: ITariffRepository;
-  private readonly _transactionService: TransactionService;
 
   constructor({
     tariffRepository,
-    transactionService,
     logger,
   }: {
     tariffRepository: ITariffRepository;
-    transactionService: TransactionService;
     logger: Logger<ILogObj>;
   }) {
     this._tariffRepository = tariffRepository;
-    this._transactionService = transactionService;
     this._logger = childLogger(logger, this.constructor.name);
   }
 

--- a/packages/ocpp/src/server/citrineos-server.ts
+++ b/packages/ocpp/src/server/citrineos-server.ts
@@ -149,6 +149,9 @@ export class CitrineOSServer {
     [EventGroup.Tenant]: {
       moduleToken: 'tenantModule',
     },
+    [EventGroup.CaliforniaPricing]: {
+      moduleToken: 'californiaPricingModule',
+    },
   };
 
   protected static readonly DEFAULT_API_SPECS: Partial<Record<EventGroup, ApiInitSpec>> = {
@@ -163,7 +166,12 @@ export class CitrineOSServer {
    * `{ ...super.moduleSpecs, [EventGroup.Foo]: { moduleToken: 'fooModule' } }`.
    */
   protected get moduleSpecs(): Partial<Record<EventGroup, ModuleInitSpec>> {
-    return CitrineOSServer.DEFAULT_MODULE_SPECS;
+    if (this._config.californiaPricing.enabled) {
+      return CitrineOSServer.DEFAULT_MODULE_SPECS;
+    }
+    const { [EventGroup.CaliforniaPricing]: _californiaPricing, ...enabled } =
+      CitrineOSServer.DEFAULT_MODULE_SPECS;
+    return enabled;
   }
 
   /** API groups this server can start, keyed by the EventGroup that selects them. */

--- a/packages/ocpp/src/server/container.ts
+++ b/packages/ocpp/src/server/container.ts
@@ -75,6 +75,10 @@ import { CommandsApi } from '@/apis/commands-api.js';
 import { OcppMessageApi } from '@/apis/ocpp-message-api.js';
 import { WebPaymentApi } from '@/apis/web-payment-api.js';
 import { registerApiServices } from '@/apis/register.js';
+import {
+  CaliforniaPricingModule,
+  registerCaliforniaPricingServices,
+} from '@modules/california-pricing/index.js';
 import { CertificatesModule, registerCertificatesServices } from '@modules/certificates/index.js';
 import {
   ConfigurationModule,
@@ -172,6 +176,7 @@ export function buildContainer(config: SystemConfig, prebuilt: Prebuilt) {
 // ============================================================
 function registerModuleServices(container: AwilixContainer): void {
   registerApiServices(container);
+  registerCaliforniaPricingServices(container);
   registerCertificatesServices(container);
   registerConfigurationServices(container);
   registerEVDriverServices(container);
@@ -443,6 +448,7 @@ function registerNetwork(container: AwilixContainer): void {
 // ============================================================
 function registerModules(container: AwilixContainer): void {
   container.register({
+    californiaPricingModule: asClass(CaliforniaPricingModule).scoped(),
     certificatesModule: asClass(CertificatesModule).scoped(),
     configurationModule: asClass(ConfigurationModule).scoped(),
     evDriverModule: asClass(EVDriverModule).scoped(),

--- a/packages/ocpp/test/handlers/requests/1.6/stop-transaction-request-ocpp-16-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/1.6/stop-transaction-request-ocpp-16-handler.test.ts
@@ -64,6 +64,11 @@ function makeHandler(transaction: ReturnType<typeof aTransaction> | null) {
 
   const transactionEventRepository = {
     createStopTransaction: vi.fn().mockResolvedValue({ id: 1 }),
+    updateTransactionTotalCostById: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const costCalculator = {
+    calculateTotalCost: vi.fn().mockResolvedValue(0),
   };
 
   const findOne = vi
@@ -76,9 +81,10 @@ function makeHandler(transaction: ReturnType<typeof aTransaction> | null) {
     authorizationRepository: authorizationRepository as unknown as IAuthorizationRepository,
     transactionEventRepository:
       transactionEventRepository as unknown as ITransactionEventRepository,
+    costCalculator,
   } as never);
 
-  return { handler, ocppSender, transactionEventRepository, findOne };
+  return { handler, ocppSender, transactionEventRepository, costCalculator, findOne };
 }
 
 const request: OCPP1_6.StopTransactionRequest = {

--- a/packages/ocpp/test/modules/california-pricing/california-pricing-handlers.test.ts
+++ b/packages/ocpp/test/modules/california-pricing/california-pricing-handlers.test.ts
@@ -1,0 +1,310 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import { DEFAULT_TENANT_ID, type IMessage } from '@citrineos/base';
+import {
+  type OcppRequest,
+  type OcppResponse,
+  EventGroup,
+  MessageOrigin,
+  MessageState,
+  OCPP1_6,
+  OCPP_CallAction,
+  OCPPVersion,
+} from '@citrineos/types';
+import {
+  CUSTOM_DISPLAY_COST_AND_PRICE_KEY,
+  DEFAULT_PRICE_KEY,
+} from '@modules/california-pricing/costmsg.js';
+import type { CaliforniaPricingService } from '@modules/california-pricing/california-pricing-service.js';
+import { CustomDisplayCostAndPriceOcpp16Handler } from '@modules/california-pricing/handlers/custom-display-cost-and-price-16-handler.js';
+import { DefaultPriceCaliforniaPricingOcpp16Handler } from '@modules/california-pricing/handlers/default-price-ocpp-16-handler.js';
+import { FinalCostCaliforniaPricingOcpp16Handler } from '@modules/california-pricing/handlers/final-cost-ocpp-16-handler.js';
+import { RunningCostCaliforniaPricingOcpp16Handler } from '@modules/california-pricing/handlers/running-cost-ocpp-16-handler.js';
+import { createTestContainer, getTestInstance } from '@test/test-container.js';
+
+const STATION = 'station-001';
+const TIMESTAMP = '2026-09-07T15:52:00Z';
+
+function makeMessage<T extends OcppRequest | OcppResponse>(
+  payload: T,
+  action: OCPP_CallAction,
+  state: MessageState,
+): IMessage<T> {
+  return {
+    context: {
+      tenantId: DEFAULT_TENANT_ID,
+      ocppConnectionName: STATION,
+      correlationId: 'corr-001',
+      timestamp: TIMESTAMP,
+    },
+    payload,
+    origin: MessageOrigin.ChargingStation,
+    eventGroup: EventGroup.CaliforniaPricing,
+    action,
+    state,
+    protocol: OCPPVersion.OCPP1_6,
+  } as unknown as IMessage<T>;
+}
+
+function registerReading(
+  value: string,
+  timestamp: string,
+  measurand?: OCPP1_6.MeterValuesRequestMeasurand,
+): OCPP1_6.MeterValuesRequest['meterValue'][0] {
+  return {
+    timestamp,
+    sampledValue: [
+      {
+        value,
+        measurand,
+        unit: OCPP1_6.MeterValuesRequestUnit.Wh,
+      },
+    ],
+  } as OCPP1_6.MeterValuesRequest['meterValue'][0];
+}
+
+describe('CaliforniaPricing handlers', () => {
+  const { container } = createTestContainer();
+  let californiaPricingService: Mocked<CaliforniaPricingService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    californiaPricingService = {
+      isEnabled: vi.fn().mockResolvedValue(true),
+      resolvePrice: vi.fn().mockResolvedValue({ kWhPrice: 10, hourPrice: 600, flatFee: 77 }),
+      calculateCost: vi.fn().mockResolvedValue(729),
+      applyStationDefaultPrice: vi.fn().mockResolvedValue(undefined),
+      sendRunningCost: vi.fn().mockResolvedValue(undefined),
+      sendFinalCost: vi.fn().mockResolvedValue(undefined),
+      sendSetUserPrice: vi.fn().mockResolvedValue(undefined),
+      requestCustomDisplayCostAndPrice: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<CaliforniaPricingService>;
+  });
+
+  describe('RunningCostCaliforniaPricingOcpp16Handler', () => {
+    function handle(payload: Partial<OCPP1_6.MeterValuesRequest>) {
+      const handler = getTestInstance(container, RunningCostCaliforniaPricingOcpp16Handler, {
+        californiaPricingService,
+      });
+      return handler.handle(
+        makeMessage(
+          {
+            connectorId: 1,
+            transactionId: 22,
+            meterValue: [registerReading('13200', TIMESTAMP)],
+            ...payload,
+          } as OCPP1_6.MeterValuesRequest,
+          OCPP_CallAction.MeterValues,
+          MessageState.Request,
+        ),
+      );
+    }
+
+    it('sends the running cost for the reading being handled', async () => {
+      await handle({});
+
+      expect(californiaPricingService.calculateCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        22,
+        // Wh to kWh conversion carries the usual binary floating point noise.
+        { meterKwh: expect.closeTo(13.2, 6), timestamp: TIMESTAMP },
+      );
+      expect(californiaPricingService.sendRunningCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        {
+          transactionId: 22,
+          timestamp: TIMESTAMP,
+          meterValue: 13200,
+          cost: 729,
+          state: 'Charging',
+          chargingPrice: { kWhPrice: 10, hourPrice: 600, flatFee: 77 },
+        },
+      );
+    });
+
+    it('uses the newest register reading in the batch', async () => {
+      await handle({
+        meterValue: [
+          registerReading('13200', TIMESTAMP),
+          registerReading('14000', '2026-09-07T15:57:00Z'),
+        ],
+      });
+
+      expect(californiaPricingService.calculateCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        22,
+        { meterKwh: expect.closeTo(14, 6), timestamp: '2026-09-07T15:57:00Z' },
+      );
+    });
+
+    it('skips a batch without an energy register reading', async () => {
+      await handle({
+        meterValue: [
+          registerReading('16', TIMESTAMP, OCPP1_6.MeterValuesRequestMeasurand.Current_Import),
+        ],
+      });
+
+      expect(californiaPricingService.calculateCost).not.toHaveBeenCalled();
+      expect(californiaPricingService.sendRunningCost).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { name: 'no transaction', payload: { transactionId: undefined } },
+      { name: 'the station-wide connector 0', payload: { connectorId: 0 } },
+    ])('sends nothing for $name', async ({ payload }) => {
+      await handle(payload);
+
+      expect(californiaPricingService.isEnabled).not.toHaveBeenCalled();
+      expect(californiaPricingService.sendRunningCost).not.toHaveBeenCalled();
+    });
+
+    it('sends nothing when the customization is disabled', async () => {
+      californiaPricingService.isEnabled.mockResolvedValue(false);
+
+      await handle({});
+
+      expect(californiaPricingService.sendRunningCost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('FinalCostCaliforniaPricingOcpp16Handler', () => {
+    function handle(payload?: Partial<OCPP1_6.StopTransactionRequest>) {
+      const handler = getTestInstance(container, FinalCostCaliforniaPricingOcpp16Handler, {
+        californiaPricingService,
+      });
+      return handler.handle(
+        makeMessage(
+          {
+            transactionId: 22,
+            meterStop: 13200,
+            timestamp: TIMESTAMP,
+            ...payload,
+          } as OCPP1_6.StopTransactionRequest,
+          OCPP_CallAction.StopTransaction,
+          MessageState.Request,
+        ),
+      );
+    }
+
+    it('costs the stop reading and sends the final cost', async () => {
+      await handle();
+
+      expect(californiaPricingService.calculateCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        22,
+        { meterKwh: expect.closeTo(13.2, 6), timestamp: TIMESTAMP },
+      );
+      expect(californiaPricingService.sendFinalCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        expect.objectContaining({ transactionId: 22, cost: 729 }),
+      );
+    });
+
+    it('reports zero when the cost can not be resolved', async () => {
+      californiaPricingService.calculateCost.mockResolvedValue(undefined);
+
+      await handle();
+
+      expect(californiaPricingService.sendFinalCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        expect.objectContaining({ cost: 0 }),
+      );
+    });
+
+    it('sends nothing when the customization is disabled', async () => {
+      californiaPricingService.isEnabled.mockResolvedValue(false);
+
+      await handle();
+
+      expect(californiaPricingService.sendFinalCost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DefaultPriceCaliforniaPricingOcpp16Handler', () => {
+    function handle(configurationKey?: OCPP1_6.GetConfigurationResponse['configurationKey']) {
+      const handler = getTestInstance(container, DefaultPriceCaliforniaPricingOcpp16Handler, {
+        californiaPricingService,
+      });
+      return handler.handle(
+        makeMessage(
+          { configurationKey } as OCPP1_6.GetConfigurationResponse,
+          OCPP_CallAction.GetConfiguration,
+          MessageState.Response,
+        ),
+      );
+    }
+
+    it('applies the default price when the charger supports the customization', async () => {
+      await handle([{ key: CUSTOM_DISPLAY_COST_AND_PRICE_KEY, value: 'true', readonly: false }]);
+
+      expect(californiaPricingService.applyStationDefaultPrice).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        null,
+      );
+    });
+
+    it('passes the reported DefaultPrice on so a redundant write can be skipped', async () => {
+      const reported = '{"priceText":"1 EUR/kWh","chargingPrice":{"kWhPrice":1}}';
+
+      await handle([
+        { key: CUSTOM_DISPLAY_COST_AND_PRICE_KEY, value: 'true', readonly: false },
+        { key: DEFAULT_PRICE_KEY, value: reported, readonly: false },
+      ]);
+
+      expect(californiaPricingService.applyStationDefaultPrice).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+        reported,
+      );
+    });
+
+    it.each([
+      {
+        name: 'the key is false',
+        keys: [{ key: CUSTOM_DISPLAY_COST_AND_PRICE_KEY, value: 'false' }],
+      },
+      { name: 'the key is absent', keys: [{ key: 'HeartbeatInterval', value: '60' }] },
+      { name: 'no keys were reported', keys: undefined },
+    ])('does nothing when $name', async ({ keys }) => {
+      await handle(keys as OCPP1_6.GetConfigurationResponse['configurationKey']);
+
+      expect(californiaPricingService.applyStationDefaultPrice).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CustomDisplayCostAndPriceOcpp16Handler', () => {
+    function handle() {
+      const handler = getTestInstance(container, CustomDisplayCostAndPriceOcpp16Handler, {
+        californiaPricingService,
+      });
+      return handler.handle(
+        makeMessage(
+          {
+            chargePointVendor: 'CTEK',
+            chargePointModel: 'Chargestorm',
+          } as OCPP1_6.BootNotificationRequest,
+          OCPP_CallAction.BootNotification,
+          MessageState.Request,
+        ),
+      );
+    }
+
+    it('asks the station for the customization flag on boot', async () => {
+      await handle();
+
+      expect(californiaPricingService.requestCustomDisplayCostAndPrice).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        STATION,
+      );
+    });
+  });
+});

--- a/packages/ocpp/test/modules/california-pricing/california-pricing-service.test.ts
+++ b/packages/ocpp/test/modules/california-pricing/california-pricing-service.test.ts
@@ -1,0 +1,396 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { beforeEach, describe, expect, it, vi, type Mocked } from 'vitest';
+import { DEFAULT_TENANT_ID } from '@citrineos/base';
+import { EventGroup, OCPP_CallAction, OCPPVersion } from '@citrineos/types';
+import type {
+  IChangeConfigurationRepository,
+  IConnectorRepository,
+  ITariffRepository,
+  ITransactionEventRepository,
+} from '@citrineos/dal';
+import type { Connector, Transaction } from '@citrineos/dal';
+import { CaliforniaPricingService } from '@modules/california-pricing/california-pricing-service.js';
+import {
+  COSTMSG_VENDOR_ID,
+  CostMsgId,
+  CUSTOM_DISPLAY_COST_AND_PRICE_KEY,
+  DEFAULT_PRICE_KEY,
+} from '@modules/california-pricing/costmsg.js';
+import type { CostCalculator } from '@modules/transactions/cost-calculator.js';
+import { createTestContainer, getTestInstance, makeMockOcppSender } from '@test/test-container.js';
+import { aTariff } from '../transactions/providers/tariff.js';
+
+const STATION = 'station-001';
+const START_TIME = '2026-09-07T15:00:00Z';
+
+describe('CaliforniaPricingService', () => {
+  const { container, logger } = createTestContainer();
+
+  let changeConfigurationRepository: Mocked<IChangeConfigurationRepository>;
+  let tariffRepository: Mocked<ITariffRepository>;
+  let transactionEventRepository: Mocked<ITransactionEventRepository>;
+  let locationRepository: Mocked<IConnectorRepository>;
+  let costCalculator: Mocked<CostCalculator>;
+  let ocppSender: ReturnType<typeof makeMockOcppSender>;
+  let service: CaliforniaPricingService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    changeConfigurationRepository = {
+      findByStationAndKey: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<IChangeConfigurationRepository>;
+
+    tariffRepository = {
+      findByConnectorId: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<ITariffRepository>;
+
+    transactionEventRepository = {
+      readTransactionByStationIdAndTransactionId: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Mocked<ITransactionEventRepository>;
+
+    locationRepository = {
+      readConnectorsByStationId: vi.fn().mockResolvedValue([]),
+    } as unknown as Mocked<IConnectorRepository>;
+
+    costCalculator = {
+      calculateTotalCost: vi.fn().mockResolvedValue(0),
+    } as unknown as Mocked<CostCalculator>;
+
+    ocppSender = makeMockOcppSender();
+
+    service = getTestInstance(container, CaliforniaPricingService, {
+      changeConfigurationRepository,
+      tariffRepository,
+      transactionEventRepository,
+      locationRepository,
+      costCalculator,
+      ocppSender,
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('is true only when the charger reported the key as true', async () => {
+      givenConfiguration(CUSTOM_DISPLAY_COST_AND_PRICE_KEY, 'true');
+      await expect(service.isEnabled(DEFAULT_TENANT_ID, STATION)).resolves.toBe(true);
+    });
+
+    it.each(['false', 'TRUE', ''])('is false for value %s', async (value) => {
+      givenConfiguration(CUSTOM_DISPLAY_COST_AND_PRICE_KEY, value);
+      await expect(service.isEnabled(DEFAULT_TENANT_ID, STATION)).resolves.toBe(false);
+    });
+
+    it('is false when the key was never reported', async () => {
+      await expect(service.isEnabled(DEFAULT_TENANT_ID, STATION)).resolves.toBe(false);
+    });
+  });
+
+  describe('resolvePrice', () => {
+    it('reports the tariff per-minute price as a price per hour', async () => {
+      givenTransaction({ connectorId: 3 });
+      tariffRepository.findByConnectorId.mockResolvedValue(
+        aTariff({ pricePerKwh: 10, pricePerMin: 10, pricePerSession: 77 }),
+      );
+
+      await expect(service.resolvePrice(DEFAULT_TENANT_ID, STATION, 22)).resolves.toEqual({
+        kWhPrice: 10,
+        hourPrice: 600,
+        flatFee: 77,
+      });
+      expect(tariffRepository.findByConnectorId).toHaveBeenCalledWith(DEFAULT_TENANT_ID, 3);
+    });
+
+    it('falls back to zero prices when the connector has no tariff', async () => {
+      givenTransaction({ connectorId: 1 });
+
+      await expect(service.resolvePrice(DEFAULT_TENANT_ID, STATION, 22)).resolves.toEqual({
+        kWhPrice: 0,
+        hourPrice: 0,
+        flatFee: 0,
+      });
+    });
+
+    it('returns undefined without a transaction id', async () => {
+      await expect(
+        service.resolvePrice(DEFAULT_TENANT_ID, STATION, undefined),
+      ).resolves.toBeUndefined();
+      expect(
+        transactionEventRepository.readTransactionByStationIdAndTransactionId,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('returns undefined when the transaction is unknown', async () => {
+      await expect(service.resolvePrice(DEFAULT_TENANT_ID, STATION, 22)).resolves.toBeUndefined();
+    });
+
+    it('returns undefined when the transaction has no connector', async () => {
+      givenTransaction({ connectorId: undefined });
+      await expect(service.resolvePrice(DEFAULT_TENANT_ID, STATION, 22)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('calculateCost', () => {
+    it('costs the reading being handled rather than the persisted snapshot', async () => {
+      // Snapshot lags one interval behind: 11.9 kWh at 47 minutes.
+      const transaction = givenTransaction({
+        connectorId: 1,
+        meterStart: 0,
+        totalKwh: 11.9,
+        timeSpentCharging: 2820,
+        startTime: START_TIME,
+      });
+
+      await service.calculateCost(DEFAULT_TENANT_ID, STATION, 22, {
+        meterKwh: 13.2,
+        timestamp: '2026-09-07T15:52:00Z',
+      });
+
+      expect(costCalculator.calculateTotalCost).toHaveBeenCalledWith(
+        DEFAULT_TENANT_ID,
+        transaction,
+      );
+      expect(transaction.totalKwh).toBe(13.2);
+      expect(transaction.timeSpentCharging).toBe(52 * 60);
+    });
+
+    it('subtracts the meter start from the reading', async () => {
+      const transaction = givenTransaction({
+        connectorId: 1,
+        meterStart: 5,
+        startTime: START_TIME,
+      });
+
+      await service.calculateCost(DEFAULT_TENANT_ID, STATION, 22, {
+        meterKwh: 13.5,
+        timestamp: '2026-09-07T15:30:00Z',
+      });
+
+      expect(transaction.totalKwh).toBe(8.5);
+    });
+
+    it('never reports negative elapsed time', async () => {
+      const transaction = givenTransaction({ connectorId: 1, startTime: START_TIME });
+
+      await service.calculateCost(DEFAULT_TENANT_ID, STATION, 22, {
+        meterKwh: 1,
+        timestamp: '2026-09-07T14:59:00Z',
+      });
+
+      expect(transaction.timeSpentCharging).toBe(0);
+    });
+
+    it('returns undefined when the transaction is unknown', async () => {
+      await expect(
+        service.calculateCost(DEFAULT_TENANT_ID, STATION, 22, {
+          meterKwh: 1,
+          timestamp: START_TIME,
+        }),
+      ).resolves.toBeUndefined();
+      expect(costCalculator.calculateTotalCost).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('applyStationDefaultPrice', () => {
+    it('sends nothing when the station has no connectors', async () => {
+      await service.applyStationDefaultPrice(DEFAULT_TENANT_ID, STATION, null);
+
+      expect(ocppSender.sendCall).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('sends nothing when connectors use different tariffs', async () => {
+      givenConnectors([
+        { id: 1, tariffId: 1 },
+        { id: 2, tariffId: 2 },
+      ]);
+
+      await service.applyStationDefaultPrice(DEFAULT_TENANT_ID, STATION, null);
+
+      expect(ocppSender.sendCall).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('lists only the price components that are set and non-zero', async () => {
+      givenConnectors([{ id: 1, tariffId: 1 }]);
+      tariffRepository.findByConnectorId.mockResolvedValue(
+        aTariff({ currency: 'USD', pricePerKwh: 10, pricePerMin: 0, pricePerSession: 77 }),
+      );
+
+      await service.applyStationDefaultPrice(DEFAULT_TENANT_ID, STATION, null);
+
+      expect(sentDefaultPrice()).toEqual({
+        priceText: '10 USD/kWh + 77 USD',
+        chargingPrice: { kWhPrice: 10, hourPrice: 0, flatFee: 77 },
+      });
+    });
+
+    it('falls back to a placeholder text when the shared tariff is missing', async () => {
+      givenConnectors([{ id: 1, tariffId: null }]);
+
+      await service.applyStationDefaultPrice(DEFAULT_TENANT_ID, STATION, null);
+
+      expect(sentDefaultPrice()).toEqual({
+        priceText: 'No tariff configured',
+        chargingPrice: { kWhPrice: 0, hourPrice: 0, flatFee: 0 },
+      });
+    });
+
+    it('skips the send when the station already reports the price it would set', async () => {
+      givenUsdTariffOnOneConnector();
+
+      await service.applyStationDefaultPrice(
+        DEFAULT_TENANT_ID,
+        STATION,
+        '{ "chargingPrice": { "flatFee": 77, "hourPrice": 0, "kWhPrice": 10 },\n' +
+          '  "priceText": "10 USD/kWh + 77 USD" }',
+      );
+
+      expect(ocppSender.sendCall).not.toHaveBeenCalled();
+    });
+
+    it('sends when the station reports a different price', async () => {
+      givenUsdTariffOnOneConnector();
+
+      await service.applyStationDefaultPrice(
+        DEFAULT_TENANT_ID,
+        STATION,
+        JSON.stringify({ priceText: 'stale' }),
+      );
+
+      expect(ocppSender.sendCall).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('sendDefaultPrice', () => {
+    const data = { priceText: '1 USD/kWh', chargingPrice: { kWhPrice: 1 } };
+
+    it('sets the configuration key', async () => {
+      await service.sendDefaultPrice(DEFAULT_TENANT_ID, STATION, data);
+
+      expect(ocppSender.sendCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ocppConnectionName: STATION,
+          protocol: OCPPVersion.OCPP1_6,
+          action: OCPP_CallAction.ChangeConfiguration,
+          eventGroup: EventGroup.CaliforniaPricing,
+          payload: { key: DEFAULT_PRICE_KEY, value: JSON.stringify(data) },
+        }),
+      );
+    });
+
+    it('logs when the charger rejects the call', async () => {
+      ocppSender.sendCall.mockResolvedValue({ success: false, payload: 'nope' });
+
+      await service.sendDefaultPrice(DEFAULT_TENANT_ID, STATION, data);
+
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('requestCustomDisplayCostAndPrice', () => {
+    it('asks for the one key rather than the whole configuration', async () => {
+      await service.requestCustomDisplayCostAndPrice(DEFAULT_TENANT_ID, STATION);
+
+      expect(ocppSender.sendCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ocppConnectionName: STATION,
+          protocol: OCPPVersion.OCPP1_6,
+          action: OCPP_CallAction.GetConfiguration,
+          eventGroup: EventGroup.CaliforniaPricing,
+          payload: { key: [CUSTOM_DISPLAY_COST_AND_PRICE_KEY] },
+        }),
+      );
+    });
+
+    it('logs when the charger rejects the call', async () => {
+      ocppSender.sendCall.mockResolvedValue({ success: false, payload: 'nope' });
+
+      await service.requestCustomDisplayCostAndPrice(DEFAULT_TENANT_ID, STATION);
+
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('costmsg DataTransfer', () => {
+    it.each([
+      {
+        name: 'RunningCost',
+        messageId: CostMsgId.RunningCost,
+        send: () =>
+          service.sendRunningCost(DEFAULT_TENANT_ID, STATION, {
+            transactionId: 22,
+            timestamp: START_TIME,
+            meterValue: 13200,
+            cost: 729,
+            state: 'Charging',
+            chargingPrice: { kWhPrice: 10 },
+          }),
+      },
+      {
+        name: 'FinalCost',
+        messageId: CostMsgId.FinalCost,
+        send: () =>
+          service.sendFinalCost(DEFAULT_TENANT_ID, STATION, {
+            transactionId: 22,
+            cost: 729,
+            priceText: 'Final cost is 729',
+          }),
+      },
+      {
+        name: 'SetUserPrice',
+        messageId: CostMsgId.SetUserPrice,
+        send: () =>
+          service.sendSetUserPrice(DEFAULT_TENANT_ID, STATION, {
+            idToken: 'TAG001',
+            priceText: '1 USD/kWh',
+          }),
+      },
+    ])('sends $name under the costmsg vendor id', async ({ messageId, send }) => {
+      await send();
+
+      const call = ocppSender.sendCall.mock.calls[0][0];
+      expect(call).toMatchObject({
+        action: OCPP_CallAction.DataTransfer,
+        protocol: OCPPVersion.OCPP1_6,
+        eventGroup: EventGroup.CaliforniaPricing,
+      });
+      expect(call.payload.vendorId).toBe(COSTMSG_VENDOR_ID);
+      expect(call.payload.messageId).toBe(messageId);
+      expect(() => JSON.parse(call.payload.data)).not.toThrow();
+    });
+  });
+
+  function givenConfiguration(key: string, value: string) {
+    changeConfigurationRepository.findByStationAndKey.mockImplementation(
+      async (_tenantId: number, _ocppConnectionName: string, requestedKey: string) =>
+        requestedKey === key ? ({ key, value } as never) : undefined,
+    );
+  }
+
+  function givenTransaction(overrides: Partial<Transaction>): Transaction {
+    const transaction = { id: 1, ...overrides } as Transaction;
+    transactionEventRepository.readTransactionByStationIdAndTransactionId.mockResolvedValue(
+      transaction,
+    );
+    return transaction;
+  }
+
+  function givenConnectors(connectors: { id: number; tariffId: number | null }[]) {
+    locationRepository.readConnectorsByStationId.mockResolvedValue(connectors as Connector[]);
+  }
+
+  function givenUsdTariffOnOneConnector() {
+    givenConnectors([{ id: 1, tariffId: 1 }]);
+    tariffRepository.findByConnectorId.mockResolvedValue(
+      aTariff({ currency: 'USD', pricePerKwh: 10, pricePerMin: 0, pricePerSession: 77 }),
+    );
+  }
+
+  function sentDefaultPrice() {
+    const call = ocppSender.sendCall.mock.calls[0][0];
+    expect(call.payload.key).toBe(DEFAULT_PRICE_KEY);
+    return JSON.parse(call.payload.value);
+  }
+});

--- a/packages/ocpp/test/modules/transactions/cost-calculator.test.ts
+++ b/packages/ocpp/test/modules/transactions/cost-calculator.test.ts
@@ -6,14 +6,12 @@ import { type ITariffRepository, Tariff } from '@citrineos/dal';
 import { afterEach, beforeEach, describe, expect, it, type Mocked, vi } from 'vitest';
 import { createTestContainer, getTestInstance } from '@test/test-container.js';
 import { CostCalculator } from '@modules/transactions/cost-calculator.js';
-import { TransactionService } from '@modules/transactions/transaction-service.js';
 import { aTariff } from './providers/tariff.js';
 import { aTransaction } from './providers/transaction-provider.js';
 
 describe('CostCalculator', () => {
   const { container } = createTestContainer();
   let tariffRepository: Mocked<ITariffRepository>;
-  let transactionService: Mocked<TransactionService>;
   let costCalculator: CostCalculator;
 
   beforeEach(() => {
@@ -21,19 +19,13 @@ describe('CostCalculator', () => {
       findByConnectorId: vi.fn(),
     } as unknown as Mocked<ITariffRepository>;
 
-    transactionService = {
-      recalculateTotalKwh: vi.fn(),
-    } as unknown as Mocked<TransactionService>;
-
     costCalculator = getTestInstance(container, CostCalculator, {
       tariffRepository,
-      transactionService,
     });
   });
 
   afterEach(() => {
     tariffRepository.findByConnectorId.mockReset();
-    transactionService.recalculateTotalKwh.mockReset();
   });
 
   describe('calculateTotalCost', () => {

--- a/packages/types/src/config/types.ts
+++ b/packages/types/src/config/types.ts
@@ -327,6 +327,12 @@ export const configSchema = z.object({
       enableGetChargingProfilesOnStartTransaction: z.boolean().default(false),
     })
     .prefault({}),
+
+  californiaPricing: z
+    .object({
+      enabled: z.boolean().default(false),
+    })
+    .prefault({}),
 });
 
 /** Post-parse config: every defaulted field is present. What `configSchema.parse()` returns. */

--- a/packages/types/src/interfaces/dto/connector-dto.ts
+++ b/packages/types/src/interfaces/dto/connector-dto.ts
@@ -33,6 +33,7 @@ export const ConnectorSchemaWithoutParent = BaseSchema.extend({
   vendorId: z.string().nullable().optional(),
   vendorErrorCode: z.string().nullable().optional(),
   termsAndConditionsUrl: z.string().nullable().optional(),
+  tariffId: z.number().int().nullable().optional(),
   tariff: TariffSchema.nullable().optional(),
 });
 

--- a/packages/types/src/interfaces/messages/internal-types.ts
+++ b/packages/types/src/interfaces/messages/internal-types.ts
@@ -36,6 +36,7 @@ export enum EventGroup {
   SmartCharging = 'smartcharging',
   Tenant = 'tenant',
   Transactions = 'transactions',
+  CaliforniaPricing = 'californiapricing',
   Cdrs = 'cdrs',
   ChargingProfiles = 'chargingprofiles',
   Commands = 'commands',


### PR DESCRIPTION
# Adds California pricing for OCPP 1.6

adds parts of California pricing v3.1 to OCPP 1.6, due to existing limits with CitrineOS some features are left out.
some optional features are also left out, since this commit is large enough as is 

the feature can be controlled using CITRINEOS_CALIFORNIAPRICING_ENABLED, defaults to false, since this feature adds additional overhead

Added:
 * defaultPrice: priceText and chargingPrice
 * runningCost:  cost, state, chargingPrice
 * finalCost: Cost, priceText
 * CustomDisplayCostAndPrice

 what has been left out:
  * runningCost.priceTextOffline: left out as it is optional
  * SetUserPrice: left out as Citrine does not take "Authorization" Tariff into account when calculating cost (handler scaffolding is included but deliberately not registered)
  * finalCost.qrCodeText:  not configurable right now, so no where to point to
  * idlePrice: optional, left out as no way of configuring in Citrine
  * runningCost.nextPeriod: optional, left out as no way of configuring in Citrine
  * multiLanguage support: optional, adds more complexity but nothing preventing the feature to be added in the future from what i can see
  * timezones: optional, should be possible to add in future
  * ConnectorUnplugged: optional, should be possible to add in future

to ensure we also keep the price in the backend OCPP 1.6 now sets totalCost and timeSpentCharging to transactions

Tests have been added for CaliforniaPricing features

Note: timeSpentCharging is derived from total session duration, as OCPP 1.6 does
not define a separate charging-time measurement.

Also adds a location lookup to the DAL repositories to resolve station tariffs.