### PR TITLE
Feature: Implement Drizzle VariableCharacteristics

### DIFF
--- a/packages/dal/index.ts
+++ b/packages/dal/index.ts
@@ -97,6 +97,7 @@ export {
   DrizzleBootRepository,
   DrizzleCertificateRepository,
   DrizzleChargingStationRepository,
+  DrizzleEvseTypeRepository,
   DrizzleDeleteCertificateAttemptRepository,
   DrizzleInstallCertificateAttemptRepository,
   DrizzleInstalledCertificateRepository,

--- a/packages/dal/index.ts
+++ b/packages/dal/index.ts
@@ -108,4 +108,5 @@ export {
   DrizzleTariffRepository,
   DrizzleTenantRepository,
   DrizzleVariableAttributeRepository,
+  DrizzleVariableCharacteristicsRepository,
 } from './src/db/drizzle/index.js';

--- a/packages/dal/src/db/drizzle/index.ts
+++ b/packages/dal/src/db/drizzle/index.ts
@@ -172,3 +172,15 @@ export {
   type VariableAttributeEntity,
   type VariableAttributeEntityInsert,
 } from './schema/variable-attribute.js';
+export {
+  DrizzleVariableCharacteristicsRepository,
+  toVariableCharacteristicsDto,
+} from '../../repositories/drizzle/variable-characteristics.js';
+export {
+  variableCharacteristicsTable,
+  tenantVariableCharacteristicsTable,
+  VariableCharacteristicsEntitySchema,
+  VariableCharacteristicsEntityInsertSchema,
+  type VariableCharacteristicsEntity,
+  type VariableCharacteristicsEntityInsert,
+} from './schema/variable-characteristics.js';

--- a/packages/dal/src/db/drizzle/index.ts
+++ b/packages/dal/src/db/drizzle/index.ts
@@ -52,6 +52,15 @@ export {
   type ChargingStationEntity,
   type ChargingStationEntityInsert,
 } from './schema/charging-station.js';
+export { DrizzleEvseTypeRepository, toEvseTypeDto } from '../../repositories/drizzle/evse-type.js';
+export {
+  evseTypeTable,
+  tenantEvseTypeTable,
+  EvseTypeEntitySchema,
+  EvseTypeEntityInsertSchema,
+  type EvseTypeEntity,
+  type EvseTypeEntityInsert,
+} from './schema/evse-type.js';
 export { DrizzleLocationRepository, toLocationDto } from '../../repositories/drizzle/location.js';
 export {
   locationTable,

--- a/packages/dal/src/repositories/drizzle/evse-type.ts
+++ b/packages/dal/src/repositories/drizzle/evse-type.ts
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { IEvseTypeRepository } from '@dal/repositories/repositories.js';
 import type { EvseTypeDto } from '@citrineos/types';
+import { and, eq, isNull } from 'drizzle-orm';
 import {
   type EvseTypeEntity,
   evseTypeTable,
@@ -27,10 +29,10 @@ export function toEvseTypeDto(entity: EvseTypeEntity): EvseTypeDto {
   return dto;
 }
 
-export class DrizzleEvseTypeRepository extends DrizzleRepository<
-  typeof evseTypeTable,
-  EvseTypeDto
-> {
+export class DrizzleEvseTypeRepository
+  extends DrizzleRepository<typeof evseTypeTable, EvseTypeDto>
+  implements IEvseTypeRepository
+{
   protected getTable(tenantId: number): typeof evseTypeTable {
     return this.useTenantSchema ? tenantEvseTypeTable(tenantId) : evseTypeTable;
   }
@@ -39,5 +41,27 @@ export class DrizzleEvseTypeRepository extends DrizzleRepository<
     return toEvseTypeDto(row);
   }
 
-  // Domain query/write methods intentionally omitted — stub outline only.
+  // ─── IEvseTypeRepository methods ─────────────────────────────────────────
+
+  async findEvseByIdAndConnectorId(
+    tenantId: number,
+    id: number,
+    connectorId: number | null,
+  ): Promise<EvseTypeDto | undefined> {
+    const table = this.getTable(tenantId);
+
+    const rows = (await this.db
+      .select()
+      .from(table)
+      .where(
+        and(
+          eq(table.id, id),
+          connectorId === null ? isNull(table.connectorId) : eq(table.connectorId, connectorId),
+          this.tenantFilter(table, tenantId),
+        ),
+      )
+      .limit(1)) as EvseTypeEntity[];
+
+    return rows[0] ? this.toDto(rows[0]) : undefined;
+  }
 }

--- a/packages/dal/src/repositories/drizzle/variable-characteristics.ts
+++ b/packages/dal/src/repositories/drizzle/variable-characteristics.ts
@@ -2,7 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import type { IVariableCharacteristicsRepository } from '@dal/repositories/repositories.js';
 import type { VariableCharacteristicsDto } from '@citrineos/types';
+import { and, eq, isNull } from 'drizzle-orm';
+import {
+  type VariableEntity,
+  variableTable,
+  tenantVariableTable,
+} from '../../db/drizzle/schema/variable.js';
 import {
   type VariableCharacteristicsEntity,
   variableCharacteristicsTable,
@@ -34,10 +41,10 @@ export function toVariableCharacteristicsDto(
   } as VariableCharacteristicsDto;
 }
 
-export class DrizzleVariableCharacteristicsRepository extends DrizzleRepository<
-  typeof variableCharacteristicsTable,
-  VariableCharacteristicsDto
-> {
+export class DrizzleVariableCharacteristicsRepository
+  extends DrizzleRepository<typeof variableCharacteristicsTable, VariableCharacteristicsDto>
+  implements IVariableCharacteristicsRepository
+{
   protected getTable(tenantId: number): typeof variableCharacteristicsTable {
     return this.useTenantSchema
       ? tenantVariableCharacteristicsTable(tenantId)
@@ -48,5 +55,51 @@ export class DrizzleVariableCharacteristicsRepository extends DrizzleRepository<
     return toVariableCharacteristicsDto(row);
   }
 
-  // Domain query/write methods intentionally omitted — stub outline only.
+  private getVariableTable(tenantId: number): typeof variableTable {
+    return this.useTenantSchema ? tenantVariableTable(tenantId) : variableTable;
+  }
+
+  // ─── IVariableCharacteristicsRepository methods ──────────────────────────
+
+  async findVariableCharacteristicsByVariableNameAndVariableInstance(
+    tenantId: number,
+    variableName: string,
+    variableInstance: string | null,
+  ): Promise<VariableCharacteristicsDto | undefined> {
+    const table = this.getTable(tenantId);
+    const variable = this.getVariableTable(tenantId);
+
+    const rows = (await this.db
+      .select({ characteristics: table, variable })
+      .from(table)
+      .innerJoin(variable, eq(table.variableId, variable.id))
+      .where(
+        and(
+          eq(variable.name, variableName),
+          variableInstance === null
+            ? isNull(variable.instance)
+            : eq(variable.instance, variableInstance),
+          this.tenantFilter(table, tenantId),
+          this.tenantFilter(variable, tenantId),
+        ),
+      )
+      .limit(1)) as { characteristics: VariableCharacteristicsEntity; variable: VariableEntity }[];
+
+    const row = rows[0];
+    if (!row) {
+      return undefined;
+    }
+
+    return {
+      ...toVariableCharacteristicsDto(row.characteristics),
+      variable: {
+        id: row.variable.id,
+        name: row.variable.name ?? '',
+        instance: row.variable.instance ?? null,
+        tenantId: row.variable.tenantId,
+        createdAt: row.variable.createdAt,
+        updatedAt: row.variable.updatedAt,
+      },
+    };
+  }
 }

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -4,6 +4,7 @@
 
 import type { CrudRepository } from '@citrineos/base';
 import type {
+  AttributeEnumType,
   AuthorizationDto,
   BootCreate,
   BootDto,
@@ -41,6 +42,7 @@ import type {
   TariffDto,
   TenantDto,
   UpdateEnumType,
+  VariableCharacteristicsDto,
 } from '@citrineos/types';
 import type { AuthorizationQuerystring } from '../interfaces/queries/authorization.js';
 import type { TariffQueryString } from '../interfaces/queries/tariff.js';
@@ -61,7 +63,6 @@ import type { ChargingStationSecurityInfo } from '../models/charging-station-sec
 import type { ChargingStationSequence } from '../models/charging-station-sequence/charging-station-sequence.js';
 import type { Component } from '../models/device-model/component.js';
 import type { VariableAttribute } from '../models/device-model/variable-attribute.js';
-import type { VariableCharacteristics } from '../models/device-model/variable-characteristics.js';
 import type { Variable } from '../models/device-model/variable.js';
 import type { ChargingStationNetworkProfile } from '../models/location/charging-station-network-profile.js';
 import type { Connector } from '../models/location/connector.js';
@@ -114,9 +115,17 @@ export interface IEvseTypeRepository {
   ): Promise<EvseTypeDto | undefined>;
 }
 
+export interface IVariableCharacteristicsRepository {
+  findVariableCharacteristicsByVariableNameAndVariableInstance(
+    tenantId: number,
+    variableName: string,
+    variableInstance: string | null,
+  ): Promise<VariableCharacteristicsDto | undefined>;
+}
+
 export interface IDeviceModelRepository
-  extends CrudRepository<OCPP2_common_types.VariableAttributeType>,
-    IEvseTypeRepository {
+  extends IEvseTypeRepository,
+    IVariableCharacteristicsRepository {
   createOrUpdateDeviceModelByStationId(
     tenantId: number,
     value: OCPP2_common_types.ReportDataType,
@@ -150,11 +159,17 @@ export interface IDeviceModelRepository
     tenantId: number,
     query: VariableAttributeQuerystring,
   ): Promise<VariableAttribute[]>;
-  existByQuerystring(tenantId: number, query: VariableAttributeQuerystring): Promise<number>;
   deleteAllByQuerystring(
     tenantId: number,
     query: VariableAttributeQuerystring,
   ): Promise<VariableAttribute[]>;
+  findVariableAttributeByComponentAndVariable(
+    tenantId: number,
+    ocppConnectionName: string,
+    attributeType: AttributeEnumType,
+    componentType: OCPP2_common_types.ComponentType,
+    variableType: OCPP2_common_types.VariableType,
+  ): Promise<VariableAttribute | undefined>;
   findComponentAndVariable(
     tenantId: number,
     componentType: OCPP2_common_types.ComponentType,
@@ -170,11 +185,6 @@ export interface IDeviceModelRepository
     componentType: OCPP2_common_types.ComponentType,
     ocppConnectionName: string,
   ): Promise<Component>;
-  findVariableCharacteristicsByVariableNameAndVariableInstance(
-    tenantId: number,
-    variableName: string,
-    variableInstance: string | null,
-  ): Promise<VariableCharacteristics | undefined>;
 }
 
 export interface ILocalAuthListRepository extends CrudRepository<LocalListVersion> {

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -21,6 +21,7 @@ import type {
   DeleteCertificateAttemptDto,
   DeleteCertificateStatusEnumType,
   EvseDto,
+  EvseTypeDto,
   LocationDto,
   HashAlgorithmEnumType,
   InstallCertificateAttemptCreate,
@@ -59,7 +60,6 @@ import type {
 import type { ChargingStationSecurityInfo } from '../models/charging-station-security-info.js';
 import type { ChargingStationSequence } from '../models/charging-station-sequence/charging-station-sequence.js';
 import type { Component } from '../models/device-model/component.js';
-import type { EvseType } from '../models/device-model/evse-type.js';
 import type { VariableAttribute } from '../models/device-model/variable-attribute.js';
 import type { VariableCharacteristics } from '../models/device-model/variable-characteristics.js';
 import type { Variable } from '../models/device-model/variable.js';
@@ -106,8 +106,17 @@ export interface IBootRepository {
   deleteByKey: (tenantId: number, key: string) => Promise<BootDto | undefined>;
 }
 
+export interface IEvseTypeRepository {
+  findEvseByIdAndConnectorId(
+    tenantId: number,
+    id: number,
+    connectorId: number | null,
+  ): Promise<EvseTypeDto | undefined>;
+}
+
 export interface IDeviceModelRepository
-  extends CrudRepository<OCPP2_common_types.VariableAttributeType> {
+  extends CrudRepository<OCPP2_common_types.VariableAttributeType>,
+    IEvseTypeRepository {
   createOrUpdateDeviceModelByStationId(
     tenantId: number,
     value: OCPP2_common_types.ReportDataType,
@@ -161,11 +170,6 @@ export interface IDeviceModelRepository
     componentType: OCPP2_common_types.ComponentType,
     ocppConnectionName: string,
   ): Promise<Component>;
-  findEvseByIdAndConnectorId(
-    tenantId: number,
-    id: number,
-    connectorId: number | null,
-  ): Promise<EvseType | undefined>;
   findVariableCharacteristicsByVariableNameAndVariableInstance(
     tenantId: number,
     variableName: string,

--- a/packages/dal/src/repositories/sequelize/device-model.ts
+++ b/packages/dal/src/repositories/sequelize/device-model.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { CrudRepository } from '@citrineos/base';
-import { OCPP2_0_1 } from '@citrineos/types';
+import { type AttributeEnumType, OCPP2_0_1, type OCPP2_common_types } from '@citrineos/types';
 import { Op } from 'sequelize';
 import { type VariableAttributeQuerystring } from '../../interfaces/queries/variable-attribute.js';
 import { type IDeviceModelRepository } from '../repositories.js';
@@ -486,15 +486,43 @@ export class SequelizeDeviceModelRepository
     return await super.readAllByQuery(tenantId, readQuery);
   }
 
-  async existByQuerystring(tenantId: number, query: VariableAttributeQuerystring): Promise<number> {
-    return await super.existByQuery(tenantId, this.constructQuery(query));
-  }
-
   async deleteAllByQuerystring(
     tenantId: number,
     query: VariableAttributeQuerystring,
   ): Promise<VariableAttribute[]> {
     return await super.deleteAllByQuery(tenantId, this.constructQuery(query));
+  }
+
+  async findVariableAttributeByComponentAndVariable(
+    tenantId: number,
+    ocppConnectionName: string,
+    attributeType: AttributeEnumType,
+    componentType: OCPP2_common_types.ComponentType,
+    variableType: OCPP2_common_types.VariableType,
+  ): Promise<VariableAttribute | undefined> {
+    const variableAttribute = await super.readOnlyOneByQuery(tenantId, {
+      where: {
+        ocppConnectionName,
+        type: attributeType,
+      },
+      include: [
+        {
+          model: Component,
+          where: {
+            name: componentType.name,
+            instance: componentType.instance ?? null,
+          },
+        },
+        {
+          model: Variable,
+          where: {
+            name: variableType.name,
+            instance: variableType.instance ?? null,
+          },
+        },
+      ],
+    });
+    return variableAttribute ?? undefined;
   }
 
   async findComponentAndVariable(

--- a/packages/dal/src/repositories/sequelize/repository-store.ts
+++ b/packages/dal/src/repositories/sequelize/repository-store.ts
@@ -16,6 +16,7 @@ import type {
   IDeleteCertificateAttemptRepository,
   IChargingStationRepository,
   IEvseTypeRepository,
+  IVariableCharacteristicsRepository,
   IDeviceModelRepository,
   IInstallCertificateAttemptRepository,
   IInstalledCertificateRepository,
@@ -37,6 +38,7 @@ import {
   DrizzleCertificateRepository,
   DrizzleChargingStationRepository,
   DrizzleEvseTypeRepository,
+  DrizzleVariableCharacteristicsRepository,
   DrizzleDeleteCertificateAttemptRepository,
   DrizzleInstallCertificateAttemptRepository,
   DrizzleInstalledCertificateRepository,
@@ -89,6 +91,7 @@ export class RepositoryStore {
   localAuthListRepository: ILocalAuthListRepository;
   chargingStationRepository: IChargingStationRepository;
   evseTypeRepository: IEvseTypeRepository;
+  variableCharacteristicsRepository: IVariableCharacteristicsRepository;
   locationRepository: ILocationDomainRepository;
   messageInfoRepository: IMessageInfoRepository;
   ocppMessageRepository: IOCPPMessageRepository;
@@ -150,6 +153,7 @@ export class RepositoryStore {
     // station-only implementation, matching the container registration.
     this.chargingStationRepository = this.locationRepository;
     this.evseTypeRepository = this.deviceModelRepository;
+    this.variableCharacteristicsRepository = this.deviceModelRepository;
     this.messageInfoRepository = new SequelizeMessageInfoRepository({
       config,
       logger,
@@ -175,6 +179,10 @@ export class RepositoryStore {
       this.certificateRepository = new DrizzleCertificateRepository({ config, logger });
       this.chargingStationRepository = new DrizzleChargingStationRepository({ config, logger });
       this.evseTypeRepository = new DrizzleEvseTypeRepository({ config, logger });
+      this.variableCharacteristicsRepository = new DrizzleVariableCharacteristicsRepository({
+        config,
+        logger,
+      });
       this.deleteCertificateAttemptRepository = new DrizzleDeleteCertificateAttemptRepository({
         config,
         logger,

--- a/packages/dal/src/repositories/sequelize/repository-store.ts
+++ b/packages/dal/src/repositories/sequelize/repository-store.ts
@@ -15,6 +15,7 @@ import type {
   IChargingStationSequenceRepository,
   IDeleteCertificateAttemptRepository,
   IChargingStationRepository,
+  IEvseTypeRepository,
   IDeviceModelRepository,
   IInstallCertificateAttemptRepository,
   IInstalledCertificateRepository,
@@ -35,6 +36,7 @@ import {
   DrizzleAuthorizationRepository,
   DrizzleCertificateRepository,
   DrizzleChargingStationRepository,
+  DrizzleEvseTypeRepository,
   DrizzleDeleteCertificateAttemptRepository,
   DrizzleInstallCertificateAttemptRepository,
   DrizzleInstalledCertificateRepository,
@@ -86,6 +88,7 @@ export class RepositoryStore {
   deviceModelRepository: IDeviceModelRepository;
   localAuthListRepository: ILocalAuthListRepository;
   chargingStationRepository: IChargingStationRepository;
+  evseTypeRepository: IEvseTypeRepository;
   locationRepository: ILocationDomainRepository;
   messageInfoRepository: IMessageInfoRepository;
   ocppMessageRepository: IOCPPMessageRepository;
@@ -146,6 +149,7 @@ export class RepositoryStore {
     // Defaults to the Location aggregate; the Drizzle branch below swaps in a
     // station-only implementation, matching the container registration.
     this.chargingStationRepository = this.locationRepository;
+    this.evseTypeRepository = this.deviceModelRepository;
     this.messageInfoRepository = new SequelizeMessageInfoRepository({
       config,
       logger,
@@ -170,6 +174,7 @@ export class RepositoryStore {
       });
       this.certificateRepository = new DrizzleCertificateRepository({ config, logger });
       this.chargingStationRepository = new DrizzleChargingStationRepository({ config, logger });
+      this.evseTypeRepository = new DrizzleEvseTypeRepository({ config, logger });
       this.deleteCertificateAttemptRepository = new DrizzleDeleteCertificateAttemptRepository({
         config,
         logger,

--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/charging-rate-units.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/charging-rate-units.ts
@@ -2,17 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 import { DataEnum } from '@citrineos/types';
-import type { IDeviceModelRepository } from '@citrineos/dal';
+import type { IVariableCharacteristicsRepository } from '@citrineos/dal';
 import { stringToSet } from '@util/index.js';
 import type { ILogObj, Logger } from 'tslog';
 
 export async function readChargingRateUnitMemberList(
-  deviceModelRepository: IDeviceModelRepository,
+  variableCharacteristicsRepository: IVariableCharacteristicsRepository,
   tenantId: number,
   logger: Logger<ILogObj>,
 ): Promise<Set<string> | undefined> {
   const chargingScheduleChargingRateUnit =
-    await deviceModelRepository.findVariableCharacteristicsByVariableNameAndVariableInstance(
+    await variableCharacteristicsRepository.findVariableCharacteristicsByVariableNameAndVariableInstance(
       tenantId,
       'RateUnit',
       null,

--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/get-charging-profiles-endpoint.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/get-charging-profiles-endpoint.ts
@@ -15,12 +15,12 @@ import {
   type OCPPVersion,
   type OCPP2_request_types,
 } from '@citrineos/types';
-import type { IDeviceModelRepository } from '@citrineos/dal';
+import type { IVariableCharacteristicsRepository } from '@citrineos/dal';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
   ocppSender: IOcppSender;
-  deviceModelRepository: IDeviceModelRepository;
+  variableCharacteristicsRepository: IVariableCharacteristicsRepository;
 }
 
 export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
@@ -32,12 +32,12 @@ export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
   };
 
   private readonly _ocppSender: IOcppSender;
-  private readonly _deviceModelRepository: IDeviceModelRepository;
+  private readonly _variableCharacteristicsRepository: IVariableCharacteristicsRepository;
 
-  constructor({ logger, ocppSender, deviceModelRepository }: Dependencies) {
+  constructor({ logger, ocppSender, variableCharacteristicsRepository }: Dependencies) {
     super(logger);
     this._ocppSender = ocppSender;
-    this._deviceModelRepository = deviceModelRepository;
+    this._variableCharacteristicsRepository = variableCharacteristicsRepository;
   }
 
   async handle(
@@ -75,7 +75,7 @@ export class GetChargingProfilesEndpoint extends AbstractMessageEndpoint {
 
     if (chargingProfile.chargingProfileId && chargingProfile.chargingProfileId.length > 1) {
       const chargingProfilesEntries =
-        await this._deviceModelRepository.findVariableCharacteristicsByVariableNameAndVariableInstance(
+        await this._variableCharacteristicsRepository.findVariableCharacteristicsByVariableNameAndVariableInstance(
           tenantId,
           'Entries',
           'ChargingProfiles',

--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
@@ -15,13 +15,14 @@ import {
   type OCPPVersion,
   type OCPP2_request_types,
 } from '@citrineos/types';
-import type { IDeviceModelRepository } from '@citrineos/dal';
+import type { IDeviceModelRepository, IEvseTypeRepository } from '@citrineos/dal';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 import { readChargingRateUnitMemberList } from './charging-rate-units.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
   ocppSender: IOcppSender;
   deviceModelRepository: IDeviceModelRepository;
+  evseTypeRepository: IEvseTypeRepository;
 }
 
 export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
@@ -34,11 +35,13 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
 
   private readonly _ocppSender: IOcppSender;
   private readonly _deviceModelRepository: IDeviceModelRepository;
+  private readonly _evseTypeRepository: IEvseTypeRepository;
 
-  constructor({ logger, ocppSender, deviceModelRepository }: Dependencies) {
+  constructor({ logger, ocppSender, deviceModelRepository, evseTypeRepository }: Dependencies) {
     super(logger);
     this._ocppSender = ocppSender;
     this._deviceModelRepository = deviceModelRepository;
+    this._evseTypeRepository = evseTypeRepository;
   }
 
   async handle(
@@ -51,7 +54,7 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
     return Promise.all(
       identifiers.map(async (ocppConnectionName) => {
         if (request.evseId !== 0) {
-          const evse = await this._deviceModelRepository.findEvseByIdAndConnectorId(
+          const evse = await this._evseTypeRepository.findEvseByIdAndConnectorId(
             tenantId,
             request.evseId,
             null,

--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/get-composite-schedule-endpoint.ts
@@ -15,14 +15,14 @@ import {
   type OCPPVersion,
   type OCPP2_request_types,
 } from '@citrineos/types';
-import type { IDeviceModelRepository, IEvseTypeRepository } from '@citrineos/dal';
+import type { IEvseTypeRepository, IVariableCharacteristicsRepository } from '@citrineos/dal';
 import { OCPP2_PROTOCOLS, ocpp2Schema } from '../schemas.js';
 import { readChargingRateUnitMemberList } from './charging-rate-units.js';
 
 interface Dependencies extends AbstractMessageEndpointDependencies {
   ocppSender: IOcppSender;
-  deviceModelRepository: IDeviceModelRepository;
   evseTypeRepository: IEvseTypeRepository;
+  variableCharacteristicsRepository: IVariableCharacteristicsRepository;
 }
 
 export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
@@ -34,14 +34,19 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
   };
 
   private readonly _ocppSender: IOcppSender;
-  private readonly _deviceModelRepository: IDeviceModelRepository;
   private readonly _evseTypeRepository: IEvseTypeRepository;
+  private readonly _variableCharacteristicsRepository: IVariableCharacteristicsRepository;
 
-  constructor({ logger, ocppSender, deviceModelRepository, evseTypeRepository }: Dependencies) {
+  constructor({
+    logger,
+    ocppSender,
+    evseTypeRepository,
+    variableCharacteristicsRepository,
+  }: Dependencies) {
     super(logger);
     this._ocppSender = ocppSender;
-    this._deviceModelRepository = deviceModelRepository;
     this._evseTypeRepository = evseTypeRepository;
+    this._variableCharacteristicsRepository = variableCharacteristicsRepository;
   }
 
   async handle(
@@ -72,7 +77,7 @@ export class GetCompositeScheduleEndpoint extends AbstractMessageEndpoint {
 
         if (request.chargingRateUnit) {
           const rateUnitMemberList = await readChargingRateUnitMemberList(
-            this._deviceModelRepository,
+            this._variableCharacteristicsRepository,
             tenantId,
             this._logger,
           );

--- a/packages/ocpp/src/apis/ocpp/2/smart-charging/set-charging-profile-endpoint.ts
+++ b/packages/ocpp/src/apis/ocpp/2/smart-charging/set-charging-profile-endpoint.ts
@@ -23,6 +23,7 @@ import type {
   IChargingProfileRepository,
   IDeviceModelRepository,
   ITransactionEventRepository,
+  IVariableCharacteristicsRepository,
 } from '@citrineos/dal';
 import { OCPP2_0_1_Mapper } from '@citrineos/dal';
 import {
@@ -38,6 +39,7 @@ type ChargingProfile = SetChargingProfileRequest['chargingProfile'];
 interface Dependencies extends AbstractMessageEndpointDependencies {
   ocppSender: IOcppSender;
   deviceModelRepository: IDeviceModelRepository;
+  variableCharacteristicsRepository: IVariableCharacteristicsRepository;
   chargingProfileRepository: IChargingProfileRepository;
   transactionEventRepository: ITransactionEventRepository;
 }
@@ -52,6 +54,7 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
 
   private readonly _ocppSender: IOcppSender;
   private readonly _deviceModelRepository: IDeviceModelRepository;
+  private readonly _variableCharacteristicsRepository: IVariableCharacteristicsRepository;
   private readonly _chargingProfileRepository: IChargingProfileRepository;
   private readonly _transactionEventRepository: ITransactionEventRepository;
 
@@ -59,12 +62,14 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
     logger,
     ocppSender,
     deviceModelRepository,
+    variableCharacteristicsRepository,
     chargingProfileRepository,
     transactionEventRepository,
   }: Dependencies) {
     super(logger);
     this._ocppSender = ocppSender;
     this._deviceModelRepository = deviceModelRepository;
+    this._variableCharacteristicsRepository = variableCharacteristicsRepository;
     this._chargingProfileRepository = chargingProfileRepository;
     this._transactionEventRepository = transactionEventRepository;
   }
@@ -308,7 +313,7 @@ export class SetChargingProfileEndpoint extends AbstractMessageEndpoint {
       )}`,
     );
     const rateUnitMemberList = await readChargingRateUnitMemberList(
-      this._deviceModelRepository,
+      this._variableCharacteristicsRepository,
       tenantId,
       this._logger,
     );

--- a/packages/ocpp/src/handlers/responses/2/set-variables-response-ocpp-2-handler.ts
+++ b/packages/ocpp/src/handlers/responses/2/set-variables-response-ocpp-2-handler.ts
@@ -20,10 +20,8 @@ import {
   OCPP2_response_types,
 } from '@citrineos/types';
 import {
-  Component,
   type IDeviceModelRepository,
   type IOCPPMessageRepository,
-  Variable,
   VariableAttribute,
 } from '@citrineos/dal';
 
@@ -166,32 +164,15 @@ export class SetVariablesResponseOcpp2Handler extends AbstractHandler {
     variableInstance: string | null,
     variableValue: string,
     attributeType: AttributeEnumType,
-  ): Promise<VariableAttribute> {
-    let existingVariableAttribute = (await this._deviceModelRepository.readOnlyOneByQuery(
-      tenantId,
-      {
-        where: {
-          ocppConnectionName,
-          type: attributeType,
-        },
-        include: [
-          {
-            model: Component,
-            where: {
-              name: componentName,
-              instance: componentInstance ? componentInstance : null,
-            },
-          },
-          {
-            model: Variable,
-            where: {
-              name: variableName,
-              instance: variableInstance ? variableInstance : null,
-            },
-          },
-        ],
-      },
-    )) as VariableAttribute;
+  ): Promise<VariableAttribute | undefined> {
+    let existingVariableAttribute =
+      await this._deviceModelRepository.findVariableAttributeByComponentAndVariable(
+        tenantId,
+        ocppConnectionName,
+        attributeType,
+        { name: componentName, instance: componentInstance ?? null },
+        { name: variableName, instance: variableInstance ?? null },
+      );
     if (!existingVariableAttribute) {
       const createdVariableAttributes =
         await this._deviceModelRepository.createOrUpdateBySetVariablesDataAndStationId(

--- a/packages/ocpp/src/server/container.ts
+++ b/packages/ocpp/src/server/container.ts
@@ -27,6 +27,7 @@ import {
   DrizzleBootRepository,
   DrizzleCertificateRepository,
   DrizzleChargingStationRepository,
+  DrizzleEvseTypeRepository,
   DrizzleDeleteCertificateAttemptRepository,
   DrizzleInstallCertificateAttemptRepository,
   DrizzleInstalledCertificateRepository,
@@ -298,6 +299,9 @@ function registerRepositories(container: AwilixContainer): void {
     chargingStationRepository: asFunction(
       ({ locationRepository }) => locationRepository,
     ).singleton(),
+    evseTypeRepository: asFunction(
+      ({ deviceModelRepository }) => deviceModelRepository,
+    ).singleton(),
   });
 
   if (process.env.CITRINEOS_USE_DRIZZLE === 'true') {
@@ -312,6 +316,7 @@ function registerRepositories(container: AwilixContainer): void {
       bootRepository: asClass(DrizzleBootRepository).singleton(),
       certificateRepository: asClass(DrizzleCertificateRepository).singleton(),
       chargingStationRepository: asClass(DrizzleChargingStationRepository).singleton(),
+      evseTypeRepository: asClass(DrizzleEvseTypeRepository).singleton(),
       deleteCertificateAttemptRepository: asClass(
         DrizzleDeleteCertificateAttemptRepository,
       ).singleton(),

--- a/packages/ocpp/src/server/container.ts
+++ b/packages/ocpp/src/server/container.ts
@@ -28,6 +28,7 @@ import {
   DrizzleCertificateRepository,
   DrizzleChargingStationRepository,
   DrizzleEvseTypeRepository,
+  DrizzleVariableCharacteristicsRepository,
   DrizzleDeleteCertificateAttemptRepository,
   DrizzleInstallCertificateAttemptRepository,
   DrizzleInstalledCertificateRepository,
@@ -302,6 +303,9 @@ function registerRepositories(container: AwilixContainer): void {
     evseTypeRepository: asFunction(
       ({ deviceModelRepository }) => deviceModelRepository,
     ).singleton(),
+    variableCharacteristicsRepository: asFunction(
+      ({ deviceModelRepository }) => deviceModelRepository,
+    ).singleton(),
   });
 
   if (process.env.CITRINEOS_USE_DRIZZLE === 'true') {
@@ -317,6 +321,9 @@ function registerRepositories(container: AwilixContainer): void {
       certificateRepository: asClass(DrizzleCertificateRepository).singleton(),
       chargingStationRepository: asClass(DrizzleChargingStationRepository).singleton(),
       evseTypeRepository: asClass(DrizzleEvseTypeRepository).singleton(),
+      variableCharacteristicsRepository: asClass(
+        DrizzleVariableCharacteristicsRepository,
+      ).singleton(),
       deleteCertificateAttemptRepository: asClass(
         DrizzleDeleteCertificateAttemptRepository,
       ).singleton(),

--- a/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
+++ b/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
@@ -228,8 +228,8 @@ describe('smartCharging message endpoints', () => {
     const build = () =>
       getTestInstance(container, GetCompositeScheduleEndpoint, {
         ocppSender: { sendCall },
+        evseTypeRepository: { findEvseByIdAndConnectorId },
         deviceModelRepository: {
-          findEvseByIdAndConnectorId,
           findVariableCharacteristicsByVariableNameAndVariableInstance: findVariableCharacteristics,
         },
       });

--- a/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
+++ b/packages/ocpp/test/apis/ocpp/smart-charging-endpoints.test.ts
@@ -123,7 +123,7 @@ describe('smartCharging message endpoints', () => {
     const build = () =>
       getTestInstance(container, GetChargingProfilesEndpoint, {
         ocppSender: { sendCall },
-        deviceModelRepository: {
+        variableCharacteristicsRepository: {
           findVariableCharacteristicsByVariableNameAndVariableInstance: findVariableCharacteristics,
         },
       });
@@ -229,7 +229,7 @@ describe('smartCharging message endpoints', () => {
       getTestInstance(container, GetCompositeScheduleEndpoint, {
         ocppSender: { sendCall },
         evseTypeRepository: { findEvseByIdAndConnectorId },
-        deviceModelRepository: {
+        variableCharacteristicsRepository: {
           findVariableCharacteristicsByVariableNameAndVariableInstance: findVariableCharacteristics,
         },
       });
@@ -321,8 +321,8 @@ describe('smartCharging message endpoints', () => {
     const build = () =>
       getTestInstance(container, SetChargingProfileEndpoint, {
         ocppSender: { sendCall },
-        deviceModelRepository: {
-          readAllByQuerystring,
+        deviceModelRepository: { readAllByQuerystring },
+        variableCharacteristicsRepository: {
           findVariableCharacteristicsByVariableNameAndVariableInstance: vi
             .fn()
             .mockResolvedValue(undefined),


### PR DESCRIPTION
## Changes
1. replace Sequelize specific method `readOnlyOneByQuery` with `findVariableAttributeByComponentAndVariable`. Its drizzle implementation will be added in later PR.
2. Remove `existByQuerystring` since no any usages.
3. Split out `IVariableCharacteristicsRepository` from `IDeviceModelRepository` and implemented method in Drizzle 
## Tests
### Use drizzle
1. query `GetCompositeSchedule` with rate unit to test `findVariableCharacteristicsByVariableNameAndVariableInstance`<img width="741" height="333" alt="Screenshot 2026-09-08 at 1 42 24 PM" src="https://github.com/user-attachments/assets/ba68c690-ce53-4722-b016-02bb353adec7" /><img width="1367" height="82" alt="Screenshot 2026-09-08 at 1 42 14 PM" src="https://github.com/user-attachments/assets/af45fa47-b64f-4e73-b6d2-4848b8008597" />
2. update variable value to test `findVariableAttributeByComponentAndVariable`. Expect no new variable attribute is created and the existed value is updated. <img width="546" height="103" alt="Screenshot 2026-09-08 at 1 49 18 PM" src="https://github.com/user-attachments/assets/cdb1054c-3d63-4b4f-85f8-25f8d6355704" /><img width="792" height="468" alt="Screenshot 2026-09-08 at 1 54 21 PM" src="https://github.com/user-attachments/assets/7224f6c1-0ab1-4783-bac1-b03285daf358" /><img width="554" height="107" alt="Screenshot 2026-09-08 at 1 52 37 PM" src="https://github.com/user-attachments/assets/2d6eaadc-c4bb-4205-a25b-a996150ea22d" />
### Regression with sequelize
Redo above tests and get expected results.