### PR TITLE
Fix: ocpp16 meter values without transaction id not linked

### DIFF
--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -401,6 +401,11 @@ export interface ITransactionEventRepository extends CrudRepository<TransactionE
     ocppConnectionName: string,
     evseId: number,
   ): Promise<Transaction | undefined>;
+  getActiveTransactionByStationIdAndConnectorId(
+    tenantId: number,
+    ocppConnectionName: string,
+    connectorId: number,
+  ): Promise<Transaction | undefined>;
   updateTransactionTotalCostById(tenantId: number, totalCost: number, id: number): Promise<void>;
   createStopTransaction(
     tenantId: number,

--- a/packages/dal/src/repositories/sequelize/transaction-event.ts
+++ b/packages/dal/src/repositories/sequelize/transaction-event.ts
@@ -576,6 +576,28 @@ export class SequelizeTransactionEventRepository
       });
   }
 
+  async getActiveTransactionByStationIdAndConnectorId(
+    tenantId: number,
+    ocppConnectionName: string,
+    connectorId: number,
+  ): Promise<Transaction | undefined> {
+    return await this.transaction
+      .readAllByQuery(tenantId, {
+        where: {
+          ocppConnectionName: ocppConnectionName,
+          connectorId: connectorId,
+          isActive: true,
+        },
+        include: [MeterValue],
+      })
+      .then((transactions) => {
+        if (transactions.length > 1) {
+          transactions.sort((t1, t2) => t2.updatedAt.getTime() - t1.updatedAt.getTime());
+        }
+        return transactions[0];
+      });
+  }
+
   async createMeterValue(
     tenantId: number,
     meterValue: OCPP2_0_1.MeterValueType,

--- a/packages/dal/src/repositories/sequelize/transaction-event.ts
+++ b/packages/dal/src/repositories/sequelize/transaction-event.ts
@@ -585,10 +585,12 @@ export class SequelizeTransactionEventRepository
       .readAllByQuery(tenantId, {
         where: {
           ocppConnectionName: ocppConnectionName,
-          connectorId: connectorId,
           isActive: true,
         },
-        include: [MeterValue],
+        include: [
+          MeterValue,
+          { model: Connector, where: { connectorId: connectorId }, required: true },
+        ],
       })
       .then((transactions) => {
         if (transactions.length > 1) {

--- a/packages/ocpp/src/handlers/requests/1.6/meter-values-request-ocpp-16-handler.ts
+++ b/packages/ocpp/src/handlers/requests/1.6/meter-values-request-ocpp-16-handler.ts
@@ -53,7 +53,7 @@ export class MeterValuesRequestOcpp16Handler extends AbstractHandler {
     const transactionId = message.payload.transactionId;
     const meterValues = message.payload.meterValue;
 
-    if (connectorId !== 0 && transactionId && meterValues.length > 0) {
+    if (connectorId !== 0 && meterValues.length > 0) {
       try {
         const meterValueEntities: MeterValueDto[] = [];
         for (const meterValue of meterValues) {
@@ -64,13 +64,29 @@ export class MeterValuesRequestOcpp16Handler extends AbstractHandler {
             meterValueEntities.push(meterValueEntity);
           }
         }
+
         if (meterValueEntities.length > 0) {
-          await this._transactionEventRepository.updateTransactionByMeterValues(
-            tenantId,
-            meterValueEntities,
-            ocppConnectionName,
-            transactionId,
-          );
+          let effectiveTransactionId = transactionId;
+          if (!effectiveTransactionId) {
+            const activeTransaction =
+              await this._transactionEventRepository.getActiveTransactionByStationIdAndConnectorId(
+                tenantId,
+                ocppConnectionName,
+                connectorId,
+              );
+            if (activeTransaction) {
+              effectiveTransactionId = Number(activeTransaction.transactionId);
+            }
+          }
+
+          if (effectiveTransactionId) {
+            await this._transactionEventRepository.updateTransactionByMeterValues(
+              tenantId,
+              meterValueEntities,
+              ocppConnectionName,
+              effectiveTransactionId,
+            );
+          }
         }
       } catch (e) {
         this._logger.error(`Failed to process MeterValues.`, e);


### PR DESCRIPTION
The OCPP 1.6 MeterValuesRequest carries an optional transactionId. When a charger omitted it (e.g. clock-aligned Sample.Clock readings), the handler's guard dropped the whole batch, so the readings were never persisted or linked
to their transaction.