### PR TITLE
fixing rabbitmq retries

### DIFF
--- a/packages/base/src/interfaces/handlers/ocpp-sender.ts
+++ b/packages/base/src/interfaces/handlers/ocpp-sender.ts
@@ -226,6 +226,7 @@ export class OcppSender implements IOcppSender {
     }
 
     message.origin = MessageOrigin.ChargingStationManagementSystem;
+    message.context = { ...message.context, timestamp: new Date().toISOString() };
     return this._sender.sendResponse(message, payload);
   }
 
@@ -271,6 +272,7 @@ export class OcppSender implements IOcppSender {
     payload: OcppError,
   ): Promise<IMessageConfirmation> {
     message.origin = MessageOrigin.ChargingStationManagementSystem;
+    message.context = { ...message.context, timestamp: new Date().toISOString() };
     return this._sender.sendResponse(message, payload);
   }
 

--- a/packages/ocpp/src/transport/queue/rabbit-mq/receiver.ts
+++ b/packages/ocpp/src/transport/queue/rabbit-mq/receiver.ts
@@ -10,6 +10,13 @@ import { Logger } from 'tslog';
 import { RabbitMQChannelManager } from './channel-manager.js';
 
 /**
+ * AMQP header carrying how many times a message has been retried. Lives on the delivery rather
+ * than in the message body: it is transport bookkeeping that no handler should see, and keeping
+ * it out of the body means the republished content is byte-identical to the original.
+ */
+const RETRY_HEADER = 'x-retries';
+
+/**
  * Implementation of a {@link IMessageHandler} using RabbitMQ as the underlying transport.
  *
  * Supports two operating modes:
@@ -46,6 +53,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
   protected _instanceQueueReady?: Promise<void>;
   protected _instanceConsumerTags: string[] = [];
   protected _instanceBindings = new Map<string, Array<Record<string, string>>>();
+  protected _messageMaxAgeSeconds: number;
 
   constructor({
     config,
@@ -62,6 +70,14 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
   }) {
     super(logger, module);
     this._channelManager = channelManager;
+    // Upper bound on how long a message may be retried for. Unlike the stale-Call guard in
+    // AbstractRouter -- which is opt-in, and only drops on delivery -- this cap always applies:
+    // a message that can never be handled within `maxCallLengthSeconds` is not worth retrying
+    // regardless of deployment, and without a bound a permanently blocked station would have us
+    // requeueing forever. It falls back to `maxCallLengthSeconds` when the operator has not
+    // opted into a stricter staleness policy.
+    this._messageMaxAgeSeconds =
+      config.timeouts.staleCallMaxAgeSeconds ?? config.timeouts.maxCallLengthSeconds;
     const exchange = config.messageBroker.amqp?.exchange;
     if (!exchange) {
       throw new Error('RabbitMQ exchange is not configured');
@@ -116,7 +132,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     });
 
     const { consumerTag } = await channel.consume(queueName, (msg) =>
-      this._onMessage(msg, channel),
+      this._onMessage(msg, channel, queueName),
     );
     this._instanceConsumerTags.push(consumerTag);
 
@@ -185,7 +201,7 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     // Re-create the single consumer on the new channel
     this._instanceConsumerTags = [];
     const { consumerTag } = await channel.consume(queueName, (msg) =>
-      this._onMessage(msg, channel),
+      this._onMessage(msg, channel, queueName),
     );
     this._instanceConsumerTags.push(consumerTag);
 
@@ -315,7 +331,9 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
     }
 
     // Start consuming messages
-    const consume = await channel.consume(queueName, (msg) => this._onMessage(msg, channel));
+    const consume = await channel.consume(queueName, (msg) =>
+      this._onMessage(msg, channel, queueName),
+    );
     const existing = this._consumerTags.get(identifier) ?? [];
     this._consumerTags.set(identifier, [...existing, consume.consumerTag]);
 
@@ -424,10 +442,12 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
    *
    * @param message The AMQPMessage to process
    * @param channel
+   * @param queueName The queue `message` was consumed from, used to requeue retries
    */
   protected async _onMessage(
     message: amqplib.ConsumeMessage | null,
     channel: amqplib.Channel,
+    queueName: string,
   ): Promise<void> {
     if (message) {
       try {
@@ -448,18 +468,51 @@ export class RabbitMqReceiver extends AbstractMessageHandler {
           messageData.payload || messageData._payload, // Keep payload as generic object
           messageData.protocol || messageData._protocol,
         );
-        await this.handle(parsed, message.properties);
-      } catch (error) {
-        if (error instanceof RetryMessageError) {
-          this._logger.warn('Retrying message: ', error.message);
-          // Retryable error, usually ongoing call with station when trying to send new call
-          channel.nack(message);
-          return;
-        } else {
-          this._logger.error('Error while processing message:', error, message);
+
+        try {
+          await this.handle(parsed, message.properties);
+        } catch (error) {
+          if (error instanceof RetryMessageError) {
+            const attempt = Number(message.properties.headers?.[RETRY_HEADER]) || 0;
+            const backoff = this._backoff(attempt);
+
+            if (!this._willStillBeFresh(parsed.context.timestamp, backoff)) {
+              this._logger.error(
+                `Dropping ${parsed.action} for ${parsed.context.ocppConnectionName} after ` +
+                  `${attempt} retries: would exceed the ${this._messageMaxAgeSeconds}s retry ` +
+                  `window. correlationId=${parsed.context.correlationId}`,
+              );
+              channel.nack(message, false, false); // discarded: no DLQ is configured
+              return;
+            }
+            if (attempt === 0) this._logger.warn('Retrying message: ', error.message);
+
+            await new Promise((resolve) => setTimeout(resolve, backoff));
+
+            channel.sendToQueue(queueName, message.content, {
+              ...message.properties,
+              headers: { ...message.properties.headers, [RETRY_HEADER]: attempt + 1 },
+            });
+            channel.ack(message);
+            return;
+          } else {
+            this._logger.error('Error while processing message:', error, message);
+          }
         }
+      } catch (error) {
+        this._logger.error('Error while parsing message:', error, message);
       }
       channel.ack(message);
     }
+  }
+
+  private _backoff(attempt: number): number {
+    const base = Math.min(50 * 2 ** attempt, 1000);
+    return base * (0.75 + Math.random() * 0.5); // ±25% jitter
+  }
+
+  private _willStillBeFresh(timestamp: string, backoff: number): boolean {
+    const age = Date.now() - new Date(timestamp).getTime();
+    return age + backoff < this._messageMaxAgeSeconds * 1000;
   }
 }

