### PR TITLE
fix(dal): stop MeterValue's timestamp getter throwing when there is none

### DIFF
--- a/packages/dal/src/models/transaction-event/meter-value.ts
+++ b/packages/dal/src/models/transaction-event/meter-value.ts
@@ -61,7 +61,7 @@ export class MeterValue extends Model implements MeterValueDto {
   @Column({
     type: DataType.DATE,
     get() {
-      return this.getDataValue('timestamp').toISOString();
+      return this.getDataValue('timestamp')?.toISOString();
     },
   })
   declare timestamp: string;

--- a/packages/dal/test/models/meter-value.test.ts
+++ b/packages/dal/test/models/meter-value.test.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2026 Contributors to the CitrineOS Project
+//
+// SPDX-License-Identifier: Apache-2.0
+import type { SystemConfig } from '@citrineos/types';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { DefaultSequelizeInstance, MeterValue } from '../../index.js';
+
+beforeAll(() => {
+  DefaultSequelizeInstance.getInstance({
+    database: { dialect: 'postgres', host: 'localhost', port: 5432, database: 'unused' },
+  } as unknown as SystemConfig);
+});
+
+describe('MeterValue', () => {
+  describe('timestamp', () => {
+    it('should be undefined when no timestamp is set', () => {
+      const meterValue = MeterValue.build({ sampledValue: [{ value: 1 }] });
+
+      expect(meterValue.timestamp).toBeUndefined();
+    });
+
+    it('should return the stored date as an ISO string', () => {
+      const meterValue = MeterValue.build({ timestamp: '2026-09-11T10:00:00+01:00' });
+
+      expect(meterValue.timestamp).toBe('2026-09-11T09:00:00.000Z');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`MeterValue`'s `timestamp` getter calls `.toISOString()` on whatever is stored, so reading `timestamp` from an instance that has none throws `TypeError: Cannot read properties of undefined (reading 'toISOString')`. The same getter on `TransactionEvent`, `StartTransaction` and `StopTransaction` already uses `?.`; this makes `MeterValue` match them.

## Where it bites

- **Static `MeterValue.update()`.** Any `MeterValue.update(values, { where })` whose values leave out `timestamp` throws before it reaches the database: Sequelize builds an instance from the update values and reads every attribute through its getter (`build.get()` in `Model.update`, `lib/model.js:1929` in 6.37.8) before validating. So re-pointing existing readings at a transaction, a stop transaction or a tariff that way is not possible today. I hit this while checking #1032's partition-key hook against a database built by the migrations.
- **Reads that leave `timestamp` out.** A query with an `attributes` list that omits it throws as soon as the instance is serialised with `toJSON()` or `get()`.
- **Rows with no timestamp.** `MeterValues."timestamp"` is nullable in the migrations, so a row stored without one throws the same way when it is read.

Nothing in the codebase takes any of these paths today, so no current flow is broken; this removes the trap for the next caller.

## Test

`packages/dal/test/models/meter-value.test.ts` builds a `MeterValue` with no timestamp and reads it - `undefined` now, a `TypeError` before - and pins that a stored timestamp still comes back as a UTC ISO string. It needs no database: the model is registered through `DefaultSequelizeInstance.getInstance`, which does not connect.

Verified on `next` at `fea3ca3`: the new test fails before the fix with that `TypeError` at `meter-value.ts:64`; with it, build clean, `pnpm test` green (335 files, 4428 passing / 8 skipped), `pnpm run lint` 0 errors.
