### PR TITLE
fix(ocpp): answer Authorize Invalid when a token fails its format check

### DIFF
--- a/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-201-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-201-handler.ts
@@ -9,7 +9,6 @@ import {
   type IMessage,
   type IMessageConfirmation,
   type IOcppSender,
-  OcppError,
   recordAuthorizeResult,
 } from '@citrineos/base';
 import {
@@ -17,7 +16,6 @@ import {
   AuthorizationStatusEnum,
   type AuthorizationStatusEnumType,
   AuthorizeCertificateStatusEnum,
-  ErrorCode,
   type HandlerProperties,
   IdTokenEnum,
   OCPP2_0_1,
@@ -91,12 +89,6 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
         token: request.idToken.idToken,
         error: tokenValidation.errorMessage,
       });
-      const messageId = message.context.correlationId;
-      const error = new OcppError(
-        messageId,
-        ErrorCode.PropertyConstraintViolation,
-        tokenValidation.errorMessage || 'Invalid token value for specified type',
-      );
       response = {
         ...response,
         idTokenInfo: {
@@ -105,7 +97,7 @@ export class AuthorizeRequestOcpp201Handler extends AbstractHandler {
       } as OCPP2_response_types.AuthorizeResponse;
 
       this._logger.error('Token validation failed:', tokenValidation.errorMessage);
-      await this._ocppSender.sendCallErrorWithMessage(message, error);
+      await this._sendAuthorizeResult(message, response);
       return;
     }
 

--- a/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-21-handler.ts
+++ b/packages/ocpp/src/handlers/requests/2/authorize-request-ocpp-21-handler.ts
@@ -9,7 +9,6 @@ import {
   type IMessage,
   type IMessageConfirmation,
   type IOcppSender,
-  OcppError,
   recordAuthorizeResult,
 } from '@citrineos/base';
 import {
@@ -17,7 +16,6 @@ import {
   AuthorizationStatusEnum,
   type AuthorizationStatusEnumType,
   AuthorizeCertificateStatusEnum,
-  ErrorCode,
   type HandlerProperties,
   IdTokenEnum,
   OCPP2_1,
@@ -94,15 +92,15 @@ export class AuthorizeRequestOcpp21Handler extends AbstractHandler {
         token: request.idToken.idToken,
         error: tokenValidation.errorMessage,
       });
-      const messageId = message.context.correlationId;
-      const error = new OcppError(
-        messageId,
-        ErrorCode.PropertyConstraintViolation,
-        tokenValidation.errorMessage || 'Invalid token value for specified type',
-      );
+      response = {
+        ...response,
+        idTokenInfo: {
+          status: AuthorizationStatusEnum.Invalid,
+        },
+      } as OCPP2_response_types.AuthorizeResponse;
 
       this._logger.error('Token validation failed:', tokenValidation.errorMessage);
-      await this._ocppSender.sendCallErrorWithMessage(message, error);
+      await this._sendAuthorizeResult(message, response);
       return;
     }
 

--- a/packages/ocpp/test/handlers/requests/2/authorize-request-ocpp-201-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/authorize-request-ocpp-201-handler.test.ts
@@ -213,3 +213,15 @@ describe('AuthorizeRequestOcpp201Handler EVSE restrictions', () => {
     expect(response.idTokenInfo.evseId).toBeUndefined();
   });
 });
+
+describe('AuthorizeRequestOcpp201Handler token format', () => {
+  it('answers Invalid for a key code that fails the format check', async () => {
+    const { handler, ocppSender } = makeHandler({ authorization: acceptedAuthorization });
+
+    await handler.handle(
+      makeMessage({ idToken: { idToken: '12 34', type: OCPP2_0_1.IdTokenEnumType.KeyCode } }),
+    );
+
+    expect(sentResponse(ocppSender).idTokenInfo.status).toBe(AuthorizationStatusEnum.Invalid);
+  });
+});

--- a/packages/ocpp/test/handlers/requests/2/authorize-request-ocpp-21-handler.test.ts
+++ b/packages/ocpp/test/handlers/requests/2/authorize-request-ocpp-21-handler.test.ts
@@ -49,6 +49,32 @@ function anAuthorizeRequest(): OCPP2_1.AuthorizeRequest {
 }
 
 describe('AuthorizeRequestOcpp21Handler', () => {
+  describe('token format', () => {
+    it('answers Invalid for a key code that fails the format check', async () => {
+      const { logger } = createTestContainer();
+      const ocppSender = makeMockOcppSender();
+      const handler = new AuthorizeRequestOcpp21Handler({
+        logger,
+        ocppSender,
+        certificateAuthorityService: {} as unknown as CertificateAuthorityService,
+        authorizers: [],
+        authorizationRepository: {} as unknown as IAuthorizationRepository,
+        deviceModelRepository: {} as unknown as IDeviceModelRepository,
+        tariffRepository: {} as unknown as ITariffRepository,
+      });
+
+      await handler.handle(
+        makeMessage({
+          idToken: { idToken: '12 34', type: OCPP2_1.IdTokenEnumType.KeyCode },
+        } as OCPP2_1.AuthorizeRequest),
+      );
+
+      const response = ocppSender.sendCallResultWithMessage.mock
+        .calls[0]?.[1] as OCPP2_1.AuthorizeResponse;
+      expect(response?.idTokenInfo?.status).toBe(AuthorizationStatusEnum.Invalid);
+    });
+  });
+
   /**
    * I08.FR.01 lets the CSMS answer with a driver-specific tariff, but a station that does not do
    * local cost calculation cannot use one - TariffCostCtrlr.Enabled[Tariff] is what says whether it


### PR DESCRIPTION
## The defect

`AuthorizeRequestOcpp201Handler` and `AuthorizeRequestOcpp21Handler` check the idToken against the format for its type after schema validation (an ISO14443 UID must be 8 or 14 hex characters, a key code only letters, digits and `* - _ = : + | @ .`, and so on). When the check fails, both answer with a `PropertyConstraintViolation` CALLERROR.

A CALLERROR carries no `IdTokenInfo`, so the station is left with no authorisation decision for the token it asked about. C04.FR.01 says what the CSMS should do instead:

> When the CSMS receives an AuthorizeRequest with a keyCode that is not valid at this Charging Station, the CSMS SHALL respond with an AuthorizeResponse message with status = Invalid.

The 2.0.1 handler already built exactly that response in this branch, then discarded it and sent the CALLERROR.

## The fix

Both handlers now send the `AuthorizeResponse` with `idTokenInfo.status = Invalid` through the same `_sendAuthorizeResult` path as every other outcome, so the result is also recorded in the Authorize metric. That applies to every format failure, not only key codes: a token that cannot be well formed for its type cannot be valid either, and `Invalid` is the status that says so.

Untouched: the format check itself, and the two log lines in that branch. Key code redaction in the log is citrineos/citrineos-core#1035's.

## Notes for review

- `apps/operator-ui/tests/e2e/fixtures/everest.ts` has a comment saying core answers such an Authorize with a `PropertyConstraintViolation` CALLERROR. The outcome it relies on - the session is not authorised - is the same with `Invalid`. I have left it alone rather than switch the operator-ui e2e lanes on for a change that is not in the UI; happy to reword it here if you would rather.

## Tests

One per handler: a `KeyCode` token containing a space. Before the fix both fail with no `CallResult` sent (the 2.0.1 one: `expected "spy" to be called once, but got 0 times`); after it, both receive `Invalid`.

## Verification

On `next` at `0fd4e1f`: build clean, full suite green (331 files, 4420 passing / 8 skipped), `pnpm run lint` 0 errors.
