### PR TITLE
fix(dal): declare what the migrations already enforce

### DIFF
--- a/packages/dal/src/db/drizzle/schema/installed-certificate.ts
+++ b/packages/dal/src/db/drizzle/schema/installed-certificate.ts
@@ -15,10 +15,10 @@ function installedCertificateColumns() {
     // FK to ChargingStation (resolved from ocppConnectionName in the domain layer).
     stationId: integer('stationId'),
     ocppConnectionName: varchar('ocppConnectionName', { length: 36 }).notNull(),
-    hashAlgorithm: varchar('hashAlgorithm', { length: 255 }),
-    issuerNameHash: varchar('issuerNameHash', { length: 255 }),
-    issuerKeyHash: varchar('issuerKeyHash', { length: 255 }),
-    serialNumber: varchar('serialNumber', { length: 255 }),
+    hashAlgorithm: varchar('hashAlgorithm', { length: 255 }).notNull(),
+    issuerNameHash: varchar('issuerNameHash', { length: 255 }).notNull(),
+    issuerKeyHash: varchar('issuerKeyHash', { length: 255 }).notNull(),
+    serialNumber: varchar('serialNumber', { length: 255 }).notNull(),
     certificateType: varchar('certificateType', { length: 255 }).notNull(),
     // FK to Certificate.
     certificateId: integer('certificateId'),

--- a/packages/dal/src/models/authorization/authorization.ts
+++ b/packages/dal/src/models/authorization/authorization.ts
@@ -125,6 +125,7 @@ export class Authorization extends Model implements AuthorizationDto {
   @Column(DataType.DECIMAL)
   declare prepaidBalance?: number | null;
 
+  @Column(DataType.JSONB)
   declare customData?: any | null;
 
   // For cases where Authorization is owned by an upstream partner, i.e. an eMSP

--- a/packages/dal/src/models/authorization/local-list-authorization.ts
+++ b/packages/dal/src/models/authorization/local-list-authorization.ts
@@ -101,6 +101,7 @@ export class LocalListAuthorization extends Model implements AuthorizationRestri
   @BelongsToMany(() => LocalListVersion, () => LocalListVersionAuthorization)
   declare localListVersions?: LocalListVersionDto[];
 
+  @Column(DataType.JSONB)
   declare customData?: any | null;
 
   @ForeignKey(() => Tenant)

--- a/packages/dal/src/models/certificate/installed-certificate.ts
+++ b/packages/dal/src/models/certificate/installed-certificate.ts
@@ -44,25 +44,25 @@ export class InstalledCertificate extends Model implements InstalledCertificateD
 
   @Column({
     type: DataType.STRING,
-    allowNull: true,
+    allowNull: false,
   })
   declare hashAlgorithm: HashAlgorithmEnumType;
 
   @Column({
     type: DataType.STRING,
-    allowNull: true,
+    allowNull: false,
   })
   declare issuerNameHash?: string | null;
 
   @Column({
     type: DataType.STRING,
-    allowNull: true,
+    allowNull: false,
   })
   declare issuerKeyHash?: string | null;
 
   @Column({
     type: DataType.STRING,
-    allowNull: true,
+    allowNull: false,
   })
   declare serialNumber?: string | null;
 

--- a/packages/dal/src/models/certificate/installed-certificate.ts
+++ b/packages/dal/src/models/certificate/installed-certificate.ts
@@ -52,19 +52,19 @@ export class InstalledCertificate extends Model implements InstalledCertificateD
     type: DataType.STRING,
     allowNull: false,
   })
-  declare issuerNameHash?: string | null;
+  declare issuerNameHash: string;
 
   @Column({
     type: DataType.STRING,
     allowNull: false,
   })
-  declare issuerKeyHash?: string | null;
+  declare issuerKeyHash: string;
 
   @Column({
     type: DataType.STRING,
     allowNull: false,
   })
