### PR TITLE
fix(docker): pull the MinIO images from quay.io

### DIFF
--- a/.github/workflows/test-build-server.yml
+++ b/.github/workflows/test-build-server.yml
@@ -31,6 +31,7 @@ jobs:
             server:
               - 'apps/ocpp-server/**'
               - 'packages/**'
+              - 'docker-compose*.yml'
 
   build:
     needs: changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,7 @@ services:
       start_period: 30s
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio
     container_name: minio
     ports:
       - '9000:9000'
@@ -177,7 +177,7 @@ services:
       start_period: 20s
 
   minio-init:
-    image: minio/mc
+    image: quay.io/minio/mc
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Summary

`minio/minio` and `minio/mc` are no longer on Docker Hub - `https://hub.docker.com/v2/repositories/minio/minio/` and `.../minio/mc/` both return 404, and `docker pull minio/mc` answers "pull access denied ... repository does not exist". So `docker compose up` fails for anyone starting the stack fresh, and the `build (ubuntu-latest)` check in "Test Server on Pull Request" now fails on every pull request at "Build and Run Docker Compose":

```
minio-init Error pull access denied for minio/mc, repository does not exist or may require 'docker login'
```

That is #1039's first run; the last green run of that workflow was at 15:47 UTC on 11 September. Re-running does not help, since the image is gone rather than rate-limited.

MinIO publishes the same images on quay.io. This points both services at `quay.io/minio/minio` and `quay.io/minio/mc`. Nothing else changes: the quay `latest` images have the same image IDs as the Docker Hub `latest` ones a local stack already has cached (`69b2ec208575` for minio, `c2ad77420d33` for mc), and the minio image still has the `curl` its healthcheck uses.

The workflow's path filter also gains `docker-compose*.yml`. It runs `docker compose -f docker-compose.yml -f docker-compose.local.yml up`, but only when `apps/ocpp-server/**`, `packages/**` or the shared build files change, so a change to the compose files themselves skipped the one check that exercises them - the first run of this PR did exactly that. With the filter, this PR's own run is the full `docker compose up` check.

## Verification

- `docker compose -f docker-compose.yml -f docker-compose.local.yml config --images` lists the two quay images, and `docker compose ... pull minio minio-init` pulls both.
- `docker compose up -d minio minio-init` (under a separate project name): `minio` from quay.io reaches `healthy`, so the `curl` healthcheck works, and `minio-init` exits 0.
- `quay.io/minio/minio:latest --version` reports `RELEASE.2025-09-07T16-13-09Z`, and `mc --version` reports `RELEASE.2025-08-13T08-35-41Z`.