--- a/packages/ocpp/test/providers/rabbit-mq-provider.ts
+++ b/packages/ocpp/test/providers/rabbit-mq-provider.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type * as amqplib from 'amqplib';
+import type { RabbitMQChannelManager } from '@/transport/queue/rabbit-mq/channel-manager.js';
 import {
   EventGroup,
   MessageOrigin,
@@ -11,8 +11,8 @@ import {
   OCPPVersion,
   type SystemConfig,
 } from '@citrineos/types';
+import type * as amqplib from 'amqplib';
 import { vi } from 'vitest';
-import type { RabbitMQChannelManager } from '@/transport/queue/rabbit-mq/channel-manager.js';
 
 /**
  * Minimal SystemConfig with AMQP configured.
@@ -122,6 +122,7 @@ export function aConsumeMessage(override?: {
           correlationId: 'test-correlation-id',
           ocppConnectionName: 'CS001',
           tenantId: '1',
+          timestamp: new Date().toISOString(),
         },
         payload: override?.payload ?? {},
         protocol: override?.protocol ?? OCPPVersion.OCPP2_0_1,

--- a/packages/ocpp/test/providers/rabbit-mq-provider.ts
+++ b/packages/ocpp/test/providers/rabbit-mq-provider.ts
@@ -22,11 +22,20 @@ export function aSystemConfigWithAmqp(override?: {
   exchange?: string;
   instanceIdentifier?: string;
   noAmqp?: boolean;
+  maxCallLengthSeconds?: number;
+  staleCallMaxAgeSeconds?: number;
 }): SystemConfig {
+  const timeouts = {
+    maxCallLengthSeconds: override?.maxCallLengthSeconds ?? 20,
+    ...(override?.staleCallMaxAgeSeconds !== undefined && {
+      staleCallMaxAgeSeconds: override.staleCallMaxAgeSeconds,
+    }),
+  };
   if (override?.noAmqp) {
-    return { messageBroker: { amqp: undefined } } as unknown as SystemConfig;
+    return { timeouts, messageBroker: { amqp: undefined } } as unknown as SystemConfig;
   }
   return {
+    timeouts,
     messageBroker: {
       amqp: {
         url: 'amqp://localhost',
@@ -59,6 +68,7 @@ export function aMockAmqpChannel(): amqplib.Channel {
     cancel: vi.fn().mockResolvedValue({}),
     ack: vi.fn(),
     nack: vi.fn(),
+    sendToQueue: vi.fn().mockReturnValue(true),
   } as unknown as amqplib.Channel;
 }
 
@@ -99,6 +109,7 @@ export function aConsumeMessage(override?: {
   context?: Record<string, unknown>;
   payload?: Record<string, unknown>;
   protocol?: string;
+  headers?: Record<string, unknown>;
 }): amqplib.ConsumeMessage {
   return {
     content: Buffer.from(
@@ -116,7 +127,7 @@ export function aConsumeMessage(override?: {
         protocol: override?.protocol ?? OCPPVersion.OCPP2_0_1,
       }),
     ),
-    properties: {} as amqplib.MessageProperties,
+    properties: { headers: override?.headers ?? {} } as unknown as amqplib.MessageProperties,
     fields: {
       deliveryTag: 1,
       redelivered: false,

--- a/packages/ocpp/test/transport/queue/rabbit-mq/receiver.test.ts
+++ b/packages/ocpp/test/transport/queue/rabbit-mq/receiver.test.ts
@@ -392,7 +392,7 @@ describe('RabbitMqReceiver', () => {
     });
 
     it('should do nothing for a null message', async () => {
-      await (receiver as any)._onMessage(null, mockChannel);
+      await (receiver as any)._onMessage(null, mockChannel, 'test-queue');
 
       expect(mockChannel.ack).not.toHaveBeenCalled();
       expect(mockChannel.nack).not.toHaveBeenCalled();
@@ -401,7 +401,7 @@ describe('RabbitMqReceiver', () => {
     it('should parse a message with direct field names, call handle, and ack', async () => {
       const msg = aConsumeMessage({ action: OCPP_CallAction.BootNotification });
 
-      await (receiver as any)._onMessage(msg, mockChannel);
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
 
       expect(receiver.handle).toHaveBeenCalledWith(
         expect.objectContaining({ _action: OCPP_CallAction.BootNotification }),
@@ -414,7 +414,7 @@ describe('RabbitMqReceiver', () => {
     it('should parse a message with underscore-prefixed field names correctly', async () => {
       const msg = aConsumeMessageWithPrefixedFields({ action: OCPP_CallAction.Heartbeat });
 
-      await (receiver as any)._onMessage(msg, mockChannel);
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
 
       expect(receiver.handle).toHaveBeenCalledWith(
         expect.objectContaining({ _action: OCPP_CallAction.Heartbeat }),
@@ -423,14 +423,92 @@ describe('RabbitMqReceiver', () => {
       expect(mockChannel.ack).toHaveBeenCalled();
     });
 
-    it('should nack and return without acking when handle throws RetryMessageError', async () => {
+    it('should republish with the retry counter started when handle throws RetryMessageError', async () => {
       vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
+      vi.spyOn(receiver as any, '_backoff').mockReturnValue(0); // don't sleep for real
       const msg = aConsumeMessage();
 
-      await (receiver as any)._onMessage(msg, mockChannel);
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
 
-      expect(mockChannel.nack).toHaveBeenCalledWith(msg);
+      expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+        'test-queue',
+        msg.content,
+        expect.objectContaining({ headers: expect.objectContaining({ 'x-retries': 1 }) }),
+      );
+      // The original delivery is acked, not nacked: the republish above is the requeue.
+      expect(mockChannel.ack).toHaveBeenCalledWith(msg);
+      expect(mockChannel.nack).not.toHaveBeenCalled();
+    });
+
+    it('should increment the retry counter carried on the redelivered message', async () => {
+      vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
+      vi.spyOn(receiver as any, '_backoff').mockReturnValue(0); // don't sleep for real
+      const msg = aConsumeMessage({ headers: { 'x-retries': 3 } });
+
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
+
+      expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+        'test-queue',
+        msg.content,
+        expect.objectContaining({ headers: expect.objectContaining({ 'x-retries': 4 }) }),
+      );
+    });
+
+    it('should preserve the original headers and content when republishing a retry', async () => {
+      vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
+      vi.spyOn(receiver as any, '_backoff').mockReturnValue(0); // don't sleep for real
+      const msg = aConsumeMessage({ headers: { action: 'BootNotification', tenantId: '1' } });
+
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
+
+      const [, content, props] = (mockChannel.sendToQueue as any).mock.calls[0];
+      expect(content).toBe(msg.content);
+      expect(props.headers).toMatchObject({
+        action: 'BootNotification',
+        tenantId: '1',
+        'x-retries': 1,
+      });
+    });
+
+    it('should back off for longer as the retry count grows', () => {
+      const backoff = (attempt: number) => (receiver as any)._backoff(attempt);
+      // Jitter is ±25%, so compare attempts far enough apart to clear the overlap.
+      expect(backoff(0)).toBeLessThan(backoff(3));
+      expect(backoff(3)).toBeLessThan(backoff(6));
+      expect(backoff(20)).toBeLessThanOrEqual(1000 * 1.25); // capped
+    });
+
+    it('should drop the message once retrying would push it past the max age', async () => {
+      vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
+      const errorSpy = vi.spyOn((receiver as any)._logger, 'error');
+      // maxCallLengthSeconds defaults to 20 in the test config.
+      const msg = aConsumeMessage({
+        context: {
+          correlationId: 'test-correlation-id',
+          ocppConnectionName: 'CS001',
+          tenantId: '1',
+          timestamp: new Date(Date.now() - 30_000).toISOString(),
+        },
+        headers: { 'x-retries': 12 },
+      });
+
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
+
+      expect(mockChannel.sendToQueue).not.toHaveBeenCalled();
+      expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
       expect(mockChannel.ack).not.toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('test-correlation-id'));
+    });
+
+    it('should keep retrying a message that has no timestamp to age off', async () => {
+      vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
+      vi.spyOn(receiver as any, '_backoff').mockReturnValue(0); // don't sleep for real
+      const msg = aConsumeMessage({ headers: { 'x-retries': 99 } });
+
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
+
+      expect(mockChannel.sendToQueue).toHaveBeenCalled();
+      expect(mockChannel.nack).not.toHaveBeenCalled();
     });
 
     it('should log the error and still ack when handle throws a non-retryable error', async () => {
@@ -438,7 +516,7 @@ describe('RabbitMqReceiver', () => {
       const errorSpy = vi.spyOn((receiver as any)._logger, 'error');
       const msg = aConsumeMessage();
 
-      await (receiver as any)._onMessage(msg, mockChannel);
+      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
 
       expect(errorSpy).toHaveBeenCalled();
       expect(mockChannel.ack).toHaveBeenCalledWith(msg);

--- a/packages/ocpp/test/transport/queue/rabbit-mq/receiver.test.ts
+++ b/packages/ocpp/test/transport/queue/rabbit-mq/receiver.test.ts
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { OCPP_CallAction, RetryMessageError } from '@citrineos/types';
 import { RabbitMqReceiver } from '@/transport/queue/rabbit-mq/receiver.js';
+import { OCPP_CallAction, RetryMessageError } from '@citrineos/types';
+import { createTestContainer, getTestInstance } from '@test/test-container.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   aConsumeMessage,
   aConsumeMessageWithPrefixedFields,
@@ -13,7 +14,6 @@ import {
   aMockConnectionManager,
   aSystemConfigWithAmqp,
 } from '../../../providers/rabbit-mq-provider.js';
-import { createTestContainer, getTestInstance } from '@test/test-container.js';
 
 describe('RabbitMqReceiver', () => {
   const { container } = createTestContainer();
@@ -498,17 +498,6 @@ describe('RabbitMqReceiver', () => {
       expect(mockChannel.nack).toHaveBeenCalledWith(msg, false, false);
       expect(mockChannel.ack).not.toHaveBeenCalled();
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('test-correlation-id'));
-    });
-
-    it('should keep retrying a message that has no timestamp to age off', async () => {
-      vi.spyOn(receiver, 'handle').mockRejectedValueOnce(new RetryMessageError('call in progress'));
-      vi.spyOn(receiver as any, '_backoff').mockReturnValue(0); // don't sleep for real
-      const msg = aConsumeMessage({ headers: { 'x-retries': 99 } });
-
-      await (receiver as any)._onMessage(msg, mockChannel, 'test-queue');
-
-      expect(mockChannel.sendToQueue).toHaveBeenCalled();
-      expect(mockChannel.nack).not.toHaveBeenCalled();
     });
 
     it('should log the error and still ack when handle throws a non-retryable error', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -852,7 +852,7 @@ importers:
         version: 13.15.10
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))
       concurrently:
         specifier: 8.2.2
         version: 8.2.2
@@ -882,7 +882,7 @@ importers:
         version: 8.17.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
 
   packages/dal:
     dependencies:
@@ -1300,7 +1300,7 @@ importers:
         version: 9.16.0
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))
+        version: 3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))
       eslint:
         specifier: 'catalog:'
         version: 9.16.0(jiti@2.7.0)
@@ -1321,7 +1321,7 @@ importers:
         version: 8.17.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@25.9.5)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
 
 packages:
 
@@ -1340,56 +1340,56 @@ packages:
     resolution: {integrity: sha512-C90iyzm/jLV7Lomv2UzwWUzRv9WZr1oRsFRKsX5HjQL4EXrbi9H/RtBkjCP+NF+ABZXUKpAa4F1dkoTaea4zHg==}
     hasBin: true
 
-  '@aws-sdk/checksums@3.1000.29':
-    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+  '@aws-sdk/checksums@3.1001.0':
+    resolution: {integrity: sha512-6uTniZc87q+B5eXouGTl+7Tmc482rEeCcvxpsvREP8EfF0gvloRZ41UOA9sbSJlyy8TbqIBXb3kKfKarEArUQA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-s3@3.1128.0':
     resolution: {integrity: sha512-tYEB4058LdhTiSS7sCVVSpqSAdjIc1jTaf1dDPoIRJbR/XI5A2ZOuCiV1Aebo/pria/pUJBOT0WjdZVIwaZtDA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.977.9':
-    resolution: {integrity: sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==}
+  '@aws-sdk/core@3.978.0':
+    resolution: {integrity: sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.70':
-    resolution: {integrity: sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==}
+  '@aws-sdk/credential-provider-env@3.972.71':
+    resolution: {integrity: sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.72':
-    resolution: {integrity: sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==}
+  '@aws-sdk/credential-provider-http@3.972.73':
+    resolution: {integrity: sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.973.15':
-    resolution: {integrity: sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==}
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    resolution: {integrity: sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.77':
-    resolution: {integrity: sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==}
+  '@aws-sdk/credential-provider-login@3.972.78':
+    resolution: {integrity: sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.82':
-    resolution: {integrity: sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==}
+  '@aws-sdk/credential-provider-node@3.972.83':
+    resolution: {integrity: sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.70':
-    resolution: {integrity: sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==}
+  '@aws-sdk/credential-provider-process@3.972.71':
+    resolution: {integrity: sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.973.14':
-    resolution: {integrity: sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==}
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    resolution: {integrity: sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.76':
-    resolution: {integrity: sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    resolution: {integrity: sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.75':
-    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
+    resolution: {integrity: sha512-NfnTkVUTBKTBuBgqaapFK9r3YdkKt1b2oRvgLzZq91bwNKh6ZS0S7sEcheguttREaL4iyfs/xQnqD7Z7AsWSsA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.44':
-    resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
+  '@aws-sdk/nested-clients@3.997.45':
+    resolution: {integrity: sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1128.0':
@@ -1400,8 +1400,8 @@ packages:
     resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1116.0':
-    resolution: {integrity: sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==}
+  '@aws-sdk/token-providers@3.1129.0':
+    resolution: {integrity: sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.974.5':
@@ -4466,11 +4466,11 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
+  '@types/node@22.20.2':
+    resolution: {integrity: sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==}
+
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
-
-  '@types/node@26.5.0':
-    resolution: {integrity: sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==}
 
   '@types/nodemailer@6.4.24':
     resolution: {integrity: sha512-Ww4u0rT9wQNXh4JiQaIwx3QWdcOFXzOjQA2zc+jtFYNmQiT4mIUqcDin51bDFdkzKubFnQCZNK7FIHlPKQ/q9w==}
@@ -5047,8 +5047,8 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
-  array-includes@3.1.9:
-    resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
+  array-includes@3.2.0:
+    resolution: {integrity: sha512-VXY5eFRarnXcYxwBjJzPmEhH55+rmP79/+ueDhi0F+TuqfHCItagIHqxeUZrmgrOPa31QTh9H85DjX3FfJ0FTg==}
     engines: {node: '>= 0.4'}
 
   array-union@2.1.0:
@@ -6157,8 +6157,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.424:
-    resolution: {integrity: sha512-rTOe76LHREmnLOWc0NlakB7AlnWjhTNflk4YE3gnIBPbSXLiY+VDEgwYl4wAYdBPD7eq9NQq6TR8lvd9Fls2CA==}
+  electron-to-chromium@1.5.425:
+    resolution: {integrity: sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -8410,8 +8410,8 @@ packages:
       '@types/pg':
         optional: true
 
-  node-releases@2.0.54:
-    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+  node-releases@2.0.55:
+    resolution: {integrity: sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==}
     engines: {node: '>=18'}
 
   node-source-walk@7.0.2:
@@ -10270,11 +10270,11 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
-
-  undici-types@8.9.0:
-    resolution: {integrity: sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==}
 
   undici@7.29.1:
     resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
@@ -10344,8 +10344,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+  use-sync-external-store@1.7.0:
+    resolution: {integrity: sha512-6L+EeigHMQhdaIPNIFUKwfWJSwWFQ8gJbJ2DLOs5sDIegTwR9fRxvnM3uciHKjIZhFz+KAv2emhWMRvDmMcY8A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10681,9 +10681,9 @@ snapshots:
 
   '@antfu/ni@23.3.1': {}
 
-  '@aws-sdk/checksums@3.1000.29':
+  '@aws-sdk/checksums@3.1001.0':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
@@ -10691,10 +10691,10 @@ snapshots:
 
   '@aws-sdk/client-s3@3.1128.0':
     dependencies:
-      '@aws-sdk/checksums': 3.1000.29
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/credential-provider-node': 3.972.82
-      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/checksums': 3.1001.0
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-node': 3.972.83
+      '@aws-sdk/middleware-sdk-s3': 3.972.76
       '@aws-sdk/signature-v4-multi-region': 3.996.46
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
@@ -10703,7 +10703,7 @@ snapshots:
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.977.9':
+  '@aws-sdk/core@3.978.0':
     dependencies:
       '@aws-sdk/types': 3.974.5
       '@aws-sdk/xml-builder': 3.972.40
@@ -10714,17 +10714,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.70':
+  '@aws-sdk/credential-provider-env@3.972.71':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.72':
+  '@aws-sdk/credential-provider-http@3.972.73':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.8.0
@@ -10732,84 +10732,84 @@ snapshots:
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.973.15':
+  '@aws-sdk/credential-provider-ini@3.973.16':
     dependencies:
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/credential-provider-env': 3.972.70
-      '@aws-sdk/credential-provider-http': 3.972.72
-      '@aws-sdk/credential-provider-login': 3.972.77
-      '@aws-sdk/credential-provider-process': 3.972.70
-      '@aws-sdk/credential-provider-sso': 3.973.14
-      '@aws-sdk/credential-provider-web-identity': 3.972.76
-      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-login': 3.972.78
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/credential-provider-imds': 4.5.2
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-login@3.972.77':
+  '@aws-sdk/credential-provider-login@3.972.78':
     dependencies:
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-node@3.972.82':
+  '@aws-sdk/credential-provider-node@3.972.83':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.70
-      '@aws-sdk/credential-provider-http': 3.972.72
-      '@aws-sdk/credential-provider-ini': 3.973.15
-      '@aws-sdk/credential-provider-process': 3.972.70
-      '@aws-sdk/credential-provider-sso': 3.973.14
-      '@aws-sdk/credential-provider-web-identity': 3.972.76
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-ini': 3.973.16
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/credential-provider-imds': 4.5.2
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.70':
+  '@aws-sdk/credential-provider-process@3.972.71':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.973.14':
+  '@aws-sdk/credential-provider-sso@3.973.15':
     dependencies:
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/nested-clients': 3.997.44
-      '@aws-sdk/token-providers': 3.1116.0
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/token-providers': 3.1129.0
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.972.76':
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
     dependencies:
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.75':
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/signature-v4-multi-region': 3.996.46
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.44':
+  '@aws-sdk/nested-clients@3.997.45':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/signature-v4-multi-region': 3.996.46
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
@@ -10820,7 +10820,7 @@ snapshots:
 
   '@aws-sdk/s3-request-presigner@3.1128.0':
     dependencies:
-      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/core': 3.978.0
       '@aws-sdk/signature-v4-multi-region': 3.996.46
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
@@ -10834,10 +10834,10 @@ snapshots:
       '@smithy/types': 4.18.0
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1116.0':
+  '@aws-sdk/token-providers@3.1129.0':
     dependencies:
-      '@aws-sdk/core': 3.977.9
-      '@aws-sdk/nested-clients': 3.997.44
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/types': 4.18.0
@@ -11900,14 +11900,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.5
 
-  '@inquirer/confirm@6.3.2(@types/node@26.5.0)':
-    dependencies:
-      '@inquirer/core': 12.0.3(@types/node@26.5.0)
-      '@inquirer/type': 4.1.1(@types/node@26.5.0)
-    optionalDependencies:
-      '@types/node': 26.5.0
-    optional: true
-
   '@inquirer/core@12.0.3(@types/node@25.9.5)':
     dependencies:
       '@inquirer/ansi': 2.0.8
@@ -11919,19 +11911,6 @@ snapshots:
       signal-exit: 4.1.0
     optionalDependencies:
       '@types/node': 25.9.5
-
-  '@inquirer/core@12.0.3(@types/node@26.5.0)':
-    dependencies:
-      '@inquirer/ansi': 2.0.8
-      '@inquirer/figures': 2.0.9
-      '@inquirer/type': 4.1.1(@types/node@26.5.0)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.2
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 26.5.0
-    optional: true
 
   '@inquirer/external-editor@1.0.3(@types/node@25.9.5)':
     dependencies:
@@ -11945,11 +11924,6 @@ snapshots:
   '@inquirer/type@4.1.1(@types/node@25.9.5)':
     optionalDependencies:
       '@types/node': 25.9.5
-
-  '@inquirer/type@4.1.1(@types/node@26.5.0)':
-    optionalDependencies:
-      '@types/node': 26.5.0
-    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -13627,22 +13601,22 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/amqplib@0.10.8':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/bcrypt@5.0.2':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/big.js@6.2.2': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/caseless@0.12.5': {}
 
@@ -13653,7 +13627,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/content-disposition@0.5.9': {}
 
@@ -13662,7 +13636,7 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 5.0.6
       '@types/keygrip': 1.0.6
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/d3-array@3.2.2': {}
 
@@ -13696,27 +13670,27 @@ snapshots:
 
   '@types/docker-modem@3.0.6':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       '@types/ssh2': 1.15.6
 
   '@types/dockerode@4.0.1':
     dependencies:
       '@types/docker-modem': 3.0.6
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       '@types/ssh2': 1.15.6
 
   '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@4.19.9':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
   '@types/express-serve-static-core@5.1.3':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -13741,7 +13715,7 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 6.0.0
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/google.maps@3.66.2': {}
 
@@ -13766,7 +13740,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/jsrsasign@10.5.15': {}
 
@@ -13789,7 +13763,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/lodash.capitalize@4.2.9':
     dependencies:
@@ -13825,23 +13799,23 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
+  '@types/node@22.20.2':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.9.5':
     dependencies:
       undici-types: 7.24.6
 
-  '@types/node@26.5.0':
-    dependencies:
-      undici-types: 8.9.0
-
   '@types/nodemailer@6.4.24':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pg@8.23.1':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       pg-protocol: 1.16.0
       pg-types: 2.2.0
 
@@ -13872,12 +13846,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/set-cookie-parser@2.4.10':
     dependencies:
@@ -13885,11 +13859,11 @@ snapshots:
 
   '@types/ssh2-streams@0.1.13':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@types/ssh2@0.5.52':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       '@types/ssh2-streams': 0.1.13
 
   '@types/ssh2@1.15.6':
@@ -13914,7 +13888,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   '@typescript-eslint/eslint-plugin@8.17.0(@typescript-eslint/parser@8.17.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -14236,25 +14210,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.12
-      debug: 4.4.3(supports-color@5.5.0)
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.2.0
-      magic-string: 0.30.21
-      magicast: 0.3.5
-      std-env: 3.10.0
-      test-exclude: 7.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -14271,15 +14226,6 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@25.9.5)(typescript@6.0.3)
       vite: 7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
-
-  '@vitest/mocker@3.2.7(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.7
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@26.5.0)(typescript@6.0.3)
-      vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -14563,14 +14509,14 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
-  array-includes@3.1.9:
+  array-includes@3.2.0:
     dependencies:
       call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-abstract: 1.24.2
       es-object-atoms: 1.1.2
-      get-intrinsic: 1.3.0
+      es-shim-unscopables: 1.1.0
       is-string: 1.1.1
       math-intrinsics: 1.1.0
 
@@ -14822,8 +14768,8 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.11.21
       caniuse-lite: 1.0.30001810
-      electron-to-chromium: 1.5.424
-      node-releases: 2.0.54
+      electron-to-chromium: 1.5.425
+      node-releases: 2.0.55
       update-browserslist-db: 1.3.2(browserslist@4.28.9)
 
   buffer-crc32@1.0.0: {}
@@ -15641,7 +15587,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.424: {}
+  electron-to-chromium@1.5.425: {}
 
   emoji-regex@8.0.0: {}
 
@@ -15987,7 +15933,7 @@ snapshots:
   eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.70.0(eslint@9.16.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.16.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
+      array-includes: 3.2.0
       array.prototype.findlastindex: 1.2.6
       array.prototype.flat: 1.3.3
       array.prototype.flatmap: 1.3.3
@@ -16016,7 +15962,7 @@ snapshots:
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.16.0(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
-      array-includes: 3.1.9
+      array-includes: 3.2.0
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
       axe-core: 4.13.0
@@ -16047,7 +15993,7 @@ snapshots:
 
   eslint-plugin-react@7.37.5(eslint@9.16.0(jiti@2.7.0)):
     dependencies:
-      array-includes: 3.1.9
+      array-includes: 3.2.0
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.3
       array.prototype.tosorted: 1.1.4
@@ -17510,7 +17456,7 @@ snapshots:
 
   jsx-ast-utils@3.3.5:
     dependencies:
-      array-includes: 3.1.9
+      array-includes: 3.2.0
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
@@ -18110,32 +18056,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3):
-    dependencies:
-      '@inquirer/confirm': 6.3.2(@types/node@26.5.0)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 15.6.1
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.2
-      type-fest: 5.9.0
-      until-async: 3.0.2
-      yargs: 17.7.3
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   multer@1.4.5-lts.2:
     dependencies:
       append-field: 1.0.0
@@ -18335,7 +18255,7 @@ snapshots:
     optionalDependencies:
       '@types/pg': 8.23.1
 
-  node-releases@2.0.54: {}
+  node-releases@2.0.55: {}
 
   node-source-walk@7.0.2:
     dependencies:
@@ -18951,7 +18871,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -19049,7 +18969,7 @@ snapshots:
     dependencies:
       '@types/use-sync-external-store': 0.0.6
       react: 19.1.4
-      use-sync-external-store: 1.6.0(react@19.1.4)
+      use-sync-external-store: 1.7.0(react@19.1.4)
     optionalDependencies:
       '@types/react': 19.2.18
       redux: 5.0.1
@@ -19204,7 +19124,7 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.2.18)(react@19.1.4)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3
-      use-sync-external-store: 1.6.0(react@19.1.4)
+      use-sync-external-store: 1.7.0(react@19.1.4)
       victory-vendor: 37.3.6
     transitivePeerDependencies:
       - '@types/react'
@@ -20460,9 +20380,9 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@7.24.6: {}
+  undici-types@6.21.0: {}
 
-  undici-types@8.9.0: {}
+  undici-types@7.24.6: {}
 
   undici@7.29.1: {}
 
@@ -20556,7 +20476,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  use-sync-external-store@1.6.0(react@19.1.4):
+  use-sync-external-store@1.7.0(react@19.1.4):
     dependencies:
       react: 19.1.4
 
@@ -20627,27 +20547,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@5.5.0)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@7.3.6(@types/node@25.9.5)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.2
@@ -20658,23 +20557,6 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.5
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      lightningcss: 1.32.0
-      sass: 1.93.2
-      tsx: 4.23.13
-      yaml: 2.9.0
-
-  vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.28.2
-      fdir: 6.5.0(picomatch@4.0.7)
-      picomatch: 4.0.7
-      postcss: 8.5.26
-      rollup: 4.63.1
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.5.0
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -20710,48 +20592,6 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.13
       '@types/node': 25.9.5
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.7(@types/debug@4.1.13)(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.7
-      '@vitest/runner': 3.2.7
-      '@vitest/snapshot': 3.2.7
-      '@vitest/spy': 3.2.7
-      '@vitest/utils': 3.2.7
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@5.5.0)
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.17
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.6(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.5.0)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.93.2)(tsx@4.23.13)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.13
-      '@types/node': 26.5.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -20875,7 +20715,7 @@ snapshots:
 
   wkx@0.5.0:
     dependencies:
-      '@types/node': 26.5.0
+      '@types/node': 22.20.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
https://github.com/citrineos/citrineos/issues/223

instead of nacking, retry now acks and republishes to the queue. this puts the message at the tail of the queue rather than the head, meaning the order of messages is no longer guaranteed, however it reduces the strain of retries on the router. Given CSMS-initiated messages rarely come back-to-back, meaning order is not a concern, this is a worthy tradeoff.