-  declare serialNumber?: string | null;
+  declare serialNumber: string;
 
   @Column({
     type: DataType.STRING,

--- a/packages/dal/src/models/charging-profile/charging-needs.ts
+++ b/packages/dal/src/models/charging-profile/charging-needs.ts
@@ -15,6 +15,7 @@ import { DEFAULT_TENANT_ID, OCPP2_Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
+  BeforeValidate,
   BelongsTo,
   Column,
   DataType,
@@ -67,7 +68,10 @@ export class ChargingNeeds extends Model implements ChargingNeedsDto {
   @Column(DataType.INTEGER)
   declare transactionDatabaseId: number;
 
-  @Column(DataType.DATE)
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
   declare transactionCreatedAt?: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
@@ -87,7 +91,7 @@ export class ChargingNeeds extends Model implements ChargingNeedsDto {
   @BelongsTo(() => Tenant, 'tenantId')
   declare tenant?: TenantDto;
 
-  @BeforeCreate
+  @BeforeValidate
   static async resolveTransactionCreatedAt(instance: ChargingNeeds): Promise<void> {
     if (instance.transactionCreatedAt == null) {
       instance.transactionCreatedAt = await Transaction.resolveCreatedAt(

--- a/packages/dal/src/models/charging-profile/charging-needs.ts
+++ b/packages/dal/src/models/charging-profile/charging-needs.ts
@@ -72,7 +72,7 @@ export class ChargingNeeds extends Model implements ChargingNeedsDto {
     type: DataType.DATE,
     allowNull: false,
   })
-  declare transactionCreatedAt?: Date;
+  declare transactionCreatedAt: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
   declare transaction: TransactionDto;

--- a/packages/dal/src/models/location/server-network-profile.ts
+++ b/packages/dal/src/models/location/server-network-profile.ts
@@ -57,7 +57,11 @@ export class ServerNetworkProfile
   @Column(DataType.BOOLEAN)
   declare allowUnknownChargingStations: boolean;
 
-  @Column(DataType.BOOLEAN)
+  @Column({
+    type: DataType.BOOLEAN,
+    allowNull: false,
+    defaultValue: false,
+  })
   declare dynamicTenantResolution: boolean;
 
   @Column(DataType.STRING)

--- a/packages/dal/src/models/tenant.ts
+++ b/packages/dal/src/models/tenant.ts
@@ -109,6 +109,7 @@ export class Tenant extends Model<TenantAttributes, TenantCreationAttributes> im
 
   @Column({
     type: DataType.BOOLEAN,
+    allowNull: false,
     defaultValue: false,
   })
   declare isUserTenant: boolean;

--- a/packages/dal/src/models/transaction-event/meter-value.ts
+++ b/packages/dal/src/models/transaction-event/meter-value.ts
@@ -54,7 +54,7 @@ export class MeterValue extends Model implements MeterValueDto {
     type: DataType.DATE,
     allowNull: false,
   })
-  declare transactionCreatedAt?: Date;
+  declare transactionCreatedAt: Date;
 
   @BelongsTo(() => StopTransaction, 'stopTransactionDatabaseId')
   declare stopTransaction?: StopTransactionDto;

--- a/packages/dal/src/models/transaction-event/meter-value.ts
+++ b/packages/dal/src/models/transaction-event/meter-value.ts
@@ -15,6 +15,7 @@ import { DEFAULT_TENANT_ID, Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
+  BeforeValidate,
   BelongsTo,
   Column,
   DataType,
@@ -49,7 +50,10 @@ export class MeterValue extends Model implements MeterValueDto {
   @Column(DataType.INTEGER)
   declare stopTransactionDatabaseId?: number | null;
 
-  @Column(DataType.DATE)
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
   declare transactionCreatedAt?: Date;
 
   @BelongsTo(() => StopTransaction, 'stopTransactionDatabaseId')
@@ -73,6 +77,7 @@ export class MeterValue extends Model implements MeterValueDto {
   @BelongsTo(() => Connector, 'connectorId')
   declare connector?: ConnectorDto;
 
+  @Column(DataType.JSONB)
   declare customData?: any | null;
 
   @ForeignKey(() => Tariff)
@@ -97,7 +102,7 @@ export class MeterValue extends Model implements MeterValueDto {
   @BelongsTo(() => Tenant, 'tenantId')
   declare tenant?: TenantDto;
 
-  @BeforeCreate
+  @BeforeValidate
   static async resolvePartitionKey(instance: MeterValue): Promise<void> {
     if (instance.transactionCreatedAt != null) {
       return;

--- a/packages/dal/src/models/transaction-event/start-transaction.ts
+++ b/packages/dal/src/models/transaction-event/start-transaction.ts
@@ -11,6 +11,7 @@ import { DEFAULT_TENANT_ID, OCPP1_6_Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
+  BeforeValidate,
   BelongsTo,
   Column,
   DataType,
@@ -51,12 +52,16 @@ export class StartTransaction extends Model implements StartTransactionDto {
 
   @Column({
     type: DataType.DATE,
+    allowNull: false,
     unique: 'transactionDatabaseId_transactionCreatedAt',
   })
   declare transactionCreatedAt?: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
   declare transaction: TransactionDto;
+
+  @Column(DataType.INTEGER)
+  declare idTokenDatabaseId?: number | null;
 
   @ForeignKey(() => Connector)
   declare connectorDatabaseId: number;
@@ -76,7 +81,7 @@ export class StartTransaction extends Model implements StartTransactionDto {
   @BelongsTo(() => Tenant, 'tenantId')
   declare tenant?: TenantDto;
 
-  @BeforeCreate
+  @BeforeValidate
   static async resolveTransactionCreatedAt(instance: StartTransaction): Promise<void> {
     if (instance.transactionCreatedAt == null) {
       instance.transactionCreatedAt = await Transaction.resolveCreatedAt(

--- a/packages/dal/src/models/transaction-event/start-transaction.ts
+++ b/packages/dal/src/models/transaction-event/start-transaction.ts
@@ -55,7 +55,7 @@ export class StartTransaction extends Model implements StartTransactionDto {
     allowNull: false,
     unique: 'transactionDatabaseId_transactionCreatedAt',
   })
-  declare transactionCreatedAt?: Date;
+  declare transactionCreatedAt: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
   declare transaction: TransactionDto;

--- a/packages/dal/src/models/transaction-event/stop-transaction.ts
+++ b/packages/dal/src/models/transaction-event/stop-transaction.ts
@@ -43,7 +43,7 @@ export class StopTransaction extends Model implements StopTransactionDto {
     allowNull: false,
     unique: 'transactionDatabaseId_transactionCreatedAt',
   })
-  declare transactionCreatedAt?: Date;
+  declare transactionCreatedAt: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
   declare transaction: TransactionDto;

--- a/packages/dal/src/models/transaction-event/stop-transaction.ts
+++ b/packages/dal/src/models/transaction-event/stop-transaction.ts
@@ -11,6 +11,7 @@ import { DEFAULT_TENANT_ID, OCPP1_6_Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
+  BeforeValidate,
   BelongsTo,
   Column,
   DataType,
@@ -39,6 +40,7 @@ export class StopTransaction extends Model implements StopTransactionDto {
 
   @Column({
     type: DataType.DATE,
+    allowNull: false,
     unique: 'transactionDatabaseId_transactionCreatedAt',
   })
   declare transactionCreatedAt?: Date;
@@ -82,7 +84,7 @@ export class StopTransaction extends Model implements StopTransactionDto {
   @BelongsTo(() => Tenant, 'tenantId')
   declare tenant?: TenantDto;
 
-  @BeforeCreate
+  @BeforeValidate
   static async resolveTransactionCreatedAt(instance: StopTransaction): Promise<void> {
     if (instance.transactionCreatedAt == null) {
       instance.transactionCreatedAt = await Transaction.resolveCreatedAt(

--- a/packages/dal/src/models/transaction-event/transaction-event.ts
+++ b/packages/dal/src/models/transaction-event/transaction-event.ts
@@ -75,7 +75,7 @@ export class TransactionEvent extends Model implements TransactionEventDto {
     type: DataType.DATE,
     allowNull: false,
   })
-  declare transactionCreatedAt?: Date;
+  declare transactionCreatedAt: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
   declare transaction?: TransactionDto;

--- a/packages/dal/src/models/transaction-event/transaction-event.ts
+++ b/packages/dal/src/models/transaction-event/transaction-event.ts
@@ -15,6 +15,7 @@ import { DEFAULT_TENANT_ID, OCPP2_Namespace } from '@citrineos/base';
 import {
   BeforeCreate,
   BeforeUpdate,
+  BeforeValidate,
   BelongsTo,
   Column,
   DataType,
@@ -70,7 +71,10 @@ export class TransactionEvent extends Model implements TransactionEventDto {
 
   declare transactionDatabaseId?: number;
 
-  @Column(DataType.DATE)
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+  })
   declare transactionCreatedAt?: Date;
 
   @BelongsTo(() => Transaction, 'transactionDatabaseId')
@@ -105,7 +109,7 @@ export class TransactionEvent extends Model implements TransactionEventDto {
   @BelongsTo(() => Tenant, 'tenantId')
   declare tenant?: TenantDto;
 
-  @BeforeCreate
+  @BeforeValidate
   static async resolveTransactionCreatedAt(instance: TransactionEvent): Promise<void> {
     if (instance.transactionCreatedAt == null) {
       instance.transactionCreatedAt = await Transaction.resolveCreatedAt(

--- a/packages/dal/src/repositories/drizzle/installed-certificate.ts
+++ b/packages/dal/src/repositories/drizzle/installed-certificate.ts
@@ -26,8 +26,7 @@ type InstalledCertificateHashData = Pick<
   InstalledCertificateDto,
   'hashAlgorithm' | 'issuerNameHash' | 'issuerKeyHash' | 'serialNumber'
 >;
-type InstalledCertificateCreateInput = Omit<InstalledCertificateCreate, 'hashAlgorithm'> & {
-  hashAlgorithm?: HashAlgorithmEnumType;
+type InstalledCertificateCreateInput = InstalledCertificateCreate & {
   certificateId?: number | null;
 };
 
@@ -41,9 +40,9 @@ export function toInstalledCertificateDto(
     id: entity.id,
     ocppConnectionName: entity.ocppConnectionName,
     hashAlgorithm: entity.hashAlgorithm as HashAlgorithmEnumType,
-    issuerNameHash: entity.issuerNameHash ?? null,
-    issuerKeyHash: entity.issuerKeyHash ?? null,
-    serialNumber: entity.serialNumber ?? null,
+    issuerNameHash: entity.issuerNameHash,
+    issuerKeyHash: entity.issuerKeyHash,
+    serialNumber: entity.serialNumber,
     certificateType: entity.certificateType as CertificateUseEnumType,
     tenantId: entity.tenantId,
     tenant: undefined,
@@ -220,9 +219,9 @@ export class DrizzleInstalledCertificateRepository
         eq(installedCertificateTable.tenantId, tenantId),
         eq(installedCertificateTable.ocppConnectionName, ocppConnectionName),
         eq(installedCertificateTable.hashAlgorithm, hashData.hashAlgorithm),
-        eq(installedCertificateTable.issuerNameHash, hashData.issuerNameHash ?? ''),
-        eq(installedCertificateTable.issuerKeyHash, hashData.issuerKeyHash ?? ''),
-        eq(installedCertificateTable.serialNumber, hashData.serialNumber ?? ''),
+        eq(installedCertificateTable.issuerNameHash, hashData.issuerNameHash),
+        eq(installedCertificateTable.issuerKeyHash, hashData.issuerKeyHash),
+        eq(installedCertificateTable.serialNumber, hashData.serialNumber),
       ),
     );
   }

--- a/packages/dal/src/repositories/repositories.ts
+++ b/packages/dal/src/repositories/repositories.ts
@@ -23,7 +23,6 @@ import type {
   DeleteCertificateAttemptDto,
   DeleteCertificateStatusEnumType,
   EvseDto,
-  HashAlgorithmEnumType,
   InstallCertificateAttemptCreate,
   InstallCertificateAttemptDto,
   InstallCertificateStatusEnumType,
@@ -491,8 +490,7 @@ type InstalledCertificateHashData = Pick<
   InstalledCertificateDto,
   'hashAlgorithm' | 'issuerNameHash' | 'issuerKeyHash' | 'serialNumber'
 >;
-type InstalledCertificateCreateInput = Omit<InstalledCertificateCreate, 'hashAlgorithm'> & {
-  hashAlgorithm?: HashAlgorithmEnumType;
+type InstalledCertificateCreateInput = InstalledCertificateCreate & {
   certificateId?: number | null;
 };
 

--- a/packages/dal/src/repositories/sequelize/installed-certificate.ts
+++ b/packages/dal/src/repositories/sequelize/installed-certificate.ts
@@ -5,7 +5,6 @@
 import type {
   CertificateDto,
   CertificateUseEnumType,
-  HashAlgorithmEnumType,
   InstalledCertificateCreate,
   InstalledCertificateDto,
 } from '@citrineos/types';
@@ -18,8 +17,7 @@ type InstalledCertificateHashData = Pick<
   InstalledCertificateDto,
   'hashAlgorithm' | 'issuerNameHash' | 'issuerKeyHash' | 'serialNumber'
 >;
-type InstalledCertificateCreateInput = Omit<InstalledCertificateCreate, 'hashAlgorithm'> & {
-  hashAlgorithm?: HashAlgorithmEnumType;
+type InstalledCertificateCreateInput = InstalledCertificateCreate & {
   certificateId?: number | null;
 };
 

--- a/packages/dal/src/repositories/sequelize/transaction-event.ts
+++ b/packages/dal/src/repositories/sequelize/transaction-event.ts
@@ -305,7 +305,7 @@ export class SequelizeTransactionEventRepository
 
       const transactionDatabaseId = finalTransaction.id;
       // Passed transactionCreatedAt explicitly because the
-      // models' @BeforeCreate fallback reads outside this sequelize transaction and so
+      // models' @BeforeValidate fallback reads outside this sequelize transaction and so
       // cannot see a Transaction created moments ago in it.
       const transactionCreatedAt = finalTransaction.createdAt;
 

--- a/packages/ocpp/src/handlers/responses/2/delete-certificate-response-ocpp-2-handler.ts
+++ b/packages/ocpp/src/handlers/responses/2/delete-certificate-response-ocpp-2-handler.ts
@@ -85,16 +85,18 @@ export class DeleteCertificateResponseOcpp2Handler extends AbstractHandler {
         existingPendingDeleteCertificateAttempt.id!,
         message.payload.status,
       );
-      if (message.payload.status === DeleteCertificateStatusEnum.Accepted) {
+      const { hashAlgorithm, issuerNameHash, issuerKeyHash, serialNumber } =
+        existingPendingDeleteCertificateAttempt;
+      if (
+        message.payload.status === DeleteCertificateStatusEnum.Accepted &&
+        issuerNameHash != null &&
+        issuerKeyHash != null &&
+        serialNumber != null
+      ) {
         await this._installedCertificateRepository.deleteByStationAndHashData(
           tenantId,
           ocppConnectionName,
-          {
-            hashAlgorithm: existingPendingDeleteCertificateAttempt.hashAlgorithm,
-            issuerNameHash: existingPendingDeleteCertificateAttempt.issuerNameHash,
-            issuerKeyHash: existingPendingDeleteCertificateAttempt.issuerKeyHash,
-            serialNumber: existingPendingDeleteCertificateAttempt.serialNumber,
-          },
+          { hashAlgorithm, issuerNameHash, issuerKeyHash, serialNumber },
         );
       }
     }

--- a/packages/ocpp/src/handlers/responses/2/get-installed-certificate-ids-response-ocpp-2-handler.ts
+++ b/packages/ocpp/src/handlers/responses/2/get-installed-certificate-ids-response-ocpp-2-handler.ts
@@ -167,10 +167,10 @@ export class GetInstalledCertificateIdsResponseOcpp2Handler extends AbstractHand
 function installedCertificateKey(
   certificateType: CertificateUseEnumType,
   hashData: {
-    hashAlgorithm?: string | null;
-    issuerNameHash?: string | null;
-    issuerKeyHash?: string | null;
-    serialNumber?: string | null;
+    hashAlgorithm: string;
+    issuerNameHash: string;
+    issuerKeyHash: string;
+    serialNumber: string;
   },
 ): string {
   return [

--- a/packages/ocpp/src/services/certificate/certificate-util.ts
+++ b/packages/ocpp/src/services/certificate/certificate-util.ts
@@ -7,7 +7,13 @@ import { CertificationRequest } from 'pkijs';
 import * as asn1js from 'asn1js';
 import { fromBER } from 'asn1js';
 import { CountryNameEnumType, SignatureAlgorithmEnumType } from '@citrineos/dal';
-import type { CertificateCreate, OCPP2_0_1, OCPP2_1 } from '@citrineos/types';
+import {
+  HashAlgorithmEnum,
+  type CertificateCreate,
+  type InstalledCertificateCreate,
+  type OCPP2_0_1,
+  type OCPP2_1,
+} from '@citrineos/types';
 import jsrsasign from 'jsrsasign';
 import { fromBase64, stringToArrayBuffer } from 'pvutils';
 import moment from 'moment';
@@ -17,6 +23,7 @@ import KJUR = jsrsasign.KJUR;
 import OCSPRequest = jsrsasign.KJUR.asn1.ocsp.OCSPRequest;
 import X509 = jsrsasign.X509;
 import KEYUTIL = jsrsasign.KEYUTIL;
+import ASN1HEX = jsrsasign.ASN1HEX;
 
 export const dateTimeFormat = 'YYMMDDHHmmssZ';
 
@@ -84,6 +91,31 @@ export function isSignedBy(certPem: string, issuerCertPem: string): boolean {
   } catch {
     return false;
   }
+}
+
+export function getCertificateHashData(
+  certificateChainPem: string,
+): Pick<
+  InstalledCertificateCreate,
+  'hashAlgorithm' | 'issuerNameHash' | 'issuerKeyHash' | 'serialNumber'
+> {
+  const [subjectPem, issuerPem = subjectPem] = parseCertificateChainPem(certificateChainPem);
+  const issuerPublicKey =
+    subjectPem && isSignedBy(subjectPem, issuerPem)
+      ? ASN1HEX.getVbyList(new X509(issuerPem).getPublicKeyHex(), 0, [1], '03', true)
+      : null;
+  if (issuerPublicKey === null) {
+    throw new Error(
+      'Cannot derive certificate hash data: the certificate must be self-signed or followed by its issuer',
+    );
+  }
+  const subject = new X509(subjectPem);
+  return {
+    hashAlgorithm: HashAlgorithmEnum.SHA256,
+    issuerNameHash: KJUR.crypto.Util.hashHex(subject.getIssuerHex(), 'sha256'),
+    issuerKeyHash: KJUR.crypto.Util.hashHex(issuerPublicKey, 'sha256'),
+    serialNumber: subject.getSerialNumberHex().replace(/^0+(?=.)/, ''),
+  };
 }
 
 /**

--- a/packages/ocpp/src/services/certificate/install-certificate-helper-service.ts
+++ b/packages/ocpp/src/services/certificate/install-certificate-helper-service.ts
@@ -32,6 +32,7 @@ import {
   extractCertificateDetails,
   generateCertificate,
   generateCSR,
+  getCertificateHashData,
   isSignedBy,
   parseCertificateChainPem,
 } from './certificate-util.js';
@@ -274,13 +275,11 @@ export class InstallCertificateHelperService {
               );
               return;
             }
-            const certificateString = certificateBuffer.toString();
-            const cert = new jsrsasign.X509();
-            cert.readCertPEM(certificateString);
             await this.installedCertificateRepository.createInstalledCertificate(tenantId, {
               ocppConnectionName,
               certificateType: existingPendingInstallCertificateAttempt.certificateType,
               certificateId: existingPendingInstallCertificateAttempt.certificateId,
+              ...getCertificateHashData(certificateBuffer.toString()),
             });
           }
         }
@@ -391,6 +390,7 @@ export class InstallCertificateHelperService {
           )) ?? existingInstalledCertificate;
       }
     } else {
+      const certificateHashData = getCertificateHashData(certificate);
       // check if certificate record exists
       let existingCertificate = await this.certificateRepository.findByFileHash(
         tenantId,
@@ -415,6 +415,7 @@ export class InstallCertificateHelperService {
           ocppConnectionName: identifier,
           certificateType: uploadExistingCertificate.certificateType,
           certificateId: existingCertificate.id!,
+          ...certificateHashData,
         });
     }
     return existingInstalledCertificate!;

--- a/packages/ocpp/test/modules/certificates/finalize-installed-certificate-integration.test.ts
+++ b/packages/ocpp/test/modules/certificates/finalize-installed-certificate-integration.test.ts
@@ -25,6 +25,7 @@ import type { Sequelize } from 'sequelize-typescript';
 import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
 import { Logger } from 'tslog';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { readFile } from '../../utils/file-util.js';
 
 /**
  * A station can have more than one certificate install in flight: the endpoint prepares an attempt
@@ -79,7 +80,9 @@ afterAll(async () => {
   await pgContainer?.stop();
 });
 
-function aService() {
+function aService(
+  fileStorage: { getFile: () => Promise<Buffer | undefined> } = { getFile: async () => undefined },
+) {
   const deps = { config, logger: undefined, sequelizeInstance } as never;
   return new InstallCertificateHelperService({
     certificateRepository: new SequelizeCertificateRepository(deps),
@@ -89,7 +92,7 @@ function aService() {
     // Unreachable for a finalize that settles an attempt row.
     deviceModelRepository: {} as never,
     certificateAuthorityService: {} as never,
-    fileStorage: { getFile: async () => undefined } as never,
+    fileStorage: fileStorage as never,
     logger: new Logger({ type: 'hidden' }),
   });
 }
@@ -180,5 +183,46 @@ describe('finalizeInstalledCertificate with more than one certificate in flight'
     );
 
     expect(await statusOf(root)).toBeNull();
+  });
+
+  it('records the accepted certificate with its hash data', async () => {
+    const certificate = await Certificate.create({
+      serialNumber: nextSerialNumber++,
+      issuerName: 'issuer',
+      organizationName: 'org',
+      commonName: 'root',
+      certificateFileHash: 'root-hash',
+      certificateFileId: 'root-file',
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+    await InstallCertificateAttempt.create({
+      ocppConnectionName: STATION,
+      certificateType: CertificateUseEnum.V2GRootCertificate,
+      certificateId: (certificate as unknown as { id: number }).id,
+      status: null,
+      tenantId: DEFAULT_TENANT_ID,
+    } as never);
+    const rootCertificatePem = readFile('RootCertificateSample.pem');
+
+    await aService({
+      getFile: async () => Buffer.from(rootCertificatePem),
+    }).finalizeInstalledCertificate(
+      DEFAULT_TENANT_ID,
+      STATION,
+      InstallCertificateStatusEnum.Accepted,
+      undefined,
+      CertificateUseEnum.V2GRootCertificate,
+    );
+
+    const installed = await InstalledCertificate.findOne({
+      where: { ocppConnectionName: STATION },
+    });
+    expect(installed?.get({ plain: true })).toMatchObject({
+      certificateType: CertificateUseEnum.V2GRootCertificate,
+      hashAlgorithm: 'SHA256',
+      issuerNameHash: '9111b7039ad923e5f68a6aaa3bac279ef1241d7a7d408c5aed836bb7763a61cb',
+      issuerKeyHash: 'b0a67b950d1104ad0ab0d8bfdd466c971bcc557faad2eacec3d6744259a3b407',
+      serialNumber: '1916c392c93',
+    });
   });
 });

--- a/packages/ocpp/test/services/certificate/certificate-util.test.ts
+++ b/packages/ocpp/test/services/certificate/certificate-util.test.ts
@@ -9,6 +9,7 @@ import {
   extractCertificateArrayFromEncodedString,
   extractCertificateDetails,
   extractEncodedContentFromCSR,
+  getCertificateHashData,
   parseCertificateChainPem,
   sendOCSPRequest,
 } from '@services/index.js';
@@ -110,6 +111,42 @@ describe('CertificateUtil', () => {
       const hex = createOcspRequest({ ...givenOcspRequestData, hashAlgorithm }).getEncodedHex();
 
       expect(parseOcspRequestHex(hex)[0].alg).toBe(hashAlgorithm.toLowerCase());
+    });
+  });
+
+  describe('getCertificateHashData', () => {
+    it('hashes a self-signed certificate against its own key', () => {
+      const givenRootCertPem = readFile('RootCertificateSample.pem');
+
+      const actualResult = getCertificateHashData(givenRootCertPem);
+
+      expect(actualResult).toEqual({
+        hashAlgorithm: 'SHA256',
+        issuerNameHash: '9111b7039ad923e5f68a6aaa3bac279ef1241d7a7d408c5aed836bb7763a61cb',
+        issuerKeyHash: 'b0a67b950d1104ad0ab0d8bfdd466c971bcc557faad2eacec3d6744259a3b407',
+        serialNumber: '1916c392c93',
+      });
+    });
+
+    it('hashes the first certificate of a chain against the key of the next', () => {
+      const givenCertChainPem = `${readFile('LeafCertificateSample.pem')}${readFile('SubCACertificateSample.pem')}`;
+
+      const actualResult = getCertificateHashData(givenCertChainPem);
+
+      expect(actualResult).toEqual({
+        hashAlgorithm: 'SHA256',
+        issuerNameHash: 'ee55de5909f09f71087d95dd9d616cc5f9dbf70803127b4beb055709ef854e16',
+        issuerKeyHash: '311dccc09d26b33d17b8ecd27063dd12a5436bc9012652c8344b1c8cded7bd0a',
+        serialNumber: '1916c392dce',
+      });
+    });
+
+    it('throws for a certificate that is neither self-signed nor followed by its issuer', () => {
+      const givenLeafCertPem = readFile('LeafCertificateSample.pem');
+
+      expect(() => getCertificateHashData(givenLeafCertPem)).toThrow(
+        'Cannot derive certificate hash data',
+      );
     });
   });
 

--- a/packages/ocpp/test/services/certificate/install-certificate-helper-service.test.ts
+++ b/packages/ocpp/test/services/certificate/install-certificate-helper-service.test.ts
@@ -34,6 +34,7 @@ const mockExtractCertificateDetails = vi.hoisted(() => vi.fn());
 const mockGenerateCertificate = vi.hoisted(() => vi.fn());
 const mockParseCertificateChainPem = vi.hoisted(() => vi.fn());
 const mockIsSignedBy = vi.hoisted(() => vi.fn());
+const mockGetCertificateHashData = vi.hoisted(() => vi.fn());
 
 let createdCertificateInstances: any[] = [];
 let createdInstallCertificateAttemptInstances: any[] = [];
@@ -63,6 +64,7 @@ vi.mock('@services/certificate/certificate-util.js', async (importOriginal) => {
     generateCertificate: mockGenerateCertificate,
     parseCertificateChainPem: mockParseCertificateChainPem,
     isSignedBy: mockIsSignedBy,
+    getCertificateHashData: mockGetCertificateHashData,
   };
 });
 
@@ -170,6 +172,12 @@ describe('InstallCertificateHelperService', () => {
   let mockCertificateAuthorityService: CertificateAuthorityService;
 
   const mockHash = 'abc123hash';
+  const mockCertificateHashData = {
+    hashAlgorithm: 'SHA256',
+    issuerNameHash: 'issuer-name-hash',
+    issuerKeyHash: 'issuer-key-hash',
+    serialNumber: '1916c392dce',
+  };
   const tenantId = 1;
   const ocppConnectionName = 'cp001';
 
@@ -200,6 +208,7 @@ describe('InstallCertificateHelperService', () => {
     createdInstallCertificateAttemptInstances = [];
     createdInstalledCertificateInstances = [];
     createdDeleteCertificateAttemptInstances = [];
+    mockGetCertificateHashData.mockReturnValue(mockCertificateHashData);
 
     mockCertificateRepository = {
       findByFileHash: mockCertificateFindByFileHash,
@@ -624,10 +633,12 @@ describe('InstallCertificateHelperService', () => {
       );
       expect(mockFileStorageGetFile).toHaveBeenCalledWith('file123');
 
+      expect(mockGetCertificateHashData).toHaveBeenCalledWith(MOCK_CERTIFICATE);
       expect(mockInstalledCreate).toHaveBeenCalledWith(tenantId, {
         ocppConnectionName,
         certificateType: MOCK_CERT_TYPE_V2G,
         certificateId: 100,
+        ...mockCertificateHashData,
       });
     });
 
@@ -870,10 +881,12 @@ describe('InstallCertificateHelperService', () => {
         mockUploadRequest,
       );
 
+      expect(mockGetCertificateHashData).toHaveBeenCalledWith(MOCK_CERTIFICATE);
       expect(mockInstalledCreate).toHaveBeenCalledWith(tenantId, {
         ocppConnectionName,
         certificateType: MOCK_CERT_TYPE_V2G,
         certificateId: 99,
+        ...mockCertificateHashData,
       });
       expect(result).toBe(mockCreatedInstalled);
     });
@@ -906,7 +919,22 @@ describe('InstallCertificateHelperService', () => {
         ocppConnectionName,
         certificateType: MOCK_CERT_TYPE_V2G,
         certificateId: 100,
+        ...mockCertificateHashData,
       });
+    });
+
+    it('should not create a certificate record when hash data cannot be derived', async () => {
+      mockInstalledFindByStationAndType.mockResolvedValue(undefined);
+      mockGetCertificateHashData.mockImplementation(() => {
+        throw new Error('Cannot derive certificate hash data');
+      });
+      vi.spyOn(service, 'createNewCertificate');
+
+      await expect(
+        service.handleUploadExistingCertificate(tenantId, ocppConnectionName, mockUploadRequest),
+      ).rejects.toThrow('Cannot derive certificate hash data');
+
+      expect(service.createNewCertificate).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ocpp/test/util/sequelize-schema-validator-migrations-integration.test.ts
+++ b/packages/ocpp/test/util/sequelize-schema-validator-migrations-integration.test.ts
@@ -20,10 +20,6 @@ interface Migration {
   up: (queryInterface: QueryInterface) => Promise<void>;
 }
 
-/**
- * Applies every migration in file-name order, as sequelize-cli does. Migrations export
- * either a default `{ up, down }` object or named `up` and `down` functions.
- */
 async function runMigrations(queryInterface: QueryInterface): Promise<string[]> {
   const files = readdirSync(MIGRATIONS_DIR)
     .filter((file) => file.endsWith('.ts'))

--- a/packages/ocpp/test/util/sequelize-schema-validator-migrations-integration.test.ts
+++ b/packages/ocpp/test/util/sequelize-schema-validator-migrations-integration.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import type { QueryInterface } from 'sequelize';
+import type { Sequelize } from 'sequelize-typescript';
+import { DefaultSequelizeInstance } from '@citrineos/dal';
+import { validateSequelizeSchema } from '@/util/index.js';
+import type { SystemConfig } from '@citrineos/types';
+
+const MIGRATIONS_DIR = fileURLToPath(
+  new URL('../../../../apps/ocpp-server/migrations/', import.meta.url),
+);
+
+interface Migration {
+  up: (queryInterface: QueryInterface) => Promise<void>;
+}
+
+/**
+ * Applies every migration in file-name order, as sequelize-cli does. Migrations export
+ * either a default `{ up, down }` object or named `up` and `down` functions.
+ */
+async function runMigrations(queryInterface: QueryInterface): Promise<string[]> {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((file) => file.endsWith('.ts'))
+    .sort();
+  for (const file of files) {
+    const module = (await import(pathToFileURL(join(MIGRATIONS_DIR, file)).href)) as Migration & {
+      default?: Migration;
+    };
+    await (module.default ?? module).up(queryInterface);
+  }
+  return files;
+}
+
+let pgContainer: StartedTestContainer;
+let sequelizeInstance: Sequelize;
+let migrationsRun: string[];
+
+beforeAll(async () => {
+  pgContainer = await new GenericContainer('postgis/postgis:16-3.4-alpine')
+    .withEnvironment({
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+      POSTGRES_DB: 'citrineos_test',
+    })
+    .withExposedPorts(5432)
+    .withWaitStrategy(Wait.forLogMessage('database system is ready to accept connections', 2))
+    .start();
+
+  const dbConfig = {
+    database: {
+      host: pgContainer.getHost(),
+      port: pgContainer.getMappedPort(5432),
+      database: 'citrineos_test',
+      dialect: 'postgres',
+      username: 'test',
+      password: 'test',
+      schema: 'public',
+      sync: false,
+      alter: false,
+      force: false,
+      maxRetries: 1,
+      retryDelay: 100,
+    },
+  } as unknown as SystemConfig;
+
+  sequelizeInstance = DefaultSequelizeInstance.getInstance(dbConfig);
+  migrationsRun = await runMigrations(sequelizeInstance.getQueryInterface());
+}, 240_000);
+
+afterAll(async () => {
+  await sequelizeInstance.close();
+  await pgContainer.stop();
+});
+
+describe('SequelizeSchemaValidatorMigrationsIntegration', () => {
+  describe('validateSequelizeSchema against a schema built by the migrations', () => {
+    it('applies every migration', () => {
+      expect(migrationsRun.length).toBeGreaterThan(0);
+    });
+
+    it('reports no errors', async () => {
+      const report = await validateSequelizeSchema(sequelizeInstance, { schema: 'public' });
+
+      expect(report.errors, JSON.stringify(report.errors, null, 2)).toEqual([]);
+      expect(report.tablesChecked).toBeGreaterThan(0);
+      expect(report.columnsChecked).toBeGreaterThan(0);
+    });
+
+    it('reports no warnings', async () => {
+      const report = await validateSequelizeSchema(sequelizeInstance, { schema: 'public' });
+
+      expect(report.warnings, JSON.stringify(report.warnings, null, 2)).toEqual([]);
+    });
+  });
+});

--- a/packages/types/src/interfaces/dto/installed-certificate-dto.ts
+++ b/packages/types/src/interfaces/dto/installed-certificate-dto.ts
@@ -10,9 +10,9 @@ export const InstalledCertificateSchema = BaseSchema.extend({
   id: z.number().int().optional(),
   ocppConnectionName: z.string().max(36),
   hashAlgorithm: HashAlgorithmEnumSchema,
-  issuerNameHash: z.string().nullable().optional(),
-  issuerKeyHash: z.string().nullable().optional(),
-  serialNumber: z.string().nullable().optional(),
+  issuerNameHash: z.string(),
+  issuerKeyHash: z.string(),
+  serialNumber: z.string(),
   certificateType: CertificateUseEnumSchema,
 });
 


### PR DESCRIPTION
## Summary

#930's schema validator reports 15 warnings against a database built by the migrations, on every install. They are all model-side: the models say less than the migrations do. This PR brings the models into line, updates the code around them so it no longer allows for a null the database cannot hold, and adds a test that keeps the models and migrations in line.

Verified by applying every migration to a fresh `postgis/postgis:16-3.4-alpine` and running `validateSequelizeSchema`: **15 warnings before, 0 after.** No migration is added or changed.

## The 15 warnings

**NOT NULL in the database, not declared in the model (11)**

| Column | Change |
|---|---|
| `transactionCreatedAt` on `ChargingNeeds`, `MeterValues`, `StartTransactions`, `StopTransactions`, `TransactionEvents` | `allowNull: false`, and the hook that resolves it moves from `@BeforeCreate` to `@BeforeValidate` - see below |
| `InstalledCertificates.hashAlgorithm`, `.issuerNameHash`, `.issuerKeyHash`, `.serialNumber` | `allowNull: true` → `false`. The migration has always declared these NOT NULL, and `CertificateHashDataType` requires all four |
| `Tenants.isUserTenant` | `allowNull: false` (it already had `defaultValue: false`) |
| `ServerNetworkProfiles.dynamicTenantResolution` | `allowNull: false, defaultValue: false`, matching the migration |

**In the database, not declared in the model (4)**

| Column | Change |
|---|---|
| `customData` on `Authorizations`, `MeterValues`, `LocalListAuthorizations` | `@Column(DataType.JSONB)`. Each model already had `declare customData` without a `@Column`, so Sequelize never read or wrote it - a `customData` in an Authorize or MeterValues was silently dropped, and `AuthorizationMapper` always emitted `undefined`. `Transaction` already maps its `customData` the same way |
| `StartTransactions.idTokenDatabaseId` | `@Column(DataType.INTEGER)`, nullable. Declared rather than dropped because Hasura exposes it and the operator UI selects it (`apps/operator-ui/src/lib/queries/transactions.ts`); removing it is a separate change touching the UI and metadata |

### Why the partition-key hook moves to `BeforeValidate`

Sequelize runs `allowNull` validation *before* `beforeCreate`, so with `allowNull: false` the existing `@BeforeCreate` hook would run too late and every insert would fail with a `notNull Violation`. `@BeforeValidate` runs first. The hooks already return early when the value is set, so on update they are no-ops; none of the five models is written through `bulkCreate` or a static `update()`, where validate hooks do not run.

## The code around those columns

**InstalledCertificate hash data.** `issuerNameHash`, `issuerKeyHash` and `serialNumber` are now non-null in `InstalledCertificateDto`, the model and the Drizzle schema (which also gets `.notNull()` on `hashAlgorithm`), and the repository create input no longer makes `hashAlgorithm` optional. The Drizzle mapper's `?? null`, the `?? ''` in `deleteByStationAndHashData`, and the optional fields on `installedCertificateKey` in the GetInstalledCertificateIds handler are gone.

Making the hash data required showed two paths that created an `InstalledCertificate` with none at all: `finalizeInstalledCertificate`, when a station accepts an InstallCertificate or CertificateSigned and no row exists yet, and `handleUploadExistingCertificate`. On a migrated database both already fail with a NOT NULL violation; they only worked on a schema built by `sync()`. Both now derive the hash data from the certificate with a new `getCertificateHashData` in `certificate-util.ts`:

- SHA-256 over the DER of the certificate's issuer name, and over the issuer's subject public key (the BIT STRING value, as in an RFC 6960 CertID);
- the serial number in hex without leading zeros, as `CertificateHashDataType` describes it in 2.1;
- the certificate is hashed against its own key if it is self-signed, otherwise against the next certificate in the chain (the CertificateSigned chain is stored whole), and it throws if the named issuer did not sign it. The upload path computes it before writing any certificate record.

The results match `openssl ocsp -req_text` for the sample root, and for the sample leaf with its sub-CA.

**DeleteCertificateAttempts** keeps nullable hash columns in its migration, so the DeleteCertificate response handler now only deletes the installed record when all four values are present. The outcome is unchanged: a null never matched a row.

**transactionCreatedAt.** The five model declarations are no longer optional, since every row read back has one. The Zod DTOs keep it optional, as they do `id` and `createdAt`: the hook assigns it on write, and the same DTOs describe meter values that have not been saved yet (the meter-value mappers, `MeterValueUtils`, the 1.6 MeterValues and StopTransaction handlers). Making it required there would mean a separate type for every pre-persist value, which is a DTO redesign rather than null handling.

## Test

`packages/ocpp/test/util/sequelize-schema-validator-migrations-integration.test.ts` applies every migration in `apps/ocpp-server/migrations` to a testcontainers Postgres, in file-name order as sequelize-cli does, and asserts the validator reports no errors and no warnings. The existing integration test validates against `sequelize.sync()`, which builds the schema *from* the models and so cannot see model-vs-migration drift; this one can. Against `next` without the model changes it fails with exactly these 15 warnings.

Also added: `getCertificateHashData` tests against the sample certificates (self-signed root, leaf plus sub-CA, and a leaf with no issuer); a `finalizeInstalledCertificate` integration test that records an accepted root and checks its stored hash data, which fails with a `notNull Violation` on all four columns without the fix; and upload-path tests that the hash data is passed through and that no certificate record is written when it cannot be derived.

Not touched: the Drizzle repositories, which have their own `customData is not persisted` note for Authorization, and the Sequelize `upsertServerNetworkProfile`, which does not copy `dynamicTenantResolution` from the websocket server config - both outside this PR.

Full suite: build clean, `pnpm test` green (333 files, 4432 tests), `pnpm run lint` clean.
